### PR TITLE
feat(vscode): refactor mcp importer provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,7 +68,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "dependencies": {
         "@getpochi/common": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/packages/vscode/src/integrations/mcp/third-party-mcp/providers/path-utils.ts
+++ b/packages/vscode/src/integrations/mcp/third-party-mcp/providers/path-utils.ts
@@ -1,0 +1,45 @@
+import { homedir } from "node:os";
+import * as path from "node:path";
+
+/**
+ * Expands path segments with environment variables and home directory
+ */
+export function expandPathSegments(pathSegments: string[]): string {
+  const homeDir = homedir() || process.env.HOME || "";
+  const expandedSegments = pathSegments.map((segment) => {
+    if (segment === "~") {
+      return homeDir;
+    }
+    if (process.platform === "win32") {
+      return segment.replace(/%([^%]+)%/g, (match, varName) => {
+        return process.env[varName] || match;
+      });
+    }
+    return segment.replace(/\$([A-Z_][A-Z0-9_]*)/g, (match, varName) => {
+      return process.env[varName] || match;
+    });
+  });
+  return path.join(...expandedSegments);
+}
+
+/**
+ * Normalizes a file path by replacing home directory with ~
+ */
+export function normalizePath(filePath: string): string {
+  const homeDir = homedir();
+  if (filePath.startsWith(homeDir)) {
+    return filePath.replace(homeDir, "~");
+  }
+  return filePath;
+}
+
+/**
+ * Expands a path string by replacing ~ with home directory
+ */
+export function expandPath(filePath: string): string {
+  if (filePath.startsWith("~")) {
+    const homeDir = homedir() || process.env.HOME || "";
+    return path.join(homeDir, filePath.slice(1));
+  }
+  return filePath;
+}


### PR DESCRIPTION
## Summary
- Refactored the VS Code MCP importer provider, improving modularity and readability.
- Introduced `path-utils.ts` to centralize and simplify path-related logic.
- Updated `vscode-provider.ts` and `base-file-provider.ts` to use the new path utilities.

## Test plan
- The changes have been manually verified in a local development environment.
- All related unit tests continue to pass successfully.

🤖 Generated with [Pochi](https://getpochi.com)