### PR TITLE
fix: correct tool call status icon in sub-tasks

### DIFF
--- a/packages/vscode-webui/src/components/tool-invocation/tools/new-task/index.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/new-task/index.tsx
@@ -2,8 +2,12 @@ import { TaskThread, type TaskThreadSource } from "@/components/task-thread";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
+import {
+  FixedStateChatContextProvider,
+  ToolCallStatusRegistry,
+} from "@/features/chat";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { StatusIcon } from "../../status-icon";
 import { ExpandIcon, ToolTitle } from "../../tool-container";
 import type { ToolProps } from "../../types";
@@ -26,11 +30,15 @@ export const newTaskTool: React.FC<NewTaskToolProps> = ({
   let isLiveTaskSource = false;
   let taskSource = taskThreadSource;
 
+  const subTaskToolCallStatusRegistry = useRef(new ToolCallStatusRegistry());
   const inlinedTaskSource = useInlinedSubTask(tool);
   if (inlinedTaskSource) {
     taskSource = inlinedTaskSource;
   } else if (uid) {
-    taskSource = useLiveSubTask({ tool, isExecuting });
+    taskSource = useLiveSubTask(
+      { tool, isExecuting },
+      subTaskToolCallStatusRegistry.current,
+    );
     isLiveTaskSource = true;
   }
 
@@ -62,7 +70,11 @@ export const newTaskTool: React.FC<NewTaskToolProps> = ({
         )}
       </ToolTitle>
       {taskSource && (
-        <TaskThread source={taskSource} showMessageList={showMessageList} />
+        <FixedStateChatContextProvider
+          toolCallStatusRegistry={subTaskToolCallStatusRegistry.current}
+        >
+          <TaskThread source={taskSource} showMessageList={showMessageList} />
+        </FixedStateChatContextProvider>
       )}
     </div>
   );

--- a/packages/vscode-webui/src/features/chat/index.ts
+++ b/packages/vscode-webui/src/features/chat/index.ts
@@ -1,6 +1,8 @@
 // Export the main context and provider
 export {
   ChatContextProvider,
+  FixedStateChatContextProvider,
+  ToolCallStatusRegistry,
   useAutoApproveGuard,
   useToolCallLifeCycle,
 } from "./lib/chat-state";

--- a/packages/vscode-webui/src/features/chat/lib/chat-state/fixed-state.tsx
+++ b/packages/vscode-webui/src/features/chat/lib/chat-state/fixed-state.tsx
@@ -1,0 +1,115 @@
+import Emittery from "emittery";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { FixedStateToolCallLifeCycle } from "../fixed-state-tool-call-life-cycle";
+import {
+  ChatContext,
+  type ChatState,
+  type ToolCallLifeCycleKey,
+} from "./types";
+
+function keyString(key: ToolCallLifeCycleKey) {
+  return JSON.stringify({
+    toolName: key.toolName,
+    toolCallId: key.toolCallId,
+  });
+}
+
+export class ToolCallStatusRegistry extends Emittery<{ updated: undefined }> {
+  private toolCallStatusMap = new Map<
+    string,
+    { toolCallId: string; toolName: string; isExecuting: boolean }
+  >();
+
+  get(key: ToolCallLifeCycleKey) {
+    return this.toolCallStatusMap.get(keyString(key));
+  }
+
+  set(key: ToolCallLifeCycleKey, value: { isExecuting: boolean }) {
+    this.toolCallStatusMap.set(keyString(key), { ...key, ...value });
+    this.emit("updated");
+  }
+
+  delete(key: ToolCallLifeCycleKey) {
+    this.toolCallStatusMap.delete(keyString(key));
+    this.emit("updated");
+  }
+
+  entries() {
+    return this.toolCallStatusMap.entries();
+  }
+}
+
+interface FixedStateChatContextProviderProps {
+  toolCallStatusRegistry?: ToolCallStatusRegistry | undefined;
+  children: ReactNode;
+}
+
+export function FixedStateChatContextProvider({
+  toolCallStatusRegistry,
+  children,
+}: FixedStateChatContextProviderProps) {
+  const autoApproveGuard = useRef(false);
+  const abortController = useRef(new AbortController());
+
+  const [toolCallLifeCycles, setToolCallLifeCycles] = useState<
+    Map<string, FixedStateToolCallLifeCycle>
+  >(new Map());
+
+  useEffect(() => {
+    if (!toolCallStatusRegistry) {
+      return;
+    }
+    const unsubscribe = toolCallStatusRegistry.on("updated", () => {
+      setToolCallLifeCycles(
+        new Map(
+          [...toolCallStatusRegistry.entries()].map(([key, value]) => {
+            return [
+              key,
+              new FixedStateToolCallLifeCycle(
+                value.toolName,
+                value.toolCallId,
+                value.isExecuting ? "execute" : "dispose",
+              ),
+            ];
+          }),
+        ),
+      );
+    });
+    return () => unsubscribe();
+  }, [toolCallStatusRegistry]);
+
+  const getToolCallLifeCycle = useCallback(
+    (key: ToolCallLifeCycleKey) => {
+      return (
+        toolCallLifeCycles.get(keyString(key)) ??
+        new FixedStateToolCallLifeCycle(key.toolName, key.toolCallId, "dispose")
+      );
+    },
+    [toolCallLifeCycles],
+  );
+
+  const executingToolCalls = useMemo(
+    () =>
+      [...toolCallLifeCycles.values()].filter((lc) => lc.status === "execute"),
+    [toolCallLifeCycles],
+  );
+
+  const completeToolCalls: FixedStateToolCallLifeCycle[] = [];
+
+  const value: ChatState = {
+    autoApproveGuard,
+    abortController,
+    getToolCallLifeCycle,
+    executingToolCalls,
+    completeToolCalls,
+  };
+
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+}

--- a/packages/vscode-webui/src/features/chat/lib/chat-state/index.tsx
+++ b/packages/vscode-webui/src/features/chat/lib/chat-state/index.tsx
@@ -28,3 +28,7 @@ export function useToolCallLifeCycle() {
 }
 
 export { ChatContextProvider } from "./chat";
+export {
+  ToolCallStatusRegistry,
+  FixedStateChatContextProvider,
+} from "./fixed-state";


### PR DESCRIPTION
## Summary

This PR fixes an issue where the tool call status icon in sub-tasks was not updating correctly.

- Introduces a `ToolCallStatusRegistry` to track the execution status of tool calls within a sub-task.
- Passes this registry to the `useLiveSubTask` hook and the `TaskThread` component to ensure the UI reflects the correct status.

## Test plan

1. Go to the `new-task-tool-gallery` storybook page.
2. In the "Sub-task" section, click the "new-task" tool to start a sub-task.
3. Observe the tool call status icons in the sub-task's thread. They should now correctly indicate when a tool is executing.

🤖 Generated with [Pochi](https://getpochi.com)