### PR TITLE
feat(webui): improve ux of settings page edit buttons

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,7 +68,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@getpochi/common": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/packages/vscode-webui/src/features/settings/components/sections/account-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/account-section.tsx
@@ -51,7 +51,7 @@ export const AccountSection: React.FC<AccountSectionProps> = ({ user }) => {
     <Section title="" className="pt-0">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <div className="flex flex-grow cursor-pointer items-center justify-between gap-3 rounded-md p-2 hover:bg-secondary">
+          <div className="flex flex-grow cursor-pointer items-center justify-between gap-3 rounded-md p-2 hover:bg-secondary/50 dark:hover:bg-secondary">
             <div className="flex items-center gap-3">
               <Avatar className="size-10">
                 <AvatarImage src={user.image ?? undefined} />

--- a/packages/vscode-webui/src/features/settings/components/sections/mcp-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/mcp-section.tsx
@@ -211,9 +211,9 @@ export const McpSection: React.FC = () => {
               href={commandForMcp("openServerSettings")}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-md p-1 hover:bg-muted"
+              className="ml-1 rounded-md p-2 hover:bg-secondary/50 hover:text-secondary-foreground dark:hover:bg-secondary"
             >
-              <PencilIcon className="ml-1 size-3" />
+              <PencilIcon className="size-3" />
             </a>
           </TooltipTrigger>
           <TooltipContent>

--- a/packages/vscode-webui/src/features/settings/components/sections/model-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/model-section.tsx
@@ -207,7 +207,7 @@ export const ModelSection: React.FC<ModelSectionProps> = ({ user }) => {
                                 href="command:pochi.openCustomModelSettings"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="relative z-10 ml-1 rounded-md p-1 py-3 transition-colors hover:bg-muted"
+                                className="relative z-10 ml-1 rounded-md p-2 transition-colors hover:bg-secondary/50 hover:text-secondary-foreground dark:hover:bg-secondary"
                               >
                                 <PencilIcon className="size-3" />
                               </a>


### PR DESCRIPTION
## Summary
- Increases the clickable area and improves the hover/focus styles for the edit buttons on the settings page, making them easier to interact with.

## Screenshot
<img width="688" height="184" alt="image" src="https://github.com/user-attachments/assets/1a9500aa-f84c-4218-ad92-2a1711e24394" />

## Test plan
Manual testing of the settings page to confirm the improved interaction.

🤖 Generated with [Pochi](https://getpochi.com)