### PR TITLE
feat(vscode-webui): remove defaultOpen from model section accordions

### DIFF
--- a/packages/vscode-webui/src/features/settings/components/sections/model-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/model-section.tsx
@@ -95,7 +95,6 @@ export const ModelSection: React.FC<ModelSectionProps> = ({ user }) => {
                 title={<div className="py-1">Pochi</div>}
                 variant="compact"
                 className="py-0"
-                defaultOpen
               >
                 <div className="space-y-2">
                   {pochiModels?.map((model) => (


### PR DESCRIPTION
## Summary
- Remove the `defaultOpen` property from the Pochi model section accordions in settings to improve UI consistency

## Test plan
- [x] Verify that the model sections in settings no longer default to open
- [x] Ensure that the accordions can still be manually opened and closed

🤖 Generated with [Pochi](https://getpochi.com)