### PR TITLE
fix(webui): adjust new task border style

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,6 @@
         "mdx": "^0.3.1",
         "next": "15.3.4",
         "react": "catalog:",
-        "react-dom": "19.0.0",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-mdx": "^3.1.0",
@@ -93,7 +92,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@getpochi/common": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -16,7 +16,6 @@
     "mdx": "^0.3.1",
     "next": "15.3.4",
     "react": "catalog:",
-    "react-dom": "19.0.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1", 
     "remark-mdx": "^3.1.0"

--- a/packages/vscode-webui/src/components/task-thread.tsx
+++ b/packages/vscode-webui/src/components/task-thread.tsx
@@ -96,7 +96,7 @@ export const TaskThread: React.FC<{
       )}
       {showMessageList && (
         <ScrollArea
-          viewportClassname="max-h-[300px] my-1 rounded-xs border border-[var(--vscode-borderColor)]"
+          viewportClassname="max-h-[300px] my-1 rounded-sm border"
           ref={newTaskContainer}
         >
           <MessageList


### PR DESCRIPTION
## screen shot
<img width="507" height="670" alt="image" src="https://github.com/user-attachments/assets/12149e40-0b8d-4df0-80cb-e7d20faf60d6" />


## Summary
- Adjusts the border style for the new task component for better visual consistency. This change replaces a custom border color with the standard theme border.

## Test plan
N/A

🤖 Generated with [Pochi](https://getpochi.com)