### PR TITLE
feat(livekit): add modelEndpointId to Pochi LLM provider

### DIFF
--- a/packages/livekit/src/chat/llm/pochi.ts
+++ b/packages/livekit/src/chat/llm/pochi.ts
@@ -26,6 +26,7 @@ export function createPochiModel(
           json: {
             id: taskId,
             model: llm.modelId,
+            modelEndpointId: llm.modelEndpointId,
             callOptions: {
               prompt,
               stopSequences,

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -58,6 +58,7 @@ const RequestData = z.object({
     z.object({
       type: z.literal("pochi"),
       modelId: z.string().optional(),
+      modelEndpointId: z.string().optional(),
       apiClient: z.custom<PochiApiClient>(),
     }),
     z.object({


### PR DESCRIPTION
## Summary

- Adds the `modelEndpointId` property to the Pochi LLM provider configuration in `packages/livekit`.
- This allows specifying a custom model endpoint, providing more flexibility for model selection.

## Test plan

- The pre-push hooks (including tests) have passed successfully.

🤖 Generated with [Pochi](https://getpochi.com)