### PR TITLE
fix(livekit): do not set system prompt for title generation, to fix anthropic models

### DIFF
--- a/packages/livekit/src/chat/generate-task-title.ts
+++ b/packages/livekit/src/chat/generate-task-title.ts
@@ -99,8 +99,6 @@ async function generateTitle(
 
   const stream = await requestLLM(undefined, llm, {
     messages,
-    // FIXME(jueliang)
-    system: "",
     abortSignal,
   });
 

--- a/packages/livekit/src/chat/llm/types.ts
+++ b/packages/livekit/src/chat/llm/types.ts
@@ -5,7 +5,7 @@ import type { Message } from "../../types";
 
 export type LLMRequest = {
   id?: string;
-  system: string;
+  system?: string;
   abortSignal?: AbortSignal;
   messages: Message[];
   tools?: Record<string, Tool>;


### PR DESCRIPTION
## Summary
- Remove unused system parameter in generateTitle function
- Make system parameter optional in LLMRequest type

This change cleans up the task title generation code by removing an unused parameter and making the system parameter optional in the LLMRequest type.

## Test plan
- [x] Verify that task title generation still works correctly
- [x] Ensure no regressions in LLM functionality

🤖 Generated with [Pochi](https://getpochi.com)