### PR TITLE
fix: correct variable reference in findLastIndex call in environment prompt

### DIFF
--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -177,7 +177,7 @@ export function injectEnvironment(
     messageToInject.parts.filter(
       (x) => x.type !== "text" || !prompts.isSystemReminder(x.text),
     ) || [];
-  const lastTextPartIndex = messageToInject.parts.findLastIndex(
+  const lastTextPartIndex = parts.findLastIndex(
     (parts) => parts.type === "text",
   );
   // Insert remainderPart before lastTextPartIndex


### PR DESCRIPTION
## Summary
- Fixed a bug where `findLastIndex` was being called on the wrong variable in the environment prompt injection logic
- Changed from `messageToInject.parts.findLastIndex` to `parts.findLastIndex` to use the filtered array instead

## Changes
- **packages/common/src/base/prompts/environment.ts**: Updated the variable reference in `findLastIndex` call to use the filtered `parts` array instead of the original `messageToInject.parts`

## Impact
This fixes a potential index mismatch issue when filtering system reminder text parts from the message parts array.

🤖 Generated with [Pochi](https://getpochi.com)