### PR TITLE
feat: add graceful shutdown to Pochi model PersistManager

### DIFF
--- a/packages/livekit/src/chat/llm/pochi.ts
+++ b/packages/livekit/src/chat/llm/pochi.ts
@@ -98,16 +98,17 @@ class PersistManager {
 
     if (typeof process !== "undefined") {
       const handleShutdown = async (
-        signal: "SIGTERM" | "SIGINT",
+        reason: "SIGTERM" | "SIGINT" | "beforeExit",
         code: number,
       ) => {
-        logger.debug(`Received ${signal}, shutting down gracefully...`);
+        logger.debug(`Received ${reason}, shutting down gracefully...`);
         await this.shutdown();
         process.exit(code);
       };
 
       process.on("SIGTERM", () => handleShutdown("SIGTERM", 143));
       process.on("SIGINT", () => handleShutdown("SIGINT", 130));
+      process.on("beforeExit", () => handleShutdown("beforeExit", 0));
     }
   }
 

--- a/packages/livekit/src/chat/llm/pochi.ts
+++ b/packages/livekit/src/chat/llm/pochi.ts
@@ -96,7 +96,7 @@ class PersistManager {
   constructor() {
     this.loop();
 
-    if (typeof process !== "undefined") {
+    if (isNodeEnvironment()) {
       const handleShutdown = async (
         reason: "SIGTERM" | "SIGINT" | "beforeExit",
         code: number,
@@ -212,3 +212,7 @@ class PersistManager {
 }
 
 const persistManager = new PersistManager();
+
+function isNodeEnvironment() {
+  return typeof process === "object" && process.on;
+}

--- a/packages/livekit/src/chat/llm/pochi.ts
+++ b/packages/livekit/src/chat/llm/pochi.ts
@@ -154,7 +154,11 @@ class PersistManager {
         continue;
       }
 
-      await this.process(job);
+      try {
+        await this.process(job);
+      } catch (err) {
+        logger.error("Failed to persist chat", err);
+      }
     }
   }
 

--- a/packages/livekit/src/chat/llm/pochi.ts
+++ b/packages/livekit/src/chat/llm/pochi.ts
@@ -134,7 +134,11 @@ class PersistManager {
     }
 
     this.isShutdownInProgress = true;
-    await Promise.all(this.queue.map((x) => this.process(x)));
+    try {
+      await Promise.all(this.queue.map((x) => this.process(x)));
+    } catch (err) {
+      logger.error("Error during shutdown", err);
+    }
   }
 
   private async loop() {

--- a/packages/livekit/src/chat/llm/pochi.ts
+++ b/packages/livekit/src/chat/llm/pochi.ts
@@ -108,7 +108,7 @@ class PersistManager {
 
       process.on("SIGTERM", () => handleShutdown("SIGTERM", 143));
       process.on("SIGINT", () => handleShutdown("SIGINT", 130));
-      process.on("beforeExit", () => handleShutdown("beforeExit", 0));
+      process.on("beforeExit", (code) => handleShutdown("beforeExit", code));
     }
   }
 


### PR DESCRIPTION
## Summary
- Add logger to PochiModel
- Implement graceful shutdown handling for SIGTERM and SIGINT signals
- Ensure all pending jobs are processed before shutdown
- Add shutdown state tracking to prevent multiple shutdown attempts

This change improves the reliability of the Pochi model by ensuring that all pending operations are completed before the process exits.

🤖 Generated with [Pochi](https://getpochi.com)