### PR TITLE
feat: support syncing BYOK messages when pochi is authenticated

### DIFF
--- a/packages/common/src/pochi-api.ts
+++ b/packages/common/src/pochi-api.ts
@@ -134,7 +134,9 @@ const stub = new Hono()
   .get("/api/models", async (c) => c.json([] as ListModelsResponse));
 
 export type PochiApi = typeof stub;
-export type PochiApiClient = ReturnType<typeof hc<PochiApi>>;
+export type PochiApiClient = ReturnType<typeof hc<PochiApi>> & {
+  authenticated?: boolean;
+};
 
 export const PochiApiErrors = {
   RequireSubscription: "REQUIRE_SUBSCRIPTION",

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -1,5 +1,6 @@
 import type { Environment } from "@getpochi/common";
 import { formatters, prompts } from "@getpochi/common";
+import type { PochiApiClient } from "@getpochi/common/pochi-api";
 import { type McpTool, selectClientTools } from "@getpochi/tools";
 import type { Store } from "@livestore/livestore";
 import {
@@ -42,17 +43,20 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
   private readonly getters: PrepareRequestGetters;
   private readonly isSubTask?: boolean;
   private readonly store: Store;
+  private readonly apiClient: PochiApiClient;
 
   constructor(options: {
     onStart?: OnStartCallback;
     getters: PrepareRequestGetters;
     isSubTask?: boolean;
     store: Store;
+    apiClient: PochiApiClient;
   }) {
     this.onStart = options.onStart;
     this.getters = options.getters;
     this.isSubTask = options.isSubTask;
     this.store = options.store;
+    this.apiClient = options.apiClient;
   }
 
   sendMessages: (
@@ -138,12 +142,12 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
         }
       },
       onFinish: async ({ messages }) => {
-        if (llm.type === "pochi") {
+        if (this.apiClient.authenticated) {
           persistManager.push({
             taskId: chatId,
             store: this.store,
             messages,
-            llm,
+            apiClient: this.apiClient,
             environment,
           });
         }

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -34,7 +34,7 @@ export type LiveChatKitOptions<T> = {
 
   store: Store;
 
-  apiClient?: PochiApiClient;
+  apiClient: PochiApiClient;
 
   chatClass: new (options: ChatInit<Message>) => T;
 
@@ -64,6 +64,7 @@ export class LiveChatKit<
     onOverrideMessages,
     getters,
     isSubTask,
+    apiClient,
     ...chatInit
   }: LiveChatKitOptions<T>) {
     this.taskId = taskId;
@@ -73,6 +74,7 @@ export class LiveChatKit<
       onStart: this.onStart,
       getters,
       isSubTask,
+      apiClient,
     });
 
     this.chat = new chatClass({

--- a/packages/livekit/src/chat/persist-manager.ts
+++ b/packages/livekit/src/chat/persist-manager.ts
@@ -1,9 +1,10 @@
 import { type Environment, getLogger } from "@getpochi/common";
+import type { PochiApiClient } from "@getpochi/common/pochi-api";
 import type { Store } from "@livestore/livestore";
 import { makeTaskQuery } from "../livestore/queries";
 import { events, tables } from "../livestore/schema";
 import { toTaskStatus } from "../task";
-import type { Message, RequestData } from "../types";
+import type { Message } from "../types";
 
 const logger = getLogger("PersistManager");
 
@@ -11,7 +12,7 @@ interface PersistJob {
   taskId: string;
   store: Store;
   messages: Message[];
-  llm: Extract<RequestData["llm"], { type: "pochi" }>;
+  apiClient: PochiApiClient;
   environment?: Environment;
 }
 
@@ -89,7 +90,7 @@ class PersistManager {
     taskId,
     store,
     messages,
-    llm,
+    apiClient,
     environment,
   }: PersistJob) {
     const lastMessage = messages.at(-1);
@@ -101,7 +102,7 @@ class PersistManager {
       lastMessage.metadata?.kind === "assistant"
         ? lastMessage.metadata.finishReason
         : undefined;
-    const resp = await llm.apiClient.api.chat.persist.$post({
+    const resp = await apiClient.api.chat.persist.$post({
       json: {
         id: taskId,
         messages,

--- a/packages/vscode-webui/src/components/tool-invocation/tools/new-task/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/new-task/use-live-sub-task.tsx
@@ -11,6 +11,7 @@ import {
   useRetry,
 } from "@/features/retry";
 import { useTodos } from "@/features/todo";
+import { apiClient } from "@/lib/auth-client";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { vscodeHost } from "@/lib/vscode";
 import { useChat } from "@ai-sdk/react";
@@ -66,6 +67,7 @@ export function useLiveSubTask(
   // FIXME: handle auto retry for output without task.
   const chatKit = useLiveChatKit({
     taskId: uid,
+    apiClient,
     abortSignal: abortController.current.signal,
     getters,
     isSubTask: true,

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -2,7 +2,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { WorkspaceRequiredPlaceholder } from "@/components/workspace-required-placeholder";
 import { ChatContextProvider, useHandleChatEvents } from "@/features/chat";
 import { usePendingModelAutoStart } from "@/features/retry";
-import type { User } from "@/lib/auth-client";
+import { type User, apiClient } from "@/lib/auth-client";
 import { useCurrentWorkspace } from "@/lib/hooks/use-current-workspace";
 import { useImageUpload } from "@/lib/hooks/use-image-upload";
 import { cn } from "@/lib/utils";
@@ -62,6 +62,7 @@ function Chat({ user, uid, prompt }: ChatProps) {
 
   const chatKit = useLiveChatKit({
     taskId: uid,
+    apiClient,
     getters,
     abortSignal: chatAbortController.current.signal,
     sendAutomaticallyWhen: (x) => {


### PR DESCRIPTION
## Summary
- Add authenticated property to PochiApiClient type
- Pass apiClient to chat components instead of llm object
- Improve auth-client implementation with proper token handling
- Make apiClient required in LiveChatKitOptions
- Update persist-manager to use apiClient instead of llm

This change improves the authentication flow by centralizing the API client and making the authentication status more explicit in the client.

## Test plan
- [x] Verify API client authentication works correctly
- [x] Ensure chat components receive and use apiClient properly
- [x] Check that persist manager correctly uses apiClient
- [x] Validate token handling in auth-client

🤖 Generated with [Pochi](https://getpochi.com)