### PR TITLE
feat: change auto approve behavior for abort / detach

### DIFF
--- a/packages/vscode-webui/src/components/tool-invocation/tools/execute-command.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/execute-command.tsx
@@ -1,4 +1,4 @@
-import { useToolCallLifeCycle } from "@/features/chat";
+import { useAutoApproveGuard, useToolCallLifeCycle } from "@/features/chat";
 import { getToolName } from "ai";
 import { useCallback } from "react";
 import { CommandExecutionPanel } from "../command-execution-panel";
@@ -57,8 +57,10 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
     completed = true;
   }
 
+  const autoApproveGuard = useAutoApproveGuard();
   const onDetach = streamingResult
     ? () => {
+        autoApproveGuard.current = false;
         streamingResult.detach();
       }
     : undefined;

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -23,7 +23,7 @@ import { ChatArea } from "./components/chat-area";
 import { ChatToolbar } from "./components/chat-toolbar";
 import { ErrorMessageView } from "./components/error-message-view";
 import { useScrollToBottom } from "./hooks/use-scroll-to-bottom";
-import { useChatAbortController } from "./lib/chat-state";
+import { useAutoApproveGuard, useChatAbortController } from "./lib/chat-state";
 import { onOverrideMessages } from "./lib/on-override-messages";
 import { useLiveChatKitGetters } from "./lib/use-live-chat-kit-getters";
 
@@ -60,6 +60,7 @@ function Chat({ user, uid, prompt }: ChatProps) {
   const chatAbortController = useChatAbortController();
   useAbortBeforeNavigation(chatAbortController.current);
 
+  const autoApproveGuard = useAutoApproveGuard();
   const chatKit = useLiveChatKit({
     taskId: uid,
     getters,
@@ -68,6 +69,11 @@ function Chat({ user, uid, prompt }: ChatProps) {
       if (chatAbortController.current.signal.aborted) {
         return false;
       }
+
+      if (!autoApproveGuard.current) {
+        return false;
+      }
+
       // AI SDK v5 will retry regardless of the status if sendAutomaticallyWhen is set.
       if (chatKit.chat.status === "error") {
         return false;

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
@@ -72,8 +72,7 @@ function overrideResult(complete: ToolCallLifeCycle["complete"]) {
   // Use an switch clause so new reason will be caught by type checker.
   switch (reason) {
     case "user-abort":
-      output.error =
-        "User aborted the tool call, please use askFollowupQuestion to clarify next step with user.";
+      output.error = "User aborted the tool call";
       break;
     case "user-reject":
       output.error =
@@ -82,7 +81,7 @@ function overrideResult(complete: ToolCallLifeCycle["complete"]) {
     case "user-detach":
       // We use info instead of error to avoid the tool call being marked as failed.
       output.info =
-        "User has detached the terminal, the job will continue running in the background, please use askFollowupQuestion to clarify next step with user.";
+        "User has detached the terminal, the job will continue running in the background.";
       break;
     case "preview-reject":
     case "execute-finish":


### PR DESCRIPTION
For user aborted / detached tool call, Pochi no longer continue execution automatically, instead it'll wait for user's input