### PR TITLE
refactor(vscode-webui): simplify useTodos hook initialization

### DIFF
--- a/packages/vscode-webui/src/features/todo/hooks/use-todos.ts
+++ b/packages/vscode-webui/src/features/todo/hooks/use-todos.ts
@@ -11,22 +11,17 @@ export function useTodos({
 }: {
   initialTodos?: Readonly<Todo[]>;
   messages: Message[];
-  todosRef: React.MutableRefObject<Todo[] | undefined>;
+  todosRef: React.RefObject<Todo[] | undefined>;
 }) {
-  const [todos, setTodosImpl] = useState<Todo[]>([]);
+  const [todos, setTodosImpl] = useState<Todo[]>(
+    JSON.parse(JSON.stringify(initialTodos ?? [])),
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies(todosRef): todosRef is a ref
   const setTodos = useCallback((newTodos: Todo[]) => {
     todosRef.current = newTodos;
     setTodosImpl(newTodos);
   }, []);
-
-  useEffect(() => {
-    if (initialTodos) {
-      // readonly -> mutable with json re-serialize
-      setTodos(JSON.parse(JSON.stringify(initialTodos)));
-    }
-  }, [initialTodos, setTodos]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies(todosRef.current): todosRef is a ref
   const updateTodos = useCallback(


### PR DESCRIPTION
## Screen record
https://jam.dev/c/fa839b5d-b7bc-4d97-8280-ec907a1bc553

## Summary
- Change `MutableRefObject` to `RefObject` for `todosRef`.
- Initialize `todos` state directly from `initialTodos` prop.
- Remove the `useEffect` that was previously used to set the initial todos.

This change simplifies the hook's logic and avoids an unnecessary re-render on initialization.

## Test plan
N/A

🤖 Generated with [Pochi](https://getpochi.com)