### PR TITLE
refactor: Move VS Code LM enable state to webview store

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -190,14 +190,10 @@ const VSCodeHostStub = {
   readVSCodeLm: async (): Promise<{
     featureAvailable: boolean;
     models: ThreadSignalSerialization<VSCodeLmModel[]>;
-    enabled: ThreadSignalSerialization<boolean>;
-    toggle: () => void;
   }> => {
     return Promise.resolve({
       featureAvailable: false,
       models: {} as ThreadSignalSerialization<VSCodeLmModel[]>,
-      enabled: {} as ThreadSignalSerialization<boolean>,
-      toggle: () => {},
     });
   },
   chatVSCodeLm: async (): Promise<void> => {

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -260,8 +260,6 @@ export interface VSCodeHostApi {
   readVSCodeLm(): Promise<{
     featureAvailable: boolean;
     models: ThreadSignalSerialization<VSCodeLmModel[]>;
-    enabled: ThreadSignalSerialization<boolean>;
-    toggle: () => void;
   }>;
 
   chatVSCodeLm: VSCodeLmRequest;

--- a/packages/vscode-webui/src/features/settings/components/sections/model-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/model-section.tsx
@@ -22,7 +22,8 @@ interface ModelSectionProps {
 }
 
 export const ModelSection: React.FC<ModelSectionProps> = ({ user }) => {
-  const { enablePochiModels } = useSettingsStore();
+  const { enablePochiModels, enableVSCodeLm, updateEnableVSCodeLm } =
+    useSettingsStore();
   const { data: pochiModelsData, isLoading: isPochiModelLoading } = useQuery({
     queryKey: ["models", user?.id],
     queryFn: async () => {
@@ -66,8 +67,6 @@ export const ModelSection: React.FC<ModelSectionProps> = ({ user }) => {
   const {
     models: vscodeLmModels,
     isLoading: isLoadingVscodeLmModels,
-    toggle,
-    enabled,
     featureAvailable,
   } = useVSCodeLmModels();
 
@@ -141,10 +140,10 @@ export const ModelSection: React.FC<ModelSectionProps> = ({ user }) => {
                     Copilot
                     <Switch
                       className="scale-75 cursor-pointer transition-all hover:bg-accent/20 hover:shadow-md "
-                      checked={enabled}
+                      checked={enableVSCodeLm}
                       onClick={(e) => {
                         e.stopPropagation();
-                        toggle?.();
+                        updateEnableVSCodeLm(!enableVSCodeLm);
                       }}
                     />
                   </div>
@@ -154,7 +153,7 @@ export const ModelSection: React.FC<ModelSectionProps> = ({ user }) => {
                 defaultOpen
               >
                 <div className="space-y-2">
-                  {enabled ? (
+                  {enableVSCodeLm ? (
                     vscodeLmModels.length > 0 ? (
                       vscodeLmModels.map((model) => (
                         <div

--- a/packages/vscode-webui/src/features/settings/store.ts
+++ b/packages/vscode-webui/src/features/settings/store.ts
@@ -20,12 +20,16 @@ export interface SettingsState {
 
   enablePochiModels: boolean;
 
+  enableVSCodeLm: boolean;
+
   updateAutoApproveSettings: (data: Partial<AutoApprove>) => void;
   updateSelectedModelId: (selectedModelId: string | undefined) => void;
   updateAutoApproveActive: (value: boolean) => void;
   updateIsDevMode: (value: boolean) => void;
 
   updateEnablePochiModels: (value: boolean) => void;
+
+  updateEnableVSCodeLm: (value: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -45,6 +49,8 @@ export const useSettingsStore = create<SettingsState>()(
 
       enablePochiModels: false,
 
+      enableVSCodeLm: false,
+
       updateSelectedModelId: (selectedModelId: string | undefined) =>
         set({ selectedModelId }),
 
@@ -60,6 +66,9 @@ export const useSettingsStore = create<SettingsState>()(
 
       updateEnablePochiModels: (value: boolean) =>
         set(() => ({ enablePochiModels: value })),
+
+      updateEnableVSCodeLm: (value: boolean) =>
+        set(() => ({ enableVSCodeLm: value })),
     }),
     {
       name: "ragdoll-settings-storage",

--- a/packages/vscode-webui/src/lib/hooks/use-vscode-lm-models.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-vscode-lm-models.ts
@@ -7,13 +7,10 @@ export const useVSCodeLmModels = () => {
   const { data, isLoading } = useQuery({
     queryKey: ["vscode-lm-models"],
     queryFn: async () => {
-      const { models, enabled, toggle, featureAvailable } =
-        await vscodeHost.readVSCodeLm();
+      const { models, featureAvailable } = await vscodeHost.readVSCodeLm();
 
       return {
         models: threadSignal(models),
-        enabled: threadSignal(enabled),
-        toggle: toggle,
         featureAvailable,
       };
     },
@@ -24,8 +21,6 @@ export const useVSCodeLmModels = () => {
     return {
       models: [],
       isLoading: false,
-      toggle: () => {},
-      enabled: false,
       featureAvailable: false,
     };
   }
@@ -33,8 +28,6 @@ export const useVSCodeLmModels = () => {
   return {
     models: data.models.value,
     isLoading,
-    toggle: data.toggle,
-    enabled: data.enabled.value,
     featureAvailable: data.featureAvailable,
   };
 };

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -352,10 +352,6 @@
                 }
               ]
             }
-          },
-          "pochi.vscodeLmEnabled": {
-            "type": "boolean",
-            "default": false
           }
         }
       }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -14,7 +14,6 @@ import { DiffOriginContentProvider } from "./integrations/editor/diff-origin-con
 import { McpHub } from "./integrations/mcp/mcp-hub";
 import { StatusBarItem } from "./integrations/status-bar-item";
 import { TerminalLinkProvider } from "./integrations/terminal-link-provider";
-import { VSCodeLm } from "./integrations/vscode-lm";
 import {
   type ApiClient,
   type AuthClient,
@@ -56,7 +55,6 @@ export async function activate(context: vscode.ExtensionContext) {
   container.resolve(FileLogger);
   container.resolve(TerminalLinkProvider);
   container.resolve(DiffChangesContentProvider);
-  container.resolve(VSCodeLm);
 }
 
 // This method is called when your extension is deactivated

--- a/packages/vscode/src/integrations/configuration.ts
+++ b/packages/vscode/src/integrations/configuration.ts
@@ -14,7 +14,6 @@ export class PochiConfiguration implements vscode.Disposable {
   readonly mcpServers = signal(getPochiMcpServersSettings());
   readonly autoSaveDisabled = signal(getAutoSaveDisabled());
   readonly customModelSettings = signal(getCustomModelSetting());
-  readonly vscodeLmEnabled = signal(getVscodeLmEnabled());
 
   constructor() {
     this.disposables.push(
@@ -35,11 +34,6 @@ export class PochiConfiguration implements vscode.Disposable {
         if (e.affectsConfiguration("pochi.customModelSettings")) {
           const settings = getCustomModelSetting();
           this.customModelSettings.value = settings;
-        }
-
-        if (e.affectsConfiguration("pochi.vscodeLmEnabled")) {
-          const enabled = getVscodeLmEnabled();
-          this.vscodeLmEnabled.value = enabled;
         }
       }),
     );
@@ -130,16 +124,4 @@ function getCustomModelSetting(): CustomModelSetting[] | undefined {
     .map((x) => CustomModelSetting.safeParse(x))
     .filter((x) => x.success)
     .map((x) => x.data);
-}
-
-function getVscodeLmEnabled() {
-  return vscode.workspace
-    .getConfiguration("pochi")
-    .get("vscodeLmEnabled", false);
-}
-
-export function updateVscodeLmEnabled(value: boolean) {
-  return vscode.workspace
-    .getConfiguration("pochi")
-    .update("vscodeLmEnabled", value, true);
 }

--- a/packages/vscode/src/integrations/vscode-lm.ts
+++ b/packages/vscode/src/integrations/vscode-lm.ts
@@ -8,8 +8,6 @@ import { signal } from "@preact/signals-core";
 import { ThreadAbortSignal } from "@quilted/threads";
 import { injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
-// biome-ignore lint/style/useImportType: needed for dependency injection
-import { PochiConfiguration, updateVscodeLmEnabled } from "./configuration";
 
 const logger = getLogger("VSCodeLm");
 
@@ -26,8 +24,8 @@ export class VSCodeLm implements vscode.Disposable {
 
   readonly models = signal<VSCodeLmModel[]>([]);
 
-  constructor(private readonly config: PochiConfiguration) {
-    if (this.config.vscodeLmEnabled.value && this.featureAvailable) {
+  constructor() {
+    if (this.featureAvailable) {
       this.initModels();
     }
   }
@@ -41,22 +39,8 @@ export class VSCodeLm implements vscode.Disposable {
     this.updateModels();
   }
 
-  toggle() {
-    if (!this.featureAvailable) {
-      return;
-    }
-    const enabled = !this.config.vscodeLmEnabled.value;
-    updateVscodeLmEnabled(enabled).then(() => {
-      if (enabled) {
-        this.initModels();
-      } else {
-        this.models.value = [];
-      }
-    });
-  }
-
   private async updateModels() {
-    if (!this.config.vscodeLmEnabled.value || !this.featureAvailable) {
+    if (!this.featureAvailable) {
       return;
     }
     try {

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -661,14 +661,10 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   readVSCodeLm = async (): Promise<{
     featureAvailable: boolean;
     models: ThreadSignalSerialization<VSCodeLmModel[]>;
-    enabled: ThreadSignalSerialization<boolean>;
-    toggle: () => void;
   }> => {
     return {
       featureAvailable: this.vscodeLm.featureAvailable,
       models: ThreadSignal.serialize(this.vscodeLm.models),
-      enabled: ThreadSignal.serialize(this.pochiConfiguration.vscodeLmEnabled),
-      toggle: this.vscodeLm.toggle.bind(this.vscodeLm),
     };
   };
 


### PR DESCRIPTION
## Summary

This pull request refactors the VS Code Language Model (Copilot) integration by moving its enable/disable state management from a VS Code configuration setting to the webview's internal Zustand store.

- Removes the `pochi.vscodeLmEnabled` setting and its related backend logic.
- Adds `enableVSCodeLm` state and `updateEnableVSCodeLm` action to the `useSettingsStore` in the webview.
- Updates the settings UI to use the new local state for the Copilot toggle.
- Simplifies the `VSCodeHostApi` by removing the need to pass `enabled` and `toggle` from the extension host.

## Test plan

1. Open the Pochi sidebar and navigate to the Settings page.
2. In the "Models" section, find the "GitHub Copilot" integration.
3. Toggle the switch on and off.
4. **Verify:** When enabled, the list of Copilot models appears. When disabled, it disappears.
5. Close and reopen the settings panel.
6. **Verify:** The toggle state is persisted.

🤖 Generated with [Pochi](https://getpochi.com)