### PR TITLE
chore(livekit): add storage formatter to persist manager

### DIFF
--- a/packages/livekit/src/chat/persist-manager.ts
+++ b/packages/livekit/src/chat/persist-manager.ts
@@ -1,4 +1,4 @@
-import { type Environment, getLogger } from "@getpochi/common";
+import { type Environment, formatters, getLogger } from "@getpochi/common";
 import type { PochiApiClient } from "@getpochi/common/pochi-api";
 import type { Store } from "@livestore/livestore";
 import { makeTaskQuery } from "../livestore/queries";
@@ -105,7 +105,7 @@ class PersistManager {
     const resp = await apiClient.api.chat.persist.$post({
       json: {
         id: taskId,
-        messages,
+        messages: formatters.storage(messages),
         environment,
         status: toTaskStatus(lastMessage, finishReason),
         parentClientTaskId: parentId ?? undefined,


### PR DESCRIPTION
## Summary
* Add formatters.storage to messages before persisting in PersistManager
* Import formatters from @getpochi/common
* Apply formatters.storage to ensure proper formatting of messages when stored

## Test plan
- [x] Verify that messages are properly formatted before persisting
- [x] Ensure no regression in existing functionality

🤖 Generated with [Pochi](https://getpochi.com)