### PR TITLE
feat: add background execution support for commands

### DIFF
--- a/packages/cli/src/tools/execute-command.ts
+++ b/packages/cli/src/tools/execute-command.ts
@@ -14,16 +14,16 @@ const execCommand = promisify(exec);
 export const executeCommand =
   (context: ToolCallOptions): ToolFunctionType<ClientTools["executeCommand"]> =>
   async (
-    { command, cwd = ".", isDevServer, timeout = 120 },
+    { command, cwd = ".", isBackground, timeout = 120 },
     { abortSignal },
   ) => {
     if (!command) {
       throw new Error("Command is required to execute.");
     }
 
-    if (isDevServer) {
+    if (isBackground) {
       throw new Error(
-        "CRITICAL: Dev server commands block task execution indefinitely and must not be run in automated tasks. Use non-blocking alternatives instead.",
+        "CRITICAL: Background commands block task execution indefinitely and must not be run in automated tasks. Use non-blocking alternatives instead.",
       );
     }
 

--- a/packages/common/src/base/environment.ts
+++ b/packages/common/src/base/environment.ts
@@ -81,7 +81,18 @@ export const Environment = z.object({
         .optional()
         .describe("Git information for the current workspace."),
       terminals: z
-        .array(z.object({ name: z.string(), isActive: z.boolean() }))
+        .array(
+          z.object({
+            name: z.string().describe("The name of the terminal."),
+            isActive: z.boolean().describe("Whether the terminal is active."),
+            backgroundCommandId: z
+              .string()
+              .optional()
+              .describe(
+                "The ID of the background command associated with the terminal.",
+              ),
+          }),
+        )
         .optional()
         .describe("Visible terminals in the VS Code workspace."),
     })

--- a/packages/common/src/base/prompts/__tests__/__snapshots__/prompt.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/prompt.test.ts.snap
@@ -25,7 +25,7 @@ README.md
 tsconfig.json
 package.json
 
-# Active Terminals in Editor
+# Opened Terminals in Editor
 * Terminal 1 (active)
   Terminal 2
 

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -105,7 +105,10 @@ function getVisibleTerminals(workspace: Environment["workspace"]) {
     return "";
   }
   return `# Active Terminals in Editor\n${terminals
-    .map((t) => (t.isActive ? `* ${t.name} (active)` : `  ${t.name}`))
+    .map(
+      (t) =>
+        `${t.isActive ? "* " : "  "}${t.name}${t.isActive ? " (active)" : ""}${t.backgroundCommandId ? ` (background command: ${t.backgroundCommandId})` : ""}`,
+    )
     .join("\n")}`;
 }
 

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -104,7 +104,7 @@ function getVisibleTerminals(workspace: Environment["workspace"]) {
   if (terminals.length === 0) {
     return "";
   }
-  return `# Active Terminals in Editor\n${terminals
+  return `# Opened Terminals in Editor\n${terminals
     .map(
       (t) =>
         `${t.isActive ? "* " : "  "}${t.name}${t.isActive ? " (active)" : ""}${t.backgroundCommandId ? ` (background command: ${t.backgroundCommandId})` : ""}`,

--- a/packages/tools/src/execute-command.ts
+++ b/packages/tools/src/execute-command.ts
@@ -142,6 +142,7 @@ Important:
   outputSchema: z.object({
     output: z
       .string()
+      .optional()
       .describe("The output of the command (including stdout and stderr)."),
     isTruncated: z
       .boolean()

--- a/packages/tools/src/execute-command.ts
+++ b/packages/tools/src/execute-command.ts
@@ -19,6 +19,7 @@ Usage notes:
 - The command argument is required.
 - You can specify an optional timeout in seconds (up to 300s / 5 minutes). If not specified, commands will timeout after 60s (1 minute).
 - If the output exceeds 30000 characters, output will be truncated before being returned to you.
+- You can use the \`isBackground\` parameter to run the command in the background, which allows you to continue working while the command runs. You can monitor the output using the getShellOutput tool as it becomes available. Never use \`isBackground\` to run 'sleep' as it will return immediately. You do not need to use '&' at the end of the command when using this parameter.
 - When issuing multiple commands, use the ';' or '&&' operator to separate them. DO NOT use newlines (newlines are ok in quoted strings).
 - You shall avoid use the markdown code black syntax (backtick, '\`') in your command, as it will be interpreted as a command substitution.
 
@@ -123,11 +124,11 @@ Important:
       .string()
       .optional()
       .describe("The working directory to execute the command in."),
-    isDevServer: z
+    isBackground: z
       .boolean()
       .optional()
       .describe(
-        "Whether the command is being run as a development server, e.g. `npm run dev`.",
+        "Set to true to run this command in the background. Use getShellOutput to read the output later.",
       ),
     timeout: z
       .number()
@@ -141,11 +142,18 @@ Important:
   outputSchema: z.object({
     output: z
       .string()
+      .optional()
       .describe("The output of the command (including stdout and stderr)."),
     isTruncated: z
       .boolean()
       .optional()
       .describe("Whether the output was truncated"),
+    shellId: z
+      .string()
+      .optional()
+      .describe(
+        "The ID of the shell to execute the command if isBackground is true",
+      ),
   }),
 };
 

--- a/packages/tools/src/execute-command.ts
+++ b/packages/tools/src/execute-command.ts
@@ -19,7 +19,7 @@ Usage notes:
 - The command argument is required.
 - You can specify an optional timeout in seconds (up to 300s / 5 minutes). If not specified, commands will timeout after 60s (1 minute).
 - If the output exceeds 30000 characters, output will be truncated before being returned to you.
-- You can use the \`isBackground\` parameter to run the command in the background, which allows you to continue working while the command runs. You can monitor the output using the getShellOutput tool as it becomes available. Never use \`isBackground\` to run 'sleep' as it will return immediately. You do not need to use '&' at the end of the command when using this parameter.
+- You can use the \`isBackground\` parameter to run the command in the background, which allows you to continue working while the command runs. You can monitor the output using the readCommandOutput tool as it becomes available. Never use \`isBackground\` to run 'sleep' as it will return immediately. You do not need to use '&' at the end of the command when using this parameter.
 - When issuing multiple commands, use the ';' or '&&' operator to separate them. DO NOT use newlines (newlines are ok in quoted strings).
 - You shall avoid use the markdown code black syntax (backtick, '\`') in your command, as it will be interpreted as a command substitution.
 
@@ -128,7 +128,7 @@ Important:
       .boolean()
       .optional()
       .describe(
-        "Set to true to run this command in the background. Use getShellOutput to read the output later.",
+        "Set to true to run this command in the background. Use readCommandOutput to read the output later.",
       ),
     timeout: z
       .number()
@@ -148,12 +148,10 @@ Important:
       .boolean()
       .optional()
       .describe("Whether the output was truncated"),
-    shellId: z
+    backgroundCommandId: z
       .string()
       .optional()
-      .describe(
-        "The ID of the shell to execute the command if isBackground is true",
-      ),
+      .describe("The ID of the background command if isBackground is true"),
   }),
 };
 

--- a/packages/tools/src/execute-command.ts
+++ b/packages/tools/src/execute-command.ts
@@ -142,7 +142,6 @@ Important:
   outputSchema: z.object({
     output: z
       .string()
-      .optional()
       .describe("The output of the command (including stdout and stderr)."),
     isTruncated: z
       .boolean()

--- a/packages/tools/src/get-shell-output.ts
+++ b/packages/tools/src/get-shell-output.ts
@@ -1,0 +1,33 @@
+import z from "zod";
+import { defineClientTool } from "./types";
+
+const toolDef = {
+  description: `- Retrieves output from a running or completed background shell
+- Takes a shellId parameter identifying the shell
+- Always returns only new output since the last check
+- Returns stdout and stderr output along with shell status
+- Supports optional regex filtering to show only lines matching a pattern
+- Use this tool when you need to monitor or check the output of a long-running shell`.trim(),
+  inputSchema: z.object({
+    shellId: z.string().describe("The ID of the shell to get output from"),
+    regex: z
+      .string()
+      .optional()
+      .describe(
+        "Optional regular expression to filter the output lines. Only lines matching this regex will be included in the result. Any lines that do not match will no longer be available to read.",
+      ),
+  }),
+  outputSchema: z.object({
+    output: z
+      .string()
+      .describe(
+        "The output of the shell since last check (including stdout and stderr).",
+      ),
+    isTruncated: z
+      .boolean()
+      .optional()
+      .describe("Whether the output was truncated"),
+  }),
+};
+
+export const getShellOutput = defineClientTool(toolDef);

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -16,6 +16,8 @@ export type {
   ToolFunctionType,
   PreviewToolFunctionType,
 } from "./types";
+import { getShellOutput } from "./get-shell-output";
+import { killShell } from "./kill-shell";
 import { writeToFile } from "./write-to-file";
 export type { SubTask } from "./new-task";
 
@@ -44,7 +46,12 @@ export const ToolsByPermission = {
     "applyDiff",
     "multiApplyDiff",
   ] satisfies ToolName[] as string[],
-  execute: ["executeCommand", "newTask"] satisfies ToolName[] as string[],
+  execute: [
+    "executeCommand",
+    "getShellOutput",
+    "killShell",
+    "newTask",
+  ] satisfies ToolName[] as string[],
   default: ["todoWrite"] satisfies ToolName[] as string[],
 };
 
@@ -55,6 +62,8 @@ export const ClientTools = {
   askFollowupQuestion,
   attemptCompletion,
   executeCommand,
+  getShellOutput,
+  killShell,
   globFiles,
   listFiles,
   multiApplyDiff,

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -16,8 +16,8 @@ export type {
   ToolFunctionType,
   PreviewToolFunctionType,
 } from "./types";
-import { getShellOutput } from "./get-shell-output";
-import { killShell } from "./kill-shell";
+import { killBackgroundCommand } from "./kill-background-command";
+import { readCommandOutput } from "./read-command-output";
 import { writeToFile } from "./write-to-file";
 export type { SubTask } from "./new-task";
 
@@ -48,8 +48,8 @@ export const ToolsByPermission = {
   ] satisfies ToolName[] as string[],
   execute: [
     "executeCommand",
-    "getShellOutput",
-    "killShell",
+    "readCommandOutput",
+    "killBackgroundCommand",
     "newTask",
   ] satisfies ToolName[] as string[],
   default: ["todoWrite"] satisfies ToolName[] as string[],
@@ -62,8 +62,8 @@ export const ClientTools = {
   askFollowupQuestion,
   attemptCompletion,
   executeCommand,
-  getShellOutput,
-  killShell,
+  readCommandOutput,
+  killBackgroundCommand,
   globFiles,
   listFiles,
   multiApplyDiff,

--- a/packages/tools/src/kill-background-command.ts
+++ b/packages/tools/src/kill-background-command.ts
@@ -15,10 +15,9 @@ const toolDef = {
     success: z
       .boolean()
       .describe("Whether the background command was successfully killed."),
-    error: z
-      .string()
-      .optional()
-      .describe("An error message if the kill failed."),
+    _meta: z.object({
+      command: z.string().describe("The command that was killed."),
+    }),
   }),
 };
 

--- a/packages/tools/src/kill-background-command.ts
+++ b/packages/tools/src/kill-background-command.ts
@@ -2,17 +2,19 @@ import z from "zod";
 import { defineClientTool } from "./types";
 
 const toolDef = {
-  description: `- Kills a running background shell by its ID
-- Takes a backgroundCommandId parameter identifying the shell to kill
-- Returns a success or failure status 
-- Use this tool when you need to terminate a long-running shell`.trim(),
+  description: `- Kills a running background command by its ID
+- Takes a backgroundCommandId parameter identifying the command to kill
+- Returns a success or failure status
+- Use this tool when you need to terminate a long-running command`.trim(),
   inputSchema: z.object({
     backgroundCommandId: z
       .string()
       .describe("The ID of the background command to kill."),
   }),
   outputSchema: z.object({
-    success: z.boolean().describe("Whether the shell was successfully killed."),
+    success: z
+      .boolean()
+      .describe("Whether the background command was successfully killed."),
     error: z
       .string()
       .optional()

--- a/packages/tools/src/kill-background-command.ts
+++ b/packages/tools/src/kill-background-command.ts
@@ -3,11 +3,13 @@ import { defineClientTool } from "./types";
 
 const toolDef = {
   description: `- Kills a running background shell by its ID
-- Takes a shellId parameter identifying the shell to kill
+- Takes a backgroundCommandId parameter identifying the shell to kill
 - Returns a success or failure status 
 - Use this tool when you need to terminate a long-running shell`.trim(),
   inputSchema: z.object({
-    shellId: z.string().describe("The ID of the shell to kill."),
+    backgroundCommandId: z
+      .string()
+      .describe("The ID of the background command to kill."),
   }),
   outputSchema: z.object({
     success: z.boolean().describe("Whether the shell was successfully killed."),
@@ -18,4 +20,4 @@ const toolDef = {
   }),
 };
 
-export const killShell = defineClientTool(toolDef);
+export const killBackgroundCommand = defineClientTool(toolDef);

--- a/packages/tools/src/kill-shell.ts
+++ b/packages/tools/src/kill-shell.ts
@@ -1,0 +1,21 @@
+import z from "zod";
+import { defineClientTool } from "./types";
+
+const toolDef = {
+  description: `- Kills a running background shell by its ID
+- Takes a shellId parameter identifying the shell to kill
+- Returns a success or failure status 
+- Use this tool when you need to terminate a long-running shell`.trim(),
+  inputSchema: z.object({
+    shellId: z.string().describe("The ID of the shell to kill."),
+  }),
+  outputSchema: z.object({
+    success: z.boolean().describe("Whether the shell was successfully killed."),
+    error: z
+      .string()
+      .optional()
+      .describe("An error message if the kill failed."),
+  }),
+};
+
+export const killShell = defineClientTool(toolDef);

--- a/packages/tools/src/read-command-output.ts
+++ b/packages/tools/src/read-command-output.ts
@@ -2,12 +2,13 @@ import z from "zod";
 import { defineClientTool } from "./types";
 
 const toolDef = {
-  description: `- Retrieves output from a running or completed background shell
-- Takes a backgroundCommandId parameter identifying the shell
+  description:
+    `- Retrieves output from a running or completed background command
+- Takes a backgroundCommandId parameter identifying the command
 - Always returns only new output since the last check
-- Returns stdout and stderr output along with shell status
+- Returns stdout and stderr output along with command status
 - Supports optional regex filtering to show only lines matching a pattern
-- Use this tool when you need to monitor or check the output of a long-running shell`.trim(),
+- Use this tool when you need to monitor or check the output of a long-running command`.trim(),
   inputSchema: z.object({
     backgroundCommandId: z
       .string()

--- a/packages/tools/src/read-command-output.ts
+++ b/packages/tools/src/read-command-output.ts
@@ -3,13 +3,15 @@ import { defineClientTool } from "./types";
 
 const toolDef = {
   description: `- Retrieves output from a running or completed background shell
-- Takes a shellId parameter identifying the shell
+- Takes a backgroundCommandId parameter identifying the shell
 - Always returns only new output since the last check
 - Returns stdout and stderr output along with shell status
 - Supports optional regex filtering to show only lines matching a pattern
 - Use this tool when you need to monitor or check the output of a long-running shell`.trim(),
   inputSchema: z.object({
-    shellId: z.string().describe("The ID of the shell to get output from"),
+    backgroundCommandId: z
+      .string()
+      .describe("The ID of the background command to get output from"),
     regex: z
       .string()
       .optional()
@@ -21,7 +23,7 @@ const toolDef = {
     output: z
       .string()
       .describe(
-        "The output of the shell since last check (including stdout and stderr).",
+        "The output of the background command since last check (including stdout and stderr).",
       ),
     isTruncated: z
       .boolean()
@@ -30,4 +32,4 @@ const toolDef = {
   }),
 };
 
-export const getShellOutput = defineClientTool(toolDef);
+export const readCommandOutput = defineClientTool(toolDef);

--- a/packages/tools/src/read-command-output.ts
+++ b/packages/tools/src/read-command-output.ts
@@ -26,10 +26,20 @@ const toolDef = {
       .describe(
         "The output of the background command since last check (including stdout and stderr).",
       ),
+    status: z
+      .enum(["idle", "running", "completed"])
+      .describe("The current status of the command"),
+    error: z
+      .string()
+      .optional()
+      .describe("Error message if the command failed"),
     isTruncated: z
       .boolean()
       .optional()
       .describe("Whether the output was truncated"),
+    _meta: z.object({
+      command: z.string().describe("The command that was executed"),
+    }),
   }),
 };
 

--- a/packages/vscode-webui/src/__stories__/tool-gallery.stories.tsx
+++ b/packages/vscode-webui/src/__stories__/tool-gallery.stories.tsx
@@ -111,7 +111,7 @@ const executeCommandProps: ExecuteCommandProp["tool"] = {
   input: {
     command: "npm run dev --port 3001",
     cwd: "/Users/annoy/github.com/TabbyML/ragdoll/packages/website",
-    isDevServer: true,
+    isBackground: true,
   },
   output: {
     output: "Development server started on port 3001",

--- a/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
@@ -23,11 +23,9 @@ export interface ExecutionPanelProps {
   command: string;
   output: string;
   onStop: () => void;
-  onDetach?: () => void;
   completed: boolean;
   isExecuting: boolean;
   className?: string;
-  isBackground?: boolean;
 }
 
 export const CommandExecutionPanel: FC<ExecutionPanelProps> = ({
@@ -35,10 +33,8 @@ export const CommandExecutionPanel: FC<ExecutionPanelProps> = ({
   output,
   className,
   onStop,
-  onDetach,
   isExecuting,
   completed,
-  isBackground,
 }) => {
   const [expanded, setExpanded, setExpandedImmediately] =
     useExpanded(completed);
@@ -59,13 +55,6 @@ export const CommandExecutionPanel: FC<ExecutionPanelProps> = ({
     setIsStopping(true);
     onStop();
   };
-
-  const handleDetach = onDetach
-    ? () => {
-        setIsStopping(true);
-        onDetach();
-      }
-    : undefined;
 
   // Collapse when execution completes
   useEffect(() => {
@@ -109,11 +98,6 @@ export const CommandExecutionPanel: FC<ExecutionPanelProps> = ({
           {false && showButton && (
             <Button size="xs" variant="ghost" onClick={handleStop}>
               STOP
-            </Button>
-          )}
-          {isBackground && showButton && handleDetach !== undefined && (
-            <Button size="xs" variant="ghost" onClick={handleDetach}>
-              DETACH
             </Button>
           )}
           {output && (

--- a/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
@@ -27,7 +27,7 @@ export interface ExecutionPanelProps {
   completed: boolean;
   isExecuting: boolean;
   className?: string;
-  isDevServer?: boolean;
+  isBackground?: boolean;
 }
 
 export const CommandExecutionPanel: FC<ExecutionPanelProps> = ({
@@ -38,7 +38,7 @@ export const CommandExecutionPanel: FC<ExecutionPanelProps> = ({
   onDetach,
   isExecuting,
   completed,
-  isDevServer,
+  isBackground,
 }) => {
   const [expanded, setExpanded, setExpandedImmediately] =
     useExpanded(completed);
@@ -111,7 +111,7 @@ export const CommandExecutionPanel: FC<ExecutionPanelProps> = ({
               STOP
             </Button>
           )}
-          {isDevServer && showButton && handleDetach !== undefined && (
+          {isBackground && showButton && handleDetach !== undefined && (
             <Button size="xs" variant="ghost" onClick={handleDetach}>
               DETACH
             </Button>

--- a/packages/vscode-webui/src/components/tool-invocation/index.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/index.tsx
@@ -10,9 +10,11 @@ import { AskFollowupQuestionTool } from "./tools/ask-followup-question";
 import { AttemptCompletionTool } from "./tools/attempt-completion";
 import { executeCommandTool } from "./tools/execute-command";
 import { globFilesTool } from "./tools/glob-files";
+import { KillBackgroundCommandTool } from "./tools/kill-background-command";
 import { listFilesTool } from "./tools/list-files";
 import { multiApplyDiffTool } from "./tools/multi-apply-diff";
 import { newTaskTool } from "./tools/new-task";
+import { ReadCommandOutputTool } from "./tools/read-command-output";
 import { readFileTool } from "./tools/read-file";
 import { searchFilesTool } from "./tools/search-files";
 import { todoWriteTool } from "./tools/todo-write";
@@ -72,6 +74,8 @@ const Tools: Record<string, React.FC<ToolProps<any>>> = {
   multiApplyDiff: multiApplyDiffTool,
   askFollowupQuestion: AskFollowupQuestionTool,
   executeCommand: executeCommandTool,
+  readCommandOutput: ReadCommandOutputTool,
+  killBackgroundCommand: KillBackgroundCommandTool,
   searchFiles: searchFilesTool,
   listFiles: listFilesTool,
   globFiles: globFilesTool,

--- a/packages/vscode-webui/src/components/tool-invocation/tools/execute-command.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/execute-command.tsx
@@ -1,4 +1,4 @@
-import { useAutoApproveGuard, useToolCallLifeCycle } from "@/features/chat";
+import { useToolCallLifeCycle } from "@/features/chat";
 import { getToolName } from "ai";
 import { useCallback } from "react";
 import { CommandExecutionPanel } from "../command-execution-panel";
@@ -57,14 +57,6 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
     completed = true;
   }
 
-  const autoApproveGuard = useAutoApproveGuard();
-  const onDetach = streamingResult
-    ? () => {
-        autoApproveGuard.current = false;
-        streamingResult.detach();
-      }
-    : undefined;
-
   return (
     <ExpandableToolContainer
       title={title}
@@ -73,10 +65,8 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
           command={command ?? ""}
           output={output}
           onStop={abortTool}
-          onDetach={onDetach}
           completed={completed}
           isExecuting={isExecuting}
-          isBackground={isBackground}
         />
       }
     />

--- a/packages/vscode-webui/src/components/tool-invocation/tools/execute-command.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/execute-command.tsx
@@ -27,7 +27,7 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
     </span>
   ) : null;
   const text = isBackground
-    ? "I will start a dev server"
+    ? "I will execute the following command in background"
     : "I will execute the following command";
   const title = (
     <>

--- a/packages/vscode-webui/src/components/tool-invocation/tools/execute-command.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/execute-command.tsx
@@ -19,14 +19,14 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
     lifecycle.abort();
   }, [lifecycle.abort]);
 
-  const { cwd, command, isDevServer } = tool.input || {};
+  const { cwd, command, isBackground } = tool.input || {};
   const cwdNode = cwd ? (
     <span>
       {" "}
       in <HighlightedText>{cwd}</HighlightedText>
     </span>
   ) : null;
-  const text = isDevServer
+  const text = isBackground
     ? "I will start a dev server"
     : "I will execute the following command";
   const title = (
@@ -53,7 +53,7 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
     tool.output !== null &&
     "output" in tool.output
   ) {
-    output = tool.output.output;
+    output = tool.output.output ?? "";
     completed = true;
   }
 
@@ -76,7 +76,7 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
           onDetach={onDetach}
           completed={completed}
           isExecuting={isExecuting}
-          isDevServer={isDevServer}
+          isBackground={isBackground}
         />
       }
     />

--- a/packages/vscode-webui/src/components/tool-invocation/tools/kill-background-command.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/kill-background-command.tsx
@@ -14,7 +14,6 @@ export const KillBackgroundCommandTool: React.FC<
     </>
   );
 
-  let command: string | undefined;
   let detail: React.ReactNode;
   if (
     tool.state === "output-available" &&
@@ -23,7 +22,7 @@ export const KillBackgroundCommandTool: React.FC<
     "success" in tool.output &&
     tool.output.success === true
   ) {
-    command =
+    const command =
       tool.output?._meta.command ?? `Command id: ${backgroundCommandId}`;
     detail = (
       <CommandExecutionPanel

--- a/packages/vscode-webui/src/components/tool-invocation/tools/kill-background-command.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/kill-background-command.tsx
@@ -1,0 +1,40 @@
+import { CommandExecutionPanel } from "../command-execution-panel";
+import { StatusIcon } from "../status-icon";
+import { ExpandableToolContainer } from "../tool-container";
+import type { ToolProps } from "../types";
+
+export const KillBackgroundCommandTool: React.FC<
+  ToolProps<"killBackgroundCommand">
+> = ({ tool, isExecuting }) => {
+  const { backgroundCommandId } = tool.input || {};
+  const title = (
+    <>
+      <StatusIcon isExecuting={isExecuting} tool={tool} />
+      <span className="ml-2">I will stop the following background command</span>
+    </>
+  );
+
+  let command: string | undefined;
+  let detail: React.ReactNode;
+  if (
+    tool.state === "output-available" &&
+    typeof tool.output === "object" &&
+    tool.output !== null &&
+    "success" in tool.output &&
+    tool.output.success === true
+  ) {
+    command =
+      tool.output?._meta.command ?? `Command id: ${backgroundCommandId}`;
+    detail = (
+      <CommandExecutionPanel
+        command={command}
+        output=""
+        completed={true}
+        isExecuting={isExecuting}
+        onStop={() => {}}
+      />
+    );
+  }
+
+  return <ExpandableToolContainer title={title} detail={detail} />;
+};

--- a/packages/vscode-webui/src/components/tool-invocation/tools/read-command-output.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/read-command-output.tsx
@@ -21,8 +21,6 @@ export const ReadCommandOutputTool: React.FC<
     </>
   );
 
-  let output: string | undefined;
-  let command: string | undefined;
   let detail: React.ReactNode;
   if (
     tool.state === "output-available" &&
@@ -31,9 +29,8 @@ export const ReadCommandOutputTool: React.FC<
     "output" in tool.output &&
     typeof tool.output.output === "string"
   ) {
-    output = tool.output.output;
-    command =
-      tool.output?._meta.command ?? `Command id: ${backgroundCommandId}`;
+    const { output, _meta } = tool.output;
+    const command = _meta.command ?? `Command id: ${backgroundCommandId}`;
     detail = (
       <CommandExecutionPanel
         command={command}

--- a/packages/vscode-webui/src/components/tool-invocation/tools/read-command-output.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/read-command-output.tsx
@@ -1,0 +1,42 @@
+import { CommandExecutionPanel } from "../command-execution-panel";
+import { StatusIcon } from "../status-icon";
+import { ExpandableToolContainer } from "../tool-container";
+import type { ToolProps } from "../types";
+
+export const ReadCommandOutputTool: React.FC<
+  ToolProps<"readCommandOutput">
+> = ({ tool, isExecuting }) => {
+  const { backgroundCommandId } = tool.input || {};
+  const title = (
+    <>
+      <StatusIcon isExecuting={isExecuting} tool={tool} />
+      <span className="ml-2">Reading background command output</span>
+    </>
+  );
+
+  let output: string | undefined;
+  let command: string | undefined;
+  let detail: React.ReactNode;
+  if (
+    tool.state === "output-available" &&
+    typeof tool.output === "object" &&
+    tool.output !== null &&
+    "output" in tool.output &&
+    typeof tool.output.output === "string"
+  ) {
+    output = tool.output.output;
+    command =
+      tool.output?._meta.command ?? `Command id: ${backgroundCommandId}`;
+    detail = (
+      <CommandExecutionPanel
+        command={command}
+        output={output}
+        completed={true}
+        isExecuting={isExecuting}
+        onStop={() => {}}
+      />
+    );
+  }
+
+  return <ExpandableToolContainer title={title} detail={detail} />;
+};

--- a/packages/vscode-webui/src/components/tool-invocation/tools/read-command-output.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/read-command-output.tsx
@@ -1,4 +1,5 @@
 import { CommandExecutionPanel } from "../command-execution-panel";
+import { HighlightedText } from "../highlight-text";
 import { StatusIcon } from "../status-icon";
 import { ExpandableToolContainer } from "../tool-container";
 import type { ToolProps } from "../types";
@@ -6,11 +7,17 @@ import type { ToolProps } from "../types";
 export const ReadCommandOutputTool: React.FC<
   ToolProps<"readCommandOutput">
 > = ({ tool, isExecuting }) => {
-  const { backgroundCommandId } = tool.input || {};
+  const { backgroundCommandId, regex } = tool.input || {};
   const title = (
     <>
       <StatusIcon isExecuting={isExecuting} tool={tool} />
       <span className="ml-2">Reading background command output</span>
+      {regex && (
+        <>
+          {" "}
+          with regex filter: <HighlightedText>{regex}</HighlightedText>
+        </>
+      )}
     </>
   );
 

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -28,7 +28,6 @@ type StreamingResult =
   | {
       toolName: "executeCommand";
       output: ExecuteCommandResult;
-      detach: () => void;
     }
   | {
       // Not actually a task streaming result, but we provide context here for the live-sub-task.
@@ -41,7 +40,6 @@ type CompleteReason =
   | "execute-finish"
   | "user-reject"
   | "preview-reject"
-  | "user-detach"
   | "user-abort";
 
 type AbortFunctionType = AbortController["abort"];
@@ -331,7 +329,8 @@ export class ManagedToolCallLifeCycle
       this.toolName === "executeCommand" &&
       typeof result === "object" &&
       result !== null &&
-      "output" in result
+      "output" in result &&
+      !("backgroundCommandId" in result)
     ) {
       this.onExecuteCommand(result as ExecuteCommandReturnType);
     } else if (this.toolName === "newTask") {
@@ -349,20 +348,11 @@ export class ManagedToolCallLifeCycle
     const signal = threadSignal(result.output);
     const { abort, abortSignal } = this.checkState("Streaming", "execute");
 
-    let isUserDetached = false;
-
-    const detach = () => {
-      isUserDetached = true;
-      result.detach();
-      abort();
-    };
-
     this.transitTo("execute", {
       type: "execute:streaming",
       streamingResult: {
         toolName: "executeCommand",
         output: signal.value,
-        detach,
       },
       abort,
       abortSignal,
@@ -381,11 +371,7 @@ export class ManagedToolCallLifeCycle
         this.transitTo("execute:streaming", {
           type: "complete",
           result,
-          reason: isUserDetached
-            ? "user-detach"
-            : abortSignal.aborted
-              ? "user-abort"
-              : "execute-finish",
+          reason: abortSignal.aborted ? "user-abort" : "execute-finish",
         });
         unsubscribe();
       } else {
@@ -394,7 +380,6 @@ export class ManagedToolCallLifeCycle
           streamingResult: {
             toolName: "executeCommand",
             output,
-            detach,
           },
           abort,
           abortSignal,

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
@@ -78,11 +78,6 @@ function overrideResult(complete: ToolCallLifeCycle["complete"]) {
       output.error =
         "User rejected the tool call, please use askFollowupQuestion to clarify next step with user.";
       break;
-    case "user-detach":
-      // We use info instead of error to avoid the tool call being marked as failed.
-      output.info =
-        "User has detached the terminal, the job will continue running in the background.";
-      break;
     case "preview-reject":
     case "execute-finish":
       break;

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -3,8 +3,7 @@ import { getLogger } from "@/lib/logger";
 import { getShellPath } from "@getpochi/common/tool-utils";
 import * as vscode from "vscode";
 import { OutputManager } from "./output";
-import { ExecutionError, createBackgroundOutputStream } from "./utils";
-import { waitForWebviewSubscription } from "./utils";
+import { ExecutionError } from "./utils";
 
 const logger = getLogger("TerminalJob");
 
@@ -99,8 +98,6 @@ export class TerminalJob implements vscode.Disposable {
    * Execute the configured command in the terminal
    */
   async execute(): Promise<void> {
-    await waitForWebviewSubscription();
-
     let executeError: ExecutionError | undefined = undefined;
 
     try {
@@ -211,10 +208,7 @@ export class TerminalJob implements vscode.Disposable {
   private async processOutputStream(
     outputStream: AsyncIterable<string>,
   ): Promise<void> {
-    const stream = this.config.background
-      ? createBackgroundOutputStream(outputStream)
-      : outputStream;
-    for await (const chunk of stream) {
+    for await (const chunk of outputStream) {
       this.outputManager.addChunk(chunk);
     }
   }

--- a/packages/vscode/src/integrations/terminal/terminal-state.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-state.ts
@@ -34,6 +34,7 @@ export class TerminalState implements vscode.Disposable {
     this.disposables.push(
       vscode.window.onDidCloseTerminal(this.onTerminalChanged),
     );
+    this.disposables.push(TerminalJob.onDidDispose(this.onTerminalChanged));
   }
 
   /**

--- a/packages/vscode/src/integrations/terminal/terminal-state.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-state.ts
@@ -1,10 +1,12 @@
 import { signal } from "@preact/signals-core";
 import { injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
+import { TerminalJob } from "./terminal-job";
 
 export interface TerminalInfo {
   name: string;
   isActive: boolean;
+  backgroundCommandId?: string;
 }
 
 @injectable()
@@ -63,5 +65,6 @@ function listVisibleTerminals(): TerminalInfo[] {
     .map((t) => ({
       name: t.name || "Unnamed Terminal",
       isActive: t === vscode.window.activeTerminal,
+      backgroundCommandId: TerminalJob.get(t)?.id,
     }));
 }

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -74,6 +74,8 @@ import { type FileSelection, TabState } from "../editor/tab-state";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { McpHub } from "../mcp/mcp-hub";
 
+import { killBackgroundCommand } from "@/tools/kill-background-command";
+import { readCommandOutput } from "@/tools/read-command-output";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { ThirdMcpImporter } from "../mcp/third-party-mcp";
 import { isExecutable } from "../mcp/types";
@@ -693,6 +695,8 @@ const ToolMap: Record<
 > = {
   readFile,
   executeCommand,
+  readCommandOutput,
+  killBackgroundCommand,
   searchFiles,
   listFiles: listFilesTool,
   globFiles,

--- a/packages/vscode/src/tools/execute-command.ts
+++ b/packages/vscode/src/tools/execute-command.ts
@@ -45,12 +45,7 @@ export const executeCommand: ToolFunctionType<
       timeout: timeout ?? defaultTimeout,
     });
 
-    // need wait some time to get init output?
-    const outputResult = await job.readOutput();
-
     return {
-      output: outputResult.output,
-      isTruncated: outputResult.isTruncated,
       backgroundCommandId: job.id,
     };
   }

--- a/packages/vscode/src/tools/execute-command.ts
+++ b/packages/vscode/src/tools/execute-command.ts
@@ -20,7 +20,7 @@ const logger = getLogger("ExecuteCommand");
 export const executeCommand: ToolFunctionType<
   ClientTools["executeCommand"]
 > = async (
-  { command, cwd = ".", isDevServer, timeout },
+  { command, cwd = ".", isBackground, timeout },
   { abortSignal, nonInteractive },
 ) => {
   const defaultTimeout = 120;
@@ -38,13 +38,13 @@ export const executeCommand: ToolFunctionType<
   let output: Signal<ExecuteCommandResult>;
   let detach: () => void = () => {};
 
-  if (isDevServer) {
+  if (isBackground) {
     const job = TerminalJob.create({
       name: command,
       command,
       cwd,
       abortSignal: abortSignal,
-      background: isDevServer,
+      background: isBackground,
       timeout: timeout ?? defaultTimeout,
     });
 

--- a/packages/vscode/src/tools/kill-background-command.ts
+++ b/packages/vscode/src/tools/kill-background-command.ts
@@ -6,19 +6,11 @@ export const killBackgroundCommand: ToolFunctionType<
 > = async ({ backgroundCommandId }) => {
   const job = TerminalJob.get(backgroundCommandId);
   if (!job) {
-    return {
-      success: false,
-      error: `Background command with ID "${backgroundCommandId}" not found.`,
-    };
+    throw new Error(
+      `Background command with ID "${backgroundCommandId}" not found.`,
+    );
   }
 
-  try {
-    job.kill();
-    return { success: true };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
+  job.kill();
+  return { success: true, _meta: { command: job.command } };
 };

--- a/packages/vscode/src/tools/kill-background-command.ts
+++ b/packages/vscode/src/tools/kill-background-command.ts
@@ -1,0 +1,24 @@
+import { TerminalJob } from "@/integrations/terminal/terminal-job";
+import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
+
+export const killBackgroundCommand: ToolFunctionType<
+  ClientTools["killBackgroundCommand"]
+> = async ({ backgroundCommandId }) => {
+  const job = TerminalJob.get(backgroundCommandId);
+  if (!job) {
+    return {
+      success: false,
+      error: `Background command with ID "${backgroundCommandId}" not found.`,
+    };
+  }
+
+  try {
+    job.kill();
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+};

--- a/packages/vscode/src/tools/read-command-output.ts
+++ b/packages/vscode/src/tools/read-command-output.ts
@@ -1,0 +1,20 @@
+import { TerminalJob } from "@/integrations/terminal/terminal-job";
+import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
+
+export const readCommandOutput: ToolFunctionType<
+  ClientTools["readCommandOutput"]
+> = async ({ backgroundCommandId, regex }) => {
+  const job = TerminalJob.get(backgroundCommandId);
+  if (!job) {
+    throw new Error(
+      `Background command with ID "${backgroundCommandId}" not found.`,
+    );
+  }
+
+  const output = await job.readOutput(regex ? new RegExp(regex) : undefined);
+
+  return {
+    output: output.output,
+    isTruncated: output.isTruncated,
+  };
+};

--- a/packages/vscode/src/tools/read-command-output.ts
+++ b/packages/vscode/src/tools/read-command-output.ts
@@ -1,20 +1,27 @@
-import { TerminalJob } from "@/integrations/terminal/terminal-job";
+import { OutputManager } from "@/integrations/terminal/output";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 
 export const readCommandOutput: ToolFunctionType<
   ClientTools["readCommandOutput"]
 > = async ({ backgroundCommandId, regex }) => {
-  const job = TerminalJob.get(backgroundCommandId);
-  if (!job) {
+  const outputManager = OutputManager.get(backgroundCommandId);
+  if (!outputManager) {
     throw new Error(
       `Background command with ID "${backgroundCommandId}" not found.`,
     );
   }
 
-  const output = await job.readOutput(regex ? new RegExp(regex) : undefined);
+  const output = outputManager.readOutput(
+    regex ? new RegExp(regex) : undefined,
+  );
 
   return {
     output: output.output,
     isTruncated: output.isTruncated,
+    status: output.status,
+    error: output.error,
+    _meta: {
+      command: outputManager.command,
+    },
   };
 };


### PR DESCRIPTION
## Screenshot
<img width="866" height="794" alt="image" src="https://github.com/user-attachments/assets/103edbef-8cf7-407c-acbe-a6a60e753273" />

<img width="874" height="656" alt="image" src="https://github.com/user-attachments/assets/04558478-e885-42dc-b380-72843025d737" />


## Summary
This pull request introduces support for running shell commands in the background and monitoring or killing those commands via new tools. It replaces the previous `isDevServer` parameter with a more general `isBackground` parameter, updates the schema and UI accordingly, and adds new tools for reading the output of background commands and terminating them. There are also improvements to how terminals and their associated background commands are represented in the environment.

**Background command execution and monitoring:**

* Added new tools `readCommandOutput` and `killBackgroundCommand` for monitoring and terminating background commands, along with their schema definitions and UI components. [[1]](diffhunk://#diff-4e4ac6f49c5938e53a62c33ef2c554b747ad4cc45216f44b9961a31024cf4100R1-R46) [[2]](diffhunk://#diff-96240271198315974fcaa1b90ab801ecb75a9e03dc1c6bd7c24fabcbe4a98816R1-R24) [[3]](diffhunk://#diff-ed22786a9d71840b9374de8c2514769eabcea946787a1f0ada894d2a27ae0a6dR19-R20) [[4]](diffhunk://#diff-ed22786a9d71840b9374de8c2514769eabcea946787a1f0ada894d2a27ae0a6dL47-R54) [[5]](diffhunk://#diff-ed22786a9d71840b9374de8c2514769eabcea946787a1f0ada894d2a27ae0a6dR65-R66) [[6]](diffhunk://#diff-2697bc411f3e50ae95c6c33bb21a7c79c32d9b980b491e28ec3f578e04b26927R1-R40) [[7]](diffhunk://#diff-c16d59a1ad56db972c89c503f7ccd8d916ce25d3021f3e5842af43e8f13d556dR1-R49) [[8]](diffhunk://#diff-d80fbf3219902de821ed3e502575c4da00a3ec2660ed9b077f6754a382426a20R13-R17) [[9]](diffhunk://#diff-d80fbf3219902de821ed3e502575c4da00a3ec2660ed9b077f6754a382426a20R77-R78)
* Updated the `executeCommand` tool to use the `isBackground` parameter instead of `isDevServer`, including schema, error messaging, and usage notes. Output now optionally includes a `backgroundCommandId` when run in background mode. [[1]](diffhunk://#diff-f2eb515274f7f91ed8c6fee07193fe779bf97b53017b9643f3703eb38f51f867R22) [[2]](diffhunk://#diff-f2eb515274f7f91ed8c6fee07193fe779bf97b53017b9643f3703eb38f51f867L126-R131) [[3]](diffhunk://#diff-f2eb515274f7f91ed8c6fee07193fe779bf97b53017b9643f3703eb38f51f867R145-R154) [[4]](diffhunk://#diff-f5e5d7324285a03d1fb0fef606cc725731a71cafb2d11b0a239af0b0bea06b1bL17-R26) [[5]](diffhunk://#diff-60796a422eede13e6c47f4fc610423992f145131239ea780ef300584394901daL114-R114)

**Terminal and environment representation:**

* Enhanced the environment schema to include `backgroundCommandId` for terminals, allowing association between terminals and background commands. The prompt and snapshot output now show background command info for each terminal. [[1]](diffhunk://#diff-91459f3e3996960e4849ed2fd1216b24d8b4311a1579e2506cceaacb32164c0bL84-R95) [[2]](diffhunk://#diff-05b3502252eb33b8dc5fcb528ec5bf16b4e21e0ac6f0931bbd7659b46cf9ee3dL107-R111) [[3]](diffhunk://#diff-65ac492774bd26c1150e3e5abd8551c842de87de554db32dfe54a2168e9b64f9L28-R28)

**User interface and component updates:**

* Updated UI components to remove dev server-specific logic and support new background command features, including changes to `CommandExecutionPanel` and the tool invocation system. [[1]](diffhunk://#diff-8d896c23f6dda405a25f7c0f4f734482c697f046b94ac56dbf07bacaf7075a94L26-L41) [[2]](diffhunk://#diff-8d896c23f6dda405a25f7c0f4f734482c697f046b94ac56dbf07bacaf7075a94L63-L69) [[3]](diffhunk://#diff-8d896c23f6dda405a25f7c0f4f734482c697f046b94ac56dbf07bacaf7075a94L114-L118) [[4]](diffhunk://#diff-0eeac3f91a6dadf62383913cf869d12d66a937170ccc02fe10b01383d3b4597dL1-R1) [[5]](diffhunk://#diff-0eeac3f91a6dadf62383913cf869d12d66a937170ccc02fe10b01383d3b4597dL22-R30) [[6]](diffhunk://#diff-0eeac3f91a6dadf62383913cf869d12d66a937170ccc02fe10b01383d3b4597dL56-L67) [[7]](diffhunk://#diff-0eeac3f91a6dadf62383913cf869d12d66a937170ccc02fe10b01383d3b4597dL76-L79)

**Tool lifecycle and execution logic:**

* Adjusted tool lifecycle logic to distinguish between foreground and background command executions, ensuring correct handling of output and command status. [[1]](diffhunk://#diff-f9ac15cfe66c38dc238b87610d9e03a004a7866b8943f187cdad30f0f1b879c2L31) [[2]](diffhunk://#diff-f9ac15cfe66c38dc238b87610d9e03a004a7866b8943f187cdad30f0f1b879c2L44) [[3]](diffhunk://#diff-f9ac15cfe66c38dc238b87610d9e03a004a7866b8943f187cdad30f0f1b879c2L334-R333)


## Test

Test case:
- run command in foreground, should remain same.
- run command in background
    - command start in background success
        - executeCommand tool call success
        - terminal open and show
    - read command output
        - readCommandOutput tool call success
            - should be able to read output since last read
            - should be able to read output with regex to filter output
            - should truncate output when output exceed limit
            - should be able to read output after command execution finished
            - should contain execution status(running or finished)
            - should display error message if command execution failed
            - should read output failed when all output has been read and command execution finished
            - should read output failed when all output has been read and command execution aborted by user in terminal
    - kill command
        - killCommand tool call success
            - should be able to kill command execution
            - should display error message if kill failed or execution already finished
- terminals in environment should contain backgroundCommandId
