### PR TITLE
fix: proper bundle vite in cli

### DIFF
--- a/packages/cli/scripts/build-cli.sh
+++ b/packages/cli/scripts/build-cli.sh
@@ -3,7 +3,7 @@ set -ex
 
 build_js() {
         bun build src/cli.ts --banner='import * as undici from "undici";' \
-                --external vite \
+                --external lightningcss \
                 --target bun \
                 --outdir ./dist
 }
@@ -11,7 +11,7 @@ build_js() {
 build_exe() {
         bun build src/cli.ts --banner='import * as undici from "undici";' \
                 --asset-naming="[name].[ext]" \
-                --external vite \
+                --external lightningcss \
                 --compile \
                 --outfile ./dist/pochi \
                 "$@"


### PR DESCRIPTION
## Summary
- Updated the CLI build script to exclude lightningcss instead of vite from the bundle
- Changed both build_js() and build_exe() functions to use --external lightningcss
- Ensures proper external dependency handling during the CLI build process

## Test plan
- [x] All existing tests pass
- [x] Build script executes successfully with new external dependency
- [x] No breaking changes to the build output

🤖 Generated with [Pochi](https://getpochi.com)