### PR TITLE
chore(constants): remove unused sandbox path constants

### DIFF
--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -1,18 +1,2 @@
-/**
- * Known XML tags that should be preserved during processing
- */
 export const KnownTags = ["file", "workflow", "compact"] as const;
-
-const SandboxHome = "/home/pochi";
-const SandboxLogDir = `${SandboxHome}/.log`;
-const RemotePochiHome = `${SandboxHome}/.remote-pochi`;
-
-export const SandboxPath = {
-  home: SandboxHome,
-  project: `${SandboxHome}/project`,
-  init: `${RemotePochiHome}/init.sh`,
-  initLog: `${SandboxLogDir}/init.log`,
-  runnerLog: `${SandboxLogDir}/runner.log`,
-};
-
 export const CompactTaskMinTokens = 50_000;


### PR DESCRIPTION
## Summary
- Remove unused SandboxPath constants that are no longer needed in the codebase
- Clean up KnownTags documentation that was no longer being used

These constants appear to be remnants from previous implementations and are not currently referenced anywhere in the codebase.

## Test plan
- [x] Verify that removing these unused constants doesn't break any existing functionality
- [x] Run tests to ensure no regressions

🤖 Generated with [Pochi](https://getpochi.com)