### PR TITLE
docs: add developer updates page & this week's digest

### DIFF
--- a/packages/docs/content/docs/developer-updates.mdx
+++ b/packages/docs/content/docs/developer-updates.mdx
@@ -12,7 +12,7 @@ Here you will find highlights on features, enhancements, and bug fixes, plus ins
 
 ---
 
-## 📝 Aug 24–28, 2025
+## Aug 28, 2025
 
 ### TL;DR
 
@@ -24,8 +24,6 @@ This week we polished the VS Code extension with some **UX upgrades**, open-sour
 - **Improved docs:** Updated structure and added guidance on model settings for easier use. [#60](https://github.com/TabbyML/pochi/pull/60), [#63](https://github.com/TabbyML/pochi/pull/63) , [900d162](https://github.com/TabbyML/pochi/commit/900d1629c4e97833e24a4450c438a585dca583d4)
 - **Model pricing at your fingertips:** Check model costs directly in settings before choosing one. [#74](https://github.com/TabbyML/pochi/pull/74)
 
-### Fixes 🐛
+### Bug Fixes 🐛
 
 - **File search now correctly surfaces matching files:** Queries that used to return empty results will now behave as expected. [#79](https://github.com/TabbyML/pochi/pull/79)
-
----

--- a/packages/docs/content/docs/developer-updates.mdx
+++ b/packages/docs/content/docs/developer-updates.mdx
@@ -12,7 +12,7 @@ Here you will find highlights on features, enhancements, and bug fixes, plus ins
 
 ---
 
-## Aug 28, 2025
+## Aug 29, 2025
 
 ### TL;DR
 

--- a/packages/docs/content/docs/developer-updates.mdx
+++ b/packages/docs/content/docs/developer-updates.mdx
@@ -1,0 +1,31 @@
+---
+title: "Developer Updates"
+icon: "FileTerminal"
+description: "Weekly update notes from Pochi developers"
+---
+
+# Developer Updates
+
+Welcome to the Pochi Developer Updates — a **weekly digest** of what's new in the codebase.
+
+Here you will find highlights on features, enhancements, and bug fixes, plus insights into how we're improving the developer experience. Come back often! 👋
+
+---
+
+## 📝 Aug 24–28, 2025
+
+### TL;DR
+
+This week we polished the VS Code extension with some **UX upgrades**, open-sourced the **Pochi CLI**, and did a few rounds of **codebase cleanup** to make contributing easier and friendlier for newcomers. We look forward to your first visit to the repo!
+
+### Enhancements ✨
+
+- **Drag & drop images:** Share visuals with Pochi in the VS Code chat just by dragging them in. [#64](https://github.com/TabbyML/pochi/pull/64)
+- **Improved docs:** Updated structure and added guidance on model settings for easier use. [#60](https://github.com/TabbyML/pochi/pull/60), [#63](https://github.com/TabbyML/pochi/pull/63) , [900d162](https://github.com/TabbyML/pochi/commit/900d1629c4e97833e24a4450c438a585dca583d4)
+- **Model pricing at your fingertips:** Check model costs directly in settings before choosing one. [#74](https://github.com/TabbyML/pochi/pull/74)
+
+### Fixes 🐛
+
+- **File search now correctly surfaces matching files:** Queries that used to return empty results will now behave as expected. [#79](https://github.com/TabbyML/pochi/pull/79)
+
+---

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -6,7 +6,6 @@
     "---Introduction---",
     "index",
     "troubleshooting",
-    "developer-updates",
     "---Usage---",
     "vscode",
     "cli",
@@ -20,6 +19,8 @@
     "models",
     "rules",
     "workflows",
-    "mcp"
+    "mcp",
+    "---Resources---",
+    "developer-updates"
   ]
 }

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -6,6 +6,7 @@
     "---Introduction---",
     "index",
     "troubleshooting",
+    "developer-updates",
     "---Usage---",
     "vscode",
     "cli",


### PR DESCRIPTION
## Context

We want a central place to track Pochi’s weekly progress — not just releases, but also enhancements, bug fixes, and developer insights. This page acts as a lightweight changelog + digest that’s easier for contributors and users to follow.

## Changes

- Added `developer updates` page
- Added this week's(Aug 24 - 28th) updates

## Result

<img width="1608" height="980" alt="Screenshot 2025-08-29 at 19 19 50" src="https://github.com/user-attachments/assets/e8ada2cd-7451-418f-8645-48867fa17200" />
