### PR TITLE
fix(webui): handle ready state in tool call lifecycle

### DIFF
--- a/packages/common/src/tool-utils/__tests__/ignore-walk.test.ts
+++ b/packages/common/src/tool-utils/__tests__/ignore-walk.test.ts
@@ -33,7 +33,6 @@ describe("ignoreWalk", () => {
   };
 
   beforeEach(() => {
-    // @ts-expect-error - Mock implementation doesn't match all overloads
     vi.mocked(fs.readdir).mockImplementation(async (path) => {
       return mockFs[path as keyof typeof mockFs] || [];
     });

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -298,15 +298,19 @@ export class ManagedToolCallLifeCycle
     if (
       this.state.type === "init" ||
       this.state.type === "pending" ||
+      this.state.type === "ready" ||
       this.state.type === "execute" ||
       this.state.type === "execute:streaming"
     ) {
       this.state.abort("user-abort");
-      this.transitTo(["init", "pending", "execute", "execute:streaming"], {
-        type: "complete",
-        result: { error: "Tool call aborted by user." },
-        reason: "user-abort",
-      });
+      this.transitTo(
+        ["init", "pending", "ready", "execute", "execute:streaming"],
+        {
+          type: "complete",
+          result: { error: "Tool call aborted by user." },
+          reason: "user-abort",
+        },
+      );
     }
   }
 

--- a/packages/vscode-webui/src/features/chat/lib/use-tool-call-life-cycles.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-tool-call-life-cycles.ts
@@ -38,7 +38,11 @@ export function useToolCallLifeCycles(abortController: AbortController) {
   const previewingToolCalls = useMemo(() => {
     const previewing = [];
     for (const lifecycle of toolCallLifeCycles.values()) {
-      if (lifecycle.status === "init" || lifecycle.status === "pending") {
+      if (
+        lifecycle.status === "init" ||
+        lifecycle.status === "pending" ||
+        lifecycle.status === "ready"
+      ) {
         previewing.push(lifecycle);
       }
     }


### PR DESCRIPTION
## Summary
This commit updates the tool call lifecycle management in the web UI. It ensures that tool calls in the 'ready' state are correctly handled when a user aborts an operation and are properly identified as previewing tool calls.

This fixes a bug where aborting a tool call in the `ready` state would not properly transition it to the `complete` state with an error.

## Test plan
- Manually verified that aborting a tool call in the `ready` state now correctly transitions it to the `complete` state.
- Existing automated tests pass.

🤖 Generated with [Pochi](https://getpochi.com)