### PR TITLE
feat(vscode-webui): show display id for background jobs

### DIFF
--- a/packages/vscode-webui/src/components/message/markdown.tsx
+++ b/packages/vscode-webui/src/components/message/markdown.tsx
@@ -10,6 +10,7 @@ import { FileBadge } from "../tool-invocation/file-badge";
 import { CodeBlock } from "./code-block";
 import { customStripTagsPlugin } from "./custom-strip-tags-plugin";
 import "./markdown.css";
+import { processBackgroundJobId } from "@/lib/hooks/use-background-job-command";
 import { addLineBreak } from "@/lib/utils/file";
 import { isKnownProgrammingLanguage } from "@/lib/utils/languages";
 import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
@@ -81,7 +82,8 @@ export function MessageMarkdown({
       const escapeTagContent = escapeMarkdownTag(tag);
       result = escapeTagContent(result);
     }
-    return result;
+
+    return processBackgroundJobId(result);
   }, [children]);
 
   const components: Components = useMemo(() => {

--- a/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
@@ -76,13 +76,33 @@ const ToggleExpandButton: FC<{ expanded: boolean; onToggle: () => void }> = ({
   );
 };
 
+const BackgroundJobIdButton: FC<{ displayId: string }> = ({ displayId }) => {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          size="sm"
+          className="size-[16px] rounded-sm"
+          variant="secondary"
+        >
+          <div className="font-bold font-mono text-[10px]">{displayId}</div>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>Background job {displayId}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
 const CommandPanelContainer: FC<{
-  command: string;
+  icon: React.ReactNode;
+  title: React.ReactNode;
   expanded?: boolean;
   actions?: React.ReactNode;
   className?: string;
   output?: string;
-}> = ({ command, expanded, actions, className, output }) => {
+}> = ({ icon, title, expanded, actions, className, output }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   return (
@@ -101,10 +121,10 @@ const CommandPanelContainer: FC<{
         )}
       >
         <div className="flex min-w-0 flex-1 space-x-3">
-          <TerminalIcon className="mt-[2px] size-4 flex-shrink-0" />
+          {icon}
           <ScrollArea className="max-h-[80px] min-w-0 flex-1 overflow-y-auto">
             <span className="whitespace-pre-wrap text-balance break-all">
-              {command}
+              {title}
             </span>
           </ScrollArea>
         </div>
@@ -131,16 +151,18 @@ const CommandPanelContainer: FC<{
   );
 };
 
-export const BackgroundJobPanel: FC<{ command: string; output?: string }> = ({
-  command,
-  output,
-}) => {
+export const BackgroundJobPanel: FC<{
+  command: string;
+  displayId?: string;
+  output?: string;
+}> = ({ command, displayId, output }) => {
   const [expanded, setExpanded] = useState(false);
   const toggleExpanded = () => setExpanded((prev) => !prev);
 
   return (
     <CommandPanelContainer
-      command={command}
+      icon={displayId && <BackgroundJobIdButton displayId={displayId} />}
+      title={command}
       expanded={output !== undefined && expanded}
       actions={
         <>
@@ -199,7 +221,8 @@ export const CommandExecutionPanel: FC<ExecutionPanelProps> = ({
   const showButton = !completed && isExecuting && !isStopping;
   return (
     <CommandPanelContainer
-      command={command}
+      icon={<TerminalIcon className="mt-[2px] size-4 flex-shrink-0" />}
+      title={command}
       expanded={output !== undefined && expanded}
       className={className}
       actions={

--- a/packages/vscode-webui/src/components/tool-invocation/tools/kill-background-job.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/kill-background-job.tsx
@@ -1,4 +1,4 @@
-import { useBackgroundJobCommand } from "@/lib/hooks/use-background-job-command";
+import { useBackgroundJobInfo } from "@/lib/hooks/use-background-job-command";
 import { BackgroundJobPanel } from "../command-execution-panel";
 import { StatusIcon } from "../status-icon";
 import { ExpandableToolContainer } from "../tool-container";
@@ -7,9 +7,9 @@ import type { ToolProps } from "../types";
 export const KillBackgroundJobTool: React.FC<
   ToolProps<"killBackgroundJob">
 > = ({ tool, isExecuting, messages }) => {
-  const command = useBackgroundJobCommand(
+  const info = useBackgroundJobInfo(
     messages,
-    tool.input?.backgroundJobId,
+    tool.state !== "input-streaming" ? tool.input?.backgroundJobId : undefined,
   );
 
   const title = (
@@ -19,7 +19,9 @@ export const KillBackgroundJobTool: React.FC<
     </>
   );
 
-  const detail = command ? <BackgroundJobPanel command={command} /> : null;
+  const detail = info ? (
+    <BackgroundJobPanel command={info.command} displayId={info.displayId} />
+  ) : null;
 
   return <ExpandableToolContainer title={title} detail={detail} />;
 };

--- a/packages/vscode-webui/src/components/tool-invocation/tools/read-background-job-output.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/read-background-job-output.tsx
@@ -1,4 +1,4 @@
-import { useBackgroundJobCommand } from "@/lib/hooks/use-background-job-command";
+import { useBackgroundJobInfo } from "@/lib/hooks/use-background-job-command";
 import { BackgroundJobPanel } from "../command-execution-panel";
 import { HighlightedText } from "../highlight-text";
 import { StatusIcon } from "../status-icon";
@@ -8,9 +8,9 @@ import type { ToolProps } from "../types";
 export const ReadBackgroundJobOutputTool: React.FC<
   ToolProps<"readBackgroundJobOutput">
 > = ({ tool, isExecuting, messages }) => {
-  const command = useBackgroundJobCommand(
+  const info = useBackgroundJobInfo(
     messages,
-    tool.input?.backgroundJobId,
+    tool.state !== "input-streaming" ? tool.input?.backgroundJobId : undefined,
   );
   const { regex } = tool.input || {};
   const title = (
@@ -26,8 +26,12 @@ export const ReadBackgroundJobOutputTool: React.FC<
     </>
   );
 
-  const detail: React.ReactNode = command ? (
-    <BackgroundJobPanel command={command} output={tool.output?.output} />
+  const detail: React.ReactNode = info ? (
+    <BackgroundJobPanel
+      command={info.command}
+      displayId={info.displayId}
+      output={tool.output?.output}
+    />
   ) : null;
 
   return <ExpandableToolContainer title={title} detail={detail} />;

--- a/packages/vscode-webui/src/components/tool-invocation/tools/start-background-job.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/start-background-job.tsx
@@ -1,3 +1,4 @@
+import { useBackgroundJobDisplayId } from "@/lib/hooks/use-background-job-command";
 import { BackgroundJobPanel } from "../command-execution-panel";
 import { HighlightedText } from "../highlight-text";
 import { StatusIcon } from "../status-icon";
@@ -8,6 +9,9 @@ export const StartBackgroundJobTool: React.FC<
   ToolProps<"startBackgroundJob">
 > = ({ tool, isExecuting }) => {
   const { cwd, command } = tool.input || {};
+  const displayId = useBackgroundJobDisplayId(
+    tool.state === "output-available" ? tool.output.backgroundJobId : undefined,
+  );
   const cwdNode = cwd ? (
     <span>
       {" "}
@@ -25,10 +29,10 @@ export const StartBackgroundJobTool: React.FC<
     </>
   );
 
-  return (
-    <ExpandableToolContainer
-      title={title}
-      detail={<BackgroundJobPanel command={command ?? ""} />}
-    />
-  );
+  const detail =
+    command && displayId ? (
+      <BackgroundJobPanel command={command} displayId={displayId} />
+    ) : null;
+
+  return <ExpandableToolContainer title={title} detail={detail} />;
 };

--- a/packages/vscode-webui/src/lib/hooks/use-background-job-command.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-background-job-command.ts
@@ -16,17 +16,46 @@ const getBackgroundJobCommandFromMessages = (
   }
 };
 
-export const useBackgroundJobCommand = (
-  messages: Message[],
+let currentDisplayId = 1;
+const displayIds = new Map<string, number>();
+const getDisplayId = (jobId: string) => {
+  if (!displayIds.has(jobId)) {
+    displayIds.set(jobId, currentDisplayId++);
+  }
+  return `#${displayIds.get(jobId)}`;
+};
+
+/**
+ * replace all background job id in content to display id
+ * @param content
+ */
+export const processBackgroundJobId = (content: string): string => {
+  let newContent = content;
+  for (const [jobId, displayId] of displayIds) {
+    newContent = newContent.replace(new RegExp(jobId, "g"), `#${displayId}`);
+  }
+  return newContent;
+};
+
+export const useBackgroundJobDisplayId = (
   backgroundJobId?: string,
 ): string | undefined => {
+  return backgroundJobId ? getDisplayId(backgroundJobId) : undefined;
+};
+
+export const useBackgroundJobInfo = (
+  messages: Message[],
+  backgroundJobId?: string,
+): { command: string; displayId: string } | undefined => {
   if (!backgroundJobId) return;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: only recompute on backgroundJobId changes, as command should be in messages(startBackgroundJob should happen before readBackgroundJobOutput and killBackgroundJob)
-  return useMemo(() => {
+  const command = useMemo(() => {
     return (
       getBackgroundJobCommandFromMessages(messages, backgroundJobId) ??
       `Job id: ${backgroundJobId}`
     );
   }, [backgroundJobId]);
+
+  return { command, displayId: getDisplayId(backgroundJobId) };
 };


### PR DESCRIPTION
## Summary
This PR improves the user experience for background jobs by assigning a more readable display ID to each job.

- Assigns a sequential display ID (e.g., #1, #2) to each background job.
- The display ID is shown in the tool invocation UI for `start-background-job`, `read-background-job-output`, and `kill-background-job`.
- Background job UUIDs in assistant messages are replaced with their corresponding display IDs for better readability.

## Test plan
Manual testing of background job functionality in the VS Code extension.

🤖 Generated with [Pochi](https://getpochi.com)