### PR TITLE
chore: add CLI-specific tool selection and configuration

### DIFF
--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -94,6 +94,7 @@ export class TaskRunner {
       store: options.store,
       chatClass: Chat,
       waitUntil: options.waitUntil,
+      isCli: true,
       getters: {
         getLLM: () => options.llm,
         getEnvironment: async () => ({

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -42,6 +42,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
   private readonly onStart?: OnStartCallback;
   private readonly getters: PrepareRequestGetters;
   private readonly isSubTask?: boolean;
+  private readonly isCli?: boolean;
   private readonly store: Store;
   private readonly apiClient: PochiApiClient;
   private readonly waitUntil?: (promise: Promise<unknown>) => void;
@@ -50,6 +51,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     onStart?: OnStartCallback;
     getters: PrepareRequestGetters;
     isSubTask?: boolean;
+    isCli?: boolean;
     store: Store;
     apiClient: PochiApiClient;
     waitUntil?: (promise: Promise<unknown>) => void;
@@ -57,6 +59,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     this.onStart = options.onStart;
     this.getters = options.getters;
     this.isSubTask = options.isSubTask;
+    this.isCli = options.isCli;
     this.store = options.store;
     this.apiClient = options.apiClient;
     this.waitUntil = this.waitUntil;
@@ -124,7 +127,10 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       }),
       abortSignal,
       tools: {
-        ...selectClientTools(!!this.isSubTask),
+        ...selectClientTools({
+          isSubTask: !!this.isSubTask,
+          isCli: !!this.isCli,
+        }),
         ...(mcpTools || {}),
       },
       maxRetries: 0,

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -31,6 +31,7 @@ export type LiveChatKitOptions<T> = {
   };
 
   isSubTask?: boolean;
+  isCli?: boolean;
 
   store: Store;
 
@@ -66,6 +67,7 @@ export class LiveChatKit<
     onOverrideMessages,
     getters,
     isSubTask,
+    isCli,
     apiClient,
     ...chatInit
   }: LiveChatKitOptions<T>) {
@@ -76,6 +78,7 @@ export class LiveChatKit<
       onStart: this.onStart,
       getters,
       isSubTask,
+      isCli,
       apiClient,
     });
 

--- a/packages/livekit/src/react.tsx
+++ b/packages/livekit/src/react.tsx
@@ -5,12 +5,15 @@ import { LiveChatKit, type LiveChatKitOptions } from "./chat/live-chat-kit";
 import type { Message } from "./types";
 
 export function useLiveChatKit(
-  props: Omit<LiveChatKitOptions<Chat<Message>>, "store" | "chatClass">,
+  props: Omit<
+    LiveChatKitOptions<Chat<Message>>,
+    "store" | "chatClass" | "isCli"
+  >,
 ) {
   const { store } = useStore();
   // biome-ignore lint/correctness/useExhaustiveDependencies: create new kit on taskId change.
   return useMemo(
-    () => new LiveChatKit({ ...props, store, chatClass: Chat }),
+    () => new LiveChatKit({ ...props, store, isCli: false, chatClass: Chat }),
     [store.storeId, props.taskId],
   );
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -59,33 +59,42 @@ export const ToolsByPermission = {
 
 export const ServerToolApproved = "<server-tool-approved>";
 
-export const ClientTools = {
+const CliTools = {
   applyDiff,
   askFollowupQuestion,
   attemptCompletion,
   executeCommand,
-  startBackgroundJob,
-  readBackgroundJobOutput,
-  killBackgroundJob,
   globFiles,
   listFiles,
   multiApplyDiff,
-  newTask,
   readFile,
   searchFiles,
   todoWrite,
   writeToFile,
 };
 
+export const ClientTools = {
+  ...CliTools,
+  newTask,
+  startBackgroundJob,
+  readBackgroundJobOutput,
+  killBackgroundJob,
+};
+
 export type ClientTools = typeof ClientTools;
 
-export const selectClientTools = (isSubTask: boolean) => {
-  if (!isSubTask) {
-    return {
-      ...ClientTools,
-    };
+export const selectClientTools = (options: {
+  isSubTask: boolean;
+  isCli: boolean;
+}) => {
+  if (options.isCli) {
+    return CliTools;
   }
 
-  const { newTask, ...rest } = ClientTools;
-  return rest;
+  if (options?.isSubTask) {
+    const { newTask, ...rest } = ClientTools;
+    return rest;
+  }
+
+  return ClientTools;
 };


### PR DESCRIPTION
## Summary

This PR updates the tool selection mechanism to support environment-specific configurations, introducing proper separation between CLI and non-CLI environments.

## Changes

- **Refactored tool selection**: Updated `selectClientTools` to accept configuration options instead of a simple boolean
- **Environment-specific tools**: Added `isCli` parameter to distinguish between CLI and non-CLI environments  
- **Tool set separation**: Split tools into CLI-specific and full client toolsets for appropriate functionality
- **Core component updates**: Updated LiveChatKit, FlexibleChatTransport, and React hooks to handle CLI context

## Files Modified
- `packages/tools/src/index.ts` - Refactored tool selection logic
- `packages/cli/src/task-runner.ts` - Added CLI identification
- `packages/livekit/src/chat/flexible-chat-transport.ts` - CLI context support
- `packages/livekit/src/chat/live-chat-kit.ts` - CLI configuration handling
- `packages/livekit/src/react.tsx` - Updated React hooks

This change maintains backward compatibility while enabling proper tool selection based on execution environment.