### PR TITLE
refactor: rename system rules to global rules and add env var support

### DIFF
--- a/packages/common/src/tool-utils/index.ts
+++ b/packages/common/src/tool-utils/index.ts
@@ -13,9 +13,8 @@ export { getSystemInfo } from "./system-info";
 export { GitStatusReader, type GitStatusReaderOptions } from "./git-status";
 export {
   collectCustomRules,
-  SystemRulesFilepath,
-  SystemRulesFileDisplayPath,
-  DefaultWorkspaceRulesFilePaths,
+  WorkspaceRulesFilePaths,
+  GlobalRules,
 } from "./custom-rules";
 export { MaxTerminalOutputSize } from "./limits";
 export { CredentialStorage } from "./credential-storage";

--- a/packages/vscode/src/lib/env.ts
+++ b/packages/vscode/src/lib/env.ts
@@ -1,9 +1,8 @@
 import path from "node:path";
 import { getLogger } from "@getpochi/common";
 import {
-  DefaultWorkspaceRulesFilePaths,
-  SystemRulesFileDisplayPath,
-  SystemRulesFilepath,
+  GlobalRules,
+  WorkspaceRulesFilePaths,
   collectCustomRules as collectCustomRulesImpl,
   getSystemInfo as getSystemInfoImpl,
 } from "@getpochi/common/tool-utils";
@@ -17,7 +16,6 @@ import {
 } from "./fs";
 
 // Path constants - using arrays for consistency
-const WorkspaceRulesFilePaths = DefaultWorkspaceRulesFilePaths;
 const WorkflowsDirPath = [".pochi", "workflows"];
 const logger = getLogger("env");
 
@@ -70,11 +68,14 @@ function getWorkflowsDirectoryUri() {
 
 export async function collectRuleFiles(): Promise<RuleFile[]> {
   const ruleFiles: RuleFile[] = [];
-  if (await isFileExists(vscode.Uri.file(SystemRulesFilepath))) {
-    ruleFiles.push({
-      filepath: SystemRulesFilepath,
-      label: SystemRulesFileDisplayPath,
-    });
+  // Add global rules
+  for (const rule of GlobalRules) {
+    if (await isFileExists(vscode.Uri.file(rule.filePath))) {
+      ruleFiles.push({
+        filepath: rule.filePath,
+        label: rule.label,
+      });
+    }
   }
   for (const uri of getWorkspaceRulesFileUris()) {
     if (await isFileExists(uri)) {
@@ -240,7 +241,7 @@ export async function detectThirdPartyRules(): Promise<string[]> {
  */
 export async function copyThirdPartyRules(
   cursorRulePaths: string[] = [],
-  targetFileName = DefaultWorkspaceRulesFilePaths[0],
+  targetFileName = WorkspaceRulesFilePaths[0],
 ): Promise<void> {
   const workspaceFolder = getWorkspaceFolder();
 


### PR DESCRIPTION
## Summary
- Rename SystemRulesFilepath to GlobalRules with improved structure
- Rename DefaultWorkspaceRulesFilePaths to WorkspaceRulesFilePaths
- Add support for POCHI_CUSTOM_INSTRUCTIONS environment variable
- Update imports and references accordingly

This change improves the organization of rule files by renaming "system rules" to "global rules" which better reflects their purpose. It also adds support for custom instructions via environment variables, providing more flexibility for users.

## Test plan
- [x] Verify that global rules are properly loaded
- [x] Verify that workspace rules are properly loaded
- [x] Verify that POCHI_CUSTOM_INSTRUCTIONS environment variable is properly handled
- [x] All existing tests pass

🤖 Generated with [Pochi](https://getpochi.com)