### PR TITLE
feat(cli): add workflow support to CLI with markdown parsing

### DIFF
--- a/packages/cli/src/lib/__tests__/workflow-loader.test.ts
+++ b/packages/cli/src/lib/__tests__/workflow-loader.test.ts
@@ -59,7 +59,7 @@ describe("workflow-loader", () => {
       const prompt = "Please use /test-workflow for this task";
       const { prompt: result, missingWorkflows } = await replaceWorkflowReferences(prompt, tempDir);
       
-      expect(result).toBe(`Please use <workflow id="test-workflow" path="${workflowPath}">This is a test workflow</workflow> for this task`);
+      expect(result).toBe(`Please use <workflow id="test-workflow" path="${path.relative(tempDir, workflowPath)}">This is a test workflow</workflow> for this task`);
       expect(missingWorkflows).toEqual([]);
     });
 
@@ -76,7 +76,7 @@ describe("workflow-loader", () => {
       const prompt = "Use /workflow1 and then /workflow2";
       const { prompt: result, missingWorkflows } = await replaceWorkflowReferences(prompt, tempDir);
       
-      expect(result).toBe(`Use <workflow id="workflow1" path="${workflowPath1}">Workflow 1 content</workflow> and then <workflow id="workflow2" path="${workflowPath2}">Workflow 2 content</workflow>`);
+      expect(result).toBe(`Use <workflow id="workflow1" path="${path.relative(tempDir, workflowPath1)}">Workflow 1 content</workflow> and then <workflow id="workflow2" path="${path.relative(tempDir, workflowPath2)}">Workflow 2 content</workflow>`);
       expect(missingWorkflows).toEqual([]);
     });
 

--- a/packages/cli/src/lib/__tests__/workflow-loader.test.ts
+++ b/packages/cli/src/lib/__tests__/workflow-loader.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { loadWorkflow, isWorkflowReference, extractWorkflowName } from "../workflow-loader";
+
+describe("workflow-loader", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Create a temporary directory for testing
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pochi-test-"));
+    
+    // Create .pochi/workflows directory structure
+    const workflowsDir = path.join(tempDir, ".pochi", "workflows");
+    await fs.mkdir(workflowsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Clean up the temporary directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("loadWorkflow", () => {
+    it("should load workflow content when workflow exists", async () => {
+      const workflowName = "test-workflow";
+      const workflowContent = "This is a test workflow";
+      const workflowPath = path.join(tempDir, ".pochi", "workflows", `${workflowName}.md`);
+      
+      await fs.writeFile(workflowPath, workflowContent);
+      
+      const result = await loadWorkflow(workflowName, tempDir);
+      expect(result).toBe(workflowContent);
+    });
+
+    it("should return null when workflow does not exist", async () => {
+      const result = await loadWorkflow("non-existent", tempDir);
+      expect(result).toBeNull();
+    });
+
+    it("should return null when workflow file cannot be read", async () => {
+      // Create a directory with the same name as a workflow file would have
+      const workflowPath = path.join(tempDir, ".pochi", "workflows", "test-workflow.md");
+      await fs.mkdir(workflowPath, { recursive: true });
+      
+      const result = await loadWorkflow("test-workflow", tempDir);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("isWorkflowReference", () => {
+    it("should return true for workflow references", () => {
+      expect(isWorkflowReference("/create-pr")).toBe(true);
+      expect(isWorkflowReference("/workflow-name")).toBe(true);
+    });
+
+    it("should return false for regular prompts", () => {
+      expect(isWorkflowReference("Create a PR")).toBe(false);
+      expect(isWorkflowReference("This is a prompt")).toBe(false);
+      expect(isWorkflowReference("")).toBe(false);
+    });
+  });
+
+  describe("extractWorkflowName", () => {
+    it("should extract workflow name from reference", () => {
+      expect(extractWorkflowName("/create-pr")).toBe("create-pr");
+      expect(extractWorkflowName("/workflow-name")).toBe("workflow-name");
+    });
+  });
+});

--- a/packages/cli/src/lib/workflow-loader.ts
+++ b/packages/cli/src/lib/workflow-loader.ts
@@ -1,0 +1,44 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+/**
+ * Loads workflow content from a workflow file
+ * @param workflowName The name of the workflow (without .md extension)
+ * @param cwd The current working directory
+ * @returns The content of the workflow file, or null if not found
+ */
+export async function loadWorkflow(
+  workflowName: string,
+  cwd: string,
+): Promise<string | null> {
+  // Construct the workflow file path
+  const workflowsDir = path.join(cwd, ".pochi", "workflows");
+  const workflowFilePath = path.join(workflowsDir, `${workflowName}.md`);
+
+  try {
+    // Check if the file exists and read its content
+    const content = await fs.readFile(workflowFilePath, "utf-8");
+    return content;
+  } catch (error) {
+    // File doesn't exist or cannot be read
+    return null;
+  }
+}
+
+/**
+ * Checks if a prompt is a workflow reference (starts with /)
+ * @param prompt The prompt to check
+ * @returns True if the prompt is a workflow reference, false otherwise
+ */
+export function isWorkflowReference(prompt: string): boolean {
+  return prompt.startsWith("/");
+}
+
+/**
+ * Extracts the workflow name from a workflow reference
+ * @param prompt The workflow reference (e.g., "/create-pr")
+ * @returns The workflow name (e.g., "create-pr")
+ */
+export function extractWorkflowName(prompt: string): string {
+  return prompt.substring(1); // Remove the leading "/"
+}

--- a/packages/cli/src/lib/workflow-loader.ts
+++ b/packages/cli/src/lib/workflow-loader.ts
@@ -2,12 +2,9 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { constants, prompts } from "@getpochi/common";
 
-function getWorkflowPath(id: string, cwd: string) {
+function getWorkflowPath(id: string) {
   // Construct the workflow file path
-  const workflowsDir = path.join(
-    cwd,
-    ...constants.WorkspaceWorkflowPathSegments,
-  );
+  const workflowsDir = path.join(...constants.WorkspaceWorkflowPathSegments);
   return path.join(workflowsDir, `${id}.md`);
 }
 
@@ -20,7 +17,10 @@ function getWorkflowPath(id: string, cwd: string) {
 async function loadWorkflow(id: string, cwd: string): Promise<string | null> {
   try {
     // Check if the file exists and read its content
-    const content = await fs.readFile(getWorkflowPath(id, cwd), "utf-8");
+    const content = await fs.readFile(
+      path.join(cwd, getWorkflowPath(id)),
+      "utf-8",
+    );
     return content;
   } catch (error) {
     // File doesn't exist or cannot be read
@@ -76,7 +76,7 @@ export async function replaceWorkflowReferences(
       // Replace only the workflow reference, preserving surrounding text
       result = result.replace(
         `/${id}`,
-        prompts.workflow(id, getWorkflowPath(id, cwd), content),
+        prompts.workflow(id, getWorkflowPath(id), content),
       );
     } else {
       missingWorkflows.push(id);

--- a/packages/cli/src/output-renderer.ts
+++ b/packages/cli/src/output-renderer.ts
@@ -4,6 +4,7 @@ import { type ToolUIPart, getToolName, isToolUIPart } from "ai";
 import chalk from "chalk";
 import ora, { type Ora } from "ora";
 import type { NodeChatState } from "./livekit/chat.node";
+import { parseMarkdown } from "@getpochi/common/message-utils";
 
 export class OutputRenderer {
   constructor(state: NodeChatState) {
@@ -56,7 +57,7 @@ export class OutputRenderer {
       if (part.type === "reasoning") {
         this.spinner.prefixText = `💭 Thinking for ${part.text.length} characters`;
       } else if (part.type === "text") {
-        this.spinner.prefixText = `${part.text.trim()}`;
+        this.spinner.prefixText = parseMarkdown(part.text.trim());
       } else {
         const { text, stop, error } = renderToolPart(part);
         this.spinner.prefixText = text;

--- a/packages/cli/src/output-renderer.ts
+++ b/packages/cli/src/output-renderer.ts
@@ -1,10 +1,10 @@
 import { formatters } from "@getpochi/common";
+import { parseMarkdown } from "@getpochi/common/message-utils";
 import type { Message, UITools } from "@getpochi/livekit";
 import { type ToolUIPart, getToolName, isToolUIPart } from "ai";
 import chalk from "chalk";
 import ora, { type Ora } from "ora";
 import type { NodeChatState } from "./livekit/chat.node";
-import { parseMarkdown } from "@getpochi/common/message-utils";
 
 export class OutputRenderer {
   constructor(state: NodeChatState) {

--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -1,2 +1,4 @@
 export const KnownTags = ["file", "workflow", "compact"] as const;
 export const CompactTaskMinTokens = 50_000;
+
+export const WorkspaceWorkflowPathSegments = [".pochi", "workflows"];

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -14,6 +14,7 @@ export const prompts = {
   inlineCompact,
   parseInlineCompact,
   generateTitle,
+  workflow: createWorkflowPrompt,
 };
 
 function createSystemReminder(content: string) {
@@ -50,4 +51,15 @@ function parseInlineCompact(text: string) {
   return {
     summary: match[1],
   };
+}
+
+function createWorkflowPrompt(id: string, path: string, content: string) {
+  // Remove extra newlines from the content
+  let processedContent = content.replace(/\n+/g, "\n");
+  // Escape '<' to avoid </workflow> being interpreted as a closing tag
+  const workflowTagRegex = /<\/?workflow\b[^>]*>/g;
+  processedContent = processedContent.replace(workflowTagRegex, (match) => {
+    return match.replace("<", "&lt;");
+  });
+  return `<workflow id="${id}" path="${path}">${processedContent}</workflow>`;
 }

--- a/packages/common/src/message-utils/index.ts
+++ b/packages/common/src/message-utils/index.ts
@@ -1,4 +1,4 @@
-export { parseTitle } from "./title";
+export { parseTitle, parseMarkdown } from "./markdown";
 export {
   isAssistantMessageWithNoToolCalls,
   isAssistantMessageWithEmptyParts,

--- a/packages/common/src/message-utils/markdown.ts
+++ b/packages/common/src/message-utils/markdown.ts
@@ -16,7 +16,10 @@ function escapeUnknownXMLTags(message: string): string {
 
 export function parseTitle(title: string | null) {
   if (!title?.trim()) return "(empty)";
+  return parseMarkdown(title).slice(0, 256) || "(empty)";
+}
 
+export function parseMarkdown(content: string) {
   const formatXMLTags = (ast: Root) => {
     function processNode(node: Parent) {
       if (node.children) {
@@ -41,7 +44,7 @@ export function parseTitle(title: string | null) {
     processNode(ast);
   };
 
-  const hast = rehype().parse(escapeUnknownXMLTags(title));
+  const hast = rehype().parse(escapeUnknownXMLTags(content));
   formatXMLTags(hast);
-  return toText(hast).slice(0, 256) || "(empty)";
+  return toText(hast);
 }

--- a/packages/vscode-webui/src/components/prompt-form/workflow-mention/extension.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/workflow-mention/extension.tsx
@@ -1,3 +1,4 @@
+import { prompts } from "@getpochi/common";
 import Mention from "@tiptap/extension-mention";
 import { PluginKey } from "@tiptap/pm/state";
 import {
@@ -5,7 +6,6 @@ import {
   NodeViewWrapper,
   ReactNodeViewRenderer,
 } from "@tiptap/react";
-import { prompts } from "@getpochi/common";
 
 /**
  * A React component to render a workflow node in the editor.

--- a/packages/vscode-webui/src/components/prompt-form/workflow-mention/extension.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/workflow-mention/extension.tsx
@@ -5,6 +5,7 @@ import {
   NodeViewWrapper,
   ReactNodeViewRenderer,
 } from "@tiptap/react";
+import { prompts } from "@getpochi/common";
 
 /**
  * A React component to render a workflow node in the editor.
@@ -38,17 +39,9 @@ export const PromptFormWorkflowExtension = Mention.extend({
   },
 
   renderText({ node }) {
-    const { id, path } = node.attrs;
-    const workflowTagRegex = /<\/?workflow\b[^>]*>/g;
-
-    let content: string = node.attrs.content || "error loading workflow";
-    // remove extra newlines from the content
-    content = content.replace(/\n+/g, "\n");
-    // escape '<' to avoid </workflow> being interpreted as a closing tag
-    content = content.replace(workflowTagRegex, (match) => {
-      return match.replace("<", "&lt;");
-    });
-    return `<workflow id="${id}" path="${path}">${content}</workflow>`;
+    const { id, path, content } = node.attrs;
+    const workflowContent: string = content || "error loading workflow";
+    return prompts.workflow(id, path, workflowContent);
   },
 
   addAttributes() {


### PR DESCRIPTION
## Summary
This PR implements workflow support for the CLI as requested in issue #109. Users can now reference workflows directly in the CLI by using `/workflow-name` syntax.
For example:
```bash
pochi -p "/create-pr"
```
This will automatically load the workflow content from `.pochi/workflows/create-pr.md` and use it as the prompt.

Additionally, this PR adds markdown parsing utilities to improve how text is displayed in the CLI output.

## Changes
- Added `workflow-loader` utility to handle loading workflow files
- Updated CLI argument parsing to detect and process workflow references
- Added comprehensive tests for the workflow loading functionality
- Updated help text to document the new feature
- Added markdown parsing utilities for better text rendering in CLI output
- Updated CLI output renderer to use markdown parsing for text parts

## Test plan
- [x] Added unit tests for the workflow loading functionality
- [x] Verified that workflow loading works correctly with existing workflow files
- [x] Verified that proper error messages are shown when workflows are not found
- [x] Verified that existing functionality (regular prompts, stdin piping) still works
- [x] Verified that markdown parsing works correctly in CLI output

Fixes #109
🤖 Generated with [Pochi](https://getpochi.com/)