### PR TITLE
refactor(vscode-webui): replace AbortController with AbortSignal in tool call lifecycle

### DIFF
--- a/packages/vscode-webui/src/features/chat/lib/chat-state/chat.tsx
+++ b/packages/vscode-webui/src/features/chat/lib/chat-state/chat.tsx
@@ -15,7 +15,7 @@ export function ChatContextProvider({ children }: ChatContextProviderProps) {
     previewingToolCalls,
     getToolCallLifeCycle,
     completeToolCalls,
-  } = useToolCallLifeCycles(abortController.current);
+  } = useToolCallLifeCycles(abortController.current.signal);
 
   const value: ChatState = {
     abortController,

--- a/packages/vscode-webui/src/features/chat/lib/use-tool-call-life-cycles.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-tool-call-life-cycles.ts
@@ -4,7 +4,7 @@ import type { ToolCallLifeCycleKey } from "./chat-state/types";
 import { ManagedToolCallLifeCycle } from "./tool-call-life-cycle";
 
 // Hook to manage tool call states
-export function useToolCallLifeCycles(abortController: AbortController) {
+export function useToolCallLifeCycles(abortSignal: AbortSignal) {
   const { store } = useStore();
 
   const [toolCallLifeCycles, setToolCallLifeCycles] = useState<
@@ -61,11 +61,7 @@ export function useToolCallLifeCycles(abortController: AbortController) {
   const getToolCallLifeCycle = useCallback(
     (key: ToolCallLifeCycleKey) => {
       if (!toolCallLifeCyclesRef.current.has(key.toolCallId)) {
-        const lifecycle = new ManagedToolCallLifeCycle(
-          store,
-          key,
-          abortController,
-        );
+        const lifecycle = new ManagedToolCallLifeCycle(store, key, abortSignal);
         toolCallLifeCyclesRef.current.set(key.toolCallId, lifecycle);
         const unsubscribe = lifecycle.onAny((name) => {
           reloadToolCallLifeCycles();
@@ -82,7 +78,7 @@ export function useToolCallLifeCycles(abortController: AbortController) {
         // Guaranteed to exist because we just set it above
       ) as ManagedToolCallLifeCycle;
     },
-    [store, abortController, reloadToolCallLifeCycles],
+    [store, abortSignal, reloadToolCallLifeCycles],
   );
 
   return {


### PR DESCRIPTION
## Summary
- Refactored the tool call lifecycle management to use AbortSignal directly instead of AbortController
- Removed the abort function from the init state type
- Updated all references to use the signal directly
- Simplified the abort logic in the lifecycle management

This provides a cleaner and more direct way to handle abort signals in the tool call lifecycle.

## Test plan
- Verified that all existing tests pass
- Manually tested tool call functionality in the VSCode web UI

🤖 Generated with [Pochi](https://getpochi.com)