### PR TITLE
fix(vscode): prevent diff view from scrolling past last line

### DIFF
--- a/packages/vscode/src/integrations/editor/diff-view.ts
+++ b/packages/vscode/src/integrations/editor/diff-view.ts
@@ -330,7 +330,8 @@ export class DiffView implements vscode.Disposable {
   }
 
   private scrollEditorToLine(line: number) {
-    const scrollLine = line + 4;
+    const lineCount = this.activeDiffEditor.document.lineCount;
+    const scrollLine = Math.min(line + 4, lineCount - 1); // Scroll a few lines ahead for context
     this.activeDiffEditor.revealRange(
       new vscode.Range(scrollLine, 0, scrollLine, 0),
       vscode.TextEditorRevealType.InCenter,


### PR DESCRIPTION
## Summary
This PR fixes a bug in the diff view where scrolling could go past the last line of the document. This was caused by not properly capping the scroll-to line number. The fix ensures that the scroll position is always within the bounds of the document.

## Test plan
Verified locally that the diff view no longer scrolls past the last line.

🤖 Generated with [Pochi](https://getpochi.com)