### PR TITLE
fix(cli): ensure directory exists before writing file

### DIFF
--- a/packages/cli/src/tools/write-to-file.ts
+++ b/packages/cli/src/tools/write-to-file.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as nodePath from "node:path";
 import { fixCodeGenerationOutput } from "@getpochi/common/message-utils";
+import { isFileExists, resolvePath } from "@getpochi/common/tool-utils";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 import type { ToolCallOptions } from "../types";
 
@@ -11,8 +12,12 @@ import type { ToolCallOptions } from "../types";
 export const writeToFile =
   (context: ToolCallOptions): ToolFunctionType<ClientTools["writeToFile"]> =>
   async ({ path, content }) => {
-    const fileUri = nodePath.join(context.cwd, path);
+    const filePath = resolvePath(path, context.cwd);
+    if (!isFileExists(filePath)) {
+      const dirPath = nodePath.dirname(filePath);
+      await fs.mkdir(dirPath, { recursive: true });
+    }
     const processedContent = fixCodeGenerationOutput(content);
-    await fs.writeFile(fileUri, processedContent);
+    await fs.writeFile(filePath, processedContent);
     return { success: true };
   };


### PR DESCRIPTION
## Summary
This PR fixes an issue where the `writeToFile` tool would fail if the target directory did not exist. It now recursively creates the directory path before writing the file, ensuring that files can be created in new or nested locations without errors.

## Test plan
Manual testing was performed to confirm that files can be written to non-existent directories.

🤖 Generated with [Pochi](https://getpochi.com)