### PR TITLE
fix(cli): handle missing workflows gracefully and fix async bug in writeToFile

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -189,8 +189,8 @@ async function parseTaskInput(options: ProgramOpts, program: Program) {
 
     // Handle missing workflows
     if (missingWorkflows.length > 0) {
-      return program.error(
-        `error: Workflow(s) '${missingWorkflows.join(", ")}' not found in .pochi/workflows/`,
+      console.warn(
+        `${chalk.yellow("warning:")} Workflow(s) '${missingWorkflows.join(", ")}' not found in .pochi/workflows/`,
       );
     }
   }

--- a/packages/cli/src/tools/write-to-file.ts
+++ b/packages/cli/src/tools/write-to-file.ts
@@ -13,7 +13,7 @@ export const writeToFile =
   (context: ToolCallOptions): ToolFunctionType<ClientTools["writeToFile"]> =>
   async ({ path, content }) => {
     const filePath = resolvePath(path, context.cwd);
-    if (!isFileExists(filePath)) {
+    if (!(await isFileExists(filePath))) {
       const dirPath = nodePath.dirname(filePath);
       await fs.mkdir(dirPath, { recursive: true });
     }


### PR DESCRIPTION
## Summary

- Changes the error message for missing workflows to a warning, allowing the CLI to continue execution.
- Fixes a bug in the `writeToFile` tool by awaiting the `isFileExists` function, ensuring correct asynchronous behavior.

🤖 Generated with [Pochi](https://getpochi.com)