### PR TITLE
fix: add auto-approve guard to pending model auto-start hook

### DIFF
--- a/packages/vscode-webui/src/features/retry/hooks/use-pending-model-auto-start.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-pending-model-auto-start.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 
+import { useAutoApproveGuard } from "@/features/chat";
 import type { Task } from "@getpochi/livekit";
 import { ReadyForRetryError } from "./use-ready-for-retry-error";
 
@@ -15,12 +16,14 @@ export const usePendingModelAutoStart = ({
   enabled,
 }: UseEventAutoStartOptions) => {
   const init = task?.status === "pending-model";
+  const autoApproveGuard = useAutoApproveGuard();
 
   const initStarted = useRef(false);
   useEffect(() => {
     if (enabled && init && !initStarted.current) {
       initStarted.current = true;
+      autoApproveGuard.current = true;
       retry(new ReadyForRetryError("ready"));
     }
-  }, [init, retry, enabled]);
+  }, [init, retry, enabled, autoApproveGuard]);
 };


### PR DESCRIPTION
## Summary

- Added useAutoApproveGuard hook to ensure tasks have proper approval context when auto-starting pending model tasks
- Set autoApproveGuard.current = true when automatically starting pending model tasks to prevent permission issues
- Updated useEffect dependencies to include autoApproveGuard for proper reactivity

## Why

When tasks are automatically started from pending-model state, they need to have the proper approval context to ensure subsequent operations (like file modifications) are allowed to proceed without manual approval prompts.

## Test plan

- [ ] Verify pending model tasks auto-start correctly
- [ ] Confirm subsequent operations have appropriate approval context
- [ ] Ensure no regression in manual task approval workflow

🤖 Generated with [Pochi](https://getpochi.com)
