### PR TITLE
fix(webui): debounce error message to prevent blinking

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/error-message-view.tsx
+++ b/packages/vscode-webui/src/features/chat/components/error-message-view.tsx
@@ -1,13 +1,21 @@
 import { ErrorMessage } from "@/components/error-message";
+import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { PochiApiErrors } from "@getpochi/common/pochi-api";
 import { ExternalLinkIcon } from "lucide-react";
+import { useEffect } from "react";
 
 export function ErrorMessageView({
   error,
 }: { error: { message: string } | undefined }) {
+  const [debouncedError, setDebouncedError] = useDebounceState(error, 300);
+
+  useEffect(() => {
+    setDebouncedError(error);
+  }, [error, setDebouncedError]);
+
   return (
     <ErrorMessage
-      error={error}
+      error={debouncedError}
       formatter={(e) => {
         if (e.message === PochiApiErrors.ReachedCreditLimit) {
           return (


### PR DESCRIPTION
## Screen record
https://jam.dev/c/1872f95c-90f6-4c93-9e2f-dab3501b3249

## Summary
- This change debounces the error state in `ErrorMessageView` to prevent the error message from blinking when it updates frequently.

## Test plan
- Manually verified that the error message no longer blinks on rapid updates.

🤖 Generated with [Pochi](https://getpochi.com)