### PR TITLE
chore: change model configuration from array to record structure

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -30,16 +30,15 @@
                 "type": "string"
               },
               "models": {
-                "type": "array",
-                "items": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
                   "type": "object",
                   "properties": {
                     "name": {
                       "description": "Display name of the model, e.g., \"GPT-4o\"",
-                      "type": "string"
-                    },
-                    "id": {
-                      "description": "Identifier for the model, e.g., \"gpt-4o\"",
                       "type": "string"
                     },
                     "maxTokens": {
@@ -55,7 +54,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["id", "maxTokens", "contextWindow"],
+                  "required": ["maxTokens", "contextWindow"],
                   "additionalProperties": false
                 }
               },
@@ -83,16 +82,15 @@
                 "type": "string"
               },
               "models": {
-                "type": "array",
-                "items": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
                   "type": "object",
                   "properties": {
                     "name": {
                       "description": "Display name of the model, e.g., \"GPT-4o\"",
-                      "type": "string"
-                    },
-                    "id": {
-                      "description": "Identifier for the model, e.g., \"gpt-4o\"",
                       "type": "string"
                     },
                     "maxTokens": {
@@ -108,7 +106,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["id", "maxTokens", "contextWindow"],
+                  "required": ["maxTokens", "contextWindow"],
                   "additionalProperties": false
                 }
               },
@@ -136,16 +134,15 @@
                 "type": "string"
               },
               "models": {
-                "type": "array",
-                "items": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
                   "type": "object",
                   "properties": {
                     "name": {
                       "description": "Display name of the model, e.g., \"GPT-4o\"",
-                      "type": "string"
-                    },
-                    "id": {
-                      "description": "Identifier for the model, e.g., \"gpt-4o\"",
                       "type": "string"
                     },
                     "maxTokens": {
@@ -161,7 +158,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["id", "maxTokens", "contextWindow"],
+                  "required": ["maxTokens", "contextWindow"],
                   "additionalProperties": false
                 }
               },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -206,7 +206,7 @@ function createLLMConfig({
   const modelId = options.model.slice(sep + 1);
 
   const modelProvider = pochiConfig.value.providers?.[modelProviderId];
-  const modelSetting = modelProvider?.models.find((x) => x.id === modelId);
+  const modelSetting = modelProvider?.models?.[modelId];
 
   if (!modelProvider) {
     return {

--- a/packages/common/src/configuration/model.ts
+++ b/packages/common/src/configuration/model.ts
@@ -5,13 +5,13 @@ const BaseModelSettings = z.object({
     .string()
     .optional()
     .describe('Model provider name, e.g., "OpenAI", "Anthropic", etc.'),
-  models: z.array(
+  models: z.record(
+    z.string(),
     z.object({
       name: z
         .string()
         .optional()
         .describe('Display name of the model, e.g., "GPT-4o"'),
-      id: z.string().describe('Identifier for the model, e.g., "gpt-4o"'),
       maxTokens: z
         .number()
         .describe("Maximum number of generated tokens for the model"),

--- a/packages/docs/content/docs/models.mdx
+++ b/packages/docs/content/docs/models.mdx
@@ -30,13 +30,12 @@ Pochi allows you to configure any LLM provider that offers an OpenAI-compatible 
     "groq": {
       "apiKey": "your_api_key",
       "baseUrl": "https://api.groq.com/openai/v1",
-      "models": [
-        {
-          "id": "moonshotai/kimi-k2-instruct",
+      "models": {
+        "moonshotai/kimi-k2-instruct": {
           "contextWindow": 131072,
           "maxTokens": 8000
         }
-      ]
+      }
     }
   }
 }

--- a/packages/vscode-webui/src/features/settings/components/sections/model-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/model-section.tsx
@@ -212,7 +212,7 @@ export const ModelSection: React.FC<ModelSectionProps> = ({ user }) => {
             Object.entries(customModelSettings).map(
               ([providerId, provider]) =>
                 provider.models &&
-                provider.models.length > 0 && (
+                Object.keys(provider.models).length > 0 && (
                   <div key={providerId} className="ml-1">
                     <AccordionSection
                       title={
@@ -244,23 +244,25 @@ export const ModelSection: React.FC<ModelSectionProps> = ({ user }) => {
                       defaultOpen
                     >
                       <div className="space-y-2">
-                        {provider.models.map((model) => (
-                          <div
-                            key={model.id}
-                            className="group rounded-md border p-2"
-                          >
-                            <div className="flex items-center justify-between">
-                              <div className="flex flex-1 items-center gap-2 overflow-x-hidden">
-                                <div className="flex size-6 shrink-0 items-center justify-center">
-                                  <DotIcon className="size-6 text-muted-foreground" />
+                        {Object.entries(provider.models).map(
+                          ([modelId, model]) => (
+                            <div
+                              key={modelId}
+                              className="group rounded-md border p-2"
+                            >
+                              <div className="flex items-center justify-between">
+                                <div className="flex flex-1 items-center gap-2 overflow-x-hidden">
+                                  <div className="flex size-6 shrink-0 items-center justify-center">
+                                    <DotIcon className="size-6 text-muted-foreground" />
+                                  </div>
+                                  <span className="truncate font-semibold">
+                                    {model.name ?? modelId}
+                                  </span>
                                 </div>
-                                <span className="truncate font-semibold">
-                                  {model.name ?? model.id}
-                                </span>
                               </div>
                             </div>
-                          </div>
-                        ))}
+                          ),
+                        )}
                       </div>
                     </AccordionSection>
                   </div>

--- a/packages/vscode-webui/src/features/settings/hooks/use-models.ts
+++ b/packages/vscode-webui/src/features/settings/hooks/use-models.ts
@@ -74,20 +74,22 @@ export function useModels() {
           ([providerId, modelSetting]) => {
             const { models, ...providerWithoutId } = modelSetting;
             const provider = { ...providerWithoutId, id: providerId };
-            return models.map<DisplayModel>((model) => {
-              return {
-                ...model,
-                type: "byok" as const,
-                name: `${provider.name ?? provider.id}/${model.name ?? model.id}`,
-                id: `${provider.id}/${model.id}`,
-                modelId: model.id,
-                contextWindow: model.contextWindow,
-                maxTokens: model.maxTokens,
-                useToolCallMiddleware: model.useToolCallMiddleware,
-                costType: "basic",
-                provider,
-              };
-            });
+            return Object.entries(models).map<DisplayModel>(
+              ([modelId, model]) => {
+                return {
+                  ...model,
+                  type: "byok" as const,
+                  name: `${provider.name ?? provider.id}/${model.name ?? modelId}`,
+                  id: `${provider.id}/${modelId}`,
+                  modelId: modelId,
+                  contextWindow: model.contextWindow,
+                  maxTokens: model.maxTokens,
+                  useToolCallMiddleware: model.useToolCallMiddleware,
+                  costType: "basic",
+                  provider,
+                };
+              },
+            );
           },
         )
       : undefined;

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -410,18 +410,16 @@ export class CommandManager implements vscode.Disposable {
         kind: "openai",
         baseURL: "https://api.openai.com/v1",
         apiKey: "your api key here",
-        models: [
-          {
-            id: "gpt-4.1",
+        models: {
+          "gpt-4.1": {
             contextWindow: 1047576,
             maxTokens: 32768,
           },
-          {
-            id: "o4-mini",
+          "o4-mini": {
             contextWindow: 200000,
             maxTokens: 100000,
           },
-        ],
+        },
       },
     } satisfies Record<string, CustomModelSetting>;
 


### PR DESCRIPTION
## Summary
- Update model configuration schema to use record/object structure instead of array
- Modify CLI, WebUI, and VSCode integration to work with new record-based model configuration
- Update documentation to reflect the new configuration format

## Changes Made
- Updated `packages/common/src/configuration/model.ts` to change models from array to record structure
- Modified `packages/cli/src/cli.ts` to access models using record syntax
- Updated `packages/vscode-webui/src/features/settings/components/sections/model-section.tsx` to handle record-based models
- Updated `packages/vscode-webui/src/features/settings/hooks/use-models.ts` to process record-based models
- Updated `packages/vscode/src/integrations/command.ts` example configuration
- Updated `packages/docs/content/docs/models.mdx` documentation
- Updated `assets/config.schema.json` configuration schema

## Test plan
- [x] All existing tests pass
- [x] Configuration schema validation works correctly
- [x] WebUI displays models correctly with new structure
- [x] CLI can parse and use new configuration format

🤖 Generated with [Pochi](https://getpochi.com)