### PR TITLE
feat(models): support use access token for google-vertex-tuning model

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -121,9 +121,17 @@
               "credentials": {
                 "description": "Credentials for the vertex model.",
                 "type": "string"
+              },
+              "projectId": {
+                "description": "Project ID for the vertex model.",
+                "type": "string"
+              },
+              "accessToken": {
+                "description": "Access token for the vertex model.",
+                "type": "string"
               }
             },
-            "required": ["models", "kind", "location", "credentials"],
+            "required": ["models", "kind", "location"],
             "additionalProperties": false
           },
           {

--- a/bun.lock
+++ b/bun.lock
@@ -295,6 +295,7 @@
   ],
   "patchedDependencies": {
     "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch",
+    "@ai-sdk/google-vertex@3.0.8": "patches/@ai-sdk%2Fgoogle-vertex@3.0.8.patch",
     "ai@5.0.15": "patches/ai@5.0.15.patch",
     "better-auth@1.2.9": "patches/better-auth@1.2.9.patch",
   },

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@better-auth/stripe@1.2.9": "patches/@better-auth%2Fstripe@1.2.9.patch",
     "@daveyplate/better-auth-ui@2.0.12": "patches/@daveyplate%2Fbetter-auth-ui@2.0.12.patch",
     "ai@5.0.15": "patches/ai@5.0.15.patch",
-    "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch"
+    "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch",
+    "@ai-sdk/google-vertex@3.0.8": "patches/@ai-sdk%2Fgoogle-vertex@3.0.8.patch"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -245,10 +245,12 @@ function createLLMConfig({
     return {
       type: "google-vertex-tuning",
       modelId,
-      credentials: modelProvider.credentials,
       contextWindow: modelSetting.contextWindow,
       maxOutputTokens: modelSetting.maxTokens,
       location: modelProvider.location,
+      credentials: modelProvider.credentials,
+      projectId: modelProvider.projectId,
+      accessToken: modelProvider.accessToken,
     };
   }
 

--- a/packages/common/src/configuration/model.ts
+++ b/packages/common/src/configuration/model.ts
@@ -40,7 +40,18 @@ const OpenAIModelSettings = BaseModelSettings.extend({
 const GoogleVertexTuningModelSettings = BaseModelSettings.extend({
   kind: z.literal("google-vertex-tuning"),
   location: z.string().describe("Location of the model, e.g., us-central1"),
-  credentials: z.string().describe("Credentials for the vertex model."),
+  credentials: z
+    .string()
+    .optional()
+    .describe("Credentials for the vertex model."),
+  projectId: z.string().optional().describe("Project ID for the vertex model."),
+  accessToken: z
+    .string()
+    .optional()
+    .describe("Access token for the vertex model."),
+}).refine((data) => data.credentials || (data.projectId && data.accessToken), {
+  message:
+    "Either credentials or both projectId and accessToken must be provided.",
 });
 
 const AiGatewayModelSettings = BaseModelSettings.extend({

--- a/packages/livekit/src/chat/models/google-vertex-tuning.ts
+++ b/packages/livekit/src/chat/models/google-vertex-tuning.ts
@@ -1,23 +1,37 @@
-import { createVertex } from "@ai-sdk/google-vertex/edge";
+import {
+  createVertex,
+  createVertexWithoutCredentials,
+} from "@ai-sdk/google-vertex/edge";
 import { wrapLanguageModel } from "ai";
 import type { RequestData } from "../../types";
 
 export function createGoogleVertexTuningModel(
   llm: Extract<RequestData["llm"], { type: "google-vertex-tuning" }>,
 ) {
-  const credentials = JSON.parse(llm.credentials);
+  const location = llm.location;
+  const credentials = llm.credentials ? JSON.parse(llm.credentials) : undefined;
+  const projectId = llm.projectId || credentials?.project_id;
+  const accessToken = llm.accessToken;
+  const baseURL = `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/publishers/google`;
 
-  const vertexFineTuning = createVertex({
-    project: credentials.project_id,
-    location: "us-central1",
-    baseURL: `https://aiplatform.googleapis.com/v1/projects/${credentials.project_id}/locations/${llm.location}/publishers/google`,
-    googleCredentials: {
-      clientEmail: credentials.client_email,
-      privateKeyId: credentials.private_key_id,
-      privateKey: credentials.private_key,
-    },
-    fetch: patchedFetchForFinetune as unknown as typeof globalThis.fetch,
-  });
+  const vertexFineTuning = accessToken
+    ? createVertexWithoutCredentials({
+        project: projectId,
+        location,
+        baseURL,
+        fetch: createPatchedFetchForFinetune(accessToken),
+      })
+    : createVertex({
+        project: projectId,
+        location,
+        baseURL,
+        googleCredentials: {
+          clientEmail: credentials.client_email,
+          privateKeyId: credentials.private_key_id,
+          privateKey: credentials.private_key,
+        },
+        fetch: createPatchedFetchForFinetune(),
+      });
   return wrapLanguageModel({
     model: vertexFineTuning(llm.modelId),
     middleware: {
@@ -30,28 +44,36 @@ export function createGoogleVertexTuningModel(
   });
 }
 
-function patchedFetchForFinetune(
-  requestInfo: Request | URL | string,
-  requestInit?: RequestInit,
-): Promise<Response> {
+function createPatchedFetchForFinetune(accessToken?: string | undefined) {
   function patchString(str: string) {
     return str.replace("/publishers/google/models", "/endpoints");
   }
 
-  if (requestInfo instanceof URL) {
-    const patchedUrl = new URL(requestInfo);
-    patchedUrl.pathname = patchString(patchedUrl.pathname);
-    return fetch(patchedUrl, requestInit);
-  }
-  if (requestInfo instanceof Request) {
-    const patchedUrl = patchString(requestInfo.url);
-    const patchedRequest = new Request(patchedUrl, requestInfo);
-    return fetch(patchedRequest, requestInit);
-  }
-  if (typeof requestInfo === "string") {
-    const patchedUrl = patchString(requestInfo);
-    return fetch(patchedUrl, requestInit);
-  }
-  // Should never happen
-  throw new Error(`Unexpected requestInfo type: ${typeof requestInfo}`);
+  return (requestInfo: Request | URL | string, requestInit?: RequestInit) => {
+    const headers = new Headers(requestInit?.headers);
+    if (accessToken) {
+      headers.append("Authorization", `Bearer ${accessToken}`);
+    }
+    const patchedRequestInit = {
+      ...requestInit,
+      headers,
+    };
+
+    if (requestInfo instanceof URL) {
+      const patchedUrl = new URL(requestInfo);
+      patchedUrl.pathname = patchString(patchedUrl.pathname);
+      return fetch(patchedUrl, patchedRequestInit);
+    }
+    if (requestInfo instanceof Request) {
+      const patchedUrl = patchString(requestInfo.url);
+      const patchedRequest = new Request(patchedUrl, requestInfo);
+      return fetch(patchedRequest, patchedRequestInit);
+    }
+    if (typeof requestInfo === "string") {
+      const patchedUrl = patchString(requestInfo);
+      return fetch(patchedUrl, patchedRequestInit);
+    }
+    // Should never happen
+    throw new Error(`Unexpected requestInfo type: ${typeof requestInfo}`);
+  };
 }

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -47,7 +47,9 @@ const RequestData = z.object({
       type: z.literal("google-vertex-tuning"),
       location: z.string(),
       modelId: z.string(),
-      credentials: z.string(),
+      credentials: z.string().optional(),
+      projectId: z.string().optional(),
+      accessToken: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -109,6 +109,8 @@ function useLLM(): React.RefObject<LLMRequestData> {
         type: "google-vertex-tuning" as const,
         location: provider.location,
         credentials: provider.credentials,
+        projectId: provider.projectId,
+        accessToken: provider.accessToken,
         modelId: selectedModel.modelId,
         maxOutputTokens: selectedModel.maxTokens,
         contextWindow: selectedModel.contextWindow,

--- a/patches/@ai-sdk%2Fgoogle-vertex@3.0.8.patch
+++ b/patches/@ai-sdk%2Fgoogle-vertex@3.0.8.patch
@@ -1,0 +1,58 @@
+diff --git a/dist/edge/index.d.mts b/dist/edge/index.d.mts
+index eb20a2cea785f8c34a2e8dfc0aae04caaafe48ff..9efcd462ed67c663a465e3fc3cfc5d68f1c7f19b 100644
+--- a/dist/edge/index.d.mts
++++ b/dist/edge/index.d.mts
+@@ -76,9 +76,10 @@ interface GoogleVertexProviderSettings extends GoogleVertexProviderSettings$1 {
+     googleCredentials?: GoogleCredentials;
+ }
+ declare function createVertex(options?: GoogleVertexProviderSettings): GoogleVertexProvider;
++declare function createVertexWithoutCredentials(options?: GoogleVertexProviderSettings$1): GoogleVertexProvider;
+ /**
+ Default Google Vertex AI provider instance.
+  */
+ declare const vertex: GoogleVertexProvider;
+ 
+-export { type GoogleVertexProvider, type GoogleVertexProviderSettings, createVertex, vertex };
++export { type GoogleVertexProvider, type GoogleVertexProviderSettings, createVertex, createVertexWithoutCredentials, vertex };
+diff --git a/dist/edge/index.d.ts b/dist/edge/index.d.ts
+index eb20a2cea785f8c34a2e8dfc0aae04caaafe48ff..9efcd462ed67c663a465e3fc3cfc5d68f1c7f19b 100644
+--- a/dist/edge/index.d.ts
++++ b/dist/edge/index.d.ts
+@@ -76,9 +76,10 @@ interface GoogleVertexProviderSettings extends GoogleVertexProviderSettings$1 {
+     googleCredentials?: GoogleCredentials;
+ }
+ declare function createVertex(options?: GoogleVertexProviderSettings): GoogleVertexProvider;
++declare function createVertexWithoutCredentials(options?: GoogleVertexProviderSettings$1): GoogleVertexProvider;
+ /**
+ Default Google Vertex AI provider instance.
+  */
+ declare const vertex: GoogleVertexProvider;
+ 
+-export { type GoogleVertexProvider, type GoogleVertexProviderSettings, createVertex, vertex };
++export { type GoogleVertexProvider, type GoogleVertexProviderSettings, createVertex, createVertexWithoutCredentials, vertex };
+diff --git a/dist/edge/index.js b/dist/edge/index.js
+index c7e1dff34b999c6ff291b3653524e6bd35f8ef45..cb33708d6caf8fe76287762837d0b30158368440 100644
+--- a/dist/edge/index.js
++++ b/dist/edge/index.js
+@@ -464,6 +464,7 @@ var vertex = createVertex2();
+ // Annotate the CommonJS export names for ESM import in node:
+ 0 && (module.exports = {
+   createVertex,
++  createVertexWithoutCredentials: createVertex,
+   vertex
+ });
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/dist/edge/index.mjs b/dist/edge/index.mjs
+index 0e7db3e9581a8465a383bd01e849e04170de4590..a6538714ac4a79331502a2226b13e94b79dd3023 100644
+--- a/dist/edge/index.mjs
++++ b/dist/edge/index.mjs
+@@ -454,6 +454,7 @@ function createVertex2(options = {}) {
+ var vertex = createVertex2();
+ export {
+   createVertex2 as createVertex,
++  createVertex as createVertexWithoutCredentials,
+   vertex
+ };
+ //# sourceMappingURL=index.mjs.map
+\ No newline at end of file


### PR DESCRIPTION
## Summary
This commit introduces support for using an access token to authenticate with Google Vertex AI tuning models. This provides a more flexible and secure authentication method compared to using static credentials.

Changes include:
- Updating the model configuration to accept an `accessToken`.
- Passing the `accessToken` to the Vertex AI client.
- Applying a patch to `@ai-sdk/google-vertex` to enable this functionality.

## Test plan
- Manually tested with a valid Google Vertex AI access token.

🤖 Generated with [Pochi](https://getpochi.com)