### PR TITLE
chore(config): loose type validation for providers / mcp

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -26,7 +26,7 @@
             "type": "object",
             "properties": {
               "name": {
-                "description": "Model provider name, e.g., \"OpenAI\", \"Anthropic\", etc.",
+                "description": "Display name of the provider, e.g., \"OpenAI\", \"Anthropic\", etc.",
                 "type": "string"
               },
               "models": {
@@ -80,7 +80,7 @@
             "type": "object",
             "properties": {
               "name": {
-                "description": "Model provider name, e.g., \"OpenAI\", \"Anthropic\", etc.",
+                "description": "Display name of the provider, e.g., \"OpenAI\", \"Anthropic\", etc.",
                 "type": "string"
               },
               "models": {
@@ -142,7 +142,7 @@
             "type": "object",
             "properties": {
               "name": {
-                "description": "Model provider name, e.g., \"OpenAI\", \"Anthropic\", etc.",
+                "description": "Display name of the provider, e.g., \"OpenAI\", \"Anthropic\", etc.",
                 "type": "string"
               },
               "models": {

--- a/packages/common/src/configuration/gen-schema.ts
+++ b/packages/common/src/configuration/gen-schema.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as z from "zod/v4";
-import { PochiConfig } from "./types";
+import { makePochiConfig } from "./types";
 
-const content = JSON.stringify(z.toJSONSchema(PochiConfig), null, 2);
+const content = JSON.stringify(z.toJSONSchema(makePochiConfig(true)), null, 2);
 
 fs.writeFileSync("./assets/config.schema.json", content);

--- a/packages/common/src/configuration/model.ts
+++ b/packages/common/src/configuration/model.ts
@@ -4,7 +4,9 @@ const BaseModelSettings = z.object({
   name: z
     .string()
     .optional()
-    .describe('Model provider name, e.g., "OpenAI", "Anthropic", etc.'),
+    .describe(
+      'Display name of the provider, e.g., "OpenAI", "Anthropic", etc.',
+    ),
   models: z.record(
     z.string(),
     z.object({

--- a/packages/common/src/configuration/types.ts
+++ b/packages/common/src/configuration/types.ts
@@ -12,8 +12,24 @@ export const PochiConfig = z.object({
       pochiToken: z.string().optional(),
     })
     .optional(),
-  providers: z.record(z.string(), CustomModelSetting).optional(),
-  mcp: z.record(z.string(), McpServerConfig).optional(),
+  providers: z
+    .record(z.string(), CustomModelSetting.optional().catch(undefined))
+    .transform(removeUndefined)
+    .optional(),
+  mcp: z
+    .record(z.string(), McpServerConfig.optional().catch(undefined))
+    .transform(removeUndefined)
+    .optional(),
 });
 
 export type PochiConfig = z.infer<typeof PochiConfig>;
+
+function removeUndefined<T>(
+  obj: Record<string, T | undefined>,
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(
+      (entry): entry is [string, T] => entry[1] !== undefined,
+    ),
+  );
+}

--- a/packages/common/src/configuration/types.ts
+++ b/packages/common/src/configuration/types.ts
@@ -2,25 +2,7 @@ import z from "zod/v4";
 import { McpServerConfig } from "./mcp";
 import { CustomModelSetting } from "./model";
 
-export const PochiConfig = z.object({
-  $schema: z
-    .string()
-    .default("https://getpochi.com/config.schema.json")
-    .optional(),
-  credentials: z
-    .object({
-      pochiToken: z.string().optional(),
-    })
-    .optional(),
-  providers: z
-    .record(z.string(), CustomModelSetting.optional().catch(undefined))
-    .transform(removeUndefined)
-    .optional(),
-  mcp: z
-    .record(z.string(), McpServerConfig.optional().catch(undefined))
-    .transform(removeUndefined)
-    .optional(),
-});
+export const PochiConfig = makePochiConfig();
 
 export type PochiConfig = z.infer<typeof PochiConfig>;
 
@@ -32,4 +14,34 @@ function removeUndefined<T>(
       (entry): entry is [string, T] => entry[1] !== undefined,
     ),
   );
+}
+
+function looseRecord<T>(
+  schema: z.ZodType<T>,
+  strict: boolean,
+): z.ZodType<Record<string, T>> {
+  if (strict) {
+    // transform is not supported in toJSONSchema, thus we need strict to control the behavior between runtime / json schema gen.
+    return z.record(z.string(), schema);
+  }
+
+  return z
+    .record(z.string(), schema.optional().catch(undefined))
+    .transform(removeUndefined);
+}
+
+export function makePochiConfig(strict = false) {
+  return z.object({
+    $schema: z
+      .string()
+      .default("https://getpochi.com/config.schema.json")
+      .optional(),
+    credentials: z
+      .object({
+        pochiToken: z.string().optional(),
+      })
+      .optional(),
+    providers: looseRecord(CustomModelSetting, strict).optional(),
+    mcp: looseRecord(McpServerConfig, strict).optional(),
+  });
 }


### PR DESCRIPTION
This PR improves the configuration schema handling and documentation clarity.

- Updated model provider name description for better clarity
- Restructured PochiConfig creation to use a helper function for runtime vs schema generation
- Enhanced handling of optional configuration entries
- Fixed JSON schema generation compatibility

All tests pass and schema generation works correctly.