### PR TITLE
docs(cli): add install using homebrew

### DIFF
--- a/packages/docs/content/docs/cli.mdx
+++ b/packages/docs/content/docs/cli.mdx
@@ -14,6 +14,13 @@ Pochi offers a command-line interface (CLI) that allows you to run an AI agent d
 curl -fsSL https://getpochi.com/install.sh | bash
 ```
 
+Alternatively, you can install pochi using Homebrew:
+
+```bash
+tap tabbyml/pochi
+brew install pochi
+```
+
 ## Authentication
 
 The Pochi CLI uses the same authentication credentials as the VS Code extension for Pochi's cloud services. When you sign in through the VS Code extension, the CLI automatically reuses these credentials.

--- a/packages/docs/content/docs/cli.mdx
+++ b/packages/docs/content/docs/cli.mdx
@@ -17,8 +17,7 @@ curl -fsSL https://getpochi.com/install.sh | bash
 Alternatively, you can install pochi using Homebrew:
 
 ```bash
-tap tabbyml/pochi
-brew install pochi
+brew install tabbyml/pochi/pochi
 ```
 
 ## Authentication


### PR DESCRIPTION
## Summary
This PR adds documentation for installing the Pochi CLI using Homebrew.

## Test plan
N/A

🤖 Generated with [Pochi](https://getpochi.com)