### PR TITLE
fix(common): add environment-specific system reminder filtering

### DIFF
--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -177,9 +177,9 @@ export function injectEnvironment(
   } satisfies TextUIPart;
 
   const parts =
-    // Remove existing system reminders.
+    // Remove existing environment system reminders.
     messageToInject.parts.filter(
-      (x) => x.type !== "text" || !prompts.isSystemReminder(x.text),
+      (x) => x.type !== "text" || !prompts.isEnvironmentSystemReminder(x.text),
     ) || [];
   const lastTextPartIndex = parts.findLastIndex(
     (parts) => parts.type === "text",

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -9,6 +9,7 @@ export const prompts = {
   environment: createEnvironmentPrompt,
   createSystemReminder,
   isSystemReminder,
+  isEnvironmentSystemReminder,
   isCompact,
   compact: createCompactPrompt,
   inlineCompact,
@@ -31,6 +32,12 @@ function isSystemReminder(content: string) {
     (content.startsWith("<environment-details>") &&
       content.endsWith("</environment-details>"))
   );
+}
+
+function isEnvironmentSystemReminder(content: string) {
+  // FIXME(meng): this is really a hack to detect if the system reminder is for environment details
+  // We should have a better way to detect this
+  return isSystemReminder(content) && content.includes("# TODOs");
 }
 
 function isCompact(content: string) {


### PR DESCRIPTION
## Summary
- Add a new function `isEnvironmentSystemReminder` to specifically identify environment-related system reminders (those that include "# TODOs")
- Update the `injectEnvironment` function to use this more specific function instead of the general `isSystemReminder` to better control which system reminders are filtered out
- Export the new function in the prompts index

This change allows for more precise control over system reminders in the environment context, enabling better customization of what gets filtered out when injecting environment information.

## Test plan
- [x] Verify that the new `isEnvironmentSystemReminder` function correctly identifies environment system reminders
- [x] Confirm that `injectEnvironment` properly filters out environment system reminders while preserving other content
- [x] Ensure existing functionality remains unaffected

🤖 Generated with [Pochi](https://getpochi.com)