### PR TITLE
ci(release): add support for publish cli to npm

### DIFF
--- a/.github/workflows/release-pochi-cli.yml
+++ b/.github/workflows/release-pochi-cli.yml
@@ -34,6 +34,22 @@ jobs:
             echo "This is a stable release version: $version"
           fi
 
+      - name: Publish to npm
+        if: github.repository_owner == 'TabbyML' && startsWith(github.ref, 'refs/tags/cli@')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd packages/cli
+          # Configure npm auth
+          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
+
+          # Publish to npm with appropriate tag
+          if [ "${{ steps.release_info.outputs.is_prerelease }}" = "true" ]; then
+            npm publish --tag beta --access public
+          else
+            npm publish --access public
+          fi
+
       - name: Release Versioned
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/cli@')

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,22 @@
+# [Pochi (Research Preview)](https://www.getpochi.com/)
+
+Your full-stack AI teammate, in research preview from TabbyML.
+Pochi is built for code, yet much more than coding.
+It's the AI agent that thinks, communicates, and works like a real engineer, for your day-to-day dev workflow.
+
+## 🚀 Start Pochi Today
+
+Install the Pochi CLI and experience what it's like to work with an AI teammate that truly gets your workflow and delivers the results.
+Pochi helps with everything from writing and refactoring code to planning tasks and dev operation - all within your native workflow.
+
+Learn more about Pochi in our official [documentation](https://docs.getpochi.com/).
+
+## 📬 Stay Connected
+
+- Join our [Discord](https://getpochi.com/discord) – ask questions and share feedback
+- Follow us on [X](https://getpochi.com/x) – get the latest updates, tips, and sneak previews
+
+---
+
+- [Terms of Service](https://www.getpochi.com/term-of-service)
+- [Privacy Policy](https://www.getpochi.com/privacy-policy)


### PR DESCRIPTION
1. please help to add action secret: NPM_TOKEN @wsxiaoys 
2. pochi could be install by `npm install -g @getpochi/cli`

fix https://github.com/TabbyML/pochi/issues/126