### PR TITLE
feat(webui): improve auto-complete trigger and interaction

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -476,7 +476,11 @@ export function FormEditor({
       if (sessionState.input) {
         try {
           const content = JSON.parse(sessionState.input);
-          editor.commands.setContent(content, true);
+          editor.view.dispatch(
+            editor.state.tr
+              .setMeta("docChangeEvent", { event: "restoreSession" })
+              .replaceWith(0, editor.state.doc.content.size, content),
+          );
         } catch (error) {
           // ignore JSON parse errors
         }

--- a/packages/vscode-webui/src/components/prompt-form/submit-history-extension.ts
+++ b/packages/vscode-webui/src/components/prompt-form/submit-history-extension.ts
@@ -138,11 +138,9 @@ export const SubmitHistoryExtension = Extension.create<
                   JSON.parse(storage.currentDraft),
                 );
 
-                const transaction = tr.replaceWith(
-                  0,
-                  tr.doc.content.size,
-                  node,
-                );
+                const transaction = tr
+                  .replaceWith(0, tr.doc.content.size, node)
+                  .setMeta("docChangeEvent", { event: "submitHistory" });
 
                 if (dispatch) {
                   dispatch(transaction);
@@ -170,7 +168,9 @@ export const SubmitHistoryExtension = Extension.create<
               );
 
               // Use transaction to replace content safely and position cursor appropriately
-              const transaction = tr.replaceWith(0, tr.doc.content.size, node);
+              const transaction = tr
+                .replaceWith(0, tr.doc.content.size, node)
+                .setMeta("docChangeEvent", { event: "submitHistory" });
               transaction.setMeta(extensionName, { direction });
 
               if (dispatch) {


### PR DESCRIPTION
## Summary

This PR improves the auto-complete trigger and interaction in the prompt form editor.

- Only triggers auto-complete on document changes, not on selection changes.
- Adds a delay before showing the auto-completion popup to improve user experience.
- Ensures auto-complete does not conflict with other mention extensions.
- Uses explicit transaction metadata for document changes from session restore and history navigation.

## Test plan

[ ] Manually test the auto-complete functionality in the prompt form.

🤖 Generated with [Pochi](https://getpochi.com)