### PR TITLE
refactor: remove translation dependencies and replace with hardcoded text

### DIFF
--- a/packages/vscode-webui/src/components/tool-invocation/tools/attempt-completion.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/attempt-completion.tsx
@@ -1,12 +1,10 @@
 import { MessageMarkdown } from "@/components/message";
 import { Check } from "lucide-react";
-import { useTranslation } from "react-i18next";
 import type { ToolProps } from "../types";
 
 export const AttemptCompletionTool: React.FC<
   ToolProps<"attemptCompletion">
 > = ({ tool: toolCall }) => {
-  const { t } = useTranslation();
   const { result = "", command = "" } = toolCall.input || {};
 
   // Return null if there's nothing to display
@@ -18,7 +16,7 @@ export const AttemptCompletionTool: React.FC<
     <div className="flex flex-col">
       <span className="flex items-center gap-2 font-bold text-emerald-700 text-sm dark:text-emerald-300">
         <Check className="size-4" />
-        {t("task.completed")}
+        Task Completed
       </span>
       <MessageMarkdown>{result}</MessageMarkdown>
       {command && (

--- a/packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { useAutoApproveGuard } from "@/features/chat";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
-import { useTranslation } from "react-i18next";
 import type { PendingRetryApproval } from "../hooks/use-pending-retry-approval";
 
 interface RetryApprovalButtonProps {
@@ -16,8 +15,6 @@ export const RetryApprovalButton: React.FC<RetryApprovalButtonProps> = ({
   pendingApproval,
   retry,
 }) => {
-  const { t } = useTranslation();
-
   useEffect(() => {
     if (pendingApproval.countdown === 0) {
       doRetry();
@@ -47,12 +44,12 @@ export const RetryApprovalButton: React.FC<RetryApprovalButtonProps> = ({
       <Button onClick={onAccept}>
         {pendingApproval.attempts !== undefined &&
         pendingApproval.countdown !== undefined
-          ? t("approval.continueIn", { seconds: pendingApproval.countdown })
-          : t("common.continue")}
+          ? `Continue in ${pendingApproval.countdown}s`
+          : "Continue"}
       </Button>
       {pendingApproval.countdown !== undefined && (
         <Button onClick={pendingApproval.stopCountdown} variant="secondary">
-          {t("common.cancel")}
+          {"Cancel"}
         </Button>
       )}
     </>

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -1,7 +1,5 @@
 {
   "common": {
-    "continue": "Continue",
-    "cancel": "Cancel",
     "disable": "Disable",
     "openFolder": "Open Folder",
     "account": "Account",
@@ -23,12 +21,6 @@
   },
   "workspace": {
     "required": "To use Pochi, please open a folder or workspace."
-  },
-  "task": {
-    "completed": "Task Completed"
-  },
-  "approval": {
-    "continueIn": "Continue in {{seconds}}s"
   },
   "chat": {
     "imageTooltip": "Attach images to chat. You can also drag and drop images or paste them into the chat input box."

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -1,7 +1,5 @@
 {
   "common": {
-    "continue": "続行",
-    "cancel": "キャンセル",
     "disable": "無効化",
     "openFolder": "フォルダーを開く",
     "account": "アカウント",
@@ -23,12 +21,6 @@
   },
   "workspace": {
     "required": "Pochi を使用するには、フォルダーまたはワークスペースを開いてください。"
-  },
-  "task": {
-    "completed": "タスク完了"
-  },
-  "approval": {
-    "continueIn": "{{seconds}}秒後に続行"
   },
   "chat": {
     "imageTooltip": "画像をチャットに添付します。画像をドラッグ＆ドロップするか、チャット入力欄に貼り付けることもできます。"

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -1,7 +1,5 @@
 {
   "common": {
-    "continue": "계속",
-    "cancel": "취소",
     "disable": "비활성화",
     "openFolder": "폴더 열기",
     "account": "계정",
@@ -23,12 +21,6 @@
   },
   "workspace": {
     "required": "Pochi를 사용하려면 폴더 또는 워크스페이스를 여십시오."
-  },
-  "task": {
-    "completed": "작업 완료"
-  },
-  "approval": {
-    "continueIn": "{{seconds}}초 후 계속"
   },
   "chat": {
     "imageTooltip": "채팅에 이미지를 첨부합니다. 이미지를 드래그 앤 드롭하거나 채팅 입력란에 붙여넣을 수도 있습니다."

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -1,7 +1,5 @@
 {
   "common": {
-    "continue": "继续",
-    "cancel": "取消",
     "disable": "禁用",
     "openFolder": "打开文件夹",
     "account": "账户",
@@ -23,12 +21,6 @@
   },
   "workspace": {
     "required": "要使用 Pochi，请打开一个文件夹或工作区。"
-  },
-  "task": {
-    "completed": "任务已完成"
-  },
-  "approval": {
-    "continueIn": "{{seconds}}秒后继续"
   },
   "chat": {
     "imageTooltip": "附加图片到对话。您也可以拖放图片或将其粘贴到聊天输入框中。"


### PR DESCRIPTION
This pull request removes internationalization (i18n) support for several UI strings in the tool invocation and approval components, replacing dynamic translations with hardcoded English text. It also deletes related translation keys from all language JSON files. This simplifies the codebase but means these UI messages will no longer be localized.

**Internationalization removal:**

* Removed `useTranslation` and translation calls from `AttemptCompletionTool` and `RetryApprovalButton` components, replacing them with hardcoded English strings for "Task Completed", "Continue", "Continue in Xs", and "Cancel". (`packages/vscode-webui/src/components/tool-invocation/tools/attempt-completion.tsx`, `packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx`) [[1]](diffhunk://#diff-88e2c1f9409e62ae7cb0cd3467a48342df895ab65b945925de3798c06a2db976L3-L9) [[2]](diffhunk://#diff-88e2c1f9409e62ae7cb0cd3467a48342df895ab65b945925de3798c06a2db976L21-R19) [[3]](diffhunk://#diff-bf8fa379dd7da5d214556a04d249ae17d5af621b850f9e563a5911d8d52d0737L7) [[4]](diffhunk://#diff-bf8fa379dd7da5d214556a04d249ae17d5af621b850f9e563a5911d8d52d0737L19-L20) [[5]](diffhunk://#diff-bf8fa379dd7da5d214556a04d249ae17d5af621b850f9e563a5911d8d52d0737L50-R52)

**Translation file cleanup:**

* Deleted UI string keys related to task completion and approval actions from all language files (`en.json`, `jp.json`, `ko.json`, `zh.json`), including "continue", "cancel", "task.completed", and "approval.continueIn". (`packages/vscode-webui/src/i18n/locales/en.json`, `packages/vscode-webui/src/i18n/locales/jp.json`, `packages/vscode-webui/src/i18n/locales/ko.json`, `packages/vscode-webui/src/i18n/locales/zh.json`) [[1]](diffhunk://#diff-21b8dca3979e7634687f943db274288ae519ba7c472814d869f0196e5c6f1677L3-L4) [[2]](diffhunk://#diff-21b8dca3979e7634687f943db274288ae519ba7c472814d869f0196e5c6f1677L27-L32) [[3]](diffhunk://#diff-fb6afb0e7d4fe7d5826d1499425b4cec46e41564b4acc30cc1eeeec5b397d981L3-L4) [[4]](diffhunk://#diff-fb6afb0e7d4fe7d5826d1499425b4cec46e41564b4acc30cc1eeeec5b397d981L27-L32) [[5]](diffhunk://#diff-9e5563a76f5f6ff16da892399c9587d01ba1b5d80c981c45b7722f21344237e2L3-L4) [[6]](diffhunk://#diff-9e5563a76f5f6ff16da892399c9587d01ba1b5d80c981c45b7722f21344237e2L27-L32) [[7]](diffhunk://#diff-176a81fc84132e38f5c16615b096668ad15d67dbed3ac21ba11277189b843a0fL3-L4) [[8]](diffhunk://#diff-176a81fc84132e38f5c16615b096668ad15d67dbed3ac21ba11277189b843a0fL27-L32)