### PR TITLE
feat(webui): add terminal link for background jobs

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -204,6 +204,23 @@ const VSCodeHostStub = {
   chatVSCodeLm: async (): Promise<void> => {
     return Promise.resolve();
   },
+  readVisibleTerminals: async (): Promise<{
+    terminals: ThreadSignalSerialization<
+      Environment["workspace"]["terminals"] | undefined
+    >;
+    openBackgroundJobTerminal: (backgroundJobId: string) => Promise<void>;
+  }> => {
+    return Promise.resolve({
+      terminals: {} as ThreadSignalSerialization<
+        Environment["workspace"]["terminals"] | undefined
+      >,
+      openBackgroundJobTerminal: async (
+        _backgroundJobId: string,
+      ): Promise<void> => {
+        return Promise.resolve();
+      },
+    });
+  },
 } satisfies VSCodeHostApi;
 
 export function createVscodeHostStub(overrides?: Partial<VSCodeHostApi>) {

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -116,6 +116,13 @@ export interface VSCodeHostApi {
     >
   >;
 
+  readVisibleTerminals(): Promise<{
+    terminals: ThreadSignalSerialization<
+      Environment["workspace"]["terminals"] | undefined
+    >;
+    openBackgroundJobTerminal: (backgroundJobId: string) => Promise<void>;
+  }>;
+
   /**
    * Opens a file at the specified file path.
    *

--- a/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
@@ -95,8 +95,8 @@ const BackgroundJobIdButton: FC<{
       <TooltipTrigger asChild>
         <Button
           size="sm"
-          className={cn("size-[16px] rounded-sm border-l-2", {
-            "border-primary ": isActive,
+          className={cn("size-[16px] rounded-sm", {
+            "text-primary": isActive,
           })}
           variant="secondary"
           onClick={onClick}

--- a/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
@@ -4,8 +4,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useBackgroundJobInfo } from "@/features/chat";
 import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
+import { useVisibleTerminals } from "@/lib/hooks/use-visible-terminals";
 import { cn } from "@/lib/utils";
 import { isVSCodeEnvironment } from "@/lib/vscode";
 import {
@@ -15,7 +17,14 @@ import {
   CopyIcon,
   TerminalIcon,
 } from "lucide-react";
-import { type FC, useEffect, useRef, useState } from "react";
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ScrollArea } from "../ui/scroll-area";
 import { XTerm } from "./xterm";
 
@@ -76,23 +85,28 @@ const ToggleExpandButton: FC<{ expanded: boolean; onToggle: () => void }> = ({
   );
 };
 
-const BackgroundJobIdButton: FC<{ displayId: string }> = ({ displayId }) => {
+const BackgroundJobIdButton: FC<{
+  displayId: string;
+  isActive?: boolean;
+  onClick: () => void;
+}> = ({ displayId, isActive, onClick }) => {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
           size="sm"
-          className="size-[16px] rounded-sm"
+          className={cn("size-[16px] rounded-sm border-l-2", {
+            "border-primary ": isActive,
+          })}
           variant="secondary"
+          onClick={onClick}
         >
           <div className="font-bold font-mono text-[10px]">{displayId}</div>
         </Button>
       </TooltipTrigger>
-      {false && (
-        <TooltipContent>
-          <span>Show {displayId}</span>
-        </TooltipContent>
-      )}
+      <TooltipContent>
+        <span>Show {displayId}</span>
+      </TooltipContent>
     </Tooltip>
   );
 };
@@ -154,24 +168,46 @@ const CommandPanelContainer: FC<{
 };
 
 export const BackgroundJobPanel: FC<{
-  command: string;
-  displayId?: string;
+  backgroundJobId: string;
   output?: string;
-}> = ({ command, displayId, output }) => {
+}> = ({ backgroundJobId, output }) => {
   const [expanded, setExpanded] = useState(false);
   const toggleExpanded = () => setExpanded((prev) => !prev);
+  const info = useBackgroundJobInfo(backgroundJobId);
+  const { terminals, openBackgroundJobTerminal } = useVisibleTerminals();
+  const isActive = useMemo(
+    () =>
+      backgroundJobId
+        ? terminals?.some(
+            (t) => t.backgroundJobId === backgroundJobId && t.isActive,
+          )
+        : false,
+    [backgroundJobId, terminals],
+  );
+
+  const openTerminal = useCallback(() => {
+    openBackgroundJobTerminal?.(backgroundJobId);
+  }, [backgroundJobId, openBackgroundJobTerminal]);
 
   return (
     <CommandPanelContainer
-      icon={displayId && <BackgroundJobIdButton displayId={displayId} />}
-      title={command}
+      icon={
+        info?.displayId && (
+          <BackgroundJobIdButton
+            displayId={info.displayId}
+            isActive={isActive}
+            onClick={openTerminal}
+          />
+        )
+      }
+      title={info?.command}
       expanded={output !== undefined && expanded}
       actions={
         <>
           {output && (
             <ToggleExpandButton expanded={expanded} onToggle={toggleExpanded} />
           )}
-          <CopyCommandButton command={command} />
+          {info?.command && <CopyCommandButton command={info?.command} />}
         </>
       }
       output={output}

--- a/packages/vscode-webui/src/components/tool-invocation/tools/kill-background-job.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/kill-background-job.tsx
@@ -1,4 +1,3 @@
-import { useBackgroundJobInfo } from "@/features/chat";
 import { BackgroundJobPanel } from "../command-execution-panel";
 import { StatusIcon } from "../status-icon";
 import { ExpandableToolContainer } from "../tool-container";
@@ -6,11 +5,9 @@ import type { ToolProps } from "../types";
 
 export const KillBackgroundJobTool: React.FC<
   ToolProps<"killBackgroundJob">
-> = ({ tool, isExecuting, messages }) => {
-  const info = useBackgroundJobInfo(
-    messages,
-    tool.state !== "input-streaming" ? tool.input?.backgroundJobId : undefined,
-  );
+> = ({ tool, isExecuting }) => {
+  const backgroundJobId =
+    tool.state !== "input-streaming" ? tool.input?.backgroundJobId : undefined;
 
   const title = (
     <>
@@ -19,9 +16,14 @@ export const KillBackgroundJobTool: React.FC<
     </>
   );
 
-  const detail = info ? (
-    <BackgroundJobPanel command={info.command} displayId={info.displayId} />
-  ) : null;
-
-  return <ExpandableToolContainer title={title} detail={detail} />;
+  return (
+    <ExpandableToolContainer
+      title={title}
+      detail={
+        backgroundJobId ? (
+          <BackgroundJobPanel backgroundJobId={backgroundJobId} />
+        ) : null
+      }
+    />
+  );
 };

--- a/packages/vscode-webui/src/components/tool-invocation/tools/read-background-job-output.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/read-background-job-output.tsx
@@ -1,4 +1,3 @@
-import { useBackgroundJobInfo } from "@/features/chat";
 import { BackgroundJobPanel } from "../command-execution-panel";
 import { HighlightedText } from "../highlight-text";
 import { StatusIcon } from "../status-icon";
@@ -7,12 +6,10 @@ import type { ToolProps } from "../types";
 
 export const ReadBackgroundJobOutputTool: React.FC<
   ToolProps<"readBackgroundJobOutput">
-> = ({ tool, isExecuting, messages }) => {
-  const info = useBackgroundJobInfo(
-    messages,
-    tool.state !== "input-streaming" ? tool.input?.backgroundJobId : undefined,
-  );
+> = ({ tool, isExecuting }) => {
   const { regex } = tool.input || {};
+  const backgroundJobId =
+    tool.state !== "input-streaming" ? tool.input?.backgroundJobId : undefined;
   const title = (
     <>
       <StatusIcon isExecuting={isExecuting} tool={tool} />
@@ -26,13 +23,17 @@ export const ReadBackgroundJobOutputTool: React.FC<
     </>
   );
 
-  const detail: React.ReactNode = info ? (
-    <BackgroundJobPanel
-      command={info.command}
-      displayId={info.displayId}
-      output={tool.output?.output}
+  return (
+    <ExpandableToolContainer
+      title={title}
+      detail={
+        backgroundJobId ? (
+          <BackgroundJobPanel
+            backgroundJobId={backgroundJobId}
+            output={tool.output?.output}
+          />
+        ) : null
+      }
     />
-  ) : null;
-
-  return <ExpandableToolContainer title={title} detail={detail} />;
+  );
 };

--- a/packages/vscode-webui/src/components/tool-invocation/tools/start-background-job.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/start-background-job.tsx
@@ -1,4 +1,3 @@
-import { useMapJobIdToDisplayId } from "@/features/chat";
 import { BackgroundJobPanel } from "../command-execution-panel";
 import { HighlightedText } from "../highlight-text";
 import { StatusIcon } from "../status-icon";
@@ -8,10 +7,11 @@ import type { ToolProps } from "../types";
 export const StartBackgroundJobTool: React.FC<
   ToolProps<"startBackgroundJob">
 > = ({ tool, isExecuting }) => {
-  const { cwd, command } = tool.input || {};
-  const displayId = useMapJobIdToDisplayId(
-    tool.state === "output-available" ? tool.output.backgroundJobId : undefined,
-  );
+  const { cwd } = tool.input || {};
+
+  const backgroundJobId =
+    tool.state === "output-available" ? tool.output.backgroundJobId : undefined;
+
   const cwdNode = cwd ? (
     <span>
       {" "}
@@ -29,10 +29,14 @@ export const StartBackgroundJobTool: React.FC<
     </>
   );
 
-  const detail =
-    command && displayId ? (
-      <BackgroundJobPanel command={command} displayId={displayId} />
-    ) : null;
-
-  return <ExpandableToolContainer title={title} detail={detail} />;
+  return (
+    <ExpandableToolContainer
+      title={title}
+      detail={
+        backgroundJobId ? (
+          <BackgroundJobPanel backgroundJobId={backgroundJobId} />
+        ) : null
+      }
+    />
+  );
 };

--- a/packages/vscode-webui/src/features/chat/index.ts
+++ b/packages/vscode-webui/src/features/chat/index.ts
@@ -11,7 +11,6 @@ export { useSendMessage, useHandleChatEvents } from "./lib/chat-events";
 export { useLiveChatKitGetters } from "./lib/use-live-chat-kit-getters";
 export {
   useBackgroundJobInfo,
-  useMapJobIdToDisplayId,
   useReplaceJobIdsInContent,
   BackgroundJobContextProvider,
 } from "./lib/use-background-job-display";

--- a/packages/vscode-webui/src/lib/hooks/use-visible-terminals.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-visible-terminals.ts
@@ -1,0 +1,36 @@
+import { threadSignal } from "@quilted/threads/signals";
+import { useQuery } from "@tanstack/react-query";
+import { vscodeHost } from "../vscode";
+
+/**
+ * Hook to get visible terminals
+ * Uses ThreadSignal for real-time updates
+ */
+/** @useSignals */
+export const useVisibleTerminals = () => {
+  const { data } = useQuery({
+    queryKey: ["visibleTerminals"],
+    queryFn: fetchVisibleTerminals,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  if (!data) {
+    return { terminals: [], openBackgroundJobTerminal: undefined };
+  }
+
+  return {
+    terminals: data.terminals.value,
+    openBackgroundJobTerminal: data?.openBackgroundJobTerminal,
+  };
+};
+
+/**
+ * Fetch visible terminals from workspace API
+ */
+async function fetchVisibleTerminals() {
+  const result = await vscodeHost.readVisibleTerminals();
+  return {
+    terminals: threadSignal(result.terminals),
+    openBackgroundJobTerminal: result.openBackgroundJobTerminal,
+  };
+}

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -80,6 +80,7 @@ function createVSCodeHost(): VSCodeHostApi {
         "readCustomModelSetting",
         "readVSCodeLm",
         "chatVSCodeLm",
+        "readVisibleTerminals",
       ],
       exports: {
         openTask(params) {

--- a/packages/vscode/src/integrations/terminal/terminal-state.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-state.ts
@@ -2,7 +2,6 @@ import { signal } from "@preact/signals-core";
 import { injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
 import { TerminalJob } from "./terminal-job";
-
 export interface TerminalInfo {
   name: string;
   isActive: boolean;
@@ -19,6 +18,15 @@ export class TerminalState implements vscode.Disposable {
 
   constructor() {
     this.setupEventListeners();
+  }
+
+  public openBackgroundJobTerminal(backgroundJobId: string) {
+    const terminal = vscode.window.terminals.find((t) => {
+      const job = TerminalJob.get(t);
+      return job?.id === backgroundJobId;
+    });
+    if (!terminal) return;
+    terminal.show();
   }
 
   /**

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -229,6 +229,15 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     return ThreadSignal.serialize(this.tabState.activeSelection);
   };
 
+  readVisibleTerminals = async () => {
+    return {
+      terminals: ThreadSignal.serialize(this.terminalState.visibleTerminals),
+      openBackgroundJobTerminal: async (backgroundJobId: string) => {
+        this.terminalState.openBackgroundJobTerminal(backgroundJobId);
+      },
+    };
+  };
+
   readCurrentWorkspace = async (): Promise<string | undefined> => {
     return vscode.workspace.workspaceFolders?.[0].uri.fsPath;
   };


### PR DESCRIPTION
## Screen record
- https://jam.dev/c/96aae672-3195-4804-88bf-0f8e79ac0a62

## Summary
This feature makes the background job ID a link that, when clicked, reveals the corresponding terminal in the VS Code panel. This improves the user experience by providing a quick way to navigate to the terminal running the background job.

## Test plan
- Run a background job.
- Verify that the job ID in the web UI is a clickable link.
- Click the link and confirm that it opens the correct terminal.

🤖 Generated with [Pochi](https://getpochi.com)