### PR TITLE
fix: Revert "feat: close existing file buffer when opening diff view (#160)"

### DIFF
--- a/packages/vscode/src/integrations/editor/diff-view.ts
+++ b/packages/vscode/src/integrations/editor/diff-view.ts
@@ -415,23 +415,6 @@ async function openDiffEditor(
         tab.input?.original?.scheme === DiffOriginContentProvider.scheme &&
         tab.input.modified.fsPath === fileUri.fsPath
       ) {
-        // Close any regular tabs for this file before returning existing diff view
-        const tabsToClose: vscode.Tab[] = [];
-        for (const group of vscode.window.tabGroups.all) {
-          for (const tab of group.tabs) {
-            if (
-              tab.input instanceof vscode.TabInputText &&
-              tab.input.uri.fsPath === fileUri.fsPath &&
-              !(tab.input instanceof vscode.TabInputTextDiff)
-            ) {
-              tabsToClose.push(tab);
-            }
-          }
-        }
-        for (const tab of tabsToClose) {
-          vscode.window.tabGroups.close(tab);
-        }
-
         for (const textEditor of vscode.window.visibleTextEditors) {
           if (textEditor.document.uri.fsPath === fileUri.fsPath) {
             return textEditor;
@@ -459,24 +442,6 @@ function runVSCodeDiff(
         resolve(editor);
       }
     });
-
-    // Close existing non-diff editor tabs for the file to prevent confusion
-    const tabsToClose: vscode.Tab[] = [];
-    for (const group of vscode.window.tabGroups.all) {
-      for (const tab of group.tabs) {
-        if (
-          tab.input instanceof vscode.TabInputText &&
-          tab.input.uri.fsPath === fileUri.fsPath &&
-          !(tab.input instanceof vscode.TabInputTextDiff)
-        ) {
-          tabsToClose.push(tab);
-        }
-      }
-    }
-    for (const tab of tabsToClose) {
-      vscode.window.tabGroups.close(tab);
-    }
-
     vscode.commands.executeCommand(
       "vscode.diff",
       vscode.Uri.parse(`${DiffOriginContentProvider.scheme}:${id}`).with({


### PR DESCRIPTION
Reverts TabbyML/pochi#165

This PR introduced buggy behavior in the 'accept tool call' functionality when the diffview window is not open. The implementation needs to be revisited to properly handle this scenario. Reverting the changes for now to restore proper functionality.