### PR TITLE
fix: auto swap to max_completion_tokens

### DIFF
--- a/-H
+++ b/-H
@@ -1,8 +1,0 @@
-{
-  "error": {
-    "message": "Invalid body: failed to parse application/x-www-form-urlencoded value that was JSON-like. Did you mean to set 'Content-Type: application/json'?",
-    "type": "invalid_request_error",
-    "param": null,
-    "code": "invalid_urlencoded_data"
-  }
-}

--- a/-H
+++ b/-H
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "Invalid body: failed to parse application/x-www-form-urlencoded value that was JSON-like. Did you mean to set 'Content-Type: application/json'?",
+    "type": "invalid_request_error",
+    "param": null,
+    "code": "invalid_urlencoded_data"
+  }
+}

--- a/packages/livekit/src/chat/models/openai.ts
+++ b/packages/livekit/src/chat/models/openai.ts
@@ -9,6 +9,7 @@ export function createOpenAIModel(
     name: "OpenAI",
     baseURL: llm.baseURL,
     apiKey: llm.apiKey,
+    fetch: patchedFetch(llm.modelId),
   });
 
   return wrapLanguageModel({
@@ -21,4 +22,51 @@ export function createOpenAIModel(
       },
     },
   });
+}
+
+function isReasoningModel(modelId: string): boolean {
+  return /^o\d|(^|-)mini(\b|$)/.test(modelId);
+}
+
+function patchedFetch(modelId: string) {
+  const changeParam = isReasoningModel(modelId);
+
+  return async (
+    input: Request | URL | string,
+    init?: RequestInit,
+  ) => {
+    const originalBody = init?.body as string | undefined;
+
+    // Pre-write the params
+    let firstInit = init;
+    if (changeParam && originalBody && typeof originalBody === "string") {
+      const patched = swapField(originalBody);
+      if (patched) {
+        firstInit = { ...init, body: patched};
+      }
+    }
+    const firstResponse = await fetch(input, firstInit);
+    return firstResponse;
+  };
+}
+
+// helper function to access & edit the raw parameter initialisation
+function swapField(body: string): string | undefined {
+  try {
+    const json = JSON.parse(body);
+    if (json && typeof json === "object") {
+      if (Object.prototype.hasOwnProperty.call(json, "max_tokens")) {
+        json.max_completion_tokens = json.max_tokens;
+        delete json.max_tokens;
+      }
+      else if (Object.prototype.hasOwnProperty.call(json, "max_completion_tokens")) {
+        json.max_tokens = json.max_completion_tokens;
+        delete json.max_completion_tokens;
+      }
+      return JSON.stringify(json);
+    }
+  } catch {
+    // ignore if body is not JSON
+  }
+  return undefined;
 }


### PR DESCRIPTION
Identified the error to originate from the call to Vercel's AI SDK, specifically creating a custom OpenAI model using `createOpenAICompatible` from '@ai-sdk/openai-compatible'. Adding a custom patched fetch (building on `FetchFunction` from '@ai-sdk/provider-utils') that acts as middleware to modify requests to reasoning models until this is resolved in the main SDK

Main changes:
- `packages/livekit/src/chat/models/openai.ts`:
  - Added a heuristic based on `modelId` to prefer `max_completion_tokens` for o-series/mini (i.e. reasoning) models.
  - Injected the patched fetch that uses the above heuristic to decide whether or not to keep `max_tokens` or replace it with `max_completion_tokens`.
  - Kept existing `maxOutputTokens` behavior via middleware.