### PR TITLE
fix: update condition to check if comment body starts with '/pochi'

### DIFF
--- a/.github/workflows/pochi.yml
+++ b/.github/workflows/pochi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pochi:
-    if: contains(github.event.comment.body, '/pochi')
+    if: startsWith(github.event.comment.body, '/pochi')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/packages/docs/content/docs/github.mdx
+++ b/packages/docs/content/docs/github.mdx
@@ -27,7 +27,7 @@ on:
 
 jobs:
   pochi:
-    if: contains(github.event.comment.body, '/pochi')
+    if: startsWith(github.event.comment.body, '/pochi')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -51,7 +51,7 @@ jobs:
 
 Notes:
 
-- Triggered by `issue_comment` (created) and runs only if the comment body contains `/pochi`
+- Triggered by `issue_comment` (created) and runs only if the comment body starts with `/pochi`
 - Requires write permissions to read changes, post comments, and add reactions to PRs
 - Provide `POCHI_TOKEN` via env; optionally set `POCHI_MODEL` to customize the model
 - By default, the action uses GitHub's built-in `GITHUB_TOKEN` (github-actions bot). You can customize this by setting a custom `GITHUB_TOKEN` environment variable with your own Personal Access Token (PAT)

--- a/packages/github-action/README.md
+++ b/packages/github-action/README.md
@@ -21,7 +21,7 @@ on:
 
 jobs:
   pochi:
-    if: contains(github.event.comment.body, '/pochi')
+    if: startsWith(github.event.comment.body, '/pochi')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -127,7 +127,7 @@ If you need to use a custom GitHub token (for cross-repo operations):
 
 ### Action doesn't respond
 
-1. Check that the PR comment contains `/pochi`
+1. Check that the PR comment starts with `/pochi`
 2. Verify `POCHI_TOKEN` is set in repository secrets
 3. Ensure workflow has correct permissions
 4. Check workflow runs in Actions tab


### PR DESCRIPTION
This pull request updates the trigger condition for the pochi GitHub Action workflow across several documentation and workflow files. The main change ensures that the workflow only runs when a comment starts with `/pochi`, rather than containing it anywhere in the comment. This helps prevent unintended triggers and improves workflow reliability.

**Workflow trigger logic update:**

* Changed the workflow condition from `contains(github.event.comment.body, '/pochi')` to `startsWith(github.event.comment.body, '/pochi')` in `.github/workflows/pochi.yml`, `packages/docs/content/docs/github.mdx`, and `packages/github-action/README.md` to ensure the action only runs when the comment begins with `/pochi`. [[1]](diffhunk://#diff-51667098354b3ce1198b0b439905eb2f2b91288ba8183c2f8b728accd8976cdfL9-R9) [[2]](diffhunk://#diff-b2b61d8e1023859b615fc86b5ea10b3d1906812fac12b03a40012ea41a6960c4L30-R30) [[3]](diffhunk://#diff-8e8752c71521962ab3c7285a0f6433414927a6bbf7938836e90ee5c53a52e667L24-R24)

**Documentation updates:**

* Updated documentation in `packages/docs/content/docs/github.mdx` and `packages/github-action/README.md` to clarify that the workflow is triggered only if the comment starts with `/pochi`, reflecting the new logic. [[1]](diffhunk://#diff-b2b61d8e1023859b615fc86b5ea10b3d1906812fac12b03a40012ea41a6960c4L54-R54) [[2]](diffhunk://#diff-8e8752c71521962ab3c7285a0f6433414927a6bbf7938836e90ee5c53a52e667L130-R130)