### PR TITLE
fix(ci): copy npmrc to release project when push to npm

### DIFF
--- a/.github/workflows/release-pochi-cli.yml
+++ b/.github/workflows/release-pochi-cli.yml
@@ -91,8 +91,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/cli@')
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          POCHI_CLI_NPM_NAME: ${{ vars.POCHI_CLI_NPM_NAME }}
         run: |
           cd packages/cli
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
           # use env to override the default npm name, so we can test the release action
-          POCHI_CLI_NPM_NAME=${{ env.POCHI_CLI_NPM_NAME }} bun release:npm
+          POCHI_CLI_NPM_NAME=$POCHI_CLI_NPM_NAME bun release:npm

--- a/packages/cli/scripts/npm-release.ts
+++ b/packages/cli/scripts/npm-release.ts
@@ -68,7 +68,8 @@ async function main() {
   );
 
   // Copy README and LICENSE if they exist
-  for (const file of ["README.md", "../../LICENSE"]) {
+  // .npmrc for auth, .npmrc will be ignore when push, so it safe to add it
+  for (const file of [".npmrc", "README.md", "../../LICENSE"]) {
     if (existsSync(file)) {
       await $`cp ${file} ${TEMP_PACKAGE_DIR}/`;
     }


### PR DESCRIPTION
Test CI: https://github.com/zwpaper/pochi/actions/runs/17511635315/job/49743974435

failed because the 0.5.0-dev pushed before to my test npm 