### PR TITLE
refactor: create centralized registry for vendors and models

### DIFF
--- a/packages/common/src/vendor/edge.ts
+++ b/packages/common/src/vendor/edge.ts
@@ -1,6 +1,5 @@
 import type { LanguageModelV2 } from "@ai-sdk/provider";
-
-const models: Record<string, CreateModelFunction> = {};
+import { createRegistry } from "./registry";
 
 type CreateModelFunction = (opts: CreateModelOptions) => LanguageModelV2;
 
@@ -14,17 +13,11 @@ export type CreateModelOptions = {
   getCredentials: () => Promise<unknown>;
 };
 
-export function registerModel(
-  vendorId: string,
-  createModel: CreateModelFunction,
-) {
-  models[vendorId] = createModel;
-}
+const { register, get } = createRegistry<CreateModelFunction>();
+
+export const registerModel = register;
 
 export function createModel(vendorId: string, opts: CreateModelOptions) {
-  const model = models[vendorId];
-  if (!model) {
-    throw new Error(`Vendor ${vendorId} not found`);
-  }
-  return model(opts);
+  const modelCreator = get(vendorId);
+  return modelCreator(opts);
 }

--- a/packages/common/src/vendor/node.ts
+++ b/packages/common/src/vendor/node.ts
@@ -1,22 +1,14 @@
+import type { VendorBase } from "./base";
+import { createRegistry } from "./registry";
+
 export { type AuthOutput, ModelOptions } from "./types";
 export { VendorBase } from "./base";
 
-import type { VendorBase } from "./base";
-
-const vendors: Record<string, VendorBase> = {};
+const { register, get, getAll } = createRegistry<VendorBase>();
 
 export function registerVendor(vendor: VendorBase) {
-  vendors[vendor.vendorId] = vendor;
+  register(vendor.vendorId, vendor);
 }
 
-export function getVendor(vendorId: string): VendorBase {
-  const vendor = vendors[vendorId];
-  if (!vendor) {
-    throw new Error(`Vendor ${vendorId} not found`);
-  }
-  return vendor;
-}
-
-export function getVendors() {
-  return vendors;
-}
+export const getVendor = get;
+export const getVendors = getAll;

--- a/packages/common/src/vendor/registry.ts
+++ b/packages/common/src/vendor/registry.ts
@@ -1,0 +1,21 @@
+export function createRegistry<T>() {
+  const items: Record<string, T> = {};
+
+  function register(id: string, item: T) {
+    items[id] = item;
+  }
+
+  function get(id: string): T {
+    const item = items[id];
+    if (!item) {
+      throw new Error(`Item with id ${id} not found in registry.`);
+    }
+    return item;
+  }
+
+  function getAll(): Record<string, T> {
+    return items;
+  }
+
+  return { register, get, getAll };
+}


### PR DESCRIPTION
## Summary

- Implement generic `createRegistry` function for type-safe registries
- Refactor vendor management in node.ts to use centralized registry instead of direct object storage
- Refactor model management in edge.ts to use centralized registry with consistent error handling
- Remove duplicate registry logic and improve maintainability across vendor system
- Maintain backward compatibility with existing vendor/model APIs

## Test plan

- [x] All existing tests pass
- [x] Pre-push hooks pass (dependency checks, linting, formatting)
- [x] Code maintains backward compatibility
- [x] Registry provides consistent error messages for missing items
- [x] Both vendor and model registration systems work with new centralized approach

🤖 Generated with [Pochi](https://getpochi.com)