### PR TITLE
fix(ci): cli in npm should publish as public package

### DIFF
--- a/packages/cli/scripts/npm-release.ts
+++ b/packages/cli/scripts/npm-release.ts
@@ -92,7 +92,7 @@ async function main() {
   process.chdir(TEMP_PACKAGE_DIR);
 
   try {
-    await $`npm publish --tag ${tag}`;
+    await $`npm publish --access public --tag ${tag}`;
     console.log("🎉 Successfully published to npm!");
   } catch (error) {
     console.error("❌ Failed to publish to npm:", error);


### PR DESCRIPTION
Passed CI: https://github.com/zwpaper/pochi/actions/runs/17515523922/job/49752544486
Published pochi under custom org: https://www.npmjs.com/package/@kweizh/pochi

<img width="2474" height="1868" alt="Google Chrome 2025-09-06 22 19 22" src="https://github.com/user-attachments/assets/7f6cab08-ba03-4273-8ade-24f1abe315c4" />


install and test:
<img width="2312" height="668" alt="CleanShot 2025-09-06 at 22 18 39@2x" src="https://github.com/user-attachments/assets/83320f40-33b4-456a-adf7-3ce2a908c097" />
