### PR TITLE
refactor: introduce generateTitleManager for async title updates

### DIFF
--- a/packages/livekit/src/chat/generate-title-manager.ts
+++ b/packages/livekit/src/chat/generate-title-manager.ts
@@ -1,0 +1,72 @@
+import type { LanguageModelV2 } from "@ai-sdk/provider";
+import { getLogger } from "@getpochi/common";
+import type { Store } from "@livestore/livestore";
+import { makeTaskQuery } from "../livestore/queries";
+import { events } from "../livestore/schema";
+import type { Message } from "../types";
+import { generateTaskTitle } from "./llm/generate-task-title";
+
+const logger = getLogger("GenerateTitleManager");
+
+interface GenerateTitleJob {
+  taskId: string;
+  store: Store;
+  messages: Message[];
+  getModel: () => LanguageModelV2;
+  waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+class GenerateTitleManager {
+  private jobs = Promise.resolve();
+  private pendingJobs = new Map<string, GenerateTitleJob>();
+
+  push(job: GenerateTitleJob) {
+    this.pendingJobs.set(job.taskId, job);
+
+    this.jobs = this.jobs.then(() => {
+      const nextJob = this.pendingJobs.values().next().value;
+      if (!nextJob) {
+        return Promise.resolve();
+      }
+
+      this.pendingJobs.delete(nextJob.taskId);
+
+      return this.process(nextJob).catch((error) => {
+        logger.error("Failed to generate title", error);
+      });
+    });
+
+    job.waitUntil?.(this.jobs);
+  }
+
+  private async process({
+    store,
+    taskId,
+    messages,
+    getModel,
+  }: GenerateTitleJob) {
+    const task = store.query(makeTaskQuery(taskId));
+    if (!task) {
+      logger.warn(`Task not found for title generation: ${taskId}`);
+      return;
+    }
+
+    const newTitle = await generateTaskTitle({
+      title: task.title,
+      messages,
+      getModel,
+    });
+
+    if (newTitle !== undefined) {
+      store.commit(
+        events.updateTitle({
+          id: taskId,
+          title: newTitle,
+          updatedAt: new Date(),
+        }),
+      );
+    }
+  }
+}
+
+export const generateTitleManager = new GenerateTitleManager();

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -12,7 +12,8 @@ import {
   FlexibleChatTransport,
   type OnStartCallback,
 } from "./flexible-chat-transport";
-import { compactTask, generateTaskTitle } from "./llm";
+import { generateTitleManager } from "./generate-title-manager";
+import { compactTask } from "./llm";
 import { createModel } from "./models";
 
 const logger = getLogger("LiveChatKit");
@@ -213,7 +214,6 @@ export class LiveChatKit<
   private readonly onStart: OnStartCallback = async ({
     messages,
     environment,
-    abortSignal,
     getters,
   }) => {
     const { store } = this;
@@ -235,10 +235,10 @@ export class LiveChatKit<
 
       const getModel = () =>
         createModel({ id: this.taskId, llm: getters.getLLM() });
-      const title = await generateTaskTitle({
-        title: task.title,
+      generateTitleManager.push({
+        taskId: this.taskId,
+        store,
         messages,
-        abortSignal,
         getModel,
       });
 
@@ -255,7 +255,6 @@ export class LiveChatKit<
                 branch: gitStatus.currentBranch,
               }
             : undefined,
-          title,
           updatedAt: new Date(),
         }),
       );

--- a/packages/livekit/src/livestore/schema.ts
+++ b/packages/livekit/src/livestore/schema.ts
@@ -129,6 +129,8 @@ export const events = {
       id: Schema.String,
       data: DBMessage,
       todos: Todos,
+      // @deprecated
+      // use updateTitle instead
       title: Schema.optional(Schema.String),
       git: Schema.optional(Git),
       updatedAt: Schema.Date,
@@ -158,6 +160,14 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       shareId: Schema.String,
+      updatedAt: Schema.Date,
+    }),
+  }),
+  updateTitle: Events.synced({
+    name: "v1.UpdateTitle",
+    schema: Schema.Struct({
+      id: Schema.String,
+      title: Schema.String,
       updatedAt: Schema.Date,
     }),
   }),
@@ -252,6 +262,8 @@ const materializers = State.SQLite.materializers(events, {
   ],
   "v1.UpdateShareId": ({ id, shareId, updatedAt }) =>
     tables.tasks.update({ shareId, updatedAt }).where({ id, shareId: null }),
+  "v1.UpdateTitle": ({ id, title, updatedAt }) =>
+    tables.tasks.update({ title, updatedAt }).where({ id }),
 });
 
 const state = State.SQLite.makeState({ tables, materializers });


### PR DESCRIPTION
## Summary
This PR refactors the task title generation logic to be asynchronous.

- Introduces `generateTitleManager` to handle title generation in the background, preventing the main process from being blocked.
- Adds a new `updateTitle` event to the `LiveStore` schema for asynchronous title updates.
- Removes the direct, synchronous call to `generateTaskTitle` from `LiveChatKit`.

🤖 Generated with [Pochi](https://getpochi.com)