### PR TITLE
chore: use getServerBaseUrl for Pochi API

### DIFF
--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -5,6 +5,7 @@ import {
 } from "@ai-sdk/provider-utils";
 import type { PochiApi, PochiApiClient } from "@getpochi/common/pochi-api";
 import type { CreateModelOptions } from "@getpochi/common/vendor/edge";
+import { getServerBaseUrl } from "@getpochi/common/vscode-webui-bridge";
 import { hc } from "hono/client";
 import type { PochiCredentials } from "./types";
 
@@ -73,7 +74,7 @@ export function createPochiModel({
 function createApiClient(
   getCredentials: () => Promise<unknown>,
 ): PochiApiClient {
-  const authClient: PochiApiClient = hc<PochiApi>("https://app.getpochi.com", {
+  const authClient: PochiApiClient = hc<PochiApi>(getServerBaseUrl(), {
     async fetch(input: string | URL | Request, init?: RequestInit) {
       const { token } = (await getCredentials()) as PochiCredentials;
       const headers = new Headers(init?.headers);

--- a/packages/vendor-pochi/src/vendor.ts
+++ b/packages/vendor-pochi/src/vendor.ts
@@ -26,9 +26,7 @@ export class Pochi extends VendorBase {
 
   override async fetchModels(): Promise<Record<string, ModelOptions>> {
     if (!this.cachedModels) {
-      const apiClient: PochiApiClient = hc<PochiApi>(
-        "https://app.getpochi.com",
-      );
+      const apiClient: PochiApiClient = hc<PochiApi>(getServerBaseUrl());
       const resp = await apiClient.api.models.$get();
       const data = await resp.json();
       this.cachedModels = Object.fromEntries(


### PR DESCRIPTION
## Summary
This PR updates the Pochi vendor package to retrieve the API endpoint via the `getServerBaseUrl()` function instead of using a hardcoded URL. This change improves flexibility, allowing the client to connect to different server environments (e.g., local development, self-hosted instances) without code modifications.

## Test plan
- All pre-push checks and tests passed successfully.
- The change is confined to how the base URL is obtained, and the rest of the API client logic remains untouched.

🤖 Generated with [Pochi](https://getpochi.com)