### PR TITLE
chore(webui): allow using Tab to select mention

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/shared.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/shared.tsx
@@ -27,6 +27,7 @@ export function useMentionKeyboardNavigation<T>(
           newIndex = selectedIndex === lastIndex ? 0 : selectedIndex + 1;
           break;
         case "Enter":
+        case "Tab":
           if (items[selectedIndex]) {
             handleSelect(items[selectedIndex]);
           }


### PR DESCRIPTION
## Summary
This change adds the ability to use the Tab key to select an item from the mention list in the prompt form.

## Test plan
N/A

🤖 Generated with [Pochi](https://getpochi.com)