### PR TITLE
feat: make general-purpose agent always available

### DIFF
--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -6,6 +6,7 @@ import {
   type CustomAgent,
   type McpTool,
   overrideCustomAgentTools,
+  overrideCustomAgents,
   selectClientTools,
 } from "@getpochi/tools";
 import type { Store } from "@livestore/livestore";
@@ -93,7 +94,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     const llm = await this.getters.getLLM();
     const environment = await this.getters.getEnvironment?.({ messages });
     const mcpToolSet = this.getters.getMcpToolSet?.();
-    const customAgents = this.getters.getCustomAgents?.();
+    const customAgents = overrideCustomAgents(this.getters.getCustomAgents?.());
 
     await this.onStart?.({
       messages,

--- a/packages/tools/src/custom-agent.ts
+++ b/packages/tools/src/custom-agent.ts
@@ -21,6 +21,19 @@ const generalPurposeAgent: CustomAgent = {
   systemPrompt: "You are a general purpose agent.",
 };
 
+export const overrideCustomAgents = (
+  customAgents: CustomAgent[] | undefined,
+): CustomAgent[] => {
+  const agents = customAgents ? [...customAgents] : [];
+  const hasGeneralPurpose = agents.some(
+    (agent) => agent.name === generalPurposeAgent.name,
+  );
+  if (!hasGeneralPurpose) {
+    agents.unshift(generalPurposeAgent);
+  }
+  return agents;
+};
+
 export const overrideCustomAgentTools = (
   customAgent: CustomAgent | undefined,
 ): CustomAgent | undefined => {
@@ -42,7 +55,7 @@ export const newCustomAgent = (customAgents?: CustomAgent[]) =>
   defineClientTool({
     description: `Launch a new agent to handle complex, multi-step tasks autonomously.
 Available agent types and the tools they have access to:
-${[generalPurposeAgent, ...(customAgents ?? [])].map((agent) => `- ${agent.name}: ${agent.description} (Tools: ${agent.tools && agent.tools.length > 0 ? agent.tools.join(", ") : "*"})`).join("\n")}
+${(customAgents ?? []).map((agent) => `- ${agent.name}: ${agent.description} (Tools: ${agent.tools && agent.tools.length > 0 ? agent.tools.join(", ") : "*"})`).join("\n")}
 
 When using the newCustomAgent tool, you must specify a agentType parameter to select which agent type to use.
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -24,6 +24,7 @@ import { writeToFile } from "./write-to-file";
 export type { SubTask } from "./new-task";
 export {
   CustomAgent,
+  overrideCustomAgents,
   overrideCustomAgentTools,
 } from "./custom-agent";
 


### PR DESCRIPTION
## Screenshot
<img width="876" height="762" alt="image" src="https://github.com/user-attachments/assets/a1894d6a-8472-445a-a74d-5f085c82f484" />

## Summary
This commit introduces a `general-purpose` agent that is now always available by default. This is achieved by adding an `overrideCustomAgents` function that ensures the `general-purpose` agent is always included in the list of custom agents. This simplifies the configuration and ensures that a fallback agent is always present.

## Test plan
- Run existing tests to ensure no regressions.

🤖 Generated with [Pochi](https://getpochi.com)