### PR TITLE
fix(webui): add spacing to workflow section items

### DIFF
--- a/packages/vscode-webui/src/features/settings/components/sections/workflows-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/workflows-section.tsx
@@ -35,22 +35,24 @@ export const WorkflowsSection: React.FC = () => {
         </div>
       ) : workflows && workflows.length > 0 ? (
         <>
-          {workflows.map(
-            (workflow: { id: string; path: string; content: string }) => (
-              <ScetionItem
-                key={workflow.id}
-                title={workflow.id}
-                icon={<Workflow className="size-4 text-muted-foreground" />}
-                onClick={() => handleEditWorkflow(workflow.id)}
-                actions={[
-                  {
-                    icon: <Edit className="size-3.5" />,
-                    onClick: () => handleEditWorkflow(workflow.id),
-                  },
-                ]}
-              />
-            ),
-          )}
+          <div className="space-y-2">
+            {workflows.map(
+              (workflow: { id: string; path: string; content: string }) => (
+                <ScetionItem
+                  key={workflow.id}
+                  title={workflow.id}
+                  icon={<Workflow className="size-4 text-muted-foreground" />}
+                  onClick={() => handleEditWorkflow(workflow.id)}
+                  actions={[
+                    {
+                      icon: <Edit className="size-3.5" />,
+                      onClick: () => handleEditWorkflow(workflow.id),
+                    },
+                  ]}
+                />
+              ),
+            )}
+          </div>
         </>
       ) : (
         <EmptySectionPlaceholder


### PR DESCRIPTION
## Summary
This change adds vertical spacing between items in the Workflows section of the settings page to improve readability.

## Test plan
- Manually verified the changes in the settings UI.

🤖 Generated with [Pochi](https://getpochi.com)