### PR TITLE
feat: add login fallback with manual token input

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -214,6 +214,9 @@ const VSCodeHostStub = {
   > => {
     return Promise.resolve({} as ThreadSignalSerialization<CustomAgentFile[]>);
   },
+  loginWithToken(_token: string) {
+    return Promise.resolve();
+  },
 } satisfies VSCodeHostApi;
 
 export function createVscodeHostStub(overrides?: Partial<VSCodeHostApi>) {

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -265,6 +265,12 @@ export interface VSCodeHostApi {
   readUserStorage(): Promise<
     ThreadSignalSerialization<Record<string, UserInfo>>
   >;
+
+  /**
+   * Login with device token.
+   * @param token - The device token from the login page.
+   */
+  loginWithToken(token: string): Promise<void>;
 }
 
 export interface WebviewHostApi {

--- a/packages/vscode-webui/src/components/welcome-screen.tsx
+++ b/packages/vscode-webui/src/components/welcome-screen.tsx
@@ -1,13 +1,25 @@
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useTokenLogin } from "@/lib/hooks/use-token-login";
 import { cn } from "@/lib/utils";
 import type { UserInfo } from "@getpochi/common/configuration";
 import { LogInIcon, SettingsIcon } from "lucide-react";
+// import { useTranslation } from "react-i18next";
 
 interface Props {
   user: UserInfo | undefined;
 }
 
 export const WelcomeScreen = ({ user }: Props) => {
+  // const { t } = useTranslation();
+  const {
+    showFallback,
+    userCode,
+    handleLoginClick,
+    handleUserCodeSubmit,
+    handleUserCodeChange,
+  } = useTokenLogin(user);
+
   return (
     <div className="flex h-screen flex-col items-center justify-center">
       {/* Main Content - Scrollable */}
@@ -51,6 +63,7 @@ export const WelcomeScreen = ({ user }: Props) => {
                     "px-4 py-2 text-sm sm:px-6 sm:py-3",
                   )}
                   href="command:pochi.openLoginPage"
+                  onClick={handleLoginClick}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -59,6 +72,23 @@ export const WelcomeScreen = ({ user }: Props) => {
                 </a>
               )}
             </div>
+            {!user && showFallback && (
+              <div className="mt-4 flex w-full max-w-md flex-col gap-2">
+                <p className="text-muted-foreground text-xs">
+                  If you clicked approve in the browser but weren't redirected
+                  back to the extension, you can manually enter the code from
+                  the login page.
+                </p>
+                <div className="flex gap-2">
+                  <Input
+                    placeholder="Enter code..."
+                    value={userCode}
+                    onChange={(e) => handleUserCodeChange(e.target.value)}
+                  />
+                  <Button onClick={handleUserCodeSubmit}>Submit</Button>
+                </div>
+              </div>
+            )}
           </div>
         </div>
         <div className="h-[12vh]" />

--- a/packages/vscode-webui/src/features/settings/components/sections/account-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/account-section.tsx
@@ -1,10 +1,13 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { useTokenLogin } from "@/lib/hooks/use-token-login";
 import { useUserStorage } from "@/lib/hooks/use-user-storage";
 import {
   ChevronsUpDown,
@@ -22,6 +25,13 @@ export const AccountSection = () => {
     users: { pochi: user } = {},
   } = useUserStorage();
   const { t } = useTranslation();
+  const {
+    showFallback,
+    userCode,
+    handleLoginClick,
+    handleUserCodeSubmit,
+    handleUserCodeChange,
+  } = useTokenLogin(user);
 
   if (!user) {
     return (
@@ -29,6 +39,7 @@ export const AccountSection = () => {
         <div className="my-2">
           <a
             href="command:pochi.openLoginPage"
+            onClick={handleLoginClick}
             target="_blank"
             rel="noopener noreferrer"
             className="flex cursor-pointer items-center gap-4 rounded-lg border border-[var(--vscode-textLink-foreground)]/70 border-dashed bg-[var(--vscode-textLink-foreground)]/5 px-4 py-5 transition-all hover:border-[var(--vscode-textLink-foreground)]/90 hover:bg-[var(--vscode-textLink-foreground)]/10 hover:shadow-sm"
@@ -45,6 +56,23 @@ export const AccountSection = () => {
               </span>
             </div>
           </a>
+          {showFallback && (
+            <div className="mt-4 flex flex-col gap-2">
+              <p className="text-muted-foreground text-xs">
+                If you clicked approve in the browser but weren't redirected
+                back to the extension, you can manually enter the code from the
+                login page.
+              </p>
+              <div className="flex gap-2">
+                <Input
+                  placeholder="Enter code..."
+                  value={userCode}
+                  onChange={(e) => handleUserCodeChange(e.target.value)}
+                />
+                <Button onClick={handleUserCodeSubmit}>Submit</Button>
+              </div>
+            </div>
+          )}
         </div>
       </Section>
     );
@@ -54,7 +82,7 @@ export const AccountSection = () => {
     <Section title="" className="pt-0">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <div className="flex flex-grow cursor-pointer items-center justify-between gap-3 rounded-md p-2 hover:bg-secondary/50 dark:hover:bg-secondary">
+          <div className="flex flex-grow cursor-pointer items-center justify-between gap-3 rounded-md p-2 hover:bg-secondary/50dark:hover:bg-secondary">
             <div className="flex items-center gap-3">
               <Avatar className="size-10">
                 <AvatarImage src={user.image ?? undefined} />

--- a/packages/vscode-webui/src/lib/hooks/use-token-login.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-token-login.ts
@@ -1,0 +1,55 @@
+import { vscodeHost } from "@/lib/vscode";
+import type { UserInfo } from "@getpochi/common/configuration";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Custom hook for handling token-based login with fallback UI
+ * @param user - Current user info, used to detect successful login
+ * @returns Object containing state and handlers for login fallback
+ */
+export const useTokenLogin = (user: UserInfo | undefined) => {
+  const [showFallback, setShowFallback] = useState(false);
+  const [userCode, setUserCode] = useState("");
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleLoginClick = () => {
+    // When user clicks, we start a timer.
+    timerRef.current = setTimeout(() => {
+      setShowFallback(true);
+    }, 5000);
+  };
+
+  const handleUserCodeSubmit = () => {
+    if (userCode) {
+      vscodeHost.loginWithToken(userCode);
+    }
+  };
+
+  const handleUserCodeChange = (value: string) => {
+    setUserCode(value);
+  };
+
+  useEffect(() => {
+    // if user is logged in, clear timer and hide fallback
+    if (user) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      setShowFallback(false);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [user]);
+
+  return {
+    showFallback,
+    userCode,
+    handleLoginClick,
+    handleUserCodeSubmit,
+    handleUserCodeChange,
+  };
+};

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -81,6 +81,7 @@ function createVSCodeHost(): VSCodeHostApi {
         "readModelList",
         "readUserStorage",
         "readCustomAgents",
+        "loginWithToken",
       ],
       exports: {
         openTask(params) {


### PR DESCRIPTION
## Summary

- Implement a fallback mechanism for the login process that displays a manual token input field after 5 seconds if automatic browser-based authentication fails. This ensures users can still complete authentication even if the redirect doesn't work properly.

## Test plan

- Manually test the login fallback on both the AccountSection and WelcomeScreen components.
- Verify that the timer correctly shows the fallback UI after 5 seconds.
- Verify that submitting a valid token completes the login process.
- Verify that the timer is cleared if login completes before the fallback is shown.

🤖 Generated with [Pochi](https://getpochi.com)