### PR TITLE
feat: add command to login with token

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -63,6 +63,11 @@
         "category": "Pochi"
       },
       {
+        "command": "pochi.loginWithToken",
+        "title": "Login with Token",
+        "category": "Pochi"
+      },
+      {
         "command": "pochi.editWorkspaceRules",
         "title": "Edit Workspace Rules",
         "category": "Pochi"
@@ -137,7 +142,11 @@
         },
         {
           "command": "pochi.logout",
-          "when": "false"
+          "title": "Pochi: Logout"
+        },
+        {
+          "command": "pochi.loginWithToken",
+          "title": "Pochi: Login with Token"
         },
         {
           "command": "pochi.webui.navigate.newTask",

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -106,6 +106,39 @@ export class CommandManager implements vscode.Disposable {
         }
       }),
 
+      vscode.commands.registerCommand("pochi.loginWithToken", async () => {
+        const token = await vscode.window.showInputBox({
+          prompt: "Enter your login token",
+          placeHolder: "Paste your token here",
+          ignoreFocusOut: true,
+        });
+
+        if (token) {
+          vscode.window.withProgress(
+            {
+              location: vscode.ProgressLocation.Notification,
+              cancellable: false,
+            },
+            async (progress) => {
+              progress.report({ message: "Login in progress, please wait..." });
+
+              const { data, error } = await this.authClient.deviceLink.verify({
+                query: { token },
+              });
+
+              if (error || "error" in data) {
+                vscode.window.showErrorMessage(
+                  "Failed to login, please try again.",
+                );
+                return;
+              }
+
+              this.authEvents.loginEvent.fire();
+            },
+          );
+        }
+      }),
+
       vscode.commands.registerCommand("pochi.editWorkspaceRules", async () => {
         try {
           const workspaceRulesUri = getWorkspaceRulesFileUri();


### PR DESCRIPTION
## Summary

This PR introduces a new command `pochi.loginWithToken` that allows users to log in by manually providing a token. This serves as a robust fallback mechanism for environments where the browser-based authentication flow may fail.

## Screen recording
https://jam.dev/c/989d4c11-5c0e-4862-8cb4-af33f77d0a57

## Changes

- Added `pochi.loginWithToken` command to `packages/vscode/src/integrations/command.ts`
- The command prompts the user for a token and uses a direct authentication flow, independent of URI handlers
- Registered the new command in `package.json` under `contributes.commands` and `contributes.menus.commandPalette` to make it accessible in the command palette

## Test Plan

- [ ] Verify the command appears in the command palette as "Pochi: Login with Token"
- [ ] Test that the command prompts for token input when executed
- [ ] Verify successful login flow with valid token
- [ ] Verify error handling with invalid token
- [ ] Ensure the command works independently of browser-based authentication

🤖 Generated with [Pochi](https://getpochi.com)