### PR TITLE
feat(webui): refactor file tool preview logic

### DIFF
--- a/packages/vscode-webui/src/components/tool-invocation/tools/apply-diff.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/apply-diff.tsx
@@ -1,6 +1,6 @@
 import { useToolCallLifeCycle } from "@/features/chat";
 import { getToolName } from "ai";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { FileBadge } from "../file-badge";
 import { NewProblems, NewProblemsIcon } from "../new-problems";
 import { StatusIcon } from "../status-icon";
@@ -18,14 +18,19 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
     toolName: getToolName(tool),
     toolCallId: tool.toolCallId,
   });
-  const handleClick = useCallback(() => {
-    return tool.state !== "output-available" &&
+
+  const shouldPreview = useMemo(() => {
+    return (
+      tool.state !== "output-available" &&
       (lifecycle.status === "init" ||
         lifecycle.status === "pending" ||
         lifecycle.status === "ready")
-      ? lifecycle.preview(tool.input, tool.state)
-      : undefined;
-  }, [tool.input, tool.state, lifecycle.status, lifecycle.preview]);
+    );
+  }, [tool.state, lifecycle.status]);
+
+  const handleClick = useCallback(() => {
+    lifecycle.preview(tool.input, tool.state);
+  }, [tool.input, tool.state, lifecycle.preview]);
 
   const result =
     tool.state === "output-available" && !("error" in tool.output)
@@ -41,7 +46,7 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
         <FileBadge
           className="ml-1"
           path={path}
-          onClick={handleClick}
+          onClick={shouldPreview ? handleClick : undefined}
           editSummary={result?._meta?.editSummary}
           changes={result?.success ? changes : undefined}
         />

--- a/packages/vscode-webui/src/components/tool-invocation/tools/multi-apply-diff.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/multi-apply-diff.tsx
@@ -1,7 +1,7 @@
 import { useToolCallLifeCycle } from "@/features/chat";
 
 import { getToolName } from "ai";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { FileBadge } from "../file-badge";
 import { NewProblems, NewProblemsIcon } from "../new-problems";
 import { StatusIcon } from "../status-icon";
@@ -20,14 +20,18 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
     toolName: getToolName(tool),
     toolCallId: tool.toolCallId,
   });
-  const handleClick = useCallback(() => {
-    return tool.state !== "output-available" &&
+  const shouldPreview = useMemo(() => {
+    return (
+      tool.state !== "output-available" &&
       (lifecycle.status === "init" ||
         lifecycle.status === "pending" ||
         lifecycle.status === "ready")
-      ? lifecycle.preview(tool.input, tool.state)
-      : undefined;
-  }, [tool.input, tool.state, lifecycle.status, lifecycle.preview]);
+    );
+  }, [tool.state, lifecycle.status]);
+
+  const handleClick = useCallback(() => {
+    lifecycle.preview(tool.input, tool.state);
+  }, [tool.input, tool.state, lifecycle.preview]);
 
   const result =
     tool.state === "output-available" &&
@@ -45,7 +49,7 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
         <FileBadge
           className="ml-1"
           path={path}
-          onClick={handleClick}
+          onClick={shouldPreview ? handleClick : undefined}
           editSummary={result?._meta?.editSummary}
           changes={result?.success ? changes : undefined}
         />

--- a/packages/vscode-webui/src/components/tool-invocation/tools/write-to-file.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/write-to-file.tsx
@@ -1,6 +1,6 @@
 import { useToolCallLifeCycle } from "@/features/chat";
 import { getToolName } from "ai";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { FileBadge } from "../file-badge";
 import { NewProblems, NewProblemsIcon } from "../new-problems";
 import { StatusIcon } from "../status-icon";
@@ -17,14 +17,18 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
     toolName: getToolName(tool),
     toolCallId: tool.toolCallId,
   });
-  const handleClick = useCallback(() => {
-    return tool.state !== "output-available" &&
+  const shouldPreview = useMemo(() => {
+    return (
+      tool.state !== "output-available" &&
       (lifecycle.status === "init" ||
         lifecycle.status === "pending" ||
         lifecycle.status === "ready")
-      ? lifecycle.preview(tool.input, tool.state)
-      : undefined;
-  }, [tool.input, tool.state, lifecycle.status, lifecycle.preview]);
+    );
+  }, [tool.state, lifecycle.status]);
+
+  const handleClick = useCallback(() => {
+    lifecycle.preview(tool.input, tool.state);
+  }, [tool.input, tool.state, lifecycle.preview]);
 
   const { path } = tool.input || {};
 
@@ -42,7 +46,7 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
         <FileBadge
           className="ml-1"
           path={path}
-          onClick={handleClick}
+          onClick={shouldPreview ? handleClick : undefined}
           editSummary={result?._meta?.editSummary}
           changes={result?.success ? changes : undefined}
         />


### PR DESCRIPTION
## Summary
This PR refactors the preview logic for the `applyDiff`, `multiApplyDiff`, and `writeToFile` tools in the web UI. The `onClick` handler for the file badge is now conditionally set, only allowing previews when the tool call is in a state where a preview is possible. This improves the user experience by preventing unnecessary or invalid preview attempts.

## Test plan
Manual testing of the file operation tools in the web UI to ensure the preview functionality works as expected.

🤖 Generated with [Pochi](https://getpochi.com)