### PR TITLE
fix(cli): correct mcp list command display alignment

### DIFF
--- a/packages/cli/src/mcp/list.ts
+++ b/packages/cli/src/mcp/list.ts
@@ -113,8 +113,12 @@ export function registerMcpListCommand(parentCommand: Command) {
 
         // Format columns with proper padding
         const namePadded = serverName.padEnd(maxNameLength);
+        // The ❌ character takes up two cells in the terminal
+        const statusVisualWidthAdjustment = serverConfig.disabled ? 1 : 0;
         const statusPadded = statusColored.padEnd(
-          statusWidth + (statusColored.length - statusText.length),
+          statusWidth +
+            (statusColored.length - statusText.length) -
+            statusVisualWidthAdjustment,
         );
         const transportPadded = transport.padEnd(transportWidth);
         const disabledToolsPadded = hasDisabledTools


### PR DESCRIPTION
## Summary

- Fixes the alignment issue in the `pochi mcp list` command output caused by the `❌` character taking up two cells in the terminal.
- Adds the `mermaid` dependency to `packages/vscode-webui` to resolve a pre-push hook failure.

## Test plan

Run `pochi mcp list` to verify the fix.

🤖 Generated with [Pochi](https://getpochi.com)