### PR TITLE
chore(action): move reaction behavior into first step of action

### DIFF
--- a/.github/workflows/pochi.yml
+++ b/.github/workflows/pochi.yml
@@ -17,6 +17,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run pochi
-        uses: tabbyml/pochi/packages/github-action@main
+        uses: sma1lboy/pochi/packages/github-action@main
         env:
           POCHI_TOKEN: ${{ secrets.POCHI_TOKEN }}

--- a/.github/workflows/pochi.yml
+++ b/.github/workflows/pochi.yml
@@ -17,6 +17,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run pochi
-        uses: sma1lboy/pochi/packages/github-action@main
+        uses: tabbyml/pochi/packages/github-action@main
         env:
           POCHI_TOKEN: ${{ secrets.POCHI_TOKEN }}

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -19,11 +19,6 @@ runs:
         COMMENT_ID=$(echo '${{ github.event.comment.id }}')
         ISSUE_NUMBER=$(echo '${{ github.event.issue.number }}')
         
-        # Debug output
-        echo "Debug: COMMENT_ID=$COMMENT_ID"
-        echo "Debug: ISSUE_NUMBER=$ISSUE_NUMBER"
-        echo "Debug: REPOSITORY=${{ github.repository }}"
-        
         # Add eyes reaction to indicate starting
         EYES_REACTION_RESPONSE=$(curl -L \
           -X POST \
@@ -33,12 +28,8 @@ runs:
           https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions \
           -d '{"content":"eyes"}')
         
-        # Debug output for eyes reaction response
-        echo "Debug: EYES_REACTION_RESPONSE=$EYES_REACTION_RESPONSE"
-        
         # Extract eyes reaction ID and export as environment variable
         EYES_REACTION_ID=$(echo "$EYES_REACTION_RESPONSE" | jq -r '.id')
-        echo "Debug: Extracted EYES_REACTION_ID=$EYES_REACTION_ID"
         echo "EYES_REACTION_ID=$EYES_REACTION_ID" >> $GITHUB_ENV
         
         # Create initial progress comment
@@ -50,12 +41,8 @@ runs:
           https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
           -d "{\"body\":\"🔄 **Pochi Running...**\\n\\nStarting Pochi execution...\\n\\n🔗 **[View GitHub Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**\"}")
         
-        # Debug output for progress comment response
-        echo "Debug: PROGRESS_COMMENT_RESPONSE=$PROGRESS_COMMENT_RESPONSE"
-        
         # Extract progress comment ID and export as environment variable
         PROGRESS_COMMENT_ID=$(echo "$PROGRESS_COMMENT_RESPONSE" | jq -r '.id')
-        echo "Debug: Extracted PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID"
         echo "PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID" >> $GITHUB_ENV
 
     - name: Install pochi CLI

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -60,6 +60,39 @@ runs:
           exit 1
         fi
 
+    - name: Add initial reaction and create progress comment
+      shell: bash
+      run: |
+        # Get comment ID from GitHub context
+        COMMENT_ID=$(echo '${{ github.event.comment.id }}')
+        ISSUE_NUMBER=$(echo '${{ github.event.issue.number }}')
+        
+        # Add eyes reaction to indicate starting
+        EYES_REACTION_RESPONSE=$(curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ github.token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions \
+          -d '{"content":"eyes"}')
+        
+        # Extract eyes reaction ID and export as environment variable
+        EYES_REACTION_ID=$(echo $EYES_REACTION_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
+        echo "EYES_REACTION_ID=$EYES_REACTION_ID" >> $GITHUB_ENV
+        
+        # Create initial progress comment
+        PROGRESS_COMMENT_RESPONSE=$(curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ github.token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
+          -d "{\"body\":\"🔄 **Pochi Running...**\\n\\nStarting Pochi execution...\\n\\n🔗 **[View GitHub Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**\"}")
+        
+        # Extract progress comment ID and export as environment variable
+        PROGRESS_COMMENT_ID=$(echo $PROGRESS_COMMENT_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
+        echo "PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID" >> $GITHUB_ENV
+
     - name: Run pochi GitHub Action
       shell: bash
       run: |
@@ -70,3 +103,5 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         POCHI_REMOTE_ENV: 1
+        PROGRESS_COMMENT_ID: ${{ env.PROGRESS_COMMENT_ID }}
+        EYES_REACTION_ID: ${{ env.EYES_REACTION_ID }}

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -19,6 +19,11 @@ runs:
         COMMENT_ID=$(echo '${{ github.event.comment.id }}')
         ISSUE_NUMBER=$(echo '${{ github.event.issue.number }}')
         
+        # Debug output
+        echo "Debug: COMMENT_ID=$COMMENT_ID"
+        echo "Debug: ISSUE_NUMBER=$ISSUE_NUMBER"
+        echo "Debug: REPOSITORY=${{ github.repository }}"
+        
         # Add eyes reaction to indicate starting
         EYES_REACTION_RESPONSE=$(curl -L \
           -X POST \
@@ -28,8 +33,12 @@ runs:
           https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions \
           -d '{"content":"eyes"}')
         
+        # Debug output for eyes reaction response
+        echo "Debug: EYES_REACTION_RESPONSE=$EYES_REACTION_RESPONSE"
+        
         # Extract eyes reaction ID and export as environment variable
         EYES_REACTION_ID=$(echo $EYES_REACTION_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
+        echo "Debug: Extracted EYES_REACTION_ID=$EYES_REACTION_ID"
         echo "EYES_REACTION_ID=$EYES_REACTION_ID" >> $GITHUB_ENV
         
         # Create initial progress comment
@@ -41,8 +50,12 @@ runs:
           https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
           -d "{\"body\":\"🔄 **Pochi Running...**\\n\\nStarting Pochi execution...\\n\\n🔗 **[View GitHub Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**\"}")
         
+        # Debug output for progress comment response
+        echo "Debug: PROGRESS_COMMENT_RESPONSE=$PROGRESS_COMMENT_RESPONSE"
+        
         # Extract progress comment ID and export as environment variable
         PROGRESS_COMMENT_ID=$(echo $PROGRESS_COMMENT_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
+        echo "Debug: Extracted PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID"
         echo "PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID" >> $GITHUB_ENV
 
     - name: Install pochi CLI

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -37,7 +37,7 @@ runs:
         echo "Debug: EYES_REACTION_RESPONSE=$EYES_REACTION_RESPONSE"
         
         # Extract eyes reaction ID and export as environment variable
-        EYES_REACTION_ID=$(echo $EYES_REACTION_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
+        EYES_REACTION_ID=$(echo "$EYES_REACTION_RESPONSE" | jq -r '.id')
         echo "Debug: Extracted EYES_REACTION_ID=$EYES_REACTION_ID"
         echo "EYES_REACTION_ID=$EYES_REACTION_ID" >> $GITHUB_ENV
         
@@ -54,7 +54,7 @@ runs:
         echo "Debug: PROGRESS_COMMENT_RESPONSE=$PROGRESS_COMMENT_RESPONSE"
         
         # Extract progress comment ID and export as environment variable
-        PROGRESS_COMMENT_ID=$(echo $PROGRESS_COMMENT_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
+        PROGRESS_COMMENT_ID=$(echo "$PROGRESS_COMMENT_RESPONSE" | jq -r '.id')
         echo "Debug: Extracted PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID"
         echo "PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID" >> $GITHUB_ENV
 

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -12,6 +12,39 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Add initial reaction and create progress comment
+      shell: bash
+      run: |
+        # Get comment ID from GitHub context
+        COMMENT_ID=$(echo '${{ github.event.comment.id }}')
+        ISSUE_NUMBER=$(echo '${{ github.event.issue.number }}')
+        
+        # Add eyes reaction to indicate starting
+        EYES_REACTION_RESPONSE=$(curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ github.token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions \
+          -d '{"content":"eyes"}')
+        
+        # Extract eyes reaction ID and export as environment variable
+        EYES_REACTION_ID=$(echo $EYES_REACTION_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
+        echo "EYES_REACTION_ID=$EYES_REACTION_ID" >> $GITHUB_ENV
+        
+        # Create initial progress comment
+        PROGRESS_COMMENT_RESPONSE=$(curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ github.token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
+          -d "{\"body\":\"🔄 **Pochi Running...**\\n\\nStarting Pochi execution...\\n\\n🔗 **[View GitHub Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**\"}")
+        
+        # Extract progress comment ID and export as environment variable
+        PROGRESS_COMMENT_ID=$(echo $PROGRESS_COMMENT_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
+        echo "PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID" >> $GITHUB_ENV
+
     - name: Install pochi CLI
       shell: bash
       run: |
@@ -59,39 +92,6 @@ runs:
           echo "Error: Failed to install dependencies"
           exit 1
         fi
-
-    - name: Add initial reaction and create progress comment
-      shell: bash
-      run: |
-        # Get comment ID from GitHub context
-        COMMENT_ID=$(echo '${{ github.event.comment.id }}')
-        ISSUE_NUMBER=$(echo '${{ github.event.issue.number }}')
-        
-        # Add eyes reaction to indicate starting
-        EYES_REACTION_RESPONSE=$(curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ github.token }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions \
-          -d '{"content":"eyes"}')
-        
-        # Extract eyes reaction ID and export as environment variable
-        EYES_REACTION_ID=$(echo $EYES_REACTION_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
-        echo "EYES_REACTION_ID=$EYES_REACTION_ID" >> $GITHUB_ENV
-        
-        # Create initial progress comment
-        PROGRESS_COMMENT_RESPONSE=$(curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ github.token }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
-          -d "{\"body\":\"🔄 **Pochi Running...**\\n\\nStarting Pochi execution...\\n\\n🔗 **[View GitHub Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**\"}")
-        
-        # Extract progress comment ID and export as environment variable
-        PROGRESS_COMMENT_ID=$(echo $PROGRESS_COMMENT_RESPONSE | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2)
-        echo "PROGRESS_COMMENT_ID=$PROGRESS_COMMENT_ID" >> $GITHUB_ENV
 
     - name: Run pochi GitHub Action
       shell: bash

--- a/packages/github-action/src/run-pochi.ts
+++ b/packages/github-action/src/run-pochi.ts
@@ -73,20 +73,12 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
   const config = readPochiConfig();
 
   const historyCommentId = process.env.PROGRESS_COMMENT_ID
-    ? (() => {
-        const id = Number.parseInt(process.env.PROGRESS_COMMENT_ID, 10);
-        console.log(`Using progress comment ID from env: ${id}`);
-        return id;
-      })()
+    ? Number.parseInt(process.env.PROGRESS_COMMENT_ID, 10)
     : await githubManager.createComment(
         `Starting Pochi execution...${createGitHubActionFooter(request.event)}`,
       );
   const eyesReactionId = process.env.EYES_REACTION_ID
-    ? (() => {
-        const id = Number.parseInt(process.env.EYES_REACTION_ID, 10);
-        console.log(`Using eyes reaction ID from env: ${id}`);
-        return id;
-      })()
+    ? Number.parseInt(process.env.EYES_REACTION_ID, 10)
     : undefined;
 
   const args = ["--prompt", request.prompt, "--max-steps", "128"];

--- a/packages/github-action/src/run-pochi.ts
+++ b/packages/github-action/src/run-pochi.ts
@@ -72,15 +72,14 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
   const request = githubManager.parseRequest();
   const config = readPochiConfig();
 
-  // Add eye reaction to indicate starting
-  const eyesReactionId = await githubManager.createReaction(
-    request.commentId,
-    "eyes",
-  );
-
-  // Create initial history comment with GitHub Action link
-  const initialComment = `Starting Pochi execution...${createGitHubActionFooter(request.event)}`;
-  const historyCommentId = await githubManager.createComment(initialComment);
+  const historyCommentId = process.env.PROGRESS_COMMENT_ID
+    ? Number.parseInt(process.env.PROGRESS_COMMENT_ID, 10)
+    : await githubManager.createComment(
+        `Starting Pochi execution...${createGitHubActionFooter(request.event)}`,
+      );
+  const eyesReactionId = process.env.EYES_REACTION_ID
+    ? Number.parseInt(process.env.EYES_REACTION_ID, 10)
+    : undefined;
 
   const args = ["--prompt", request.prompt, "--max-steps", "128"];
 

--- a/packages/github-action/src/run-pochi.ts
+++ b/packages/github-action/src/run-pochi.ts
@@ -73,12 +73,20 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
   const config = readPochiConfig();
 
   const historyCommentId = process.env.PROGRESS_COMMENT_ID
-    ? Number.parseInt(process.env.PROGRESS_COMMENT_ID, 10)
+    ? (() => {
+        const id = Number.parseInt(process.env.PROGRESS_COMMENT_ID, 10);
+        console.log(`Using progress comment ID from env: ${id}`);
+        return id;
+      })()
     : await githubManager.createComment(
         `Starting Pochi execution...${createGitHubActionFooter(request.event)}`,
       );
   const eyesReactionId = process.env.EYES_REACTION_ID
-    ? Number.parseInt(process.env.EYES_REACTION_ID, 10)
+    ? (() => {
+        const id = Number.parseInt(process.env.EYES_REACTION_ID, 10);
+        console.log(`Using eyes reaction ID from env: ${id}`);
+        return id;
+      })()
     : undefined;
 
   const args = ["--prompt", request.prompt, "--max-steps", "128"];


### PR DESCRIPTION
This pull request introduces improvements to the GitHub Action workflow for the Pochi CLI by moving the creation of the initial progress comment and the "eyes" reaction from the TypeScript implementation to the shell script steps in the workflow YAML. This change streamlines the workflow setup and ensures that environment variables for these resources are available to subsequent steps and the CLI itself.

**Workflow enhancements:**

* Added a new shell script step in `action.yml` to create the initial "eyes" reaction and progress comment via GitHub API calls, exporting their IDs as environment variables for use in later steps.
* Updated environment variables in the workflow to include `PROGRESS_COMMENT_ID` and `EYES_REACTION_ID`, making them available to the Pochi CLI execution step.

**Codebase adjustments:**

* Modified `run-pochi.ts` to use the pre-created comment and reaction IDs from environment variables if available, falling back to creating them in code only if not set. This avoids duplicate API calls and leverages the workflow setup.