### PR TITLE
fix(ripgrep): improve error logging for rg command execution

### DIFF
--- a/packages/common/src/tool-utils/ripgrep.ts
+++ b/packages/common/src/tool-utils/ripgrep.ts
@@ -134,8 +134,8 @@ export async function searchFilesWithRipgrep(
     }
     // biome-ignore lint/suspicious/noExplicitAny: exception catch has to be any
   } catch (error: any) {
-    logger.error("rg command error: ", error);
     if (!(error satisfies ExecError)) {
+      logger.error("rg command error: ", error);
       throw error;
     }
 


### PR DESCRIPTION
Relate https://github.com/TabbyML/pochi/issues/225

<img width="854" height="327" alt="image" src="https://github.com/user-attachments/assets/5ba0657f-03f7-492b-883c-d39df26830e9" />

This pull request makes a minor adjustment to error logging in the `searchFilesWithRipgrep` function. The change ensures that the error is only logged if it does not satisfy the `ExecError` type, improving the clarity and accuracy of error reporting.