### PR TITLE
feat(webui): stream executeCommand output

### DIFF
--- a/packages/vscode-webui/src/features/chat/lib/fixed-state-tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/fixed-state-tool-call-life-cycle.ts
@@ -1,17 +1,16 @@
 import type { ToolUIPart } from "ai";
-import type { ToolCallLifeCycle } from "./tool-call-life-cycle";
+import type {
+  StreamingResult,
+  ToolCallLifeCycle,
+} from "./tool-call-life-cycle";
 
 export class FixedStateToolCallLifeCycle implements ToolCallLifeCycle {
   constructor(
     readonly toolName: string,
     readonly toolCallId: string,
     readonly status: "execute" | "dispose",
+    readonly streamingResult: StreamingResult | undefined,
   ) {}
-
-  get streamingResult() {
-    // streaming result is unsupported in FixedStateToolCallLifeCycle
-    return undefined;
-  }
 
   get complete(): { result: unknown; reason: "execute-finish" | "user-abort" } {
     throw new Error(

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -24,7 +24,7 @@ type NewTaskReturnType = {
 };
 type ExecuteReturnType = ExecuteCommandReturnType | NewTaskReturnType | unknown;
 
-type StreamingResult =
+export type StreamingResult =
   | {
       toolName: "executeCommand";
       output: ExecuteCommandResult;

--- a/packages/vscode/src/tools/execute-command.ts
+++ b/packages/vscode/src/tools/execute-command.ts
@@ -18,10 +18,7 @@ const logger = getLogger("ExecuteCommand");
 
 export const executeCommand: ToolFunctionType<
   ClientTools["executeCommand"]
-> = async (
-  { command, cwd = ".", timeout },
-  { abortSignal, nonInteractive },
-) => {
+> = async ({ command, cwd = ".", timeout }, { abortSignal }) => {
   const defaultTimeout = 120;
   if (!command) {
     throw new Error("Command is required to execute.");
@@ -69,33 +66,6 @@ export const executeCommand: ToolFunctionType<
         };
       });
   });
-
-  if (nonInteractive) {
-    return new Promise((resolve) => {
-      logger.debug(
-        "Executing in non-interactive mode, waiting for output to complete...",
-      );
-      const unsubscribe = output.subscribe((outputResult) => {
-        if (outputResult.status === "completed") {
-          const result: {
-            output: string;
-            isTruncated: boolean;
-            error?: string;
-          } = {
-            output: outputResult.content,
-            isTruncated: outputResult.isTruncated ?? false,
-          };
-          // do not set error property if it is undefined
-          if (outputResult.error) {
-            result.error = outputResult.error;
-          }
-
-          unsubscribe();
-          resolve(result);
-        }
-      });
-    });
-  }
 
   // biome-ignore lint/suspicious/noExplicitAny: pass thread signal
   return { output: ThreadSignal.serialize(output) as any };


### PR DESCRIPTION
## Summary
This change introduces support for streaming the output of the 'executeCommand' tool to the web UI. It updates the 'executeCommand' tool to always return a ThreadSignal and modifies the web UI components to subscribe to this signal and display the streaming output in real-time.

## Test plan
- Run the web UI and execute a command to verify that the output is streamed correctly.

🤖 Generated with [Pochi](https://getpochi.com)