### PR TITLE
fix(vscode): clear user cache on config deletion

### DIFF
--- a/packages/vscode/src/lib/user-storage.ts
+++ b/packages/vscode/src/lib/user-storage.ts
@@ -21,6 +21,8 @@ export class UserStorage implements vscode.Disposable {
         this.fetchUserStorage().then((users) => {
           this.users.value = users;
         });
+      } else {
+        this.users.value = {};
       }
     });
   }


### PR DESCRIPTION
## Screen record

- https://jam.dev/c/0a180633-1589-4d8b-b14c-51917b057d09

## Summary
This change ensures that when the user deletes the `~/.pochi/config.jsonc` file, the user information is cleared from the cache. This will ensure that the UI accurately reflects the user's logged-out state.

## Test plan
1. Run the VS Code extension.
2. Log in.
3. Observe user info in the settings page.
4. Delete `~/.pochi/config.jsonc`.
5. Observe that the settings page now shows the login view.

🤖 Generated with [Pochi](https://getpochi.com)