### PR TITLE
fix: correct store ID return value and improve credential fetching logic

### DIFF
--- a/packages/livekit/src/index.ts
+++ b/packages/livekit/src/index.ts
@@ -13,5 +13,5 @@ export function getStoreId(cwd: string, jwt: string | null) {
     return `store-${sub}-${id}`;
   }
 
-  return id;
+  return `store-local-${id}`;
 }

--- a/packages/vscode-webui/src/lib/hooks/use-pochi-credentials.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-pochi-credentials.ts
@@ -1,15 +1,23 @@
 import { vscodeHost } from "@/lib/vscode";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
+import { useUserStorage } from "./use-user-storage";
 
 /** @useSignals this comment is needed to enable signals in this hook */
 export const usePochiCredentials = () => {
-  const { data } = useQuery({
+  const { data, refetch } = useQuery({
     queryKey: ["pochiCredentials"],
     queryFn: fetchPochiCredentials,
     // Every 5 minutes
     refetchInterval: 1000 * 60 * 5,
   });
+
+  const userStorage = useUserStorage();
+  // refecth whenever user changed.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: allow
+  useEffect(() => {
+    refetch();
+  }, [userStorage.users?.pochi]);
 
   return useMemo(
     () => ({


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
