### PR TITLE
fix(vendor-pochi): encode file part data to base64

### DIFF
--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -1,6 +1,11 @@
-import { APICallError, type LanguageModelV2 } from "@ai-sdk/provider";
+import {
+  APICallError,
+  type LanguageModelV2,
+  type LanguageModelV2Prompt,
+} from "@ai-sdk/provider";
 import {
   EventSourceParserStream,
+  convertToBase64,
   extractResponseHeaders,
 } from "@ai-sdk/provider-utils";
 import type { PochiApi, PochiApiClient } from "@getpochi/common/pochi-api";
@@ -29,7 +34,7 @@ export function createPochiModel({
         id,
         model: modelId,
         callOptions: {
-          prompt,
+          prompt: convertFilePartDataToBase64(prompt),
           stopSequences,
           tools,
         },
@@ -89,4 +94,26 @@ function createApiClient(
   });
 
   return authClient;
+}
+
+function convertFilePartDataToBase64(
+  prompt: LanguageModelV2Prompt,
+): LanguageModelV2Prompt {
+  return prompt.map((message) => {
+    if (message.role === "system") {
+      return message;
+    }
+    return {
+      ...message,
+      content: message.content.map((part) => {
+        if (part.type === "file" && part.data instanceof Uint8Array) {
+          return {
+            ...part,
+            data: convertToBase64(part.data),
+          };
+        }
+        return part;
+      }),
+    };
+  }) as LanguageModelV2Prompt;
 }


### PR DESCRIPTION
## Summary

- The Pochi API expects file part data to be base64 encoded. This change introduces a utility function to convert Uint8Array file data to base64 before sending the request.

## Test plan

The pre-push hooks already ran the tests, and they all passed.

🤖 Generated with [Pochi](https://getpochi.com)