### PR TITLE
fix(vscode-webui): reset submit history navigation on every attempt

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/submit-history-extension.ts
+++ b/packages/vscode-webui/src/components/prompt-form/submit-history-extension.ts
@@ -69,6 +69,10 @@ export const SubmitHistoryExtension = Extension.create<
       addToSubmitHistory: (content: string) => () => {
         const storage = this.storage;
 
+        // Reset navigation index
+        storage.currentIndex = -1;
+        storage.isNavigating = false;
+
         // Don't add empty content or duplicate consecutive entries
         if (!content.trim()) return false;
 
@@ -82,10 +86,6 @@ export const SubmitHistoryExtension = Extension.create<
         if (storage.history.length > this.options.maxHistorySize) {
           storage.history = storage.history.slice(-this.options.maxHistorySize);
         }
-
-        // Reset navigation index
-        storage.currentIndex = -1;
-        storage.isNavigating = false;
 
         try {
           vscodeHost.setWorkspaceState(


### PR DESCRIPTION
## Summary
- This commit moves the reset logic for the submit history navigation to ensure that the navigation index is cleared every time a new submission is attempted, not just when it's successfully added to the history. This prevents stale navigation state when submitting empty content.

## Test plan
- Manually verified that the submit history navigation is reset correctly after attempting to submit empty content.
- Confirmed that navigation (up/down arrows) through history works as expected after valid submissions.

🤖 Generated with [Pochi](https://getpochi.com)