### PR TITLE
feat(cli): add interactive vendor selection for auth commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,9 +21,6 @@
       "bin": {
         "pochi": "src/cli.ts",
       },
-      "dependencies": {
-        "@inquirer/select": "^4.3.2",
-      },
       "devDependencies": {
         "@commander-js/extra-typings": "^14.0.0",
         "@getpochi/common": "workspace:*",
@@ -31,6 +28,7 @@
         "@getpochi/tools": "workspace:*",
         "@getpochi/vendor-gemini-cli": "workspace:*",
         "@getpochi/vendor-pochi": "workspace:*",
+        "@inquirer/select": "^4.3.2",
         "@livestore/adapter-node": "catalog:",
         "@livestore/livestore": "catalog:",
         "@livestore/wa-sqlite": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,9 @@
       "bin": {
         "pochi": "src/cli.ts",
       },
+      "dependencies": {
+        "@inquirer/select": "^4.3.2",
+      },
       "devDependencies": {
         "@commander-js/extra-typings": "^14.0.0",
         "@getpochi/common": "workspace:*",
@@ -756,6 +759,14 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.3", "", { "os": "win32", "cpu": "x64" }, "sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g=="],
+
+    "@inquirer/core": ["@inquirer/core@10.2.0", "", { "dependencies": { "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA=="],
+
+    "@inquirer/figures": ["@inquirer/figures@1.0.13", "", {}, "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw=="],
+
+    "@inquirer/select": ["@inquirer/select@4.3.2", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-nwous24r31M+WyDEHV+qckXkepvihxhnyIaod2MG7eCE6G0Zm/HUF6jgN8GXgf4U7AU6SLseKdanY195cwvU6w=="],
+
+    "@inquirer/type": ["@inquirer/type@3.0.8", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw=="],
 
     "@ioredis/commands": ["@ioredis/commands@1.2.0", "https://registry.npmmirror.com/@ioredis/commands/-/commands-1.2.0.tgz", {}, "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="],
 
@@ -1569,7 +1580,7 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
-    "ansi-escapes": ["ansi-escapes@7.0.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw=="],
+    "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
@@ -1734,6 +1745,8 @@
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
 
     "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
@@ -2797,7 +2810,7 @@
 
     "mustache": ["mustache@2.2.1", "", { "bin": { "mustache": "./bin/mustache" } }, "sha512-azYRexmi9y6h2lk2JqfBLh1htlDMjKYyEYOkxoGKa0FRdr5aY4f5q8bH4JIecM181DtUEYLSz8PcRO46mgzMNQ=="],
 
-    "mute-stream": ["mute-stream@0.0.8", "", {}, "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="],
+    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
     "nan": ["nan@2.23.0", "https://registry.npmmirror.com/nan/-/nan-2.23.0.tgz", {}, "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ=="],
 
@@ -3683,6 +3696,8 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
+
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
@@ -3730,6 +3745,8 @@
     "@effect/sql/@effect/platform": ["@effect/platform@0.82.4", "", { "dependencies": { "find-my-way-ts": "^0.1.5", "msgpackr": "^1.11.2", "multipasta": "^0.2.5" }, "peerDependencies": { "effect": "^3.15.2" } }, "sha512-og5DIzx4wz7nIXd/loDfenXvV3c/NT+NDG+YJsi3g6a5Xb6xwrNJuX97sDaV2LJ29G3LroeVJCmYUmfdf/h5Vg=="],
 
     "@iconify/utils/globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
+
+    "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -3971,6 +3988,8 @@
 
     "ajv-keywords/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
+    "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "ast-v8-to-istanbul/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.30", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q=="],
@@ -4119,6 +4138,8 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
+    "log-update/ansi-escapes": ["ansi-escapes@7.0.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw=="],
+
     "log-update/slice-ansi": ["slice-ansi@7.1.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg=="],
 
     "loud-rejection/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
@@ -4226,6 +4247,8 @@
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "react-i18next/@babel/runtime": ["@babel/runtime@7.28.3", "", {}, "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="],
+
+    "read/mute-stream": ["mute-stream@0.0.8", "", {}, "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="],
 
     "read-pkg/path-type": ["path-type@3.0.0", "", { "dependencies": { "pify": "^3.0.0" } }, "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg=="],
 
@@ -4336,6 +4359,12 @@
     "youch/cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -4911,6 +4940,12 @@
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@inquirer/core/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "@livestore/adapter-node/vite/rollup/@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.50.1", "", { "os": "android", "cpu": "arm" }, "sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag=="],
 
     "@livestore/adapter-node/vite/rollup/@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.50.1", "", { "os": "android", "cpu": "arm64" }, "sha512-PZlsJVcjHfcH53mOImyt3bc97Ep3FJDXRpk9sMdGX0qgLmY0EIWxCag6EigerGhLVuL8lDVYNnSo8qnTElO4xw=="],
@@ -5150,6 +5185,8 @@
     "wrap-ansi-cjs/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@inquirer/core/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "@storybook/react-vite/@storybook/test/@storybook/instrumenter/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,5 +34,8 @@
     "listr2": "^9.0.3",
     "ora": "^8.2.0",
     "semver": "^7.6.3"
+  },
+  "dependencies": {
+    "@inquirer/select": "^4.3.2"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,9 +33,7 @@
     "hono": "catalog:",
     "listr2": "^9.0.3",
     "ora": "^8.2.0",
-    "semver": "^7.6.3"
-  },
-  "dependencies": {
+    "semver": "^7.6.3",
     "@inquirer/select": "^4.3.2"
   }
 }

--- a/packages/cli/src/auth/cmd.ts
+++ b/packages/cli/src/auth/cmd.ts
@@ -120,8 +120,11 @@ export function registerAuthCommand(program: Command) {
       } catch (err) {
         if (err instanceof Error) {
           // Handle user cancellation (Ctrl+C)
-          if (err.name === 'ExitPromptError' || err.message.includes('force closed')) {
-            console.log('Logout cancelled');
+          if (
+            err.name === "ExitPromptError" ||
+            err.message.includes("force closed")
+          ) {
+            console.log("Logout cancelled");
             return;
           }
           return logoutCommand.error(err.message);

--- a/packages/cli/src/auth/cmd.ts
+++ b/packages/cli/src/auth/cmd.ts
@@ -4,12 +4,13 @@ import {
   updateVendorConfig,
 } from "@getpochi/common/configuration";
 import { getVendors } from "@getpochi/common/vendor";
+import select from "@inquirer/select";
 import chalk from "chalk";
 import { login } from "./login";
+import { confirmVendorSelection, selectVendor } from "./vendor-selector";
 
 export function registerAuthCommand(program: Command) {
   const vendors = getVendors();
-  const vendorNames = Object.keys(vendors).join(", ");
 
   const authCommand = program
     .command("auth")
@@ -26,60 +27,107 @@ export function registerAuthCommand(program: Command) {
   });
 
   const loginCommand = authCommand.command("login");
-  loginCommand
-    .requiredOption(
-      "-v, --vendor <vendor>",
-      `Vendor to login to: ${vendorNames}`,
-    )
-    .action(async ({ vendor }) => {
-      const auth = vendors[vendor as keyof typeof vendors];
-      if (auth.authenticated) {
+  loginCommand.description("log in to a provider").action(async () => {
+    try {
+      const selectedVendor = await selectVendor();
+      const auth = vendors[selectedVendor as keyof typeof vendors];
+      if (!auth) {
+        return loginCommand.error(`Unknown vendor: ${selectedVendor}`);
+      }
+
+      const shouldProceed = await confirmVendorSelection(selectedVendor);
+      if (!shouldProceed) {
         const user = await auth.getUserInfo();
-        console.log("You're already logged in as", renderUser(user));
+        console.log("Using existing authentication for", renderUser(user));
         return;
       }
 
-      try {
-        const user = await login(vendor);
-        console.log("Logged in as", renderUser(user));
-      } catch (err) {
-        if (err instanceof Error) {
-          return loginCommand.error(err.message);
+      const user = await login(selectedVendor);
+      console.log("Logged in as", renderUser(user));
+    } catch (err) {
+      if (err instanceof Error) {
+        if (
+          err.name === "ExitPromptError" ||
+          err.message.includes("force closed")
+        ) {
+          console.log("Login cancelled");
+          return;
         }
-
-        throw err;
+        return loginCommand.error(err.message);
       }
-    });
+      throw err;
+    }
+  });
 
   const logoutCommand = authCommand.command("logout");
   logoutCommand
+    .description("log out from a configured provider")
     .option("-a, --all")
-    .option("-v, --vendor <vendor>", `Vendor to logout from: ${vendors}`)
-    .action(async ({ vendor, all }) => {
+    .action(async ({ all }) => {
       const logout = async (name: string) => {
         await updateVendorConfig(name, null);
         console.log(`Logged out from ${name}`);
       };
-      if (vendor) {
-        const auth = vendors[vendor as keyof typeof vendors];
-        if (auth.authenticated) {
-          await logout(vendor);
-        } else {
-          return logoutCommand.error(`You are not logged in to ${vendor}`);
-        }
-        return;
-      }
 
       if (all) {
+        let loggedOutCount = 0;
         for (const [name, auth] of Object.entries(vendors)) {
           if (auth.authenticated) {
             await logout(name);
+            loggedOutCount++;
           }
+        }
+        if (loggedOutCount === 0) {
+          console.log(chalk.gray("No authenticated vendors found"));
         }
         return;
       }
 
-      return logoutCommand.error("Please specify a provider or use --all");
+      // Prompt for selection from authenticated vendors
+      try {
+        const authenticatedVendors = Object.entries(vendors).filter(
+          ([, auth]) => auth.authenticated,
+        );
+
+        if (authenticatedVendors.length === 0) {
+          console.log(chalk.gray("No authenticated vendors found"));
+          return;
+        }
+
+        const choices = await Promise.all(
+          authenticatedVendors.map(async ([vendorId, vendor]) => {
+            try {
+              const userInfo = await vendor.getUserInfo();
+              return {
+                name: `${vendorId} - ${userInfo?.name || userInfo?.email || "authenticated user"}`,
+                value: vendorId,
+              };
+            } catch {
+              return {
+                name: `${vendorId} - authenticated user`,
+                value: vendorId,
+              };
+            }
+          }),
+        );
+
+        const selectedVendor = await select({
+          message: "Select a vendor to logout from:",
+          choices,
+        });
+
+        await logout(selectedVendor);
+      } catch (err) {
+        if (err instanceof Error) {
+          // Handle user cancellation (Ctrl+C)
+          if (err.name === 'ExitPromptError' || err.message.includes('force closed')) {
+            console.log('Logout cancelled');
+            return;
+          }
+          return logoutCommand.error(err.message);
+        }
+        throw err;
+      }
     });
 }
 

--- a/packages/cli/src/auth/vendor-selector.ts
+++ b/packages/cli/src/auth/vendor-selector.ts
@@ -1,0 +1,94 @@
+import { getVendors } from "@getpochi/common/vendor";
+import select from "@inquirer/select";
+import chalk from "chalk";
+
+export interface VendorChoice {
+  name: string;
+  value: string;
+  description?: string;
+}
+
+export async function selectVendor(): Promise<string> {
+  const vendors = getVendors();
+  const vendorEntries = Object.entries(vendors);
+
+  if (vendorEntries.length === 0) {
+    throw new Error("No vendors are available");
+  }
+
+  // If only one vendor is available, use it directly
+  if (vendorEntries.length === 1) {
+    const [vendorId] = vendorEntries[0];
+    console.log(chalk.gray(`Using ${vendorId} (only available vendor)`));
+    return vendorId;
+  }
+
+  const choices: VendorChoice[] = await Promise.all(
+    vendorEntries.map(async ([vendorId, vendor]) => {
+      let description = "";
+
+      if (vendor.authenticated) {
+        try {
+          const userInfo = await vendor.getUserInfo();
+          description = `✓ Logged in as ${userInfo?.name || userInfo?.email || "authenticated user"}`;
+        } catch {
+          description = "✓ Authenticated";
+        }
+      } else {
+        description = "Not logged in";
+      }
+      return {
+        name: `${vendorId.charAt(0).toUpperCase() + vendorId.slice(1)} ${chalk.white("-")} ${vendor.authenticated ? chalk.green(description) : chalk.gray(description)}`,
+        value: vendorId,
+        description: `\n${chalk.gray("Current selection:")} ${chalk.gray(description)}`,
+      };
+    }),
+  );
+
+  const answer = await select({
+    message: "Select a vendor to authenticate with:",
+    instructions: {
+      navigation: "Use arrow keys to navigate, enter to select",
+      pager: "Press space to load more",
+    },
+    theme: {
+      helpMode: "always",
+      style: {
+        help: (text: string) => chalk.gray(text),
+        message: (text: string) => chalk.bold(text),
+      },
+    },
+    choices,
+  });
+
+  return answer;
+}
+
+export async function confirmVendorSelection(
+  vendorId: string,
+): Promise<boolean> {
+  const vendors = getVendors();
+  const vendor = vendors[vendorId];
+
+  if (!vendor) {
+    throw new Error(`Vendor ${vendorId} not found`);
+  }
+
+  if (vendor.authenticated) {
+    try {
+      const userInfo = await vendor.getUserInfo();
+      const confirm = await select({
+        message: `You're already logged in to ${vendorId} as ${userInfo?.name || userInfo?.email}. Do you want to re-authenticate?`,
+        choices: [
+          { name: "No, use existing authentication", value: false },
+          { name: "Yes, re-authenticate", value: true },
+        ],
+      });
+      return confirm;
+    } catch {
+      return true;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
https://jam.dev/c/bc86bbbb-ae5c-42e2-ad9d-8f715d8570cd

## Summary

• Add interactive vendor selection for authentication commands using inquirer
• Improve error handling for authentication cancellation scenarios
• Replace required vendor flags with user-friendly selection prompts
• Add support for showing authentication status in vendor selection

## Changes

• **Interactive Selection**: Replace `-v, --vendor` required option with interactive prompts using `@inquirer/select`
• **Enhanced UX**: Show authentication status and user information in vendor selection
• **Better Error Handling**: Handle user cancellation (Ctrl+C) gracefully for both login and logout
• **Smart Defaults**: Auto-select single vendor when only one is available
• **Improved Logout**: Interactive selection from authenticated vendors with user details

## Test plan

- [x] Test login flow with multiple vendors
- [x] Test login flow with single vendor (auto-selection)
- [x] Test login cancellation handling
- [x] Test logout with multiple authenticated vendors
- [x] Test logout with no authenticated vendors
- [x] Test logout cancellation handling
- [x] Test re-authentication confirmation for already logged-in vendors

🤖 Generated with [Pochi](https://getpochi.com)

<img width="1191" height="158" alt="image" src="https://github.com/user-attachments/assets/48e1a076-359e-4b36-a1bb-a098443e1b1f" />
<img width="777" height="69" alt="image" src="https://github.com/user-attachments/assets/c2dd05fe-a826-4bda-8cee-39daa7172a0e" />

<img width="1017" height="83" alt="image" src="https://github.com/user-attachments/assets/22fb8e7d-2693-45c4-9f68-08647dbf666b" />

