### PR TITLE
feat(livekit-cf): add sharding support

### DIFF
--- a/packages/livekit-cf/.dev.vars
+++ b/packages/livekit-cf/.dev.vars
@@ -1,0 +1,1 @@
+ENVIRONMENT=dev

--- a/packages/livekit-cf/src/lib/shard.ts
+++ b/packages/livekit-cf/src/lib/shard.ts
@@ -1,0 +1,17 @@
+import type { Env } from "@/types";
+
+export function selectShard(env: Env, doId: bigint): D1Database {
+  const shard = doId % BigInt(1);
+  switch (shard) {
+    case 0n:
+      return env.DB_SHARD_1;
+    default:
+      throw new Error(`Invalid shard: ${shard}`);
+  }
+}
+
+export function selectShardByStoreId(env: Env, storeId: string): D1Database {
+  const id = env.SYNC_BACKEND_DO.idFromName(storeId).toString();
+  const doId = BigInt(`0x${id}`);
+  return selectShard(env, doId);
+}

--- a/packages/livekit-cf/src/router/app.ts
+++ b/packages/livekit-cf/src/router/app.ts
@@ -1,4 +1,5 @@
 import { verifyJWT } from "@/lib/jwt";
+import { selectShardByStoreId } from "@/lib/shard";
 import type { Env } from "@/types";
 import { zValidator } from "@hono/zod-validator";
 import * as SyncBackend from "@livestore/sync-cf/cf-worker";
@@ -39,11 +40,15 @@ app
       const requestParamsResult = SyncBackend.getSyncRequestSearchParams(
         c.req.raw,
       );
+
       if (requestParamsResult._tag === "Some") {
         return SyncBackend.handleSyncRequest({
           request: c.req.raw,
           searchParams: requestParamsResult.value,
-          env: c.env,
+          env: {
+            ...c.env,
+            DB: selectShardByStoreId(c.env, query.storeId),
+          },
           ctx: c.executionCtx as SyncBackend.CfTypes.ExecutionContext,
           options: {
             async validatePayload(inputPayload, { storeId }) {

--- a/packages/livekit-cf/src/types.ts
+++ b/packages/livekit-cf/src/types.ts
@@ -5,9 +5,12 @@ import type * as SyncBackend from "@livestore/sync-cf/cf-worker";
 export type Env = {
   CLIENT_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback>;
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackend.SyncBackendRpcInterface>;
-  DB: D1Database;
+  // DB: D1Database;
   ADMIN_SECRET: string;
   ENVIRONMENT: "dev" | "prod" | undefined;
+
+  // DB shards
+  DB_SHARD_1: D1Database;
 };
 
 export type User = {

--- a/packages/livekit-cf/src/worker.ts
+++ b/packages/livekit-cf/src/worker.ts
@@ -1,16 +1,18 @@
 import type { CfTypes } from "@livestore/sync-cf/cf-worker";
 import * as SyncBackend from "@livestore/sync-cf/cf-worker";
+import { selectShard } from "./lib/shard";
 import { fetch } from "./router";
 import type { Env } from "./types";
 
-export class SyncBackendDO extends SyncBackend.makeDurableObject({
-  // onPush: async (_message, _data) => {
-  //   console.log(`onPush for store (${_data.storeId})`);
-  // },
-  // onPull: async (_message, _data) => {
-  //   console.log(`onPull for store (${_data.storeId})`);
-  // },
-}) {}
+export class SyncBackendDO extends SyncBackend.makeDurableObject() {
+  constructor(controller: CfTypes.DurableObjectState, env: Env) {
+    const doId = BigInt(`0x${controller.id.toString()}`);
+    super(controller, {
+      ...env,
+      DB: selectShard(env, doId),
+    });
+  }
+}
 
 // Scoped by storeId
 export { LiveStoreClientDO } from "./client";

--- a/packages/livekit-cf/wrangler.toml
+++ b/packages/livekit-cf/wrangler.toml
@@ -22,13 +22,9 @@ tag = "v1"
 new_sqlite_classes = ["SyncBackendDO", "LiveStoreClientDO"]
 
 [[d1_databases]]
-binding = "DB"
-database_name = "pochi-livekit-events"
-database_id = "29b297f5-75ee-437e-8a9a-94ae9de0fc0a"
-
-
-[vars]
-ENVIRONMENT = "dev"
+binding = "DB_SHARD_1"
+database_name = "pochi-livekit-events-1"
+database_id = "64639b33-fb9a-4827-bf6e-791d4e8baa76"
 
 # should be set via CF dashboard (as secret)
 # ADMIN_SECRET = "..."


### PR DESCRIPTION
## Summary
This PR introduces sharding support to the `livekit-cf` package to distribute data across multiple databases.

- Adds a `shard.ts` utility to select the correct database shard based on the store ID.
- Updates the Hono router to use the sharding utility for incoming sync requests.
- Modifies the `SyncBackendDO` to be shard-aware, ensuring that each durable object instance connects to the appropriate database shard.
- Updates `wrangler.toml` to define the database shard bindings.

## Test plan
- CI should pass.

🤖 Generated with [Pochi](https://getpochi.com)