### PR TITLE
refactor: centralize store ID generation and improve API routing

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,8 @@
     "./git-utils": "./src/git-utils.ts",
     "./diff-utils": "./src/diff-utils.ts",
     "./tool-utils": "./src/tool-utils/index.ts",
-    "./vscode-webui-bridge": "./src/vscode-webui-bridge/index.ts"
+    "./vscode-webui-bridge": "./src/vscode-webui-bridge/index.ts",
+    "./store-id-utils": "./src/store-id-utils.ts"
   },
   "scripts": {
     "tsc": "tsc",

--- a/packages/common/src/configuration/config-manager.ts
+++ b/packages/common/src/configuration/config-manager.ts
@@ -3,13 +3,13 @@ import * as fsPromise from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type ReadonlySignal, type Signal, signal } from "@preact/signals-core";
-import { binary_to_base58 } from "base58-js";
 import * as jose from "jose";
 import * as JSONC from "jsonc-parser/esm";
 import { machineId } from "node-machine-id";
 import { funnel, isDeepEqual, mergeDeep } from "remeda";
 import * as fleece from "silver-fleece";
 import { getLogger } from "../base";
+import { encodeStoreId } from "../store-id-utils";
 import { type PochiCredentials, isDev } from "../vscode-webui-bridge";
 import { PochiConfig } from "./types";
 import type { VendorConfig } from "./vendor";
@@ -154,14 +154,8 @@ class PochiConfigManager {
     const { credentials } = this.cfg.value?.vendors?.pochi || {};
     const { jwt = null } = (credentials as PochiCredentials | undefined) || {};
 
-    const sub = jwt ? jose.decodeJwt(jwt).sub : "anonymous";
-    const storeId = JSON.stringify({
-      sub,
-      machineId: await machineId(),
-      cwd,
-    });
-
-    return binary_to_base58(new TextEncoder().encode(storeId));
+    const sub = (jwt ? jose.decodeJwt(jwt).sub : undefined) ?? "anonymous";
+    return encodeStoreId({ sub, machineId: await machineId(), cwd });
   };
 }
 

--- a/packages/common/src/store-id-utils.ts
+++ b/packages/common/src/store-id-utils.ts
@@ -1,0 +1,20 @@
+import { base58_to_binary, binary_to_base58 } from "base58-js";
+import z from "zod/v4";
+
+export const StoreId = z.object({
+  sub: z.string(),
+  machineId: z.string(),
+  cwd: z.string(),
+});
+
+export type StoreId = z.infer<typeof StoreId>;
+
+export function encodeStoreId(storeId: StoreId): string {
+  const encoded = new TextEncoder().encode(JSON.stringify(storeId));
+  return binary_to_base58(encoded);
+}
+
+export function decodeStoreId(storeId: string): StoreId {
+  const decoded = new TextDecoder().decode(base58_to_binary(storeId));
+  return StoreId.parse(JSON.parse(decoded));
+}

--- a/packages/livekit-cf/package.json
+++ b/packages/livekit-cf/package.json
@@ -10,11 +10,11 @@
     "@livestore/peer-deps": "catalog:",
     "@livestore/sync-cf": "catalog:",
     "@getpochi/livekit": "workspace:*",
+    "@getpochi/common": "workspace:*",
     "@hono/zod-validator": "catalog:",
     "hono": "catalog:",
     "jose": "catalog:",
-    "zod": "catalog:",
-    "base58-js": "catalog:"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "wrangler": "^4.33.0"

--- a/packages/livekit-cf/src/router/app.ts
+++ b/packages/livekit-cf/src/router/app.ts
@@ -1,8 +1,8 @@
 import { verifyJWT } from "@/lib/jwt";
 import type { Env } from "@/types";
+import { decodeStoreId } from "@getpochi/common/store-id-utils";
 import { zValidator } from "@hono/zod-validator";
 import * as SyncBackend from "@livestore/sync-cf/cf-worker";
-import { base58_to_binary } from "base58-js";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
@@ -69,14 +69,5 @@ app
 
 async function verifyStoreId(env: Env, jwt: string, storeId: string) {
   const user = await verifyJWT(env, jwt);
-  return user.sub === decodeSubFromStoreId(storeId);
+  return user.sub === decodeStoreId(storeId).sub;
 }
-
-const decodeSubFromStoreId = (storeId: string) => {
-  const decoded = new TextDecoder().decode(base58_to_binary(storeId));
-  return (
-    JSON.parse(decoded) as {
-      sub: string;
-    }
-  ).sub;
-};


### PR DESCRIPTION
## Summary
- Centralize store ID generation logic in a new module `store-id-utils` with Zod schema validation
- Move store ID encoding logic from config-manager to the new module
- Update LiveKit CF router to use the new decoding function
- Add export for the new module in common package.json
- Fix dependency issues in livekit-cf package

## Test plan
- [x] Verify store ID generation works correctly
- [x] Ensure API routing with store ID verification functions properly
- [x] Run all tests to ensure no regressions

🤖 Generated with [Pochi](https://getpochi.com)