### PR TITLE
feat(livekit-cf): implement task persistence to Pochi API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,15 +138,16 @@
       "version": "0.0.1-dev",
       "dependencies": {
         "@cloudflare/workers-types": "4.20250823.0",
+        "@getpochi/common": "workspace:*",
         "@getpochi/livekit": "workspace:*",
         "@hono/zod-validator": "catalog:",
         "@livestore/adapter-cloudflare": "catalog:",
         "@livestore/livestore": "catalog:",
         "@livestore/peer-deps": "catalog:",
         "@livestore/sync-cf": "catalog:",
-        "base58-js": "catalog:",
         "hono": "catalog:",
         "jose": "catalog:",
+        "moment": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -2796,6 +2797,8 @@
     "mocha": ["mocha@10.8.2", "", { "dependencies": { "ansi-colors": "^4.1.3", "browser-stdout": "^1.3.1", "chokidar": "^3.5.3", "debug": "^4.3.5", "diff": "^5.2.0", "escape-string-regexp": "^4.0.0", "find-up": "^5.0.0", "glob": "^8.1.0", "he": "^1.2.0", "js-yaml": "^4.1.0", "log-symbols": "^4.1.0", "minimatch": "^5.1.6", "ms": "^2.1.3", "serialize-javascript": "^6.0.2", "strip-json-comments": "^3.1.1", "supports-color": "^8.1.1", "workerpool": "^6.5.1", "yargs": "^16.2.0", "yargs-parser": "^20.2.9", "yargs-unparser": "^2.0.0" }, "bin": { "mocha": "bin/mocha.js", "_mocha": "bin/_mocha" } }, "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg=="],
 
     "module-not-found-error": ["module-not-found-error@1.0.1", "", {}, "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g=="],
+
+    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
 
     "motion": ["motion@12.12.1", "", { "dependencies": { "framer-motion": "^12.12.1", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-vN/3p++Ix0lVt9NH0ZqPrAy8QRTkff27t5z3z5+4BJ3cXPxtOia2EBZS4snM+JUTfl7J0JXP/5ERqu9GT/8IgA=="],
 

--- a/packages/livekit-cf/.dev.vars
+++ b/packages/livekit-cf/.dev.vars
@@ -1,1 +1,0 @@
-ENVIRONMENT=dev

--- a/packages/livekit-cf/.gitignore
+++ b/packages/livekit-cf/.gitignore
@@ -1,1 +1,2 @@
 .wrangler
+.dev.vars

--- a/packages/livekit-cf/package.json
+++ b/packages/livekit-cf/package.json
@@ -14,7 +14,8 @@
     "@hono/zod-validator": "catalog:",
     "hono": "catalog:",
     "jose": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "moment": "catalog:"
   },
   "devDependencies": {
     "wrangler": "^4.33.0"

--- a/packages/livekit-cf/src/client/app.ts
+++ b/packages/livekit-cf/src/client/app.ts
@@ -6,6 +6,11 @@ import type { Env } from "./types";
 const store = new Hono<{ Bindings: Env }>();
 
 store
+  .get("/", async (c) => {
+    // Activate store
+    await c.env.getStore();
+    return c.json({ success: true });
+  })
   .get("/tasks", async (c) => {
     const store = await c.env.getStore();
     const tasks = store.query(catalog.queries.tasks$);

--- a/packages/livekit-cf/src/client/do.ts
+++ b/packages/livekit-cf/src/client/do.ts
@@ -1,12 +1,16 @@
 import { DurableObject } from "cloudflare:workers";
 import type { Env } from "@/types";
-import { catalog } from "@getpochi/livekit";
+import type { PochiApi, PochiApiClient } from "@getpochi/common/pochi-api";
+import { decodeStoreId } from "@getpochi/common/store-id-utils";
+import { type Task, catalog } from "@getpochi/livekit";
 import {
   type ClientDoWithRpcCallback,
   createStoreDoPromise,
 } from "@livestore/adapter-cloudflare";
 import { type Store, type Unsubscribe, nanoid } from "@livestore/livestore";
 import { handleSyncUpdateRpc } from "@livestore/sync-cf/client";
+import { hc } from "hono/client";
+import moment from "moment";
 import { app } from "./app";
 import type { Env as ClientEnv } from "./types";
 
@@ -72,13 +76,14 @@ export class LiveStoreClientDO
 
   private async subscribeToStore() {
     const store = await this.getStore();
-    // Do whatever you like with the store here :)
 
     // Make sure to only subscribe once
     if (this.storeSubscription === undefined) {
       this.storeSubscription = store.subscribe(catalog.queries.tasks$, {
-        onUpdate: (_tasks) => {
-          // FIXME
+        onUpdate: (tasks) => {
+          for (const task of tasks) {
+            this.persistTask(store, task);
+          }
         },
       });
     }
@@ -94,4 +99,79 @@ export class LiveStoreClientDO
   async syncUpdateRpc(payload: unknown) {
     await handleSyncUpdateRpc(payload);
   }
+
+  private async persistTask(store: Store<typeof catalog.schema>, task: Task) {
+    const { sub: userId } = decodeStoreId(store.storeId);
+    const apiClient = createApiClient(this.env.POCHI_API_KEY, userId);
+
+    // FIXME(meng): implement this with store.events stream when it's ready
+    const now = moment();
+    if (!moment(task.updatedAt).subtract(5, "minute").isBefore(now)) {
+      return;
+    }
+
+    // If a task was updated in the last 5 minutes, persist it to the pochi api
+    const messages = store
+      .query(catalog.queries.makeMessagesQuery(task.id))
+      .map((x) => x.data);
+    const resp = await apiClient.api.chat.persist.$post({
+      json: {
+        id: task.id,
+        // @ts-expect-error - ignore readonly modifier and unknown conversion.
+        messages: messages,
+        status: task.status,
+        parentClientTaskId: task.parentId || undefined,
+        environment: {
+          info: {
+            cwd: "",
+            shell: "",
+            os: "",
+            homedir: "",
+          },
+          currentTime: now.toString(),
+          workspace: {
+            files: [],
+            isTruncated: false,
+            gitStatus: task.git
+              ? {
+                  origin: task.git.origin,
+                  status: "",
+                  mainBranch: "",
+                  currentBranch: task.git.branch,
+                  recentCommits: [],
+                }
+              : undefined,
+          },
+          todos: task.todos as DeepWriteable<typeof task.todos>,
+        },
+      },
+    });
+
+    if (resp.status !== 200) {
+      console.error(`Failed to persist chat: ${resp.statusText}`);
+      return;
+    }
+
+    const { shareId } = await resp.json();
+    if (!task.shareId) {
+      store.commit(
+        catalog.events.updateShareId({
+          id: task.id,
+          shareId,
+          updatedAt: new Date(),
+        }),
+      );
+    }
+  }
+}
+
+type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };
+
+function createApiClient(apiKey: string, userId: string): PochiApiClient {
+  const prodServerUrl = "https://app.getpochi.com";
+  return hc<PochiApi>(prodServerUrl, {
+    headers: {
+      authorization: `${apiKey},${userId}`,
+    },
+  });
 }

--- a/packages/livekit-cf/src/router/app.ts
+++ b/packages/livekit-cf/src/router/app.ts
@@ -40,6 +40,11 @@ app
         c.req.raw,
       );
 
+      // Run a fetch to active CLIENT_DO
+      c.env.CLIENT_DO.get(c.env.CLIENT_DO.idFromName(query.storeId)).fetch(
+        `https://${c.req.header("host")}/stores/${query.storeId}`,
+      );
+
       if (requestParamsResult._tag === "Some") {
         return SyncBackend.handleSyncRequest({
           request: c.req.raw,

--- a/packages/livekit-cf/src/types.ts
+++ b/packages/livekit-cf/src/types.ts
@@ -6,6 +6,7 @@ export type Env = {
   CLIENT_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback>;
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackend.SyncBackendRpcInterface>;
   ADMIN_SECRET: string;
+  POCHI_API_KEY: string;
   ENVIRONMENT: "dev" | "prod" | undefined;
 };
 

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -21,7 +21,6 @@ import {
 } from "ai";
 import { pickBy } from "remeda";
 import type { Message, Metadata, RequestData } from "../types";
-import { schedulePersistJob } from "./background-job";
 import { makeRepairToolCall } from "./llm";
 import { parseMcpToolSet } from "./mcp-utils";
 import {
@@ -182,17 +181,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
           } satisfies Metadata;
         }
       },
-      onFinish: async ({ messages }) => {
-        if (this.apiClient.authenticated) {
-          schedulePersistJob({
-            taskId: chatId,
-            store: this.store,
-            messages,
-            apiClient: this.apiClient,
-            environment,
-            waitUntil: this.waitUntil,
-          });
-        }
+      onFinish: async () => {
+        // DO NOTHING
       },
     });
   };

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -79,6 +79,11 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     this.apiClient = options.apiClient;
     this.waitUntil = options.waitUntil;
     this.customAgent = overrideCustomAgentTools(options.customAgent);
+
+    // Get rid of unused check.
+    // FIXME(meng): remove these two fields once we finalize everything to cloudflare sync.
+    this.apiClient;
+    this.waitUntil;
   }
 
   sendMessages: (

--- a/packages/livekit/src/livestore/index.ts
+++ b/packages/livekit/src/livestore/index.ts
@@ -1,5 +1,5 @@
 export {
-  // events,
+  events,
   schema,
   // tables
 } from "./schema";


### PR DESCRIPTION
- Add moment.js dependency for time handling
- Implement task persistence logic in LiveStoreClientDO
- Add POCHI_API_KEY to environment variables
- Remove old background job persistence in favor of DO-based approach
- Add endpoint to activate store
- Export events from livestore schema

This change moves task persistence from the client-side background jobs to the Cloudflare Durable Objects, ensuring better reliability and consistency.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
