### PR TITLE
chore(vscode-webui): add debounce to hint plugin

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/auto-completion/extension.ts
+++ b/packages/vscode-webui/src/components/prompt-form/auto-completion/extension.ts
@@ -344,6 +344,7 @@ function createHintPlugin(options: {
 }) {
   let searchVersion = 0;
   let isHintVisible = false;
+  let showHintTimeout: ReturnType<typeof setTimeout> | undefined;
 
   const showHint = () => {
     if (isHintVisible) return;
@@ -351,7 +352,13 @@ function createHintPlugin(options: {
     options.onHintVisibilityChange?.(true);
   };
 
+  const debouncedShowHint = () => {
+    clearTimeout(showHintTimeout);
+    showHintTimeout = setTimeout(showHint, 300);
+  };
+
   const hideHint = () => {
+    clearTimeout(showHintTimeout);
     if (!isHintVisible) return;
     isHintVisible = false;
     options.onHintVisibilityChange?.(false);
@@ -407,7 +414,7 @@ function createHintPlugin(options: {
           }
 
           if (items.length > 0) {
-            showHint();
+            debouncedShowHint();
           } else {
             hideHint();
           }


### PR DESCRIPTION
## Screen recording
https://jam.dev/c/6b4d157b-7a14-4262-87d6-fcb37ebfb68b

## Summary

- Adds a debounce to the hint plugin to delay showing the hint.
- Hides the hint immediately when it's no longer needed.

## Test plan

- [ ] Verify that the hint appears with a slight delay when typing.
- [ ] Verify that the hint disappears immediately when the text no longer matches.

🤖 Generated with [Pochi](https://getpochi.com)