### PR TITLE
fix(webui): correct tooltip arrow display and adjust chat toolbar style

### DIFF
--- a/packages/vscode-webui/src/components/ui/tooltip.tsx
+++ b/packages/vscode-webui/src/components/ui/tooltip.tsx
@@ -36,8 +36,11 @@ function TooltipContent({
   className,
   sideOffset = 0,
   children,
+  showArrow = true,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  showArrow?: boolean;
+}) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -50,7 +53,9 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-popover fill-popover/90" />
+        {!!showArrow && (
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-popover fill-popover/90" />
+        )}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -251,7 +251,14 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
                 <PaperclipIcon className="size-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{t("chat.attachmentTooltip")}</TooltipContent>
+            <TooltipContent
+              showArrow={false}
+              className="max-w-[80vw]"
+              side="top"
+              sideOffset={4}
+            >
+              {t("chat.attachmentTooltip")}
+            </TooltipContent>
           </Tooltip>
           <SubmitStopButton
             isSubmitDisabled={isSubmitDisabled}


### PR DESCRIPTION
## Summary
This PR addresses a styling issue with the tooltip component and improves its usage in the chat toolbar.

- A `showArrow` prop has been added to the `TooltipContent` component to provide control over the visibility of the tooltip arrow.
- The chat toolbar has been updated to hide the tooltip arrow for the attachment button and adjust its positioning for a cleaner UI.

## Test plan
- Manually verify that the tooltip for the attachment button in the chat toolbar no longer shows an arrow.
- Check that other tooltips throughout the application continue to display correctly with an arrow.

🤖 Generated with [Pochi](https://getpochi.com)