### PR TITLE
refactor(common): remove unused old code completion api

### DIFF
--- a/packages/common/src/pochi-api.ts
+++ b/packages/common/src/pochi-api.ts
@@ -63,74 +63,6 @@ export const UploadFileResponse = z.object({
 });
 export type UploadFileResponse = z.infer<typeof UploadFileResponse>;
 
-// Tabby-compatible Code Completion API
-export const CodeCompletionRequest = z.object({
-  language: z.string().optional().describe("Programming language identifier"),
-  segments: z
-    .object({
-      prefix: z.string().describe("Code before cursor"),
-      suffix: z.string().optional().describe("Code after cursor"),
-      filepath: z.string().optional().describe("Relative file path"),
-      gitUrl: z.string().optional().describe("Git repository URL"),
-      declarations: z
-        .array(
-          z.object({
-            filepath: z.string().describe("File path (relative or URI)"),
-            body: z.string().describe("Declaration code"),
-          }),
-        )
-        .optional()
-        .describe("LSP-provided declarations"),
-      relevantSnippetsFromChangedFiles: z
-        .array(
-          z.object({
-            filepath: z.string().describe("File path"),
-            body: z.string().describe("Code snippet"),
-            score: z.number().optional().describe("Relevance score"),
-          }),
-        )
-        .optional()
-        .describe("Recent edit context"),
-      relevantSnippetsFromRecentlyOpenedFiles: z
-        .array(
-          z.object({
-            filepath: z.string().describe("File path"),
-            body: z.string().describe("Code snippet"),
-            score: z.number().optional().describe("Relevance score"),
-          }),
-        )
-        .optional()
-        .describe("Recent file context"),
-      clipboard: z.string().optional().describe("Clipboard content"),
-    })
-    .describe("Code completion segments"),
-  temperature: z
-    .number()
-    .min(0)
-    .max(1)
-    .optional()
-    .describe("Model temperature (0.0-1.0)"),
-  mode: z
-    .enum(["standard", "next_edit_suggestion"])
-    .optional()
-    .describe("Completion mode"),
-});
-
-export const CodeCompletionResponse = z.object({
-  id: z.string().describe("Completion ID"),
-  choices: z
-    .array(
-      z.object({
-        index: z.number().describe("Choice index"),
-        text: z.string().describe("Generated completion text"),
-      }),
-    )
-    .describe("Completion choices"),
-});
-
-export type CodeCompletionRequest = z.infer<typeof CodeCompletionRequest>;
-export type CodeCompletionResponse = z.infer<typeof CodeCompletionResponse>;
-
 // Code Completion FIM API
 export const CodeCompletionFIMRequest = z.object({
   prompt: z.string().describe("Code before cursor"),
@@ -174,11 +106,6 @@ const stub = new Hono()
   .post("/api/chat/stream", zValidator("json", ModelGatewayRequest))
   .post("/api/chat/persist", zValidator("json", PersistRequest), async (c) =>
     c.json({} as PersistResponse),
-  )
-  .post(
-    "/api/code/completion",
-    zValidator("json", CodeCompletionRequest),
-    async (c) => c.json({} as CodeCompletionResponse),
   )
   .post(
     "/api/code/fim/completion",


### PR DESCRIPTION
## Summary
- This PR removes the unused old code completion API, including `CodeCompletionRequest` and `CodeCompletionResponse`, from `packages/common/src/pochi-api.ts`.
- The endpoint for the old code completion API has also been removed from the Hono stub.

## Test plan
N/A

🤖 Generated with [Pochi](https://getpochi.com)