### PR TITLE
feat(github-action): output stderr to process for better error visibility

### DIFF
--- a/packages/github-action/src/run-pochi.ts
+++ b/packages/github-action/src/run-pochi.ts
@@ -121,6 +121,7 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
       child.stderr.setEncoding("utf8");
       child.stderr.on("data", (data: string) => {
         context.outputBuffer += data;
+        process.stderr.write(data);
       });
     }
 


### PR DESCRIPTION
## Summary
- Added stderr output to process in GitHub Action to improve error visibility when running Pochi

This change ensures that stderr from the Pochi process is written to the GitHub Actions stderr, making error messages visible in the action logs.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>


https://github.com/Sma1lboy/pochi/actions/runs/17741640047/job/50416789819
