### PR TITLE
fix(output-renderer): simplify task completion message formatting

### DIFF
--- a/packages/cli/src/output-renderer.ts
+++ b/packages/cli/src/output-renderer.ts
@@ -255,7 +255,7 @@ function renderToolPart(part: ToolUIPart<UITools>): {
 
   if (part.type === "tool-attemptCompletion") {
     const { result = "" } = part.input || {};
-    const text = `${chalk.bold(chalk.green("🎉 Task Completed"))}\n${chalk.dim("└─")} ${result}`;
+    const text = `${chalk.bold(chalk.green("🎉 Task Completed"))}\n${result}`;
 
     return {
       text,


### PR DESCRIPTION
## Summary
Simplify the task completion message formatting by removing the dimmed prefix "└─" from the result display.

## Changes
- Removed the `└─` prefix from task completion messages in `packages/cli/src/output-renderer.ts`
- This makes the output cleaner and more direct

🤖 Generated with [Pochi](https://getpochi.com)