### PR TITLE
feat(cli): add interactive task list

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -370,6 +370,7 @@
     "@ast-grep/cli",
   ],
   "patchedDependencies": {
+    "@livestore/livestore@0.4.0-dev.7": "patches/@livestore%2Flivestore@0.4.0-dev.7.patch",
     "better-auth@1.2.9": "patches/better-auth@1.2.9.patch",
     "silver-fleece@1.2.1": "patches/silver-fleece@1.2.1.patch",
     "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ai@5.0.15": "patches/ai@5.0.15.patch",
     "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch",
     "@ai-sdk/google-vertex@3.0.8": "patches/@ai-sdk%2Fgoogle-vertex@3.0.8.patch",
-    "silver-fleece@1.2.1": "patches/silver-fleece@1.2.1.patch"
+    "silver-fleece@1.2.1": "patches/silver-fleece@1.2.1.patch",
+    "@livestore/livestore@0.4.0-dev.7": "patches/@livestore%2Flivestore@0.4.0-dev.7.patch"
   }
 }

--- a/packages/cli/src/livekit/store.ts
+++ b/packages/cli/src/livekit/store.ts
@@ -33,15 +33,14 @@ export async function createStore(cwd: string) {
       : undefined,
   });
 
-  const store = await createStorePromise<LiveStoreSchema>({
+  return createStorePromise<LiveStoreSchema>({
     adapter,
     schema: catalog.schema,
-    storeId: storeId,
+    storeId,
     syncPayload: {
       jwt,
     },
   });
-  return store;
 }
 
 async function getPochiCredentials() {

--- a/packages/cli/src/task/list.ts
+++ b/packages/cli/src/task/list.ts
@@ -1,5 +1,6 @@
 import type { Command } from "@commander-js/extra-typings";
-import { catalog } from "@getpochi/livekit";
+import { type Task, catalog } from "@getpochi/livekit";
+import select from "@inquirer/select";
 import chalk from "chalk";
 import { createStore } from "../livekit/store";
 
@@ -11,7 +12,7 @@ export function registerTaskListCommand(taskCommand: Command) {
     .option(
       "-n, --limit <number>",
       "The maximum number of tasks to display.",
-      "10",
+      "100",
     )
     .action(async (options) => {
       const limit = Number.parseInt(options.limit, 10);
@@ -36,40 +37,59 @@ export function registerTaskListCommand(taskCommand: Command) {
           return;
         }
 
-        console.log(chalk.bold(`\nRecent Tasks (${tasks.length}):`));
-        console.log();
+        const taskId = await select({
+          message: `Showing the last ${chalk.bold(limit)} tasks`,
+          choices: tasks.map((task) => ({
+            name: formatTaskForSelect(task),
+            short: task.id,
+            value: task.id,
+            description: formatTaskDescription(task),
+            disabled: !task.shareId,
+          })),
+          pageSize: 10,
+          theme: {
+            style: {
+              description: (text: string) => text,
+            },
+            helpMode: "never",
+            indexMode: "number",
+          },
+        });
 
-        for (const task of tasks) {
-          const statusColor = getStatusColor(task.status);
-          const title = task.title || task.id.substring(0, 8);
-          const timeAgo = getTimeAgo(task.updatedAt);
-
-          const shareInfo = task.shareId
-            ? chalk.blue(` [${task.shareId.substring(0, 8)}]`)
-            : "";
-
+        const task = tasks.find((t) => t.id === taskId);
+        if (task) {
           console.log(
-            `${statusColor(getStatusIcon(task.status))} ${chalk.bold(title)}${shareInfo} ${chalk.gray(`(${timeAgo})`)}`,
+            `\n${formatTaskForSelect(task)}\n${formatTaskDescription(task)}`,
           );
-          console.log(chalk.gray(`   ID: ${task.id}`));
-
-          if (task.shareId) {
-            console.log(
-              chalk.gray(
-                `   Share: https://app.getpochi.com/share/${task.shareId}`,
-              ),
-            );
-          }
-          console.log();
         }
       } catch (error) {
-        return taskCommand.error(
-          `Failed to list tasks: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
+        if (error instanceof Error && error.message.includes("SIGINT")) {
+          // ignore ctrl-c
+        } else {
+          return taskCommand.error(
+            `Failed to list tasks: ${error instanceof Error ? error.message : "Unknown error"}`,
+          );
+        }
       } finally {
         await store.shutdown();
       }
     });
+}
+
+function formatTaskForSelect(task: Task): string {
+  const statusColor = getStatusColor(task.status);
+  const title = clipTitle(task.title || task.id.substring(0, 8), 75);
+  return `${statusColor(getStatusIcon(task.status))} ${chalk.bold(title)}`;
+}
+
+function formatTaskDescription(task: Task): string {
+  const timeAgo = getTimeAgo(task.updatedAt);
+  let description = `\n  ID: ${chalk.cyan(task.id)}`;
+  description += `\n  Last Updated: ${chalk.gray(timeAgo)}`;
+  if (task.shareId) {
+    description += `\n  Share URL: ${chalk.underline(`https://app.getpochi.com/share/${task.shareId}`)}`;
+  }
+  return description;
 }
 
 function getStatusColor(status: string) {
@@ -115,4 +135,9 @@ function getTimeAgo(date: Date): string {
   if (diffDays < 7) return `${diffDays}d ago`;
 
   return date.toLocaleDateString();
+}
+
+function clipTitle(title: string, maxLength: number): string {
+  if (title.length <= maxLength) return title;
+  return `${title.substring(0, maxLength - 3)}...`;
 }

--- a/packages/cli/src/task/share.ts
+++ b/packages/cli/src/task/share.ts
@@ -12,9 +12,8 @@ export function registerTaskShareCommand(taskCommand: Command) {
     .action(async (taskId) => {
       const store = await createStore(process.cwd());
 
-      const shareId = store.query(
-        catalog.queries.makeTaskQuery(taskId),
-      )?.shareId;
+      const { shareId } =
+        store.query(catalog.queries.makeTaskQuery(taskId)) || {};
 
       if (shareId) {
         const shareUrl = `https://app.getpochi.com/share/${shareId}`;
@@ -25,6 +24,6 @@ export function registerTaskShareCommand(taskCommand: Command) {
         console.log(chalk.red("❌ No share URL found for this task"));
       }
 
-      store.shutdown();
+      await store.shutdown();
     });
 }

--- a/patches/@livestore%2Flivestore@0.4.0-dev.7.patch
+++ b/patches/@livestore%2Flivestore@0.4.0-dev.7.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/store/create-store.js b/dist/store/create-store.js
+index 390adad0711d3a2773bde85e093389ed2c0bd945..8f628c56c86fc006756ddd1d96aff00e48e69d34 100644
+--- a/dist/store/create-store.js
++++ b/dist/store/create-store.js
+@@ -29,7 +29,7 @@ export const createStorePromise = async ({ signal, otelOptions, ...options }) =>
+     return yield* createStore({ ...options }).pipe(Scope.extend(scope));
+ }).pipe(Effect.withSpan('createStore', {
+     attributes: { storeId: options.storeId, disableDevtools: options.disableDevtools },
+-}), provideOtel(omitUndefineds({ parentSpanContext: otelOptions?.rootSpanContext, otelTracer: otelOptions?.tracer })), Effect.tapCauseLogPretty, Effect.annotateLogs({ thread: 'window' }), Effect.provide(Logger.prettyWithThread('window')), Logger.withMinimumLogLevel(LogLevel.Debug), Effect.runPromise);
++}), provideOtel(omitUndefineds({ parentSpanContext: otelOptions?.rootSpanContext, otelTracer: otelOptions?.tracer })), Effect.tapCauseLogPretty, Effect.annotateLogs({ thread: 'window' }), Effect.provide(Logger.prettyWithThread('window')), Logger.withMinimumLogLevel(LogLevel.Error), Effect.runPromise);
+ export const createStore = ({ schema, adapter, storeId, context = {}, boot, batchUpdates, disableDevtools, onBootStatus, shutdownDeferred, params, debug, confirmUnsavedChanges = true, syncPayload, }) => Effect.gen(function* () {
+     const lifetimeScope = yield* Scope.make();
+     yield* validateStoreId(storeId);


### PR DESCRIPTION
## Summary

*   Replaces the static task list in `pochi task list` with an interactive selection interface using `@inquirer/select`.
*   Improves the formatting of task details for better readability.
*   Adds a patch for `@livestore/livestore` to reduce log noise during development.

## Test plan

*   Run `pochi task list` and verify the interactive list appears.
*   Select a task and confirm the details are displayed correctly.
*   Verify that `Ctrl+C` exits the interactive list gracefully.

🤖 Generated with [Pochi](https://getpochi.com)