### PR TITLE
docs: improve TOC for dev updates page and fix image containers

### DIFF
--- a/packages/docs/content/docs/permissions.mdx
+++ b/packages/docs/content/docs/permissions.mdx
@@ -8,9 +8,9 @@ icon: "Shield"
 
 By default, all permissions in Pochi are enabled. You can customize these permissions at any time using the Auto-Approve settings.
 
-<p align="center">
+<div align="center">
 ![Auto Approve](../assets/images/auto-approve.png)
-</p>
+</div>
 
 - **Read**: Read the file content Pochi decides to look up for analyzing or completing tasks.
 - **Write**: Creates new files, edits existing code, generates boilerplate, and writes documentation.

--- a/packages/docs/content/docs/rules.mdx
+++ b/packages/docs/content/docs/rules.mdx
@@ -61,7 +61,6 @@ Pochi also reads global rules defined in `~/.pochi/README.pochi.md`. These rules
 
 You can view current active rules in toolbar's token usage popover
 
-<p align="center">
+<div align="center">
 ![Token Usage](../assets/images/usage-token-popover.png)
-</p>
-
+</div>

--- a/packages/docs/content/docs/share.mdx
+++ b/packages/docs/content/docs/share.mdx
@@ -12,9 +12,9 @@ The **Share** feature in Pochi's toolbar allows you to share your current develo
   Shared conversations are publicly accessible to anyone with the link. Do not share sensitive information or private code.
 </Callout>
 
-<p align="center">
+<div align="center">
 ![Task Sharing](../assets/images/task-sharing.png)
-</p>
+</div>
 
 ### How it works
 

--- a/packages/docs/content/docs/tab-completion.mdx
+++ b/packages/docs/content/docs/tab-completion.mdx
@@ -12,9 +12,9 @@ Pochi uses a state-of-the-art model that adapts to your coding patterns in real 
 drawing on recent edits, diagnostics, and surrounding context to generate helpful,
 relevant completions right in your editor.
 
-<p align="center">
+<div align="center">
 ![Tab completion showing inline suggestions](../assets/images/completion.png)
-</p>
+</div>
 
 ### Multi-Language Support
 Works across popular programming languages including:

--- a/packages/docs/content/docs/vscode.mdx
+++ b/packages/docs/content/docs/vscode.mdx
@@ -32,7 +32,7 @@ The panel's title bar includes actions for starting a new task and viewing all t
 
 <div align="center">![The main Chat panel is where you interact with Pochi.](../assets/images/chat-page.png)</div>
 
-## Promping 
+## Prompting
 
 The input box, located below the chat history, is where you'll compose your messages and control the chat.
 

--- a/packages/docs/content/docs/vscode.mdx
+++ b/packages/docs/content/docs/vscode.mdx
@@ -22,7 +22,7 @@ Upon first launch, Pochi's Welcome page offers two ways to get started:
 - **Sign in to Pochi:** Click "Sign In" and authorize in your browser to use Pochi subscriptions, models, and cloud features.
 - **Bring Your Own Key (BYOK):** Use your own models by running `Pochi: Open Custom Model Settings` from the Command Palette. This opens `~/.pochi/config.jsonc` for you to add API keys. See [Models](/models) for details.
 
-<p align="center">![The Welcome page provides options to sign in or configure your own models.](../assets/images/welcome-page.png)</p>
+<div align="center">![The Welcome page provides options to sign in or configure your own models.](../assets/images/welcome-page.png)</div>
 
 ## Chat
 
@@ -30,7 +30,7 @@ Access the Pochi chat panel via the Activity Bar icon or shortcut (macOS: `Cmd+L
 
 The panel's title bar includes actions for starting a new task and viewing all tasks.
 
-<p align="center">![The main Chat panel is where you interact with Pochi.](../assets/images/chat-page.png)</p>
+<div align="center">![The main Chat panel is where you interact with Pochi.](../assets/images/chat-page.png)</div>
 
 ## Promping 
 
@@ -45,9 +45,9 @@ The input box, located below the chat history, is where you'll compose your mess
     - **Sharing:** Share your chat session with others (requires a Pochi account).
     - **Submit/Stop Button:** The send button dynamically transforms into a stop button during message generation, allowing you to interrupt the AI at any time.
 
-<p align="center">
+<div align="center">
   ![The Prompt Zone provides access to key features like model selection and auto-approval.](../assets/images/home-page-toolbox.png)
-</p>
+</div>
 
 ## Tasks
 
@@ -60,7 +60,7 @@ By default sub-tasks are hidden in the task list.
 By default, task history is stored locally. Signing in to a Pochi account enables cloud storage for your tasks, along with sharing and team collaboration features.
 Be aware that clearing VS Code's extension data may erase your local task history.
 
-<p align="center">![The Task List page shows your historical task sessions.](../assets/images/task-page.png)</p>
+<div align="center">![The Task List page shows your historical task sessions.](../assets/images/task-page.png)</div>
 
 ## Troubleshooting
 

--- a/packages/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/packages/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -14,12 +14,18 @@ export default async function Page(props: {
 
   const MDXContent = page.data.body;
 
+  // Only show h1 and h2 in TOC for developer updates page to avoid having too many items
+  const isDeveloperUpdatesPage = page.slugs.includes('developer-updates');
+  const filteredToc = isDeveloperUpdatesPage
+    ? page.data.toc.filter(item => item.depth <= 2)
+    : page.data.toc;
+
   // Construct the file path for GitHub edit
   const filePath = page.slugs.join('/');
 
   return (
-    <DocsPage 
-      toc={page.data.toc} 
+    <DocsPage
+      toc={filteredToc}
       full={page.data.full}
       editOnGithub={
         {


### PR DESCRIPTION
## Context
- As we add more dev updates, TOC on the right side is cluttered with the `<h3>`s, such as `TL;DR`, `Enhancements` etc
 
<img width="1512" height="945" alt="Screenshot 2025-09-16 at 08 30 48" src="https://github.com/user-attachments/assets/e2bab6f1-6667-4dcd-9506-bdea93ab9c59" />

- Locally, some doc pages render with error `In HTML, <p> cannot be a descendant of <p>. This will cause a hydration error.`
<img width="1512" height="945" alt="Screenshot 2025-09-16 at 08 07 11" src="https://github.com/user-attachments/assets/02034ad3-53d7-4c48-8398-b28fa3d397b4" />

## Changes
- Only render `h1` and `h2` in TOC for dev updates page.
- Wrap images inside of `<div>` instead of `<p>`

## Result
### Dev updates page's new TOC 
<img width="1512" height="945" alt="Screenshot 2025-09-16 at 08 28 05" src="https://github.com/user-attachments/assets/734e7d64-df17-4761-b63b-bc59350010bd" />

### Render Error is gone and image display looks the same 👌
<img width="1512" height="945" alt="Screenshot 2025-09-16 at 08 09 15" src="https://github.com/user-attachments/assets/c5f2306c-2537-48df-8830-a0009c8b6468" />
