### PR TITLE
fix: bind methods in VendorBase constructor for proper context

### DIFF
--- a/packages/common/src/vendor/base.ts
+++ b/packages/common/src/vendor/base.ts
@@ -8,7 +8,10 @@ import {
 import type { AuthOutput, ModelOptions } from "./types";
 
 export abstract class VendorBase {
-  constructor(readonly vendorId: string) {}
+  constructor(readonly vendorId: string) {
+    this.getCredentials = this.getCredentials.bind(this);
+    this.getUserInfo = this.getUserInfo.bind(this);
+  }
 
   getCredentials = runExclusive.buildMethod(async (): Promise<unknown> => {
     const { credentials } = this.getVendorConfig();


### PR DESCRIPTION
### Summary

When running the compiled CLI binary, the application crashes with a runtime error in `VendorBase` methods wrapped by `runExclusive.buildMethod` (`Error: Run exclusive, <this> should be an object`). This issue only occurs in the compiled CLI (`./dist/pochi`) and not in the VSCode extension.

### Root Cause

Bun’s compilation process fails to preserve the correct `this` context when class property arrow functions are combined with `runExclusive.buildMethod`. As a result, the compiled code loses the instance reference, breaking methods like `getCredentials()` and `getUserInfo()`.

### Fix

A dual-binding strategy was applied in `/packages/common/src/vendor/base.ts`:

* Explicitly bind `getCredentials` and `getUserInfo` in the constructor.
* Keep arrow functions for lexical `this`.

This ensures:

* Lexical `this` from arrow functions is preserved.
* Constructor binding guarantees correct context even when methods are extracted.
* Works consistently in both development (VSCode) and compiled CLI environments.

### Impact

* Resolves critical runtime error blocking CLI usage.
* Restores proper authentication flow in compiled binaries.
* No breaking changes to the existing API.

