### PR TITLE
chore(github-action):  output fix and adding quote 

### DIFF
--- a/packages/github-action/src/preprocess-action.ts
+++ b/packages/github-action/src/preprocess-action.ts
@@ -19,8 +19,9 @@ async function setup() {
     );
     core.exportVariable("EYES_REACTION_ID", eyesReactionId?.toString() || "");
 
-    const initialContent = `Starting Pochi execution...${githubManager.createGitHubActionFooter()}`;
-    const progressCommentId = await githubManager.createComment(initialContent);
+    const progressCommentId = await githubManager.createComment(
+      "Starting Pochi execution...",
+    );
     core.exportVariable("PROGRESS_COMMENT_ID", progressCommentId.toString());
 
     console.log("Setup completed successfully");

--- a/packages/github-action/src/preprocess-action.ts
+++ b/packages/github-action/src/preprocess-action.ts
@@ -20,7 +20,7 @@ async function setup() {
     core.exportVariable("EYES_REACTION_ID", eyesReactionId?.toString() || "");
 
     const progressCommentId = await githubManager.createComment(
-      "Starting Pochi execution...",
+      "```\nStarting Pochi execution...\n```",
     );
     core.exportVariable("PROGRESS_COMMENT_ID", progressCommentId.toString());
 

--- a/packages/github-action/src/run-pochi.ts
+++ b/packages/github-action/src/run-pochi.ts
@@ -40,9 +40,13 @@ async function cleanupExecution(
   // Finalize history comment
   const truncatedOutput = buildBatchOutput(context.outputBuffer);
 
-  await githubManager.updateComment(context.historyCommentId, `\`\`\`\n${truncatedOutput}\n\`\`\``, {
-    success,
-  });
+  await githubManager.updateComment(
+    context.historyCommentId,
+    `\`\`\`\n${truncatedOutput}\n\`\`\``,
+    {
+      success,
+    },
+  );
 
   // Handle reactions
   await githubManager.createReaction(request.commentId, reaction);
@@ -132,7 +136,10 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
     context.updateInterval = setInterval(async () => {
       try {
         const truncatedOutput = buildBatchOutput(context.outputBuffer);
-        await githubManager.updateComment(historyCommentId, `\`\`\`\n${truncatedOutput}\n\`\`\``);
+        await githubManager.updateComment(
+          historyCommentId,
+          `\`\`\`\n${truncatedOutput}\n\`\`\``,
+        );
       } catch (error) {
         console.error("Failed to update comment:", error);
       }

--- a/packages/github-action/src/run-pochi.ts
+++ b/packages/github-action/src/run-pochi.ts
@@ -40,7 +40,7 @@ async function cleanupExecution(
   // Finalize history comment
   const truncatedOutput = buildBatchOutput(context.outputBuffer);
 
-  await githubManager.updateComment(context.historyCommentId, truncatedOutput, {
+  await githubManager.updateComment(context.historyCommentId, `\`\`\`\n${truncatedOutput}\n\`\`\``, {
     success,
   });
 
@@ -54,14 +54,9 @@ async function cleanupExecution(
   }
 
   if (context.outputBuffer.trim()) {
-    const markdownFormattedOutput = context.outputBuffer
-      .replace(/\n\n/g, "<<<DOUBLE_NEWLINE>>>")
-      .replace(/\n/g, "\n\n")
-      .replace(/<<<DOUBLE_NEWLINE>>>/g, "\n\n");
-
     await core.summary
       .addHeading("Task Details")
-      .addRaw(markdownFormattedOutput)
+      .addCodeBlock(context.outputBuffer, "text")
       .addRaw(
         `**[View Full GitHub Action](${githubManager.createGitHubActionFooter().match(/\[View GitHub Action\]\((.*?)\)/)?.[1] || "#"})**\n\n`,
       )
@@ -97,7 +92,7 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
   }
 
   const context: ExecutionContext = {
-    outputBuffer: "Starting Pochi execution...\n",
+    outputBuffer: "",
     updateInterval: null,
     handled: false,
     historyCommentId,
@@ -107,7 +102,7 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
   // Execute pochi CLI with output capture
   await new Promise<void>((resolve, reject) => {
     const child = spawn(pochiCliPath, args, {
-      stdio: [null, "inherit", "pipe"], // Capture stderr
+      stdio: [null, "pipe", "pipe"],
       cwd: process.cwd(),
       env: {
         ...process.env,
@@ -116,7 +111,15 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
       },
     });
 
-    // Capture stderr output
+    // Capture stdout and stderr output
+    if (child.stdout) {
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (data: string) => {
+        context.outputBuffer += data;
+        process.stdout.write(data);
+      });
+    }
+
     if (child.stderr) {
       child.stderr.setEncoding("utf8");
       child.stderr.on("data", (data: string) => {
@@ -129,7 +132,7 @@ export async function runPochi(githubManager: GitHubManager): Promise<void> {
     context.updateInterval = setInterval(async () => {
       try {
         const truncatedOutput = buildBatchOutput(context.outputBuffer);
-        await githubManager.updateComment(historyCommentId, truncatedOutput);
+        await githubManager.updateComment(historyCommentId, `\`\`\`\n${truncatedOutput}\n\`\`\``);
       } catch (error) {
         console.error("Failed to update comment:", error);
       }


### PR DESCRIPTION
This pull request improves the formatting and output handling for the Pochi GitHub Action, ensuring that execution logs and task details are consistently presented as code blocks for better readability. It also refines how output is captured from the Pochi CLI process, including both stdout and stderr, and updates the initial output buffer handling.

**Output formatting improvements:**

* All progress and history comments are now wrapped in code blocks for clearer presentation in GitHub comments. (`preprocess-action.ts`, `run-pochi.ts`) [[1]](diffhunk://#diff-18b33c3cb645fe34617eb135cf51980e5416e4440e11b58a19dfe1334b542465L22-R24) [[2]](diffhunk://#diff-1da9488865f3b7352fd2eb04c1169de754bd33266e396c2cb2aab11ff021d5a6L43-R49) [[3]](diffhunk://#diff-1da9488865f3b7352fd2eb04c1169de754bd33266e396c2cb2aab11ff021d5a6L132-R142)
* Task details in the GitHub Action summary are now displayed as code blocks instead of using manual markdown formatting. (`run-pochi.ts`)

**Process output handling:**

* The Pochi CLI output is now captured from both stdout and stderr, and appended to the output buffer, ensuring comprehensive logging. (`run-pochi.ts`) [[1]](diffhunk://#diff-1da9488865f3b7352fd2eb04c1169de754bd33266e396c2cb2aab11ff021d5a6L110-R109) [[2]](diffhunk://#diff-1da9488865f3b7352fd2eb04c1169de754bd33266e396c2cb2aab11ff021d5a6L119-R126)

**Initialization changes:**

* The initial `outputBuffer` is now set to an empty string instead of a default starting message, as the starting message is handled via a comment. (`run-pochi.ts`)