### PR TITLE
docs: Update create-pr.md workflow instructions

### DIFF
--- a/.pochi/workflows/create-pr.md
+++ b/.pochi/workflows/create-pr.md
@@ -1,7 +1,8 @@
 Please help create a PR for the current staging changes, following these guidelines:
+- If an issue number is not provided, use askFollowupQuestion to ask for it. If user provides a valid issue number, link to the issue with `Resolves <ISSUE_NUMBER>` at the beginning of the PR description.
 - If there are no staging changes but there are uncommitted changes, please stage them first.
 - Create a branch name based on the current git diff status.
-- Write a meaningful commit message/PR title.
+- Write a meaningful commit message/PR title/PR description.
 - Use the gh CLI to create a PR.
 - When running the push operation, it might be aborted due to a husky pre-push hook. For formatting issues, amend the files and try again. For other issues, try to resolve them as much as possible.
 - The base branch for the PR should always be `origin/main`.


### PR DESCRIPTION
## Summary
This PR updates the `.pochi/workflows/create-pr.md` file to include more detailed instructions for creating a pull request.

Specifically, it adds:
- A guideline to ask for an issue number if one is not provided.
- A clarification to write a meaningful PR description, in addition to the title and commit message.

🤖 Generated with [Pochi](https://getpochi.com)