### PR TITLE
fix(vscode-webui): correct styling for file drag-and-drop in input box

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -555,7 +555,7 @@ export function FormEditor({
       ref={formRef}
       onSubmit={handleSubmit}
       className={cn(
-        "relative rounded-sm border border-[var(--input-border)] bg-input p-1 transition-color duration-300 focus-within:border-ring",
+        "relative rounded-sm border border-[var(--input-border)] bg-input p-1 focus-within:border-ring",
         {
           "form-editor-loading": isLoading,
           "bg-zinc-50 dark:bg-zinc-950": isDragOver,
@@ -576,7 +576,12 @@ export function FormEditor({
           className="prose !border-none min-h-25 w-full max-w-none overflow-hidden break-words text-[var(--vscode-input-foreground)] focus:outline-none"
         />
       </ScrollArea>
-      <div className="h-5 bg-input py-0.5 pl-2">
+      <div
+        className={cn("h-5 py-0.5 pl-2", {
+          "bg-input": !isDragOver,
+          "bg-zinc-50 dark:bg-zinc-950": isDragOver,
+        })}
+      >
         {isAutoCompleteHintVisible && (
           <div className="flex items-center text-muted-foreground text-xs">
             Use Tab <ArrowRightToLine className="mr-1.5 ml-0.5 size-4" /> to see
@@ -588,8 +593,8 @@ export function FormEditor({
       {/* Drop zone overlay - shows when dragging over the editor */}
       {isDragOver && (
         <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-sm border-2 border-zinc-500 border-dashed dark:bg-zinc-500/30">
-          <div className="rounded-md border bg-white px-4 py-2 shadow-lg dark:bg-gray-800">
-            <p className="font-medium text-sm">
+          <div className="rounded-md border bg-white px-4 py-2 shadow-lg dark:border-gray-700 dark:bg-gray-800">
+            <p className="font-medium text-sm text-zinc-900 dark:text-zinc-100">
               Drop files here to attach them to your message
             </p>
           </div>


### PR DESCRIPTION
## Screenshot
<img width="1114" height="304" alt="image" src="https://github.com/user-attachments/assets/9215656f-7bd1-46f0-82b7-b7204e41cf90" />


## Summary

This PR fixes the styling of the input box in the prompt form editor during a drag-and-drop operation. The background color and border are now consistent when dragging files over the input area.

## Test plan

- Manually tested by dragging a file over the prompt input in the VS Code extension.

🤖 Generated with [Pochi](https://getpochi.com)