### PR TITLE
fix(vscode-webui): update readStoreId to always return a string

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -215,8 +215,8 @@ const VSCodeHostStub = {
   > => {
     return Promise.resolve({} as ThreadSignalSerialization<CustomAgentFile[]>);
   },
-  readStoreId: async (): Promise<string | undefined> => {
-    return Promise.resolve(undefined);
+  readStoreId: async (): Promise<string> => {
+    return Promise.resolve("default");
   },
 } satisfies VSCodeHostApi;
 

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -23,7 +23,7 @@ export interface VSCodeHostApi {
 
   readPochiCredentials(): Promise<PochiCredentials | null>;
 
-  readStoreId(): Promise<string | undefined>;
+  readStoreId(): Promise<string>;
 
   getSessionState<K extends keyof SessionState>(
     keys?: K[],

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -144,12 +144,9 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     }
   };
 
-  readStoreId = async (): Promise<string | undefined> => {
+  readStoreId = async (): Promise<string> => {
     const cwd = await this.readCurrentWorkspace();
-    if (cwd) {
-      return getStoreId(cwd);
-    }
-    return undefined;
+    return getStoreId(cwd || "default");
   };
 
   getSessionState = async <K extends keyof SessionState>(


### PR DESCRIPTION
## Summary
- Update VSCodeHostApi.readStoreId() to return Promise<string> instead of Promise<string | undefined>
- Modify VSCodeHostImpl.readStoreId() implementation to always return a store ID, using "default" when no workspace is available
- Update webview-stub.ts to match the new signature
- This change ensures consistent behavior when accessing store IDs across the application

## Test plan
- [x] All existing tests should pass
- [x] Type checking should pass

🤖 Generated with [Pochi](https://getpochi.com)