### PR TITLE
fix(cli): correct the right cli entry when packaging npm

### DIFF
--- a/.github/workflows/release-pochi-cli.yml
+++ b/.github/workflows/release-pochi-cli.yml
@@ -106,8 +106,8 @@ jobs:
 
           IS_PRERELEASE=${{ steps.release_info.outputs.is_prerelease }}
 
-          # we use cli.ts for local dev, and ./dist/cli.js for npm package
+          # we use cli.ts for local dev, and dist/cli.js for npm package
           # so we have to replace the bin path in package.json here
-          sed -i.bak 's|"pochi": "./src/cli.ts"|"pochi": "./dist/cli.js"|' package.json
+          sed -i.bak 's|"pochi": "src/cli.ts"|"pochi": "dist/cli.js"|' package.json
           rm -f package.json.bak
           bun publish --access public ${IS_PRERELEASE:+"--tag beta"}


### PR DESCRIPTION
This PR fixes an issue where the CLI entry point was incorrect when packaging for npm.