### PR TITLE
fix(webui): allow retry on all API call errors

### DIFF
--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
@@ -2,7 +2,6 @@ import type { UseChatHelpers } from "@ai-sdk/react";
 import { prompts } from "@getpochi/common";
 import { prepareLastMessageForRetry } from "@getpochi/common/message-utils";
 import type { Message } from "@getpochi/livekit";
-import { APICallError } from "ai";
 import { useCallback } from "react";
 import { ReadyForRetryError } from "./use-ready-for-retry-error";
 
@@ -18,10 +17,6 @@ export function useRetry({
   const retryRequest = useCallback(
     async (error: Error) => {
       if (messages.length === 0) {
-        return;
-      }
-
-      if (APICallError.isInstance(error) && error.isRetryable === false) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- Removes the condition that prevents retrying API calls when `error.isRetryable` is `false`.
- This allows users to manually trigger a retry for any failed API call, providing more control over error handling.

## Test plan
- Verify the change in `packages/vscode-webui/src/features/retry/hooks/use-retry.ts` removes the intended logic.
- Run `bun run test` to ensure all existing tests pass.

🤖 Generated with [Pochi](https://getpochi.com)