### PR TITLE
fix(chat): ensure tools are properly passed to flexible chat transport

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -146,6 +146,7 @@
         "@cloudflare/workers-types": "4.20250823.0",
         "@getpochi/common": "workspace:*",
         "@getpochi/livekit": "workspace:*",
+        "@getpochi/tools": "workspace:*",
         "@livestore/adapter-cloudflare": "catalog:",
         "@livestore/livestore": "catalog:",
         "@livestore/peer-deps": "catalog:",


### PR DESCRIPTION
## Summary
- Fix issue where tools were not being properly passed to the model in FlexibleChatTransport
- Extract tools selection logic to avoid duplication
- Pass tools to convertToModelMessages to ensure proper tool handling

## Test plan
- [x] All existing tests pass
- [x] Verified that tool handling now works correctly in chat scenarios

🤖 Generated with [Pochi](https://getpochi.com)