### PR TITLE
fix(chat): improve queued messages handling in chat submit

### DIFF
--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -104,14 +104,15 @@ export function useChatSubmit({
 
       // Compacting is not allowed to be stopped.
       if (newCompactTaskPending) return;
+      if (isSubmitDisabled) return;
+
+      const allMessages = [...queuedMessages];
+      // Clear queued messages after adding them to allMessages
+      setQueuedMessages([]);
 
       const content = input.trim();
-      const allMessages = [...queuedMessages];
       if (content) {
         allMessages.push(content);
-      }
-      if (isSubmitDisabled) {
-        return;
       }
 
       if (handleStop()) {
@@ -133,7 +134,6 @@ export function useChatSubmit({
           });
 
           setInput("");
-          setQueuedMessages([]);
           autoApproveGuard.current = "auto";
         } catch (error) {
           // Error is already handled by the hook
@@ -145,7 +145,6 @@ export function useChatSubmit({
           text: allMessages.join("\n\n"),
         });
         setInput("");
-        setQueuedMessages([]);
         autoApproveGuard.current = "auto";
       }
     },


### PR DESCRIPTION
## Summary
This PR refactors the chat submit hook to improve how queued messages are handled:
- Move setQueuedMessages([]) to execute earlier in the flow
- Add a comment explaining the purpose of clearing queued messages
- Reorder operations to ensure messages are properly collected before clearing

This ensures that queued messages are properly processed and cleared in a more predictable manner.

🤖 Generated with [Pochi](https://getpochi.com)