### PR TITLE
fix(vendor-gemini-cli): handle non-ok responses in fetch

### DIFF
--- a/packages/vendor-gemini-cli/src/model.ts
+++ b/packages/vendor-gemini-cli/src/model.ts
@@ -61,7 +61,7 @@ function createPatchedFetch(
       "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
       patchedRequestInit,
     );
-    if (!resp.body) {
+    if (!resp.ok || !resp.body) {
       throw new APICallError({
         message: `Failed to fetch: ${resp.status} ${resp.statusText}`,
         statusCode: resp.status,


### PR DESCRIPTION
## Summary

This PR fixes an issue where the gemini-cli model would not correctly handle non-ok responses from the API. This change ensures that we throw an error when the response is not `ok`.

## Test plan

Existing tests should cover this.

🤖 Generated with [Pochi](https://getpochi.com)