### PR TITLE
fix(vscode-webui): prevent forceOpen during loading state in workflows section

### DIFF
--- a/packages/vscode-webui/src/features/settings/components/sections/workflows-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/workflows-section.tsx
@@ -26,7 +26,7 @@ export const WorkflowsSection: React.FC = () => {
       localStorageKey="workflows-section"
       title={t("settings.workflows.title")}
       collapsable={workflows.length > 3}
-      forceOpen={workflows.length <= 3}
+      forceOpen={!isLoading && workflows.length <= 3}
     >
       {isLoading ? (
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Add isLoading check to forceOpen prop to prevent UI issues when workflows are being loaded
- This ensures the workflows section doesn't force open during loading state, improving user experience

## Test plan
- [ ] Verify workflows section behaves correctly during loading state
- [ ] Test that forceOpen only applies when !isLoading && workflows.length <= 3
- [ ] Check that the section remains collapsable when workflows.length > 3

🤖 Generated with [Pochi](https://getpochi.com)