### PR TITLE
chore(calendar): improve calendar usability with new features

### DIFF
--- a/packages/vscode-webui/src/components/ui/calendar.tsx
+++ b/packages/vscode-webui/src/components/ui/calendar.tsx
@@ -26,8 +26,11 @@ function Calendar({
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"];
+  selected: Date;
 }) {
   const defaultClassNames = getDefaultClassNames();
+  const defaultMonth =
+    props.selected instanceof Date ? props.selected : undefined;
 
   return (
     <DayPicker
@@ -44,6 +47,8 @@ function Calendar({
           date.toLocaleString("default", { month: "short" }),
         ...formatters,
       }}
+      defaultMonth={defaultMonth}
+      startMonth={new Date(2022, 0)}
       classNames={{
         root: cn("w-fit", defaultClassNames.root),
         months: cn(

--- a/packages/vscode-webui/src/routes/tasks.tsx
+++ b/packages/vscode-webui/src/routes/tasks.tsx
@@ -388,6 +388,20 @@ function DatePicker({
                 setOpen(false);
               }
             }}
+            footer={
+              <div className="mt-2 flex justify-end px-2 py-1">
+                <Button
+                  variant="outline"
+                  className="h-7 px-2 py-0 text-xs"
+                  onClick={() => {
+                    setDate(new Date());
+                    setOpen(false);
+                  }}
+                >
+                  Today
+                </Button>
+              </div>
+            }
           />
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
## Summary
- Add `startMonth` to hide unnecessary years and fix year select panel overflow.
- Add `defaultMonth` to default the calendar picker to the selected value.
- Add "Today" button for quick navigation.

## Screenshot
<img width="494" height="762" alt="image" src="https://github.com/user-attachments/assets/acc25bd0-b763-4a16-ac2f-9c2dd1f9b67a" />


🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>