### PR TITLE
refactor(livekit): remove cwd parameter from LiveChatKit constructors

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,5 @@
+set -e
+
 check_git_clean() {
     git diff --exit-code
     git diff --staged --exit-code

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -128,7 +128,6 @@ export class TaskRunner {
     this.stepCount = new StepCount(options.maxSteps, options.maxRetries);
     this.chatKit = new LiveChatKit<Chat>({
       taskId: options.uid,
-      cwd: options.cwd,
       store: options.store,
       chatClass: Chat,
       isCli: true,
@@ -162,7 +161,7 @@ export class TaskRunner {
           parts: [{ type: "text", text: options.prompt }],
         });
       } else {
-        this.chatKit.init(options.prompt);
+        this.chatKit.init(options.cwd, options.prompt);
       }
     }
 

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -56,7 +56,6 @@ export type ChatTransportOptions = {
   isCli?: boolean;
   store: Store;
   customAgent?: CustomAgent;
-  cwd: string;
 };
 
 export class FlexibleChatTransport implements ChatTransport<Message> {
@@ -66,7 +65,6 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
   private readonly isCli?: boolean;
   private readonly store: Store;
   private readonly customAgent?: CustomAgent;
-  private readonly cwd: string;
 
   constructor(options: ChatTransportOptions) {
     this.onStart = options.onStart;
@@ -75,7 +73,6 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     this.isCli = options.isCli;
     this.store = options.store;
     this.customAgent = overrideCustomAgentTools(options.customAgent);
-    this.cwd = options.cwd;
   }
 
   sendMessages: (
@@ -107,7 +104,12 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
 
     if (!this.isSubTask) {
       middlewares.push(
-        createNewTaskMiddleware(this.store, this.cwd, chatId, customAgents),
+        createNewTaskMiddleware(
+          this.store,
+          environment?.info.cwd,
+          chatId,
+          customAgents,
+        ),
       );
     }
 

--- a/packages/livekit/src/chat/middlewares/new-task-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/new-task-middleware.ts
@@ -14,7 +14,7 @@ import { events } from "../../livestore/schema";
 
 export function createNewTaskMiddleware(
   store: Store,
-  cwd: string,
+  cwd: string | undefined,
   parentTaskId: string,
   customAgents?: CustomAgent[],
 ): LanguageModelV2Middleware {

--- a/packages/livekit/src/react.tsx
+++ b/packages/livekit/src/react.tsx
@@ -14,6 +14,6 @@ export function useLiveChatKit(
   // biome-ignore lint/correctness/useExhaustiveDependencies: create new kit on taskId change.
   return useMemo(
     () => new LiveChatKit({ ...props, store, isCli: false, chatClass: Chat }),
-    [store.storeId, props.taskId, props.cwd],
+    [store.storeId, props.taskId],
   );
 }

--- a/packages/vscode-webui/src/components/tool-invocation/tools/new-task/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/new-task/use-live-sub-task.tsx
@@ -11,8 +11,6 @@ import {
   useRetry,
 } from "@/features/retry";
 import { useTodos } from "@/features/todo";
-
-import { useCurrentWorkspace } from "@/lib/hooks/use-current-workspace";
 import { useCustomAgent } from "@/lib/hooks/use-custom-agents";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { vscodeHost } from "@/lib/vscode";
@@ -35,8 +33,6 @@ export function useLiveSubTask(
   { tool, isExecuting }: Pick<ToolProps<"newTask">, "tool" | "isExecuting">,
   toolCallStatusRegistry: ToolCallStatusRegistry,
 ): TaskThreadSource {
-  const { data: cwd } = useCurrentWorkspace();
-
   const lifecycle = useToolCallLifeCycle().getToolCallLifeCycle({
     toolName: getToolName(tool),
     toolCallId: tool.toolCallId,
@@ -79,7 +75,6 @@ export function useLiveSubTask(
 
   // FIXME: handle auto retry for output without task.
   const chatKit = useLiveChatKit({
-    cwd: cwd || "default",
     taskId: uid,
     abortSignal: abortController.current.signal,
     getters,

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -65,7 +65,6 @@ function Chat({ user, uid, prompt }: ChatProps) {
     useCurrentWorkspace();
   const isWorkspaceActive = !!currentWorkspace;
   const chatKit = useLiveChatKit({
-    cwd: currentWorkspace || "default",
     taskId: uid,
     getters,
     isSubTask: !!subtask,
@@ -112,9 +111,9 @@ function Chat({ user, uid, prompt }: ChatProps) {
 
   useEffect(() => {
     if (prompt && !chatKit.inited) {
-      chatKit.init(prompt);
+      chatKit.init(currentWorkspace, prompt);
     }
-  }, [prompt, chatKit]);
+  }, [currentWorkspace, prompt, chatKit]);
 
   usePendingModelAutoStart({
     enabled:


### PR DESCRIPTION
## Summary
This PR removes the `cwd` parameter from LiveChatKit constructors and passes it through the `init` method instead. This allows for more flexible initialization where the working directory can be determined at runtime.

## Changes
- Removed `cwd` from `LiveChatKitOptions`, `ChatTransportOptions`, and constructor parameters
- Modified `LiveChatKit.init()` to accept `cwd` as the first parameter
- Updated middleware to accept optional `cwd` and get it from environment when not provided
- Removed `cwd` dependency from React hooks and passed it via `init()` calls
- Updated task runner to pass `cwd` to `init()` method
- Added `set -e` to pre-push hook for better error handling

## Testing
All existing tests pass, and the changes maintain backward compatibility by making `cwd` optional in the `init` method.