### PR TITLE
refactor(livekit): rename user to owner and add task reload

### DIFF
--- a/packages/livekit-cf/src/do/livestore-client/app.ts
+++ b/packages/livekit-cf/src/do/livestore-client/app.ts
@@ -7,12 +7,46 @@ import type { Store } from "@livestore/livestore";
 import type { UIMessage } from "ai";
 import type { InferToolInput } from "ai";
 import { Hono } from "hono";
+import type { MiddlewareHandler } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { DeepWritable, Env } from "./types";
 
-const store = new Hono<{ Bindings: Env }>();
+type RequestVariables = {
+  isOwner: boolean;
+};
+
+const checkOwner: MiddlewareHandler<{
+  Bindings: Env;
+  Variables: RequestVariables;
+}> = async (c, next) => {
+  const store = await c.env.getStore();
+  const jwt = c.req.header("authorization")?.replace("Bearer ", "");
+  const user = jwt && (await verifyJWT(undefined, jwt));
+  const isOwner = user && user.sub === decodeStoreId(store.storeId).sub;
+  c.set("isOwner", !!isOwner);
+  await next();
+};
+
+const store = new Hono<{ Bindings: Env; Variables: RequestVariables }>().use(
+  checkOwner,
+);
 
 store
+  .post("/tasks/share", async (c) => {
+    if (!c.get("isOwner")) {
+      throw new HTTPException(403, { message: "Unauthorized" });
+    }
+    const tasks = await c.env.reloadShareTasks();
+    return c.json(tasks);
+  })
+  .patch("/tasks", async (c) => {
+    if (!c.get("isOwner")) {
+      throw new HTTPException(403, { message: "Unauthorized" });
+    }
+    const store = await c.env.getStore();
+    const tasks = store.query(catalog.queries.tasks$);
+    return c.json(tasks);
+  })
   .get("/tasks/:taskId/json", async (c) => {
     const store = await c.env.getStore();
     const taskId = c.req.param("taskId");
@@ -24,10 +58,7 @@ store
     }
 
     if (!task.isPublicShared) {
-      const jwt = c.req.header("authorization")?.replace("Bearer ", "");
-      const user = jwt && (await verifyJWT(undefined, jwt));
-      const isOwner = user && user.sub === decodeStoreId(store.storeId).sub;
-      if (!isOwner) {
+      if (!c.get("isOwner")) {
         throw new HTTPException(403, { message: "Task is not public" });
       }
     }
@@ -37,7 +68,7 @@ store
       .map((x) => x.data as UIMessage);
     const subTasks = collectSubTasks(store, taskId);
 
-    const user = await c.env.getUser();
+    const user = await c.env.getOwner();
 
     return c.json({
       type: "share",

--- a/packages/livekit-cf/src/do/livestore-client/app.ts
+++ b/packages/livekit-cf/src/do/livestore-client/app.ts
@@ -39,14 +39,6 @@ store
     const tasks = await c.env.reloadShareTasks();
     return c.json(tasks);
   })
-  .patch("/tasks", async (c) => {
-    if (!c.get("isOwner")) {
-      throw new HTTPException(403, { message: "Unauthorized" });
-    }
-    const store = await c.env.getStore();
-    const tasks = store.query(catalog.queries.tasks$);
-    return c.json(tasks);
-  })
   .get("/tasks/:taskId/json", async (c) => {
     const store = await c.env.getStore();
     const taskId = c.req.param("taskId");

--- a/packages/livekit-cf/src/do/livestore-client/do.ts
+++ b/packages/livekit-cf/src/do/livestore-client/do.ts
@@ -31,7 +31,7 @@ export class LiveStoreClientDO
     this.onTasksUpdate = runExclusive.buildMethod(this.onTasksUpdate);
   }
 
-  async setUser(user: User): Promise<void> {
+  async setOwner(user: User): Promise<void> {
     await this.state.storage.put("user", user);
   }
 
@@ -46,11 +46,18 @@ export class LiveStoreClientDO
       getStore: async () => {
         return this.getStore();
       },
-      getUser: async () => {
+      getOwner: async () => {
         return await this.state.storage.get<User>("user");
       },
       setStoreId: (storeId: string) => {
         this.storeId = storeId;
+      },
+      reloadShareTasks: async () => {
+        const store = await this.getStore();
+        const tasks = await store.query(catalog.queries.tasks$);
+        console.log("Force reloading share tasks", tasks.length);
+        await this.onTasksUpdate(tasks, true);
+        return tasks;
       },
       ASSETS: this.env.ASSETS,
     } satisfies ClientEnv);
@@ -103,14 +110,14 @@ export class LiveStoreClientDO
     await handleSyncUpdateRpc(payload);
   }
 
-  private onTasksUpdate = async (tasks: readonly Task[] | undefined) => {
+  onTasksUpdate = async (tasks: readonly Task[] | undefined, force = false) => {
     if (!tasks) return;
     const store = await this.getStore();
     const oneMinuteAgo = moment().subtract(1, "minute");
 
     console.log(`Updating ${tasks.length} tasks`);
-    const updatedTasks = tasks.filter((task) =>
-      moment(task.updatedAt).isAfter(oneMinuteAgo),
+    const updatedTasks = tasks.filter(
+      (task) => force || moment(task.updatedAt).isAfter(oneMinuteAgo),
     );
 
     if (!updatedTasks.length) return;

--- a/packages/livekit-cf/src/do/livestore-client/do.ts
+++ b/packages/livekit-cf/src/do/livestore-client/do.ts
@@ -57,7 +57,7 @@ export class LiveStoreClientDO
         const tasks = await store.query(catalog.queries.tasks$);
         console.log("Force reloading share tasks", tasks.length);
         await this.onTasksUpdate(tasks, true);
-        return tasks;
+        return await store.query(catalog.queries.tasks$);
       },
       ASSETS: this.env.ASSETS,
     } satisfies ClientEnv);

--- a/packages/livekit-cf/src/do/livestore-client/do.ts
+++ b/packages/livekit-cf/src/do/livestore-client/do.ts
@@ -110,7 +110,10 @@ export class LiveStoreClientDO
     await handleSyncUpdateRpc(payload);
   }
 
-  onTasksUpdate = async (tasks: readonly Task[] | undefined, force = false) => {
+  private onTasksUpdate = async (
+    tasks: readonly Task[] | undefined,
+    force = false,
+  ) => {
     if (!tasks) return;
     const store = await this.getStore();
     const oneMinuteAgo = moment().subtract(1, "minute");

--- a/packages/livekit-cf/src/do/livestore-client/types.ts
+++ b/packages/livekit-cf/src/do/livestore-client/types.ts
@@ -1,12 +1,13 @@
 import type { User } from "@/types";
-import type { catalog } from "@getpochi/livekit";
+import type { Task, catalog } from "@getpochi/livekit";
 import type { Store } from "@livestore/livestore";
 import type { CfTypes } from "@livestore/sync-cf/cf-worker";
 
 export type Env = {
   getStore: () => Promise<Store<typeof catalog.schema>>;
   setStoreId: (storeId: string) => void;
-  getUser: () => Promise<User | undefined>;
+  getOwner: () => Promise<User | undefined>;
+  reloadShareTasks: () => Promise<readonly Task[] | undefined>;
   ASSETS: CfTypes.Fetcher;
 };
 

--- a/packages/livekit-cf/src/types.ts
+++ b/packages/livekit-cf/src/types.ts
@@ -20,6 +20,6 @@ export type User = {
 };
 
 export interface ClientDoCallback extends ClientDoWithRpcCallback {
-  setUser: (user: User) => Promise<void>;
+  setOwner: (user: User) => Promise<void>;
   signalKeepAlive: (storeId: string) => Promise<void>;
 }

--- a/packages/livekit-cf/src/worker.ts
+++ b/packages/livekit-cf/src/worker.ts
@@ -45,7 +45,7 @@ app
 
             const id = c.env.CLIENT_DO.idFromName(storeId);
             const stub = c.env.CLIENT_DO.get(id);
-            await stub.setUser(user);
+            await stub.setOwner(user);
           },
         },
       });

--- a/packages/livekit/src/livestore/queries.ts
+++ b/packages/livekit/src/livestore/queries.ts
@@ -18,7 +18,7 @@ export const makeMessagesQuery = (taskId: string) =>
   });
 
 export const tasks$ = queryDb(
-  () => tables.tasks.where("parentId", "=", null).orderBy("updatedAt", "desc"),
+  () => tables.tasks.where("parentId", "=", null).orderBy("createdAt", "desc"),
   {
     label: "tasks",
   },


### PR DESCRIPTION
## Summary
- Refactors `user` to `owner` in `livekit-cf` and `livekit` for clarity on ownership.
- Introduces an endpoint to reload shared tasks for the store owner.
- Enhances security with an ownership check middleware for protected endpoints.

## Test plan
- All existing tests should continue to pass.
- The new `POST /tasks/share` endpoint should be tested to ensure it reloads tasks correctly for the owner.
- Access to owner-only endpoints should be denied for non-owners.

🤖 Generated with [Pochi](https://getpochi.com)