### PR TITLE
refactor(common): use looseRecord for vendor configuration

### DIFF
--- a/packages/common/src/configuration/types.ts
+++ b/packages/common/src/configuration/types.ts
@@ -37,7 +37,7 @@ export function makePochiConfig(strict = false) {
       .string()
       .default("https://getpochi.com/config.schema.json")
       .optional(),
-    vendors: z.record(z.string(), VendorConfig.nullable()).optional(),
+    vendors: looseRecord(VendorConfig.nullable(), strict).optional(),
     providers: looseRecord(CustomModelSetting, strict).optional(),
     mcp: looseRecord(McpServerConfig, strict).optional(),
   });


### PR DESCRIPTION
## Summary
This PR refactors the vendor configuration to use `looseRecord`, providing more flexibility.

## Test plan
- All existing tests should continue to pass.

🤖 Generated with [Pochi](https://getpochi.com)