### PR TITLE
fix(mcp): ignore stderr output from MCP processes

### DIFF
--- a/packages/common/src/mcp-utils/mcp-connection.ts
+++ b/packages/common/src/mcp-utils/mcp-connection.ts
@@ -319,6 +319,7 @@ export class McpConnection implements Disposable {
             command: this.config.command,
             args: this.config.args,
             cwd: this.config.cwd,
+            stderr: "ignore",
             env: {
               ...getDefaultEnvironment(),
               ...this.config.env,


### PR DESCRIPTION
## Summary
- Add stderr: "ignore" configuration to MCP connection to prevent stderr output from interfering with process communication

## Test plan
- [x] All existing tests pass
- [x] MCP connection functionality verified
- [x] No regression in MCP process handling

🤖 Generated with [Pochi](https://getpochi.com)