### PR TITLE
fix(vscode): set GIT_DIR environment variable for bare repository initialization

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/shadow-git-repo.ts
+++ b/packages/vscode/src/integrations/checkpoint/shadow-git-repo.ts
@@ -45,7 +45,7 @@ export class ShadowGitRepo implements vscode.Disposable {
     private workspaceDir: string,
   ) {
     // For bare repository, we initialize simple-git with the bare repository directory
-    this.git = simpleGit(this.gitPath);
+    this.git = simpleGit(this.gitPath).env("GIT_DIR", this.gitPath);
   }
 
   async init() {


### PR DESCRIPTION
## Summary
This PR fixes an issue in the shadow Git repository initialization where the GIT_DIR environment variable was not being set properly for bare repositories. This ensures proper git operations in the shadow repository.

## Test plan
- [x] Verified the fix works in local testing
- [x] Existing tests continue to pass

🤖 Generated with [Pochi](https://getpochi.com)