### PR TITLE
refactor(vendor-codex): move extractAccountId to utils module

### DIFF
--- a/packages/vendor-codex/src/auth.ts
+++ b/packages/vendor-codex/src/auth.ts
@@ -4,12 +4,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { UserInfo } from "@getpochi/common/configuration";
 import type { AuthOutput } from "@getpochi/common/vendor";
 import { AuthIssuer, OAuthConfig } from "./constants";
-import type {
-  AuthClaims,
-  CodexCredentials,
-  CodexTokenResponse,
-  IdClaims,
-} from "./types";
+import type { CodexCredentials, CodexTokenResponse, IdClaims } from "./types";
 
 export async function startOAuthFlow(): Promise<AuthOutput> {
   const pkce = generatePKCE();
@@ -286,17 +281,6 @@ function parseIdToken(idToken: string): {
     };
   } catch {
     return {};
-  }
-}
-
-export function extractAccountId(accessToken: string): string {
-  try {
-    const [, payload] = accessToken.split(".");
-    const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
-    const authClaims = claims["https://api.openai.com/auth"] as AuthClaims;
-    return authClaims?.chatgpt_account_id || "";
-  } catch {
-    return "";
   }
 }
 

--- a/packages/vendor-codex/src/model.ts
+++ b/packages/vendor-codex/src/model.ts
@@ -1,9 +1,9 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import type { CreateModelOptions } from "@getpochi/common/vendor/edge";
 import { wrapLanguageModel } from "ai";
-import { extractAccountId } from "./auth";
 import { transformToCodexFormat } from "./transformers";
 import type { CodexCredentials } from "./types";
+import { extractAccountId } from "./utils";
 
 /**
  * Create headers for Codex API requests

--- a/packages/vendor-codex/src/utils.ts
+++ b/packages/vendor-codex/src/utils.ts
@@ -1,0 +1,12 @@
+import type { AuthClaims } from "./types";
+
+export function extractAccountId(accessToken: string): string {
+  try {
+    const [, payload] = accessToken.split(".");
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+    const authClaims = claims["https://api.openai.com/auth"] as AuthClaims;
+    return authClaims?.chatgpt_account_id || "";
+  } catch {
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary
- Move extractAccountId function from auth.ts to new utils.ts file
- Update imports in model.ts to use the new utils module
- Clean up unused AuthClaims import in auth.ts

## Test plan
- [ ] All existing tests should pass
- [ ] Vendor-codex package should continue to work correctly
- [ ] No functional changes - this is purely a code organization refactor

🤖 Generated with [Pochi](https://getpochi.com)