### PR TITLE
refactor(vscode): update pochi code completion client to use direct API

### DIFF
--- a/packages/common/src/pochi-api.ts
+++ b/packages/common/src/pochi-api.ts
@@ -61,54 +61,10 @@ export const UploadFileResponse = z.object({
 });
 export type UploadFileResponse = z.infer<typeof UploadFileResponse>;
 
-// Code Completion FIM API
-export const CodeCompletionFIMRequest = z.object({
-  prompt: z.string().describe("Code before cursor"),
-  suffix: z.string().optional().describe("Code after cursor"),
-  model: z.string().optional().describe("Model to use for this request."),
-  temperature: z
-    .number()
-    .min(0)
-    .max(1)
-    .optional()
-    .describe("Temperature (0.0-1.0)"),
-  maxTokens: z
-    .number()
-    .min(1)
-    .optional()
-    .describe("Maximum number of tokens to generate"),
-  stop: z
-    .array(z.string())
-    .optional()
-    .describe("Sequences where the model will stop generating further tokens"),
-});
-
-export const CodeCompletionFIMResponse = z.object({
-  id: z.string().describe("Completion ID"),
-  choices: z
-    .array(
-      z.object({
-        index: z.number().describe("Choice index"),
-        text: z.string().describe("Generated completion text"),
-      }),
-    )
-    .describe("Completion choices"),
-});
-
-export type CodeCompletionFIMRequest = z.infer<typeof CodeCompletionFIMRequest>;
-export type CodeCompletionFIMResponse = z.infer<
-  typeof CodeCompletionFIMResponse
->;
-
 const stub = new Hono()
   .post("/api/chat/stream", zValidator("json", ModelGatewayRequest))
   .post("/api/chat/persist", zValidator("json", PersistRequest), async (c) =>
     c.json({} as PersistResponse),
-  )
-  .post(
-    "/api/code/fim/completion",
-    zValidator("json", CodeCompletionFIMRequest),
-    async (c) => c.json({} as CodeCompletionFIMResponse),
   )
   .post("/api/upload", zValidator("form", UploadFileRequest), async (c) =>
     c.json({} as UploadFileResponse),


### PR DESCRIPTION
## Summary
- Remove unused FIM API types from pochi-api.ts
- Update Pochi code completion client to use direct API calls instead of ApiClient
- Switch to using getVendor for credentials
- Update request/response types to match Mistral API format
- Change maxTokens to max_tokens to match API expectations

## Test plan
- [x] Verify code completion still works with Pochi provider
- [x] Check that API calls are properly formatted
- [x] Ensure error handling is appropriate

🤖 Generated with [Pochi](https://getpochi.com)