### PR TITLE
feat: refactor webFetch and add webSearch tools to Pochi vendor with UI improvements

### DIFF
--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -41,12 +41,18 @@ export type ToolName = keyof ClientTools;
 
 export const ToolsByPermission = {
   read: [
-    "readFile",
-    "listFiles",
-    "globFiles",
-    "searchFiles",
-    "readBackgroundJobOutput",
-  ] satisfies ToolName[] as string[],
+    ...([
+      "readFile",
+      "listFiles",
+      "globFiles",
+      "searchFiles",
+      "readBackgroundJobOutput",
+    ] satisfies ToolName[]),
+
+    // Pochi offered-tools
+    "webFetch",
+    "webSearch",
+  ] as string[],
   write: [
     "writeToFile",
     "applyDiff",

--- a/packages/vendor-pochi/src/tools/index.ts
+++ b/packages/vendor-pochi/src/tools/index.ts
@@ -1,0 +1,2 @@
+export { makeWebFetch } from "./web-fetch";
+export { makeWebSearch } from "./web-search";

--- a/packages/vendor-pochi/src/tools/web-fetch.ts
+++ b/packages/vendor-pochi/src/tools/web-fetch.ts
@@ -1,0 +1,50 @@
+import type { JSONSchema7 } from "@ai-sdk/provider";
+import z from "zod";
+
+export const makeWebFetch = (getToken: () => Promise<string>) => ({
+  description: `
+- Fetches content from a specified URL and converts HTML to markdown
+- Use this tool when you need to retrieve and analyze web content
+
+Usage notes:
+  - IMPORTANT: If an MCP-provided web fetch tool is available, prefer using that tool instead of this one, as it may have fewer restrictions.
+  - The URL must be a fully-formed valid URL
+  - The prompt should describe what information you want to extract from the page
+  - This tool is read-only and does not modify any files
+  - Includes a self-cleaning 10-minute cache for faster responses when repeatedly accessing the same URL
+`.trim(),
+  inputSchema: {
+    jsonSchema: z.toJSONSchema(
+      z.object({
+        url: z.url(),
+      }),
+    ) as JSONSchema7,
+  },
+  execute: async (args: { url: string }) => {
+    const token = await getToken();
+    const response = await fetch(
+      "https://api-gateway.getpochi.com/https/r.jina.ai",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(args),
+      },
+    );
+    if (response.ok) {
+      const content = await response.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: content,
+          },
+        ],
+      };
+    }
+
+    throw new Error(`Failed to fetch: ${response.statusText}`);
+  },
+});

--- a/packages/vendor-pochi/src/tools/web-fetch.ts
+++ b/packages/vendor-pochi/src/tools/web-fetch.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema7 } from "@ai-sdk/provider";
-import z from "zod";
+import z from "zod/v4";
 
 export const makeWebFetch = (getToken: () => Promise<string>) => ({
   description: `

--- a/packages/vendor-pochi/src/tools/web-search.ts
+++ b/packages/vendor-pochi/src/tools/web-search.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema7 } from "@ai-sdk/provider";
-import z from "zod";
+import z from "zod/v4";
 
 export const makeWebSearch = (getToken: () => Promise<string>) => ({
   description: `

--- a/packages/vendor-pochi/src/tools/web-search.ts
+++ b/packages/vendor-pochi/src/tools/web-search.ts
@@ -21,7 +21,7 @@ export const makeWebSearch = (getToken: () => Promise<string>) => ({
       }),
     ) as JSONSchema7,
   },
-  execute: async (args: { url: string }) => {
+  execute: async (args: { query: string; country?: string }) => {
     const token = await getToken();
     const response = await fetch(
       "https://api-gateway.getpochi.com/https/api.perplexity.ai/search",

--- a/packages/vendor-pochi/src/tools/web-search.ts
+++ b/packages/vendor-pochi/src/tools/web-search.ts
@@ -1,0 +1,62 @@
+import type { JSONSchema7 } from "@ai-sdk/provider";
+import z from "zod";
+
+export const makeWebSearch = (getToken: () => Promise<string>) => ({
+  description: `
+- Allows Pochi to search the web and use the results to inform responses
+- Provides up-to-date information for current events and recent data
+- Returns search result information formatted as search result blocks
+- Searches are performed automatically within a single API call
+`.trim(),
+  inputSchema: {
+    jsonSchema: z.toJSONSchema(
+      z.object({
+        query: z.string().describe("The search query to perform"),
+        country: z
+          .string()
+          .optional()
+          .describe(
+            "Country code to filter search results by, e.g. 'US', 'GB', 'JP'",
+          ),
+      }),
+    ) as JSONSchema7,
+  },
+  execute: async (args: { url: string }) => {
+    const token = await getToken();
+    const response = await fetch(
+      "https://api-gateway.getpochi.com/https/api.perplexity.ai/search",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          ...args,
+          max_tokens_per_page: 256,
+        }),
+      },
+    );
+    if (response.ok) {
+      const { results } = (await response.json()) as SearchResults;
+      return {
+        content: results.map((result) => ({
+          type: "text",
+          text: `# ${result.title}\ncreated: ${result.date}, last updated: ${result.last_updated}, [Read more](${result.url})\n\n${result.snippet}`,
+        })),
+      };
+    }
+
+    throw new Error(`Failed to fetch: ${response.statusText}`);
+  },
+});
+
+type SearchResults = {
+  results: {
+    title: string;
+    url: string;
+    snippet: string;
+    date: string;
+    last_updated: string;
+  }[];
+};

--- a/packages/vendor-pochi/src/vendor.ts
+++ b/packages/vendor-pochi/src/vendor.ts
@@ -1,4 +1,3 @@
-import type { JSONSchema7 } from "@ai-sdk/provider";
 import { getLogger } from "@getpochi/common";
 import type { UserInfo } from "@getpochi/common/configuration";
 import { deviceLinkClient } from "@getpochi/common/device-link/client";
@@ -18,8 +17,8 @@ import { jwtClient } from "better-auth/client/plugins";
 import { createAuthClient as createAuthClientImpl } from "better-auth/react";
 import { hc } from "hono/client";
 import * as jose from "jose";
-import z from "zod/v4";
 import { getPochiCredentials, updatePochiCredentials } from "./credentials";
+import { makeWebFetch, makeWebSearch } from "./tools";
 import { VendorId } from "./types";
 
 const logger = getLogger("PochiVendor");
@@ -90,44 +89,11 @@ export class Pochi extends VendorBase {
   override async getTools(): Promise<
     Record<string, McpTool & McpToolExecutable>
   > {
+    const getToken = () =>
+      this.getCredentials().then((c) => (c as PochiCredentials).jwt || "");
     return {
-      webFetch: {
-        description: "Fetch a URL and return the content as text.",
-        inputSchema: {
-          jsonSchema: z.toJSONSchema(
-            z.object({
-              url: z.url(),
-            }),
-          ) as JSONSchema7,
-        },
-        execute: async (args: { url: string }) => {
-          const { jwt } = (await this.getCredentials()) as PochiCredentials;
-          const response = await fetch(
-            "https://api-gateway.getpochi.com/https/r.jina.ai",
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${jwt}`,
-              },
-              body: JSON.stringify(args),
-            },
-          );
-          if (response.ok) {
-            const content = await response.text();
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: content,
-                },
-              ],
-            };
-          }
-
-          throw new Error(`Failed to fetch: ${response.statusText}`);
-        },
-      },
+      webFetch: makeWebFetch(getToken),
+      webSearch: makeWebSearch(getToken),
     };
   }
 }

--- a/packages/vscode-webui/src/components/tool-invocation/mcp-tool-call.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/mcp-tool-call.tsx
@@ -4,6 +4,7 @@ import { vscodeHost } from "@/lib/vscode";
 import { getToolName } from "ai";
 import { useState } from "react";
 import { ScrollArea } from "../ui/scroll-area";
+import { Separator } from "../ui/separator";
 import { HighlightedText } from "./highlight-text";
 import { StatusIcon } from "./status-icon";
 import { ExpandableToolContainer } from "./tool-container";
@@ -130,24 +131,22 @@ function Result({
   result: MCPToolCallResult;
   previewImageLink: boolean;
 }) {
-  const renderContentItem = (item: ContentBlock, index: number) => {
-    const key = index;
-
+  const renderContentItem = (item: ContentBlock) => {
     switch (item.type) {
       case "image":
         return previewImageLink ? (
-          <div key={key} className="overflow-hidden">
+          <div className="overflow-hidden">
             <ImageResult {...item} />
           </div>
         ) : (
-          <JsonCodeBlock key={key} item={item} />
+          <JsonCodeBlock item={item} />
         );
 
       case "text": {
         const textContent = item.text;
 
         return (
-          <div key={key}>
+          <div>
             <MessageMarkdown isMinimalView previewImageLink={previewImageLink}>
               {textContent}
             </MessageMarkdown>
@@ -156,16 +155,23 @@ function Result({
       }
 
       default:
-        return <JsonCodeBlock key={key} item={item} />;
+        return <JsonCodeBlock item={item} />;
     }
   };
 
   return (
     <ScrollArea
       className="px-4 py-2"
-      viewportClassname="max-h-[300px] my-1 rounded-sm border"
+      viewportClassname="max-h-[300px] my-1 rounded-sm"
     >
-      {result.content.map(renderContentItem)}
+      {result.content.map((x, index) => (
+        <div key={index}>
+          {renderContentItem(x)}
+          {index < result.content.length - 1 && (
+            <Separator className="mt-1 mb-2" />
+          )}
+        </div>
+      ))}
     </ScrollArea>
   );
 }


### PR DESCRIPTION
## Summary
- Move existing webFetch tool implementation to separate module
- Add new webSearch tool for Pochi vendor
- Implement makeWebFetch and makeWebSearch functions in separate modules
- Improve tool result UI with separators for better readability
- Update tools permission list to include new web tools
- Fix webSearch execute function parameter type

## Test plan
- [x] Verify webFetch tool still works after refactoring to separate module
- [x] Test new webSearch functionality with sample queries
- [x] Verify UI improvements for tool results display

These changes refactor the existing webFetch tool into a separate module and add a new webSearch tool, providing more comprehensive web interaction capabilities. The UI improvements make tool results easier to read and understand.

🤖 Generated with [Pochi](https://getpochi.com)