### PR TITLE
fix(vendor-qwen-code): Add Qwen VL Max vision model support

### DIFF
--- a/packages/vendor-qwen-code/src/model.ts
+++ b/packages/vendor-qwen-code/src/model.ts
@@ -14,7 +14,6 @@ export function createQwenModel({
   modelId,
   getCredentials,
 }: CreateModelOptions): LanguageModelV2 {
-
   const actualModelId = ModelIdMap[modelId] || modelId;
   const qwenModel = createOpenAICompatible({
     name: "OpenAI",

--- a/packages/vendor-qwen-code/src/model.ts
+++ b/packages/vendor-qwen-code/src/model.ts
@@ -6,17 +6,23 @@ import type { QwenCoderCredentials } from "./types";
 
 const BaseUrl = "https://portal.qwen.ai/v1";
 
+const ModelIdMap: Record<string, string> = {
+  "qwen-vl-max": "vision-model",
+};
+
 export function createQwenModel({
   modelId,
   getCredentials,
 }: CreateModelOptions): LanguageModelV2 {
+
+  const actualModelId = ModelIdMap[modelId] || modelId;
   const qwenModel = createOpenAICompatible({
     name: "OpenAI",
     baseURL: BaseUrl,
     fetch: createPatchedFetch(
       getCredentials as () => Promise<QwenCoderCredentials>,
     ),
-  })(modelId);
+  })(actualModelId);
 
   return wrapLanguageModel({
     model: qwenModel,

--- a/packages/vendor-qwen-code/src/vendor.ts
+++ b/packages/vendor-qwen-code/src/vendor.ts
@@ -31,8 +31,8 @@ export class QwenCode extends VendorBase {
         contextWindow: 1_000_000,
         useToolCallMiddleware: false,
       },
-      "qwen3-coder": {
-        contextWindow: 256_000,
+      "qwen-vl-max": {
+        contextWindow: 128_000,
         useToolCallMiddleware: false,
       },
     };


### PR DESCRIPTION
## Summary
- Add model ID mapping to support Qwen VL Max vision model
- Map "qwen-vl-max" to "vision-model" for API compatibility
- Update model configuration to include qwen-vl-max with 128k context window
- Remove qwen3-coder model from configuration

## Changes
- Added `ModelIdMap` to map user-facing model IDs to API-specific model identifiers
- Updated `createQwenModel` to use the mapped model ID
- Replaced qwen3-coder configuration with qwen-vl-max configuration

## Test plan
- [ ] Verify qwen-vl-max model can be used with the vendor
- [ ] Confirm model ID mapping works correctly
- [ ] Test vision capabilities with the new model

🤖 Generated with [Pochi](https://getpochi.com)