### PR TITLE
refactor: remove workspace-specific config handling

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,10 +20,7 @@ import "@getpochi/vendor-qwen-code/edge";
 
 import { Command } from "@commander-js/extra-typings";
 import { constants, getLogger } from "@getpochi/common";
-import {
-  pochiConfig,
-  setPochiConfigWorkspacePath,
-} from "@getpochi/common/configuration";
+import { pochiConfig } from "@getpochi/common/configuration";
 import { getVendor, getVendors } from "@getpochi/common/vendor";
 import { createModel } from "@getpochi/common/vendor/edge";
 import type { LLMRequestData } from "@getpochi/livekit";
@@ -183,7 +180,6 @@ program.hook("preAction", async () => {
   await Promise.all([
     checkForUpdates().catch(() => {}),
     waitForSync().catch(console.error),
-    setPochiConfigWorkspacePath(process.cwd()).catch(() => {}),
   ]);
 });
 

--- a/packages/common/src/configuration/config-manager.ts
+++ b/packages/common/src/configuration/config-manager.ts
@@ -206,8 +206,6 @@ const {
   updateConfig,
   getVendorConfig,
   updateVendorConfig,
-  inspect,
-  setWorkspacePath,
   getConfigFilePath,
   watchKeys,
 } = new PochiConfigManager();
@@ -217,8 +215,6 @@ export {
   updateConfig as updatePochiConfig,
   getVendorConfig,
   updateVendorConfig,
-  inspect as inspectPochiConfig,
-  setWorkspacePath as setPochiConfigWorkspacePath,
   getConfigFilePath as getPochiConfigFilePath,
   watchKeys as watchPochiConfigKeys,
 };

--- a/packages/common/src/configuration/index.ts
+++ b/packages/common/src/configuration/index.ts
@@ -4,9 +4,6 @@ export {
   getVendorConfig,
   updateVendorConfig,
   getPochiConfigFilePath,
-  inspectPochiConfig,
-  setPochiConfigWorkspacePath,
-  pochiConfigRelativePath,
   watchPochiConfigKeys,
 } from "./config-manager";
 export type { PochiConfigTarget } from "./config-manager";

--- a/packages/common/src/mcp-utils/mcp-hub.ts
+++ b/packages/common/src/mcp-utils/mcp-hub.ts
@@ -3,10 +3,7 @@ import { type Signal, batch, computed, signal } from "@preact/signals-core";
 import * as R from "remeda";
 import { getLogger } from "../base";
 import type { McpServerConfig } from "../configuration/index.js";
-import {
-  inspectPochiConfig,
-  updatePochiConfig,
-} from "../configuration/index.js";
+import { updatePochiConfig } from "../configuration/index.js";
 import { McpConnection } from "./mcp-connection";
 import type {
   McpServerConnection,
@@ -129,16 +126,10 @@ export class McpHub implements Disposable {
   }
 
   private async saveConfig(newConfig: Record<string, McpServerConfig>) {
-    for (const [name, config] of Object.entries(newConfig)) {
-      const { effectiveTargets } = inspectPochiConfig(`mcp.${name}`);
-      const editTarget = effectiveTargets[0] || "user";
-      // Persist configuration changes to file
-      await updatePochiConfig({ mcp: { [name]: config } }, editTarget).catch(
-        (error) => {
-          logger.error("Failed to persist MCP configuration changes", error);
-        },
-      );
-    }
+    // Persist configuration changes to file
+    await updatePochiConfig({ mcp: newConfig }).catch((error) => {
+      logger.error("Failed to persist MCP configuration changes", error);
+    });
   }
 
   private async onConfigChanged() {

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -277,7 +277,6 @@ export class CommandManager implements vscode.Disposable {
           await this.ensureDefaultMcpServer();
           await this.pochiConfiguration.revealConfig({
             key: serverName ? `mcp.${serverName}` : "mcp",
-            configTarget: serverName ? undefined : "user", // open user config if no specific server
           });
         },
       ),


### PR DESCRIPTION
## Summary
- Remove workspace-specific configuration handling that was previously used to manage .pochi config files in workspace directories
- Simplify MCP hub configuration saving logic
- Remove workspace config watching in VSCode extension
- Clean up unused imports and configuration target parameters

## Test plan
- [x] All existing tests pass
- [x] Manual testing of configuration functionality
- [x] Verify MCP server configuration persistence works correctly

This change simplifies the configuration system by removing the complex workspace-specific handling and focusing on user-level configuration only. This should resolve issues with configuration complexity and potential conflicts between user and workspace level settings.

🤖 Generated with [Pochi](https://getpochi.com)