### PR TITLE
fix: ensure unique custom agents are loaded by name

### DIFF
--- a/packages/vscode/src/lib/custom-agent.ts
+++ b/packages/vscode/src/lib/custom-agent.ts
@@ -5,9 +5,9 @@ import { getLogger } from "@getpochi/common";
 import { parseAgentFile } from "@getpochi/common/tool-utils";
 import type { CustomAgentFile } from "@getpochi/common/vscode-webui-bridge";
 import { signal } from "@preact/signals-core";
+import { uniqueBy } from "remeda";
 import { injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
-import { uniqueBy } from "remeda";
 
 const logger = getLogger("CustomAgentManager");
 


### PR DESCRIPTION
## Summary
- Ensure unique custom agents are loaded by name to prevent duplicates
- Format import statements with biome

## Test plan
- [x] Verify custom agents are loaded without duplicates
- [x] Ensure existing functionality remains intact

🤖 Generated with [Pochi](https://getpochi.com)