### PR TITLE
fix(cli): prevent duplicate agents by using remeda's uniqueBy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "node-machine-id": "catalog:",
         "omelette": "^0.4.17",
         "ora": "^8.2.0",
+        "remeda": "catalog:",
         "semver": "^7.6.3",
       },
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "node-machine-id": "catalog:",
     "omelette": "^0.4.17",
     "ora": "^8.2.0",
+    "remeda": "catalog:",
     "semver": "^7.6.3"
   }
 }

--- a/packages/cli/src/lib/load-agents.ts
+++ b/packages/cli/src/lib/load-agents.ts
@@ -9,6 +9,7 @@ import type {
 } from "@getpochi/common/vscode-webui-bridge";
 import { isValidCustomAgentFile } from "@getpochi/common/vscode-webui-bridge";
 import type { CustomAgent } from "@getpochi/tools";
+import { uniqueBy } from "remeda";
 
 const logger = getLogger("loadAgents");
 
@@ -59,7 +60,7 @@ export async function loadAgents(
     }
 
     // Filter out invalid agents for CLI usage
-    const validAgents = allAgents.filter(
+    const validAgents = uniqueBy(allAgents, (agent) => agent.name).filter(
       (agent): agent is ValidCustomAgentFile => {
         if (isValidCustomAgentFile(agent)) {
           return true;


### PR DESCRIPTION
## Summary
This PR addresses an issue where duplicate custom agents could be loaded. It introduces the `remeda` library and utilizes its `uniqueBy` function to ensure that agents are unique by name before being loaded.

This change involves:
- Adding `remeda` as a dependency in `packages/cli/package.json`.
- Updating `packages/cli/src/lib/load-agents.ts` to use `uniqueBy` to filter out duplicate agents.
- The `bun.lock` file has been updated accordingly.

## Test plan
The pre-push hooks which run tests have passed. Manual verification of agent loading should confirm that only unique agents are loaded.

🤖 Generated with [Pochi](https://getpochi.com)