### PR TITLE
fix(cli): change task runner return value from next to retry

### DIFF
--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -305,7 +305,7 @@ export class TaskRunner {
         ),
       );
       this.chat.appendOrReplaceMessage(message);
-      return "next";
+      return "retry";
     }
   }
 


### PR DESCRIPTION
This PR changes the task runner logic to return "retry" instead of "next" when handling certain message scenarios. This ensures proper retry behavior in the task execution flow.

Fixes #342

🤖 Generated with [Pochi](https://getpochi.com)