### PR TITLE
fix(vscode): improve extractResult function to handle user cursor placeholder

### DIFF
--- a/packages/vscode/src/nes/client/google-vertex-tuning.ts
+++ b/packages/vscode/src/nes/client/google-vertex-tuning.ts
@@ -78,7 +78,9 @@ function extractResult(text: string): string {
     text.indexOf("<|editable_region_start|>") +
     "<|editable_region_start|>".length;
   const endIndex = text.indexOf("<|editable_region_end|>");
-  return text.slice(startIndex, endIndex);
+  return text
+    .slice(startIndex, endIndex)
+    .replace("<|user_cursor_is_here|>", "");
 }
 
 const SystemPromptTemplate =


### PR DESCRIPTION
## Summary
- Fixed the `extractResult` function in Google Vertex tuning to properly remove the `<|user_cursor_is_here|>` placeholder from the extracted text

## Test plan
- Verified the change works as expected in the Google Vertex tuning functionality

🤖 Generated with [Pochi](https://getpochi.com)