### PR TITLE
fix(vscode-webui): improve retry count management logic

### DIFF
--- a/packages/vscode-webui/src/components/tool-invocation/tools/new-task/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/new-task/use-live-sub-task.tsx
@@ -263,6 +263,13 @@ export function useLiveSubTask(
     isExecuting,
   ]);
 
+  useEffect(() => {
+    if (isExecuting && status === "ready" && errorForRetry === undefined) {
+      // Reset retry count when status is ok and no error
+      setRetryCount(0);
+    }
+  }, [isExecuting, status, errorForRetry]);
+
   const stepCount = useMemo(() => {
     return messages
       .flatMap((message) => message.parts)
@@ -272,7 +279,6 @@ export function useLiveSubTask(
   useEffect(() => {
     if (isExecuting && stepCount > currentStepCount) {
       setCurrentStepCount(stepCount);
-      setRetryCount(0); // Reset retry count when a new step is started
     }
   }, [stepCount, currentStepCount, isExecuting]);
 

--- a/packages/vscode-webui/src/features/approval/hooks/use-pending-retry-approval.ts
+++ b/packages/vscode-webui/src/features/approval/hooks/use-pending-retry-approval.ts
@@ -104,11 +104,11 @@ export function usePendingRetryApproval({
   }, [error]);
 
   useEffect(() => {
-    // reset retry count when status is ok
-    if (status === "ready") {
+    // reset retry count when status is ok and no error
+    if (status === "ready" && error === undefined) {
       setRetryCount(undefined);
     }
-  }, [status]);
+  }, [status, error]);
 
   useEffect(() => {
     // reset retry count when settings updated to enable auto-retry


### PR DESCRIPTION
## Summary
This PR refactors the retry count management to be more precise:
- Reset retry count when status is ready and no error exists
- Move retry count reset logic to be based on execution status rather than step count
- Ensure proper dependency tracking in useEffect hooks

Fixes the issue where retry count was being reset incorrectly during task execution.

Fixes: https://github.com/TabbyML/pochi/issues/342

🤖 Generated with [Pochi](https://getpochi.com)