### PR TITLE
refactor(vscode-webui): remove environment building from chat toolbar and dev mode button

### DIFF
--- a/packages/vscode-webui/src/components/dev-mode-button.tsx
+++ b/packages/vscode-webui/src/components/dev-mode-button.tsx
@@ -10,7 +10,6 @@ import { useIsDevMode } from "@/features/settings";
 import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 import { usePochiCredentials } from "@/lib/hooks/use-pochi-credentials";
 import { vscodeHost } from "@/lib/vscode";
-import type { Environment } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
 import { useStore } from "@livestore/react";
@@ -50,14 +49,9 @@ function CopyMenuItem({ fetchContent, text }: UpdatedCopyMenuItemProps) {
 interface DevModeButtonProps {
   messages: Message[];
   todos: Todo[] | undefined;
-  buildEnvironment: () => Promise<Environment>;
 }
 
-export function DevModeButton({
-  messages,
-  buildEnvironment,
-  todos,
-}: DevModeButtonProps) {
+export function DevModeButton({ messages, todos }: DevModeButtonProps) {
   const [isDevMode] = useIsDevMode();
   if (!isDevMode) return null;
   const getMessagesContent = () => {
@@ -74,11 +68,6 @@ export function DevModeButton({
       ignoreIncompleteToolCalls: true,
     });
     return JSON.stringify(coreMessages, null, 2);
-  };
-
-  const getEnvironmentContent = async () => {
-    const environment = await buildEnvironment();
-    return JSON.stringify(environment, null, 2);
   };
 
   const getTodosContent = () => {
@@ -119,10 +108,6 @@ export function DevModeButton({
           <CopyMenuItem
             fetchContent={getCoreMessagesContent}
             text="Copy Core Messages"
-          />
-          <CopyMenuItem
-            fetchContent={getEnvironmentContent}
-            text="Copy Environment"
           />
           <CopyMenuItem
             fetchContent={getCheckpintCommand}


### PR DESCRIPTION
## Summary
- Removed the environment building logic from the chat toolbar component
- Updated the DevModeButton component to no longer require the buildEnvironment prop
- Simplified the component structure and reduced unnecessary dependencies

## Test plan
- Verified that all existing tests pass
- Confirmed that the PR branch builds successfully
- Checked that the changes don't introduce any new type errors

🤖 Generated with Pochi
