### PR TITLE
fix(vscode): isPreviewing shall exclude UserInputTools and AutoApproveTools

### DIFF
--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -26,11 +26,19 @@ export {
 } from "./new-task";
 export type { SubTask } from "./new-task";
 
+export function isUserInputToolName(name: string): boolean {
+  return name === "askFollowupQuestion" || name === "attemptCompletion";
+}
+
 export function isUserInputToolPart(part: UIMessagePart<UIDataTypes, UITools>) {
   return (
     part.type === "tool-askFollowupQuestion" ||
     part.type === "tool-attemptCompletion"
   );
+}
+
+export function isAutoApproveToolName(name: string): boolean {
+  return ToolsByPermission.default.some((tool) => name === tool);
 }
 
 export function isAutoApproveTool(part: ToolUIPart): boolean {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,5 +1,12 @@
 export { McpTool } from "./mcp-tools";
-import type { ToolUIPart, UIDataTypes, UIMessagePart, UITools } from "ai";
+import {
+  type ToolUIPart,
+  type UIDataTypes,
+  type UIMessagePart,
+  type UITools,
+  getToolName,
+  isToolUIPart,
+} from "ai";
 import { applyDiff } from "./apply-diff";
 import { askFollowupQuestion } from "./ask-followup-question";
 import { attemptCompletion } from "./attempt-completion";
@@ -31,10 +38,8 @@ export function isUserInputToolName(name: string): boolean {
 }
 
 export function isUserInputToolPart(part: UIMessagePart<UIDataTypes, UITools>) {
-  return (
-    part.type === "tool-askFollowupQuestion" ||
-    part.type === "tool-attemptCompletion"
-  );
+  if (!isToolUIPart(part)) return false;
+  return isUserInputToolName(getToolName(part));
 }
 
 export function isAutoApproveToolName(name: string): boolean {
@@ -42,7 +47,7 @@ export function isAutoApproveToolName(name: string): boolean {
 }
 
 export function isAutoApproveTool(part: ToolUIPart): boolean {
-  return ToolsByPermission.default.some((tool) => part.type === `tool-${tool}`);
+  return isAutoApproveToolName(getToolName(part));
 }
 
 export type ToolName = keyof ClientTools;

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
@@ -1,3 +1,4 @@
+import { isAutoApproveToolName, isUserInputToolName } from "@getpochi/tools";
 import { useToolCallLifeCycle } from "../lib/chat-state";
 
 interface UseChatStatusProps {
@@ -21,7 +22,11 @@ export function useChatStatus({
 }: UseChatStatusProps) {
   const { executingToolCalls, previewingToolCalls } = useToolCallLifeCycle();
   const isExecuting = executingToolCalls.length > 0;
-  const isPreviewing = previewingToolCalls.length > 0;
+  const isPreviewing =
+    previewingToolCalls.filter(
+      (x) =>
+        !isUserInputToolName(x.toolName) && !isAutoApproveToolName(x.toolName),
+    ).length > 0;
 
   const isBusyCore = isModelsLoading || newCompactTaskPending;
 


### PR DESCRIPTION
## Summary
- Updated the chat status hook to properly filter out user input tools and auto-approved tools when determining if the chat is in a previewing state
- Modified `isUserInputToolPart` to use `getToolName` and `isToolUIPart` for better type safety
- Updated `isAutoApproveTool` to use `getToolName` for consistency
- Enhanced the `isPreviewing` calculation in `useChatStatus` hook to exclude both user input tools and auto-approved tools

This provides a more accurate representation of when the chat is actually waiting for user interaction versus when it's processing automatically approved tools.

## Test plan
- Verified that the updated functions work correctly
- Tested that the chat status hook properly filters previewing tool calls
- Ran existing test suites to ensure no regressions

🤖 Generated with [Pochi](https://getpochi.com)