### PR TITLE
refactor(vscode): reduce duplication in logo128.png usage

### DIFF
--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -4,6 +4,7 @@ import { getUri } from "@/lib/get-uri";
 import { getLogger } from "@getpochi/common";
 import { getCorsProxyPort } from "@getpochi/common/cors-proxy";
 import type {
+  ResourceURI,
   SessionState,
   VSCodeHostApi,
   WebviewHostApi,
@@ -18,6 +19,11 @@ import type { PochiConfiguration } from "../configuration";
 import type { VSCodeHostImpl } from "./vscode-host-impl";
 
 const logger = getLogger("WebviewBase");
+
+/**
+ * Path segments for the logo resource
+ */
+const LogoPathSegments = ["assets", "icons", "logo128.png"];
 
 /**
  * BASE WEBVIEW CLASS
@@ -48,6 +54,28 @@ export abstract class WebviewBase implements vscode.Disposable {
 
   protected setupWebviewHtml(webview: vscode.Webview): void {
     webview.html = this.getHtmlForWebview(webview);
+  }
+
+  /**
+   * Build resource URIs for the webview
+   */
+  protected buildResourceURI(webview: vscode.Webview): ResourceURI {
+    return {
+      logo128: getUri(
+        webview,
+        this.context.extensionUri,
+        LogoPathSegments,
+      ).toString(),
+    };
+  }
+
+  /**
+   * Get the logo icon path for VS Code UI
+   */
+  protected static getLogoIconPath(
+    extensionUri: vscode.Uri,
+  ): vscode.Uri | { light: vscode.Uri; dark: vscode.Uri } {
+    return vscode.Uri.joinPath(extensionUri, ...LogoPathSegments);
   }
 
   private getHtmlForWebview(webview: vscode.Webview): string {

--- a/packages/vscode/src/integrations/webview/pochi-webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/pochi-webview-panel.ts
@@ -1,5 +1,4 @@
 import { AuthEvents } from "@/lib/auth-events";
-import { getUri } from "@/lib/get-uri";
 import { getLogger } from "@getpochi/common";
 import type {
   ResourceURI,
@@ -69,13 +68,7 @@ export class PochiWebviewPanel
 
   protected getReadResourceURI(): VSCodeHostApi["readResourceURI"] {
     return async (): Promise<ResourceURI> => {
-      return {
-        logo128: getUri(this.panel.webview, this.context.extensionUri, [
-          "assets",
-          "icons",
-          "logo128.png",
-        ]).toString(),
-      };
+      return this.buildResourceURI(this.panel.webview);
     };
   }
 
@@ -96,15 +89,7 @@ export class PochiWebviewPanel
     );
 
     // Set icon
-    panel.iconPath = {
-      light: vscode.Uri.joinPath(
-        extensionUri,
-        "assets",
-        "icons",
-        "logo128.png",
-      ),
-      dark: vscode.Uri.joinPath(extensionUri, "assets", "icons", "logo128.png"),
-    };
+    panel.iconPath = WebviewBase.getLogoIconPath(extensionUri);
 
     // Get dependencies from container
     const context = container.resolve<vscode.ExtensionContext>(

--- a/packages/vscode/src/integrations/webview/webview-sidebar.ts
+++ b/packages/vscode/src/integrations/webview/webview-sidebar.ts
@@ -1,6 +1,5 @@
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { AuthEvents } from "@/lib/auth-events";
-import { getUri } from "@/lib/get-uri";
 import type {
   ResourceURI,
   VSCodeHostApi,
@@ -60,13 +59,7 @@ export class PochiWebviewSidebar
         throw new Error("Webview not initialized");
       }
 
-      return {
-        logo128: getUri(this.view.webview, this.context.extensionUri, [
-          "assets",
-          "icons",
-          "logo128.png",
-        ]).toString(),
-      };
+      return this.buildResourceURI(this.view.webview);
     };
   }
 


### PR DESCRIPTION
## Summary
- Added LogoPathSegments constant in base class (following PascalCase naming)
- Created buildResourceURI helper method for consistent resource URI building
- Created getLogoIconPath static method for VS Code icon paths
- Refactored both webview implementations to use shared helpers
- Removed unused getUri imports

## Test plan
- [x] Verify VS Code extension builds and runs correctly
- [x] Verify both sidebar and editor panel webviews display the logo correctly
- [x] Verify all tests pass

🤖 Generated with [Pochi](https://getpochi.com)