### PR TITLE
feat(vscode): allow webview pane (individual tab) sync with webview sidebar through bridgeStoreEvent

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -222,6 +222,8 @@ const VSCodeHostStub = {
   },
 
   openPochiInNewTab: async (): Promise<void> => {},
+
+  bridgeStoreEvent: async (): Promise<void> => {},
 } satisfies VSCodeHostApi;
 
 export function createVscodeHostStub(overrides?: Partial<VSCodeHostApi>) {

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -271,6 +271,11 @@ export interface VSCodeHostApi {
   >;
 
   openPochiInNewTab(): Promise<void>;
+
+  bridgeStoreEvent(
+    webviewKind: "sidebar" | "pane",
+    event: unknown,
+  ): Promise<void>;
 }
 
 export interface WebviewHostApi {
@@ -286,4 +291,6 @@ export interface WebviewHostApi {
   onAuthChanged(): void;
 
   isFocused(): Promise<boolean>;
+
+  commitStoreEvent(event: unknown): Promise<void>;
 }

--- a/packages/vscode-webui/ambient.d.ts
+++ b/packages/vscode-webui/ambient.d.ts
@@ -1,0 +1,6 @@
+declare namespace globalThis {
+  // biome-ignore lint/style/noVar: <explanation>
+  var POCHI_CORS_PROXY_PORT: string;
+  // biome-ignore lint/style/noVar: <explanation>
+  var POCHI_WEBVIEW_KIND: "sidebar" | "pane";
+}

--- a/packages/vscode-webui/ambient.d.ts
+++ b/packages/vscode-webui/ambient.d.ts
@@ -1,6 +1,4 @@
 declare namespace globalThis {
   // biome-ignore lint/style/noVar: <explanation>
-  var POCHI_CORS_PROXY_PORT: string;
-  // biome-ignore lint/style/noVar: <explanation>
   var POCHI_WEBVIEW_KIND: "sidebar" | "pane";
 }

--- a/packages/vscode-webui/src/routes/tasks.tsx
+++ b/packages/vscode-webui/src/routes/tasks.tsx
@@ -29,7 +29,6 @@ import { vscodeHost } from "@/lib/vscode";
 import { parseTitle } from "@getpochi/common/message-utils";
 import { type Task, catalog } from "@getpochi/livekit";
 import { useStore } from "@livestore/react";
-import { useQuery } from "@tanstack/react-query";
 import { Link, createFileRoute, useRouter } from "@tanstack/react-router";
 import {
   Brain,
@@ -369,18 +368,12 @@ function GitBadge({
 function OpenInTabButton() {
   const { t } = useTranslation();
   const { openInTab } = useSettingsStore();
-  const { data: credentials } = useQuery({
-    queryKey: ["pochi-credentials"],
-    queryFn: () => vscodeHost.readPochiCredentials(),
-  });
 
   const handleOpenInTab = async () => {
     await vscodeHost.openPochiInNewTab();
   };
 
-  const showOpenInTab = openInTab && credentials;
-
-  if (!showOpenInTab) {
+  if (!openInTab) {
     return <div className="w-6" />;
   }
 

--- a/packages/vscode/src/integrations/webview/pochi-webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/pochi-webview-panel.ts
@@ -56,7 +56,10 @@ export class PochiWebviewPanel
     };
 
     // Use base class methods
-    this.setupWebviewHtml(this.panel.webview);
+    this.panel.webview.html = this.getHtmlForWebview(
+      this.panel.webview,
+      "pane",
+    );
     this.setupAuthEventListeners();
 
     // Listen to panel events

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -47,6 +47,7 @@ import { getVendor } from "@getpochi/common/vendor";
 import type {
   CustomAgentFile,
   PochiCredentials,
+  WebviewHostApi,
 } from "@getpochi/common/vscode-webui-bridge";
 import type {
   CaptureEvent,
@@ -124,6 +125,8 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     }
     this.customAgentManager = new CustomAgentManager(this.cwd);
   }
+
+  sidebarWebviewHostApi: WebviewHostApi | null = null;
 
   listRuleFiles = async (): Promise<RuleFile[]> => {
     return this.cwd ? await collectRuleFiles(this.cwd) : [];
@@ -729,6 +732,15 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     ThreadSignalSerialization<CustomAgentFile[]>
   > => {
     return ThreadSignal.serialize(this.customAgentManager.agents);
+  };
+
+  bridgeStoreEvent = async (
+    webviewType: "sidebar" | "pane",
+    event: unknown,
+  ): Promise<void> => {
+    // Ignore messages from the sidebar WebView as they're synced already.
+    if (webviewType === "sidebar") return;
+    await this.sidebarWebviewHostApi?.commitStoreEvent(event);
   };
 
   dispose() {

--- a/packages/vscode/src/integrations/webview/webview-sidebar.ts
+++ b/packages/vscode/src/integrations/webview/webview-sidebar.ts
@@ -5,12 +5,11 @@ import type {
   VSCodeHostApi,
   WebviewHostApi,
 } from "@getpochi/common/vscode-webui-bridge";
-import { inject, injectable, singleton } from "tsyringe";
+import { container, inject, injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { PochiConfiguration } from "../configuration";
 import { WebviewBase } from "./base";
-// biome-ignore lint/style/useImportType: needed for dependency injection
 import { VSCodeHostImpl } from "./vscode-host-impl";
 
 /**
@@ -93,13 +92,18 @@ export class PochiWebviewSidebar
     };
 
     // Use base class methods
-    this.setupWebviewHtml(this.view.webview);
+    this.view.webview.html = this.getHtmlForWebview(
+      this.view.webview,
+      "sidebar",
+    );
     this.setupAuthEventListeners();
 
-    this.createWebviewThread(webviewView.webview).then(() => {
+    this.createWebviewThread(webviewView.webview).then((thread) => {
       if (this.webviewHost) {
         this.webviewHostReady.fire(this.webviewHost);
       }
+
+      container.resolve(VSCodeHostImpl).sidebarWebviewHostApi = thread.imports;
     });
   }
 


### PR DESCRIPTION
## Summary
- Added bridgeStoreEvent API to VSCodeHostApi interface to enable communication between webview pane and sidebar
- Implemented commitStoreEvent in the webview to handle store events from the pane webview
- Created a proxy store in pane webviews that forwards commits to the sidebar for synchronization
- Set up proper webview kind detection (sidebar vs pane) using ambient type definitions
- Ensured changes made in individual task tabs are properly synchronized with the main sidebar view

## Test plan
- [x] Verify that changes in task pane are reflected in sidebar
- [x] Verify that sidebar remains functional when pane is open
- [x] Test both sidebar and pane webview functionality
- [x] Ensure no regressions in existing webview features

🤖 Generated with [Pochi](https://getpochi.com)