### PR TITLE
refactor(tools): remove command field from attemptCompletion tool

### DIFF
--- a/packages/tools/src/attempt-completion.ts
+++ b/packages/tools/src/attempt-completion.ts
@@ -7,12 +7,6 @@ export const attemptCompletionSchema = z.object({
     .describe(
       "The result of the task. Formulate this result in a way that is final and does not require further input from the user.",
     ),
-  command: z
-    .string()
-    .optional()
-    .describe(
-      "A CLI command to execute to show a live demo of the result to the user.",
-    ),
 });
 
 const toolDef = {

--- a/packages/vscode-webui/src/__stories__/tool-gallery.stories.tsx
+++ b/packages/vscode-webui/src/__stories__/tool-gallery.stories.tsx
@@ -256,7 +256,6 @@ const attemptCompletionProps: AttemptCompletionProp["tool"] = {
   input: {
     result:
       "The new Button component has been created and styled with the primary theme.",
-    command: "git status",
   },
   output: {
     success: true,

--- a/packages/vscode-webui/src/components/tool-invocation/tools/attempt-completion.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/attempt-completion.tsx
@@ -5,7 +5,7 @@ import type { ToolProps } from "../types";
 export const AttemptCompletionTool: React.FC<
   ToolProps<"attemptCompletion">
 > = ({ tool: toolCall }) => {
-  const { result = "", command = "" } = toolCall.input || {};
+  const { result = "" } = toolCall.input || {};
 
   // Return null if there's nothing to display
   if (!result) {
@@ -19,9 +19,6 @@ export const AttemptCompletionTool: React.FC<
         Task Completed
       </span>
       <MessageMarkdown>{result}</MessageMarkdown>
-      {command && (
-        <span className="mx-auto mt-1 font-mono font-semibold">{command}</span>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Removed command field from attemptCompletion tool schema
- Updated tool gallery stories to remove command example
- Updated UI component to no longer display command information

This change removes the command field from the attemptCompletion tool across the codebase. The command field was used to execute CLI commands to show live demos of results, but it's being removed as part of a refactor to simplify the tool interface.

## Test plan
- [x] Verify that all tests pass after the changes
- [x] Check that the UI components render correctly without the command field
- [x] Confirm that the tool schema is correctly updated

🤖 Generated with [Pochi](https://getpochi.com)