### PR TITLE
feat(tools): add CLI implementation of editNotebook tool and extract common utilities

### DIFF
--- a/packages/cli/src/tools/edit-notebook.ts
+++ b/packages/cli/src/tools/edit-notebook.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs/promises";
+import {
+  editNotebookCell,
+  parseNotebook,
+  resolvePath,
+  serializeNotebook,
+  validateNotebookPath,
+} from "@getpochi/common/tool-utils";
+import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
+
+/**
+ * Implements the editNotebook tool for CLI.
+ * Edits a specific cell in a Jupyter notebook by its cell ID.
+ */
+export const editNotebook =
+  (): ToolFunctionType<ClientTools["editNotebook"]> =>
+  async ({ path: filePath, cellId, content }, { cwd }) => {
+    try {
+      const absolutePath = resolvePath(filePath, cwd);
+      validateNotebookPath(absolutePath);
+
+      const fileContent = await fs.readFile(absolutePath, "utf-8");
+      const notebook = parseNotebook(fileContent);
+      const updatedNotebook = editNotebookCell(notebook, cellId, content);
+      const serialized = serializeNotebook(updatedNotebook);
+
+      await fs.writeFile(absolutePath, serialized, "utf-8");
+
+      return { success: true };
+    } catch (error) {
+      return { success: false };
+    }
+  };

--- a/packages/cli/src/tools/index.ts
+++ b/packages/cli/src/tools/index.ts
@@ -4,6 +4,7 @@ import type { ToolFunctionType } from "@getpochi/tools";
 import { type ToolUIPart, getToolName } from "ai";
 import type { ToolCallOptions } from "../types";
 import { applyDiff } from "./apply-diff";
+import { editNotebook } from "./edit-notebook";
 import { executeCommand } from "./execute-command";
 import { globFiles } from "./glob-files";
 import { listFiles } from "./list-files";
@@ -21,6 +22,7 @@ const ToolMap: Record<
 > = {
   readFile,
   applyDiff,
+  editNotebook,
   globFiles,
   listFiles,
   multiApplyDiff,

--- a/packages/common/src/tool-utils/__tests__/notebook-utils.test.ts
+++ b/packages/common/src/tool-utils/__tests__/notebook-utils.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  type NotebookContent,
+  editNotebookCell,
+  parseNotebook,
+  serializeNotebook,
+  validateNotebookPath,
+  validateNotebookStructure,
+} from "../notebook-utils";
+
+describe("notebook-utils", () => {
+  describe("validateNotebookPath", () => {
+    it("should pass for .ipynb files", () => {
+      expect(() => validateNotebookPath("test.ipynb")).not.toThrow();
+      expect(() => validateNotebookPath("/path/to/test.ipynb")).not.toThrow();
+    });
+
+    it("should throw for non-.ipynb files", () => {
+      expect(() => validateNotebookPath("test.py")).toThrow(
+        "File must be a Jupyter notebook (.ipynb)",
+      );
+      expect(() => validateNotebookPath("test.txt")).toThrow(
+        "File must be a Jupyter notebook (.ipynb)",
+      );
+    });
+  });
+
+  describe("validateNotebookStructure", () => {
+    it("should pass for valid notebook structure", () => {
+      expect(() =>
+        validateNotebookStructure({ cells: [] }),
+      ).not.toThrow();
+      expect(() =>
+        validateNotebookStructure({ cells: [{ source: "test" }] }),
+      ).not.toThrow();
+    });
+
+    it("should throw for invalid structures", () => {
+      expect(() => validateNotebookStructure(null)).toThrow(
+        "Invalid notebook format: no cells array found",
+      );
+      expect(() => validateNotebookStructure(undefined)).toThrow(
+        "Invalid notebook format: no cells array found",
+      );
+      expect(() => validateNotebookStructure({})).toThrow(
+        "Invalid notebook format: no cells array found",
+      );
+      expect(() => validateNotebookStructure({ cells: "not an array" })).toThrow(
+        "Invalid notebook format: no cells array found",
+      );
+    });
+  });
+
+  describe("parseNotebook", () => {
+    it("should parse valid notebook JSON", () => {
+      const json = JSON.stringify({ cells: [{ source: "test" }] });
+      const notebook = parseNotebook(json);
+      expect(notebook.cells).toHaveLength(1);
+      expect(notebook.cells[0].source).toBe("test");
+    });
+
+    it("should throw for invalid JSON", () => {
+      expect(() => parseNotebook("invalid json")).toThrow();
+    });
+
+    it("should throw for invalid notebook structure", () => {
+      const json = JSON.stringify({ notCells: [] });
+      expect(() => parseNotebook(json)).toThrow(
+        "Invalid notebook format: no cells array found",
+      );
+    });
+  });
+
+  describe("editNotebookCell", () => {
+    it("should edit cell by ID", () => {
+      const notebook: NotebookContent = {
+        cells: [
+          { id: "cell-1", source: "original" },
+          { id: "cell-2", source: "content" },
+        ],
+      };
+
+      const updated = editNotebookCell(notebook, "cell-2", "updated");
+      expect(updated.cells[1].source).toBe("updated");
+      expect(updated.cells[0].source).toBe("original");
+    });
+
+    it("should edit cell by index", () => {
+      const notebook: NotebookContent = {
+        cells: [
+          { id: "cell-1", source: "original" },
+          { id: "cell-2", source: "content" },
+        ],
+      };
+
+      const updated = editNotebookCell(notebook, "0", "updated");
+      expect(updated.cells[0].source).toBe("updated");
+      expect(updated.cells[1].source).toBe("content");
+    });
+
+    it("should edit cell without ID by index", () => {
+      const notebook: NotebookContent = {
+        cells: [{ source: "original" }, { source: "content" }],
+      };
+
+      const updated = editNotebookCell(notebook, "1", "updated");
+      expect(updated.cells[1].source).toBe("updated");
+      expect(updated.cells[0].source).toBe("original");
+    });
+
+    it("should throw when cell not found", () => {
+      const notebook: NotebookContent = {
+        cells: [{ id: "cell-1", source: "original" }],
+      };
+
+      expect(() => editNotebookCell(notebook, "non-existent", "updated")).toThrow(
+        'Cell with ID "non-existent" not found in notebook',
+      );
+    });
+
+    it("should throw when index is out of range", () => {
+      const notebook: NotebookContent = {
+        cells: [{ id: "cell-1", source: "original" }],
+      };
+
+      expect(() => editNotebookCell(notebook, "5", "updated")).toThrow(
+        'Cell with ID "5" not found in notebook',
+      );
+    });
+  });
+
+  describe("serializeNotebook", () => {
+    it("should serialize notebook to formatted JSON", () => {
+      const notebook: NotebookContent = {
+        cells: [{ id: "cell-1", source: "test" }],
+      };
+
+      const json = serializeNotebook(notebook);
+      expect(json).toContain('"cells"');
+      expect(json).toContain('"id": "cell-1"');
+      expect(json).toContain('"source": "test"');
+      // Check it's formatted (has newlines and indentation)
+      expect(json.split("\n").length).toBeGreaterThan(1);
+    });
+
+    it("should handle empty cells array", () => {
+      const notebook: NotebookContent = { cells: [] };
+      const json = serializeNotebook(notebook);
+      const parsed = JSON.parse(json);
+      expect(parsed.cells).toEqual([]);
+    });
+  });
+
+  describe("round-trip serialization", () => {
+    it("should maintain structure through parse and serialize", () => {
+      const original = {
+        cells: [
+          { id: "cell-1", source: "print('hello')" },
+          { id: "cell-2", source: "print('world')" },
+        ],
+      };
+
+      const json = serializeNotebook(original);
+      const parsed = parseNotebook(json);
+      expect(parsed).toEqual(original);
+    });
+  });
+});
+

--- a/packages/common/src/tool-utils/index.ts
+++ b/packages/common/src/tool-utils/index.ts
@@ -24,3 +24,12 @@ export {
 } from "./shell";
 export { parseAgentFile } from "./agent-parser";
 export { parseWorkflowFrontmatter } from "./workflow-parser";
+export {
+  type NotebookCell,
+  type NotebookContent,
+  validateNotebookPath,
+  validateNotebookStructure,
+  parseNotebook,
+  editNotebookCell,
+  serializeNotebook,
+} from "./notebook-utils";

--- a/packages/common/src/tool-utils/notebook-utils.ts
+++ b/packages/common/src/tool-utils/notebook-utils.ts
@@ -1,0 +1,80 @@
+export interface NotebookCell {
+  id?: string;
+  source: string | string[];
+}
+
+export interface NotebookContent {
+  cells: NotebookCell[];
+}
+
+/**
+ * Validates that a file path is a Jupyter notebook file
+ */
+export function validateNotebookPath(filePath: string): void {
+  if (!filePath.endsWith(".ipynb")) {
+    throw new Error("File must be a Jupyter notebook (.ipynb)");
+  }
+}
+
+/**
+ * Validates that a notebook has the correct structure
+ */
+export function validateNotebookStructure(notebook: unknown): void {
+  if (
+    !notebook ||
+    typeof notebook !== "object" ||
+    !("cells" in notebook) ||
+    !Array.isArray((notebook as NotebookContent).cells)
+  ) {
+    throw new Error("Invalid notebook format: no cells array found");
+  }
+}
+
+/**
+ * Parses a notebook from JSON string
+ */
+export function parseNotebook(content: string): NotebookContent {
+  const notebook = JSON.parse(content);
+  validateNotebookStructure(notebook);
+  return notebook as NotebookContent;
+}
+
+/**
+ * Edits a cell in a notebook by its ID or index
+ * @param notebook The notebook to edit
+ * @param cellId The cell ID or index (as string)
+ * @param newContent The new content for the cell
+ * @returns The updated notebook
+ * @throws Error if the cell is not found
+ */
+export function editNotebookCell(
+  notebook: NotebookContent,
+  cellId: string,
+  newContent: string,
+): NotebookContent {
+  let cellFound = false;
+
+  for (let i = 0; i < notebook.cells.length; i++) {
+    const cell = notebook.cells[i];
+    const currentCellId = cell.id;
+
+    if (currentCellId === cellId || i.toString() === cellId) {
+      notebook.cells[i].source = newContent;
+      cellFound = true;
+      break;
+    }
+  }
+
+  if (!cellFound) {
+    throw new Error(`Cell with ID "${cellId}" not found in notebook`);
+  }
+
+  return notebook;
+}
+
+/**
+ * Serializes a notebook to JSON string
+ */
+export function serializeNotebook(notebook: NotebookContent): string {
+  return JSON.stringify(notebook, null, 2);
+}

--- a/packages/vscode/src/tools/edit-notebook.ts
+++ b/packages/vscode/src/tools/edit-notebook.ts
@@ -1,53 +1,26 @@
 import * as fs from "node:fs/promises";
-import { resolvePath } from "@getpochi/common/tool-utils";
+import {
+  editNotebookCell,
+  parseNotebook,
+  resolvePath,
+  serializeNotebook,
+  validateNotebookPath,
+} from "@getpochi/common/tool-utils";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
-
-interface NotebookCell {
-  id?: string;
-  source: string | string[];
-}
-
-interface NotebookContent {
-  cells: NotebookCell[];
-}
 
 export const editNotebook: ToolFunctionType<
   ClientTools["editNotebook"]
 > = async ({ path: filePath, cellId, content }, { cwd }) => {
   try {
     const absolutePath = resolvePath(filePath, cwd);
-
-    if (!absolutePath.endsWith(".ipynb")) {
-      throw new Error("File must be a Jupyter notebook (.ipynb)");
-    }
+    validateNotebookPath(absolutePath);
 
     const fileContent = await fs.readFile(absolutePath, "utf-8");
-    const notebook: NotebookContent = JSON.parse(fileContent);
+    const notebook = parseNotebook(fileContent);
+    const updatedNotebook = editNotebookCell(notebook, cellId, content);
+    const serialized = serializeNotebook(updatedNotebook);
 
-    if (!notebook.cells || !Array.isArray(notebook.cells)) {
-      throw new Error("Invalid notebook format: no cells array found");
-    }
-
-    let cellFound = false;
-
-    for (let i = 0; i < notebook.cells.length; i++) {
-      const cell = notebook.cells[i];
-
-      const currentCellId = cell.id;
-
-      if (currentCellId === cellId || i.toString() === cellId) {
-        notebook.cells[i].source = content;
-        cellFound = true;
-        break;
-      }
-    }
-
-    if (!cellFound) {
-      throw new Error(`Cell with ID "${cellId}" not found in notebook`);
-    }
-
-    const updatedContent = JSON.stringify(notebook, null, 2);
-    await fs.writeFile(absolutePath, updatedContent, "utf-8");
+    await fs.writeFile(absolutePath, serialized, "utf-8");
 
     return { success: true };
   } catch (error) {

--- a/rules/no-workspace-folders.yaml
+++ b/rules/no-workspace-folders.yaml
@@ -1,0 +1,13 @@
+id: no-workspace-folders
+language: tsx
+rule:
+  pattern: $$$.workspaceFolders
+message: "Do not access workspace.workspaceFolders directly. Use the workspace helpers instead."
+severity: error
+ignores:
+  - "**/__test__/**"
+  - "packages/vscode/src/integrations/webview/vscode-host-impl.ts"
+  - "packages/vscode/src/integrations/uri-handler.ts"
+  - "packages/vscode/src/lib/workspace-job.ts"
+files:
+  - "packages/vscode/src/**/*.ts"


### PR DESCRIPTION
- Created shared notebook utilities in @getpochi/common/tool-utils:
  - validateNotebookPath() - validates .ipynb extension
  - validateNotebookStructure() - validates notebook structure
  - parseNotebook() - parses and validates notebook JSON
  - editNotebookCell() - edits cell by ID or index
  - serializeNotebook() - serializes to formatted JSON

- Implemented editNotebook tool for CLI package using shared utilities
- Refactored VSCode editNotebook to use shared utilities, eliminating code duplication
- Added comprehensive tests (15 tests) for all notebook utilities
- All existing tests pass (102 VSCode tests + 15 new common tests)

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
