### PR TITLE
refactor(vscode): introduce workspace-scoped dependency injection

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -36,7 +36,7 @@
     "views": {
       "pochi": [
         {
-          "id": "pochiWebui",
+          "id": "pochiSidebar",
           "type": "webview",
           "name": "Pochi"
         }
@@ -127,7 +127,7 @@
         "category": "Pochi"
       },
       {
-        "command": "pochi.openInEditor",
+        "command": "pochi.openInPanel",
         "title": "Open in Editor",
         "category": "Pochi",
         "icon": "$(window)"
@@ -178,17 +178,17 @@
       "view/title": [
         {
           "command": "pochi.webui.navigate.newTask",
-          "when": "view == pochiWebui",
+          "when": "view == pochiSidebar",
           "group": "navigation@0"
         },
         {
           "command": "pochi.webui.navigate.taskList",
-          "when": "view == pochiWebui",
+          "when": "view == pochiSidebar",
           "group": "navigation@1"
         },
         {
           "command": "pochi.webui.navigate.settings",
-          "when": "view == pochiWebui",
+          "when": "view == pochiSidebar",
           "group": "navigation@2"
         }
       ]

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -14,29 +14,40 @@ import "@getpochi/vendor-github-copilot";
 import "@getpochi/vendor-qwen-code";
 
 import RagdollUriHandler from "@/integrations/uri-handler";
+import {
+  pochiConfigRelativePath,
+  setPochiConfigWorkspacePath,
+} from "@getpochi/common/configuration";
 import { startCorsProxy } from "@getpochi/common/cors-proxy";
-import type { McpHub } from "@getpochi/common/mcp-utils";
+import { McpHub } from "@getpochi/common/mcp-utils";
 import { container, instanceCachingFactory } from "tsyringe";
-import type * as vscode from "vscode";
+import * as vscode from "vscode";
 import { CompletionProvider } from "./code-completion";
 import { PochiAuthenticationProvider } from "./integrations/auth-provider";
 import { CommandManager } from "./integrations/command";
 import { DiffChangesContentProvider } from "./integrations/editor/diff-changes-content-provider";
 import { DiffOriginContentProvider } from "./integrations/editor/diff-origin-content-provider";
-import { createMcpHub } from "./integrations/mcp/mcp-hub-factory";
+import { createMcpHub } from "./integrations/mcp";
 import { StatusBarItem } from "./integrations/status-bar-item";
 import { TerminalLinkProvider } from "./integrations/terminal-link-provider";
 import { PochiWebviewSidebar } from "./integrations/webview";
 import { type AuthClient, createAuthClient } from "./lib/auth-client";
 import { FileLogger } from "./lib/file-logger";
+import { getLogger } from "./lib/logger";
 import { PostInstallActions } from "./lib/post-install-actions";
+import { WorkspaceScope } from "./lib/workspace-scoped";
 import { NESProvider } from "./nes";
+
+const logger = getLogger("Extension");
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {
+  const cwd = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+
   // Container will dispose all the registered instances when itself is disposed
   context.subscriptions.push(container);
+  context.subscriptions.push(createWorkspaceConfigWatcher(cwd));
   if (!process.env.POCHI_TEST) {
     context.subscriptions.push(startCorsProxy());
   }
@@ -48,16 +59,19 @@ export async function activate(context: vscode.ExtensionContext) {
     // AuthClient is also a singleton
     useFactory: instanceCachingFactory(createAuthClient),
   });
-  container.register<McpHub>("McpHub", {
+
+  container.register(WorkspaceScope, {
+    useValue: new WorkspaceScope(cwd ?? null),
+  });
+  container.register<McpHub>(McpHub, {
     // McpHub is also a singleton
     useFactory: instanceCachingFactory(createMcpHub),
   });
-
+  container.resolve(PochiWebviewSidebar);
   container.resolve(CompletionProvider);
   container.resolve(NESProvider);
   container.resolve(StatusBarItem);
   container.resolve(PochiAuthenticationProvider);
-  container.resolve(PochiWebviewSidebar);
   container.resolve(RagdollUriHandler);
   container.resolve(CommandManager);
   container.resolve(DiffOriginContentProvider);
@@ -69,3 +83,33 @@ export async function activate(context: vscode.ExtensionContext) {
 
 // This method is called when your extension is deactivated
 export function deactivate() {}
+
+function createWorkspaceConfigWatcher(cwd: string | undefined) {
+  // Watch workspace .pochi/config.jsonc directory
+  if (cwd) {
+    setPochiConfigWorkspacePath(cwd);
+    const workspaceConfigPattern = new vscode.RelativePattern(
+      cwd,
+      pochiConfigRelativePath,
+    );
+    const configWatcher = vscode.workspace.createFileSystemWatcher(
+      workspaceConfigPattern,
+    );
+
+    configWatcher.onDidCreate(() => {
+      logger.debug("Workspace configuration file created.", cwd);
+      setPochiConfigWorkspacePath(cwd);
+    });
+
+    configWatcher.onDidDelete(() => {
+      logger.debug("Workspace configuration file deleted.");
+      setPochiConfigWorkspacePath(undefined);
+    });
+
+    return configWatcher;
+  }
+
+  return {
+    dispose: () => {},
+  };
+}

--- a/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
+++ b/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
@@ -1,10 +1,13 @@
 import { mkdir } from "node:fs/promises";
 import * as path from "node:path";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { WorkspaceScope } from "@/lib/workspace-scoped";
 import { getLogger, toErrorMessage } from "@getpochi/common";
 import type {
   SaveCheckpointOptions,
   UserEditsDiff,
 } from "@getpochi/common/vscode-webui-bridge";
+import { Lifecycle, inject, injectable, scoped } from "tsyringe";
 import type * as vscode from "vscode";
 import { ShadowGitRepo } from "./shadow-git-repo";
 import type { GitDiff } from "./types";
@@ -16,15 +19,25 @@ import {
 
 const logger = getLogger("CheckpointService");
 
+@scoped(Lifecycle.ContainerScoped)
+@injectable()
 export class CheckpointService implements vscode.Disposable {
   private shadowGit: ShadowGitRepo | undefined;
   private readyDefer = new Deferred<void>();
   private initialized = false;
 
   constructor(
-    private readonly cwd: string,
+    private readonly workspaceScope: WorkspaceScope,
+    @inject("vscode.ExtensionContext")
     private readonly context: vscode.ExtensionContext,
   ) {}
+
+  private get cwd() {
+    if (!this.workspaceScope.cwd) {
+      throw new Error("No workspace folder found. Please open a workspace.");
+    }
+    return this.workspaceScope.cwd;
+  }
 
   /**
    * Lazy initializes the checkpoint service.

--- a/packages/vscode/src/integrations/command-palette.ts
+++ b/packages/vscode/src/integrations/command-palette.ts
@@ -35,7 +35,7 @@ export class CommandPalette {
           label: "Chat",
           iconPath: new vscode.ThemeIcon("comment"),
           onDidAccept: () => {
-            vscode.commands.executeCommand("pochiWebui.focus");
+            vscode.commands.executeCommand("pochiSidebar.focus");
           },
         },
         {

--- a/packages/vscode/src/integrations/mcp/index.ts
+++ b/packages/vscode/src/integrations/mcp/index.ts
@@ -1,0 +1,1 @@
+export { createMcpHub } from "./mcp-hub-factory";

--- a/packages/vscode/src/integrations/mcp/mcp-hub-factory.ts
+++ b/packages/vscode/src/integrations/mcp/mcp-hub-factory.ts
@@ -3,7 +3,6 @@ import { pochiConfig } from "@getpochi/common/configuration";
 import { McpHub } from "@getpochi/common/mcp-utils";
 import { computed } from "@preact/signals-core";
 import type { DependencyContainer } from "tsyringe";
-import type * as vscode from "vscode";
 
 /**
  * Creates a McpHub instance configured for VSCode environment
@@ -11,23 +10,14 @@ import type * as vscode from "vscode";
  * @returns Configured McpHub instance
  */
 export function createMcpHub(container: DependencyContainer): McpHub {
-  const context = container.resolve<vscode.ExtensionContext>(
-    "vscode.ExtensionContext",
-  );
-
   const vendorTools = container.resolve(VendorTools);
-
   // Create a computed signal for MCP servers configuration
   const config = computed(() => pochiConfig.value.mcp || {});
 
   const mcpHub = new McpHub({
     config,
     vendorTools: vendorTools.tools,
-    clientName: context.extension.id,
   });
-
-  // Register for cleanup when context is disposed
-  context.subscriptions.push(mcpHub);
 
   return mcpHub;
 }

--- a/packages/vscode/src/integrations/mcp/third-party-mcp/importer.ts
+++ b/packages/vscode/src/integrations/mcp/third-party-mcp/importer.ts
@@ -1,7 +1,8 @@
 import { getLogger } from "@/lib/logger";
 import type { McpServerConfig } from "@getpochi/common/configuration";
-import type { McpHub } from "@getpochi/common/mcp-utils";
-import { inject, injectable, singleton } from "tsyringe";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { McpHub } from "@getpochi/common/mcp-utils";
+import { injectable, singleton } from "tsyringe";
 import type { McpConfigProvider } from "./provider";
 import { ClaudeDesktopMcpProvider } from "./providers/claude-desktop-provider";
 import { ClineMcpProvider } from "./providers/cline-provider";
@@ -22,7 +23,7 @@ export class ThirdMcpImporter {
     new RooCodeMcpProvider(),
   ];
 
-  constructor(@inject("McpHub") private readonly mcpHub: McpHub) {}
+  constructor(private readonly mcpHub: McpHub) {}
 
   async getAvailableProviders(): Promise<McpConfigProvider[]> {
     const availableProviders: McpConfigProvider[] = [];

--- a/packages/vscode/src/integrations/uri-handler.ts
+++ b/packages/vscode/src/integrations/uri-handler.ts
@@ -34,7 +34,7 @@ class RagdollUriHandler implements vscode.UriHandler, vscode.Disposable {
   }
 
   private async handleUriImpl(uri: vscode.Uri) {
-    await vscode.commands.executeCommand("pochiWebui.focus");
+    await vscode.commands.executeCommand("pochiSidebar.focus");
 
     /**
      * Supported URI formats:

--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -344,3 +344,5 @@ export abstract class WebviewBase implements vscode.Disposable {
     }
   }
 }
+
+export const commitStore = new vscode.EventEmitter<{ event: unknown }>();

--- a/packages/vscode/src/integrations/webview/index.ts
+++ b/packages/vscode/src/integrations/webview/index.ts
@@ -1,2 +1,2 @@
-export { PochiWebviewPanel } from "./pochi-webview-panel";
+export { PochiWebviewPanel } from "./webview-panel";
 export { PochiWebviewSidebar } from "./webview-sidebar";

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1,5 +1,6 @@
 import * as os from "node:os";
 import path from "node:path";
+// biome-ignore lint/style/useImportType: needed for dependency injection
 import { CustomAgentManager } from "@/lib/custom-agent";
 import {
   collectCustomRules,
@@ -18,6 +19,8 @@ import { ModelList } from "@/lib/model-list";
 import { PostHog } from "@/lib/posthog";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { UserStorage } from "@/lib/user-storage";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { WorkspaceScope } from "@/lib/workspace-scoped";
 import { applyDiff, previewApplyDiff } from "@/tools/apply-diff";
 import { editNotebook } from "@/tools/edit-notebook";
 import { executeCommand } from "@/tools/execute-command";
@@ -37,7 +40,8 @@ import { previewWriteToFile, writeToFile } from "@/tools/write-to-file";
 import type { Environment, GitStatus } from "@getpochi/common";
 import type { UserInfo } from "@getpochi/common/configuration";
 import type { McpStatus } from "@getpochi/common/mcp-utils";
-import type { McpHub } from "@getpochi/common/mcp-utils";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { McpHub } from "@getpochi/common/mcp-utils";
 import {
   GitStatusReader,
   ignoreWalk,
@@ -48,7 +52,6 @@ import { getVendor } from "@getpochi/common/vendor";
 import type {
   CustomAgentFile,
   PochiCredentials,
-  WebviewHostApi,
 } from "@getpochi/common/vscode-webui-bridge";
 import type {
   CaptureEvent,
@@ -77,8 +80,9 @@ import type { Tool } from "ai";
 import { machineId } from "node-machine-id";
 import { keys } from "remeda";
 import * as runExclusive from "run-exclusive";
-import { inject, injectable, singleton } from "tsyringe";
+import { Lifecycle, inject, injectable, scoped } from "tsyringe";
 import * as vscode from "vscode";
+// biome-ignore lint/style/useImportType: needed for dependency injection
 import { CheckpointService } from "../checkpoint/checkpoint-service";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { PochiConfiguration } from "../configuration";
@@ -94,20 +98,16 @@ import {
 } from "../terminal-link-provider/url-utils";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { TerminalState } from "../terminal/terminal-state";
+import { commitStore } from "./base";
 
 const logger = getLogger("VSCodeHostImpl");
 
+@scoped(Lifecycle.ContainerScoped)
 @injectable()
-@singleton()
 export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   private toolCallGroup = runExclusive.createGroupRef();
   private checkpointGroup = runExclusive.createGroupRef();
   private disposables: vscode.Disposable[] = [];
-  // cwd === null means no workspace is currently open.
-  private cwd: string | null =
-    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? null;
-  private checkpointService: CheckpointService | null = null;
-  private customAgentManager: CustomAgentManager;
 
   constructor(
     @inject("vscode.ExtensionContext")
@@ -115,19 +115,19 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     private readonly tabState: TabState,
     private readonly terminalState: TerminalState,
     private readonly posthog: PostHog,
-    @inject("McpHub") private readonly mcpHub: McpHub,
+    private readonly mcpHub: McpHub,
     private readonly thirdMcpImporter: ThirdMcpImporter,
     private readonly pochiConfiguration: PochiConfiguration,
     private readonly modelList: ModelList,
     private readonly userStorage: UserStorage,
-  ) {
-    if (this.cwd) {
-      this.checkpointService = new CheckpointService(this.cwd, this.context);
-    }
-    this.customAgentManager = new CustomAgentManager(this.cwd);
-  }
+    private readonly workspaceScope: WorkspaceScope,
+    private readonly checkpointService: CheckpointService,
+    private readonly customAgentManager: CustomAgentManager,
+  ) {}
 
-  sidebarWebviewHostApi: WebviewHostApi | null = null;
+  private get cwd() {
+    return this.workspaceScope.cwd;
+  }
 
   listRuleFiles = async (): Promise<RuleFile[]> => {
     return this.cwd ? await collectRuleFiles(this.cwd) : [];
@@ -618,9 +618,6 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       message: string,
       options?: SaveCheckpointOptions,
     ): Promise<string | null> => {
-      if (!this.checkpointService) {
-        return null;
-      }
       return await this.checkpointService.saveCheckpoint(message, options);
     },
   );
@@ -628,12 +625,12 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   restoreCheckpoint = runExclusive.build(
     this.checkpointGroup,
     async (commitHash: string): Promise<void> => {
-      await this.checkpointService?.restoreCheckpoint(commitHash);
+      await this.checkpointService.restoreCheckpoint(commitHash);
     },
   );
 
   readCheckpointPath = async (): Promise<string | undefined> => {
-    return this.checkpointService?.getShadowGitPath();
+    return this.checkpointService.getShadowGitPath();
   };
 
   diffWithCheckpoint = runExclusive.build(
@@ -642,7 +639,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       try {
         // Get changes using existing method
         const changes =
-          await this.checkpointService?.getCheckpointUserEditsDiff(
+          await this.checkpointService.getCheckpointUserEditsDiff(
             fromCheckpoint,
           );
         if (!changes || changes.length === 0) {
@@ -665,7 +662,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       checkpoint: { origin: string; modified?: string },
       displayPath?: string,
     ) => {
-      const changedFiles = await this.checkpointService?.getCheckpointChanges(
+      const changedFiles = await this.checkpointService.getCheckpointChanges(
         checkpoint.origin,
         checkpoint.modified,
       );
@@ -757,7 +754,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   };
 
   openPochiInNewTab = async (): Promise<void> => {
-    await vscode.commands.executeCommand("pochi.openInEditor");
+    await vscode.commands.executeCommand("pochi.openInPanel");
   };
 
   readCustomAgents = async (): Promise<
@@ -772,7 +769,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   ): Promise<void> => {
     // Ignore messages from the sidebar WebView as they're synced already.
     if (webviewType === "sidebar") return;
-    await this.sidebarWebviewHostApi?.commitStoreEvent(event);
+    commitStore.fire({ event });
   };
 
   dispose() {

--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -4,7 +4,7 @@ import type {
   ResourceURI,
   VSCodeHostApi,
 } from "@getpochi/common/vscode-webui-bridge";
-import { container } from "tsyringe";
+import type { DependencyContainer } from "tsyringe";
 import * as vscode from "vscode";
 import { PochiConfiguration } from "../configuration";
 import { WebviewBase } from "./base";
@@ -31,13 +31,13 @@ export class PochiWebviewPanel
   extends WebviewBase
   implements vscode.Disposable
 {
-  private static readonly viewType = "pochiEditor";
+  private static readonly viewType = "pochiPanel";
   private static panels = new Map<string, PochiWebviewPanel>();
   private static panelCounter = 0;
 
   private readonly panel: vscode.WebviewPanel;
 
-  private constructor(
+  constructor(
     panel: vscode.WebviewPanel,
     sessionId: string,
     context: vscode.ExtensionContext,
@@ -75,7 +75,10 @@ export class PochiWebviewPanel
     };
   }
 
-  public static createOrShow(extensionUri: vscode.Uri): void {
+  public static createOrShow(
+    workspaceContainer: DependencyContainer,
+    extensionUri: vscode.Uri,
+  ): void {
     // Generate unique session ID
     const sessionId = `editor-${Date.now()}-${++PochiWebviewPanel.panelCounter}`;
 
@@ -95,12 +98,12 @@ export class PochiWebviewPanel
     panel.iconPath = WebviewBase.getLogoIconPath(extensionUri);
 
     // Get dependencies from container
-    const context = container.resolve<vscode.ExtensionContext>(
+    const context = workspaceContainer.resolve<vscode.ExtensionContext>(
       "vscode.ExtensionContext",
     );
-    const events = container.resolve(AuthEvents);
-    const pochiConfiguration = container.resolve(PochiConfiguration);
-    const vscodeHost = container.resolve(VSCodeHostImpl);
+    const events = workspaceContainer.resolve(AuthEvents);
+    const pochiConfiguration = workspaceContainer.resolve(PochiConfiguration);
+    const vscodeHost = workspaceContainer.resolve(VSCodeHostImpl);
 
     // Create panel instance
     const pochiPanel = new PochiWebviewPanel(

--- a/packages/vscode/src/lib/custom-agent.ts
+++ b/packages/vscode/src/lib/custom-agent.ts
@@ -5,7 +5,10 @@ import { parseAgentFile } from "@getpochi/common/tool-utils";
 import type { CustomAgentFile } from "@getpochi/common/vscode-webui-bridge";
 import { signal } from "@preact/signals-core";
 import { uniqueBy } from "remeda";
+import { Lifecycle, injectable, scoped } from "tsyringe";
 import * as vscode from "vscode";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { WorkspaceScope } from "./workspace-scoped";
 
 const logger = getLogger("CustomAgentManager");
 
@@ -36,16 +39,20 @@ async function readAgentsFromDir(dir: string): Promise<CustomAgentFile[]> {
   return agents;
 }
 
+@scoped(Lifecycle.ContainerScoped)
+@injectable()
 export class CustomAgentManager implements vscode.Disposable {
   private disposables: vscode.Disposable[] = [];
-  private readonly cwd: string | null;
 
   readonly agents = signal<CustomAgentFile[]>([]);
 
-  constructor(cwd: string | null) {
-    this.cwd = cwd;
+  constructor(private readonly workspaceScope: WorkspaceScope) {
     this.initWatchers();
     this.loadAgents();
+  }
+
+  private get cwd() {
+    return this.workspaceScope.cwd;
   }
 
   private initWatchers() {

--- a/packages/vscode/src/lib/post-install-actions.ts
+++ b/packages/vscode/src/lib/post-install-actions.ts
@@ -91,7 +91,7 @@ class OpenTaskFromEnvAction implements Action {
     const uid = process.env.POCHI_TASK_ID;
     if (uid) {
       logger.info(`Opening task from POCHI_TASK_ID: ${uid}`);
-      await vscode.commands.executeCommand("pochiWebui.focus");
+      await vscode.commands.executeCommand("pochiSidebar.focus");
       await new Promise((resolve) => setTimeout(resolve, 500));
       await vscode.commands.executeCommand("pochi.openTask", uid);
     }

--- a/packages/vscode/src/lib/workspace-scoped.ts
+++ b/packages/vscode/src/lib/workspace-scoped.ts
@@ -1,0 +1,26 @@
+import { getLogger } from "@getpochi/common";
+import { type DependencyContainer, container } from "tsyringe";
+
+const logger = getLogger("WorkspaceScoped");
+const activeContainers = new Map<string | null, DependencyContainer>();
+
+export class WorkspaceScope {
+  // cwd === null means no workspace is currently open.
+  constructor(readonly cwd: string | null) {}
+}
+
+export function workspaceScoped(cwd: string): DependencyContainer {
+  let childContainer = activeContainers.get(cwd);
+  if (childContainer) {
+    return childContainer;
+  }
+  logger.debug(
+    `Creating workspace-scoped container for cwd: ${cwd ?? "(no workspace)"}`,
+  );
+  childContainer = container.createChildContainer();
+  childContainer.register(WorkspaceScope, {
+    useValue: new WorkspaceScope(cwd),
+  });
+  activeContainers.set(cwd, childContainer);
+  return childContainer;
+}

--- a/rules/no-workspace-folders.yaml
+++ b/rules/no-workspace-folders.yaml
@@ -6,7 +6,8 @@ message: "Do not access workspace.workspaceFolders directly. Use the workspace h
 severity: error
 ignores:
   - "**/__test__/**"
-  - "packages/vscode/src/integrations/webview/vscode-host-impl.ts"
+  - "packages/vscode/src/extension.ts"
+  - "packages/vscode/src/integrations/command.ts"
   - "packages/vscode/src/integrations/uri-handler.ts"
   - "packages/vscode/src/lib/workspace-job.ts"
 files:


### PR DESCRIPTION
This commit refactors the VSCode extension to support workspace-scoped
dependency injection, enabling better isolation between different
workspace instances.

Key changes:
- Add WorkspaceScope class and workspaceScoped() factory function for
  managing workspace-scoped containers
- Refactor VSCodeHostImpl, CheckpointService, and CustomAgentManager to
  use container-scoped lifecycle instead of singleton
- Rename PochiWebviewPanel file and update to use workspace containers
- Update command naming for consistency (pochiWebui -> pochiSidebar,
  openInEditor -> openInPanel)
- Implement event-based store synchronization using commitStore
  EventEmitter
- Clean up MCP dependency injection by removing manual clientName passing
- Update rules to reflect new workspace access patterns

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
