### PR TITLE
feat: add workspace-scoped configuration support

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,7 +20,10 @@ import "@getpochi/vendor-qwen-code/edge";
 
 import { Command, Option } from "@commander-js/extra-typings";
 import { constants, getLogger } from "@getpochi/common";
-import { pochiConfig } from "@getpochi/common/configuration";
+import {
+  pochiConfig,
+  setPochiConfigWorkspacePath,
+} from "@getpochi/common/configuration";
 import { getVendor, getVendors } from "@getpochi/common/vendor";
 import { createModel } from "@getpochi/common/vendor/edge";
 import type { LLMRequestData } from "@getpochi/livekit";
@@ -198,6 +201,7 @@ program.hook("preAction", async () => {
   await Promise.all([
     checkForUpdates().catch(() => {}),
     waitForSync().catch(console.error),
+    setPochiConfigWorkspacePath(process.cwd()).catch(() => {}),
   ]);
 });
 

--- a/packages/cli/src/lib/mcp-hub-factory.ts
+++ b/packages/cli/src/lib/mcp-hub-factory.ts
@@ -19,7 +19,6 @@ export async function createCliMcpHub(): Promise<McpHub> {
   const mcpHub = new McpHub({
     config,
     vendorTools,
-    clientName: "pochi-cli",
   });
 
   return mcpHub;

--- a/packages/common/src/configuration/config-manager.ts
+++ b/packages/common/src/configuration/config-manager.ts
@@ -33,7 +33,7 @@ const AllowedWorkspaceConfigKeys = ["mcp"] as const;
 
 const configFileName = isDev ? "dev-config.jsonc" : "config.jsonc";
 
-export const pochiConfigRelativePath = path.join(".pochi", configFileName);
+const pochiConfigRelativePath = path.join(".pochi", configFileName);
 
 const UserConfigFilePath = path.join(os.homedir(), pochiConfigRelativePath);
 
@@ -208,6 +208,8 @@ const {
   updateVendorConfig,
   getConfigFilePath,
   watchKeys,
+  inspect,
+  setWorkspacePath,
 } = new PochiConfigManager();
 
 export {
@@ -217,4 +219,7 @@ export {
   updateVendorConfig,
   getConfigFilePath as getPochiConfigFilePath,
   watchKeys as watchPochiConfigKeys,
+  inspect as inspectPochiConfig,
+  setWorkspacePath as setPochiConfigWorkspacePath,
+  pochiConfigRelativePath,
 };

--- a/packages/common/src/configuration/index.ts
+++ b/packages/common/src/configuration/index.ts
@@ -5,6 +5,9 @@ export {
   updateVendorConfig,
   getPochiConfigFilePath,
   watchPochiConfigKeys,
+  inspectPochiConfig,
+  setPochiConfigWorkspacePath,
+  pochiConfigRelativePath,
 } from "./config-manager";
 export type { PochiConfigTarget } from "./config-manager";
 

--- a/packages/common/src/mcp-utils/mcp-hub.ts
+++ b/packages/common/src/mcp-utils/mcp-hub.ts
@@ -3,7 +3,10 @@ import { type Signal, batch, computed, signal } from "@preact/signals-core";
 import * as R from "remeda";
 import { getLogger } from "../base";
 import type { McpServerConfig } from "../configuration/index.js";
-import { updatePochiConfig } from "../configuration/index.js";
+import {
+  inspectPochiConfig,
+  updatePochiConfig,
+} from "../configuration/index.js";
 import { McpConnection } from "./mcp-connection";
 import type {
   McpServerConnection,
@@ -126,10 +129,16 @@ export class McpHub implements Disposable {
   }
 
   private async saveConfig(newConfig: Record<string, McpServerConfig>) {
-    // Persist configuration changes to file
-    await updatePochiConfig({ mcp: newConfig }).catch((error) => {
-      logger.error("Failed to persist MCP configuration changes", error);
-    });
+    for (const [name, config] of Object.entries(newConfig)) {
+      const { effectiveTargets } = inspectPochiConfig(`mcp.${name}`);
+      const editTarget = effectiveTargets[0] || "user";
+      // Persist configuration changes to file
+      await updatePochiConfig({ mcp: { [name]: config } }, editTarget).catch(
+        (error) => {
+          logger.error("Failed to persist MCP configuration changes", error);
+        },
+      );
+    }
   }
 
   private async onConfigChanged() {


### PR DESCRIPTION
This commit adds support for workspace-scoped configuration, allowing
configuration to be set at different levels (user, workspace, folder).

Key changes:
- Export inspectPochiConfig() and setPochiConfigWorkspacePath() from
  config-manager for configuration inspection and workspace path setting
- Update McpHub to save configuration per effective target based on
  inspection results
- CLI now sets workspace path on startup to enable workspace-scoped
  config
- VSCode revealConfig() now determines target based on effective config
  locations and opens the appropriate file
- Remove clientName parameter from MCP initialization as it's no longer
  needed

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"introduce-workspace-scoped-di","parentHead":"9afc2cfc7a6a94feb1ca88f346d73159ea0dccf0","parentPull":510,"trunk":"main"}
```
-->
