### PR TITLE
feat: add .pochiignore file support to ignore files and directories

### DIFF
--- a/packages/common/src/tool-utils/__tests__/ignore-walk.test.ts
+++ b/packages/common/src/tool-utils/__tests__/ignore-walk.test.ts
@@ -54,6 +54,48 @@ describe("ignoreWalk", () => {
     ]);
   });
 
+  it("should respect useGitignore option", async () => {
+    vi.mocked(fs.readFile).mockImplementation(async (path) => {
+      if (path === "/workspace/.gitignore") {
+        return "dir1";
+      }
+      return "";
+    });
+
+    // With useGitignore: false, dir1 should not be ignored
+    const resultsNoGitignore = await ignoreWalk({ dir: "/workspace", useGitignore: false });
+    expect(resultsNoGitignore.map((r) => r.relativePath)).toEqual([
+      "file1.ts",
+      "dir1",
+      "dir1/file2.ts",
+    ]);
+
+    // With useGitignore: true (default), dir1 should be ignored
+    const resultsWithGitignore = await ignoreWalk({ dir: "/workspace", useGitignore: true });
+    expect(resultsWithGitignore.map((r) => r.relativePath)).toEqual(["file1.ts"]);
+  });
+
+  it("should respect usePochiignore option", async () => {
+    vi.mocked(fs.readFile).mockImplementation(async (path) => {
+      if (path === "/workspace/.pochiignore") {
+        return "dir1";
+      }
+      return "";
+    });
+
+    // With usePochiignore: false, dir1 should not be ignored
+    const resultsNoPochiignore = await ignoreWalk({ dir: "/workspace", usePochiignore: false });
+    expect(resultsNoPochiignore.map((r) => r.relativePath)).toEqual([
+      "file1.ts",
+      "dir1",
+      "dir1/file2.ts",
+    ]);
+
+    // With usePochiignore: true (default), dir1 should be ignored
+    const resultsWithPochiignore = await ignoreWalk({ dir: "/workspace", usePochiignore: true });
+    expect(resultsWithPochiignore.map((r) => r.relativePath)).toEqual(["file1.ts"]);
+  });
+
   it("should not walk recursively if disabled", async () => {
     const results = await ignoreWalk({ dir: "/workspace", recursive: false });
 

--- a/packages/common/src/tool-utils/list-files.ts
+++ b/packages/common/src/tool-utils/list-files.ts
@@ -54,6 +54,7 @@ export async function listFiles(
       recursive: !!recursive,
       abortSignal,
       useGitignore: false,
+      usePochiignore: false,
     });
 
     const isTruncated = fileResults.length > MaxListFileItems;


### PR DESCRIPTION
## Summary

Implements `.pochiignore` file support to allow users to specify files and directories that should be excluded from Pochi's context, addressing the need to filter out irrelevant files in large repositories.

### Changes

- **Add `.pochiignore` support**: New `usePochiignore` option in `ignoreWalk` function (enabled by default)
- **Refactor ignore file loading**: Generalized `attemptLoadIgnoreFromPath` to `attemptLoadIgnoreFile` to handle both `.gitignore` and `.pochiignore`
- **Fix directory matching**: Append trailing slash to directory paths for proper ignore pattern matching
- **Comprehensive tests**: Added tests for both `useGitignore` and `usePochiignore` options
- **Tool integration**: Updated `listFiles` tool to disable `.pochiignore` when listing files directly

### Files Modified

- `packages/common/src/tool-utils/ignore-walk.ts` - Core implementation
- `packages/common/src/tool-utils/__tests__/ignore-walk.test.ts` - Test coverage
- `packages/common/src/tool-utils/list-files.ts` - Integration with list-files tool

### Usage

Users can now create a `.pochiignore` file in their project root with gitignore-style patterns:

\`\`\`
# Example .pochiignore
node_modules/
dist/
*.log
build/
\`\`\`

Fixes #515

🤖 Generated with [Pochi](https://getpochi.com)