### PR TITLE
fix(cli): await isFileExists in load-agents.ts

### DIFF
--- a/packages/cli/src/lib/load-agents.ts
+++ b/packages/cli/src/lib/load-agents.ts
@@ -19,7 +19,7 @@ const logger = getLogger("loadAgents");
 async function readAgentsFromDir(dir: string): Promise<CustomAgentFile[]> {
   const agents: CustomAgentFile[] = [];
   try {
-    if (!isFileExists(dir)) {
+    if (!(await isFileExists(dir))) {
       return agents;
     }
 


### PR DESCRIPTION
## Summary
* Fix a bug where isFileExists was not being awaited, causing the function to always evaluate to true since it was checking the Promise object rather than its resolved value

## Test plan
* Run the existing tests to ensure no regressions
* Verify that the fix correctly handles the async nature of isFileExists

🤖 Generated with [Pochi](https://getpochi.com)

---
before:

<img width="2406" height="760" alt="CleanShot 2025-10-09 at 19 38 09@2x" src="https://github.com/user-attachments/assets/4e34d08d-d052-4457-9744-48a765f82d67" />

after:
<img width="2086" height="558" alt="CleanShot 2025-10-09 at 19 38 38@2x" src="https://github.com/user-attachments/assets/272db4d4-8eb9-41c5-be45-0dbaf4d005ce" />


