### PR TITLE
fix(cli): turn LiveKit sync by default

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -397,7 +397,7 @@ async function waitForSync(
   inputStore?: Store,
   timeoutDuration: Duration.DurationInput = "1 second",
 ) {
-  if (!process.env.POCHI_LIVEKIT_SYNC_ON) {
+  if (process.env.POCHI_LIVEKIT_SYNC_OFF) {
     return;
   }
   const store = inputStore || (await createStore());

--- a/packages/cli/src/livekit/store.ts
+++ b/packages/cli/src/livekit/store.ts
@@ -16,9 +16,9 @@ import { machineId } from "node-machine-id";
 export async function createStore() {
   const { jwt = null } = (await getPochiCredentials()) || {};
   const storeId = await getStoreId(jwt);
-  const enableSync = !!process.env.POCHI_LIVEKIT_SYNC_ON;
+  const disableSync = !!process.env.POCHI_LIVEKIT_SYNC_OFF;
   const adapter = makeAdapter({
-    storage: enableSync
+    storage: !disableSync
       ? {
           type: "fs",
           baseDirectory: path.join(os.homedir(), ".pochi", "storage"),
@@ -30,7 +30,7 @@ export async function createStore() {
         }
       : undefined,
     sync:
-      jwt && enableSync
+      jwt && !disableSync
         ? {
             backend: makeWsSync({
               url: getSyncBaseUrl(),

--- a/packages/cli/src/task/cmd.ts
+++ b/packages/cli/src/task/cmd.ts
@@ -3,8 +3,8 @@ import { registerTaskListCommand } from "./list";
 import { registerTaskShareCommand } from "./share";
 
 export function registerTaskCommand(program: Command) {
-  const enableSync = !!process.env.POCHI_LIVEKIT_SYNC_ON;
-  if (!enableSync) return;
+  const disableSync = !!process.env.POCHI_LIVEKIT_SYNC_OFF;
+  if (disableSync) return;
 
   const taskCommand = program
     .command("task")


### PR DESCRIPTION
Currently the livekit sync is not turned on by default,
making the tasks NOT sync to server by default, which would:
1. cli task is not show in website
2. task from slack is not updated

This PR turn it on by default and can be off by setting the env.

## Summary
- Change the environment variable check from `POCHI_LIVEKIT_SYNC_ON` to `POCHI_LIVEKIT_SYNC_OFF` for better developer experience
- This makes the default behavior to have sync enabled, and only disable it when explicitly requested via the environment variable
- Fixes the logic for checking whether LiveKit sync is enabled/disabled

## Test plan
- [x] Verify that LiveKit sync works by default
- [x] Verify that setting `POCHI_LIVEKIT_SYNC_OFF=1` disables sync
- [x] All existing tests pass

🤖 Generated with [Pochi](https://getpochi.com)