### PR TITLE
fix(vscode): do not open workspace again when current one match target

### DIFF
--- a/packages/vscode/src/integrations/uri-handler.ts
+++ b/packages/vscode/src/integrations/uri-handler.ts
@@ -109,8 +109,14 @@ class RagdollUriHandler implements vscode.UriHandler, vscode.Disposable {
     );
 
     // Open the workspace, only open in newWindow when there is a existed workspace
-    // In Remote Pochi, There is no opened workspace, opening new window would cause a new tab.
-    const forceNewWindow = !!this.currentWorkspaceUri;
+    // In Remote Pochi, when opening a existed task, the workspace is opened by uri, so we don't need to open it again
+    const currentUri = this.currentWorkspaceUri;
+    if (currentUri && currentUri.toString() === existingProject.toString()) {
+      logger.info("Workspace is already open, skipping open command");
+      return true;
+    }
+
+    const forceNewWindow = !!currentUri;
     await vscode.commands.executeCommand("vscode.openFolder", existingProject, {
       forceNewWindow,
     });


### PR DESCRIPTION
Manually built and installed the vsix, and then reopen the url:
https://jam.dev/c/f4f8de7e-5817-4a64-a23f-b0f686e2e788

## Summary
- Improved the logic for opening workspaces in the URI handler to prevent duplicate opening of the same workspace
- When a workspace is already open, we now skip the open command instead of opening it again in a new window
- This addresses an issue where opening an existing task would cause a new tab to be created unnecessarily

## Test plan
- [x] Verified the fix works as expected in URI handler
- [x] Ensured no regressions in workspace opening functionality

🤖 Generated with [Pochi](https://getpochi.com)