### PR TITLE
fix: handle empty changes array when moving cursor

### DIFF
--- a/packages/vscode/src/nes/decoration-manager.ts
+++ b/packages/vscode/src/nes/decoration-manager.ts
@@ -143,11 +143,13 @@ export class NESDecorationManager implements vscode.Disposable {
     this.hide();
 
     // Move cursor to the end of the last change
-    const lastChange = solution.changes[solution.changes.length - 1];
-    const cursorPosition = editor.document.positionAt(
-      lastChange.rangeOffset + lastChange.text.length,
-    );
-    editor.selection = new vscode.Selection(cursorPosition, cursorPosition);
+    if (solution.changes.length > 0) {
+      const lastChange = solution.changes[solution.changes.length - 1];
+      const cursorPosition = editor.document.positionAt(
+        lastChange.rangeOffset + lastChange.text.length,
+      );
+      editor.selection = new vscode.Selection(cursorPosition, cursorPosition);
+    }
   }
 
   reject() {


### PR DESCRIPTION
Add check for empty changes array to prevent runtime errors when moving cursor to last change position

This PR addresses an issue where the code would attempt to access the last element of an empty changes array, which could cause runtime errors.

<img width="503" height="76" alt="image" src="https://github.com/user-attachments/assets/98574f37-c84f-486b-9d33-e08ad4b425eb" />



🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>