### PR TITLE
Fix DiffView error handling in apply-diff tools

### DIFF
--- a/packages/vscode/src/tools/apply-diff.ts
+++ b/packages/vscode/src/tools/apply-diff.ts
@@ -53,7 +53,9 @@ export const previewApplyDiff: PreviewToolFunctionType<
       abortSignal,
     );
   } catch (error) {
-    DiffView.revertAndClose(toolCallId);
+    if (state === "call") {
+      DiffView.revertAndClose(toolCallId);
+    }
     throw error;
   }
 };

--- a/packages/vscode/src/tools/multi-apply-diff.ts
+++ b/packages/vscode/src/tools/multi-apply-diff.ts
@@ -40,7 +40,9 @@ export const previewMultiApplyDiff: PreviewToolFunctionType<
       abortSignal,
     );
   } catch (error) {
-    DiffView.revertAndClose(toolCallId);
+    if (state === "call") {
+      DiffView.revertAndClose(toolCallId);
+    }
     throw error;
   }
 };

--- a/packages/vscode/src/tools/write-to-file.ts
+++ b/packages/vscode/src/tools/write-to-file.ts
@@ -26,7 +26,9 @@ export const previewWriteToFile: PreviewToolFunctionType<
       abortSignal,
     );
   } catch (error) {
-    DiffView.revertAndClose(toolCallId);
+    if (state === "call") {
+      DiffView.revertAndClose(toolCallId);
+    }
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- Fix apply-diff tool to conditionally revert DiffView on error based on state
- Fix multi-apply-diff tool to conditionally revert DiffView on error based on state
- Fix write-to-file tool to conditionally revert DiffView on error based on state

This PR addresses an issue where the DiffView was not being properly reverted on error in certain states, which could lead to inconsistent UI behavior.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>