### PR TITLE
fix(vscode): improve status bar item to show nes ongoing request

### DIFF
--- a/packages/vscode/src/code-completion/index.ts
+++ b/packages/vscode/src/code-completion/index.ts
@@ -84,11 +84,7 @@ export class CompletionProvider
     private readonly editorOptionsProvider: EditorOptionsProvider,
     private readonly client: CodeCompletionClient,
   ) {
-    if (
-      !pochiConfiguration.advancedSettings.value.nextEditSuggestion?.enabled
-    ) {
-      this.initialize();
-    }
+    this.initialize();
   }
 
   private initialize() {
@@ -119,7 +115,14 @@ export class CompletionProvider
     }
     const { disabled, disabledLanguages } =
       this.pochiConfiguration.advancedSettings.value.inlineCompletion ?? {};
-    if (disabled || disabledLanguages?.includes(document.languageId)) {
+    const nesEnabled =
+      this.pochiConfiguration.advancedSettings.value.nextEditSuggestion
+        ?.enabled;
+    if (
+      disabled ||
+      disabledLanguages?.includes(document.languageId) ||
+      nesEnabled
+    ) {
       return null;
     }
 

--- a/packages/vscode/src/nes/utils.ts
+++ b/packages/vscode/src/nes/utils.ts
@@ -6,9 +6,9 @@ export function applyEdit(original: string, changes: TextContentChange[]) {
   });
   let text = "";
   let index = 0;
-  for (const changes of sortedChanges) {
-    text += original.slice(index, changes.rangeOffset) + changes.text;
-    index = changes.rangeOffset + changes.rangeLength;
+  for (const change of sortedChanges) {
+    text += original.slice(index, change.rangeOffset) + change.text;
+    index = change.rangeOffset + change.rangeLength;
   }
   text += original.slice(index);
   return text;


### PR DESCRIPTION
Changes:

* improve status bar item to show NES ongoing request
* disable/enable nes in config no longer requires restart

---

## Summary
This PR improves the Next Edit Suggestion (NES) implementation and inline completion handling in the VS Code extension:

- Refactor NESProvider to use signals for fetching state management
- Fix initialization logic for NESProvider to ensure proper setup
- Improve inline completion handling in status bar to correctly reflect NES state
- Update completion provider to properly handle NES enabled state
- Fix variable naming in applyEdit function for better clarity
- Fix import ordering issues identified by pre-push hooks

## Test plan
- [x] Verified all existing tests pass
- [x] Tested NES functionality in VS Code extension
- [x] Verified inline completion behavior with NES enabled/disabled
- [x] Checked status bar indicators reflect correct states

🤖 Generated with [Pochi](https://getpochi.com)