### PR TITLE
chore(common): add default value for Google Vertex service account key

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -260,6 +260,7 @@
                     "type": "object",
                     "properties": {
                       "serviceAccountKey": {
+                        "default": "",
                         "type": "string"
                       },
                       "location": {

--- a/packages/common/src/configuration/model.ts
+++ b/packages/common/src/configuration/model.ts
@@ -57,7 +57,9 @@ const AnthropicModelSettings = ExtendedModelSettings.extend({
 
 export const GoogleVertexModel = z.union([
   z.object({
-    serviceAccountKey: z.string(),
+    serviceAccountKey: z
+      .string()
+      .default(process.env.POCHI_VERTEX_SERVICE_ACCOUNT_KEY ?? ""),
     location: z.string(),
   }),
   z.object({
@@ -66,14 +68,8 @@ export const GoogleVertexModel = z.union([
     location: z.string(),
   }),
   z.object({
-    issueUrl: z
-      .string()
-      .optional()
-      .default(process.env.POCHI_VERTEX_ISSUE_URL ?? ""),
-    modelUrl: z
-      .string()
-      .optional()
-      .default(process.env.POCHI_VERTEX_MODEL_URL ?? ""),
+    issueUrl: z.string().default(process.env.POCHI_VERTEX_ISSUE_URL ?? ""),
+    modelUrl: z.string().default(process.env.POCHI_VERTEX_MODEL_URL ?? ""),
   }),
 ]);
 


### PR DESCRIPTION
## Summary
- Add a default value for the Google Vertex service account key in the configuration model to improve developer experience
- Simplified the modelUrl and issueUrl definitions by removing unnecessary optional() calls since default() already handles undefined values
- Updated the config schema to include the default value

## Test plan
- [x] Verify that the Google Vertex configuration works with the new default value
- [x] Ensure existing functionality is not broken
- [x] Test that environment variable fallback works correctly

🤖 Generated with [Pochi](https://getpochi.com)