### PR TITLE
fix(cli): Mark task as failed when max rounds/retries

### DIFF
--- a/packages/cli/src/lib/step-count.ts
+++ b/packages/cli/src/lib/step-count.ts
@@ -16,6 +16,20 @@ export function stepToString(stepInfo: StepInfo): string {
   return `Round ${stepInfo.step}`;
 }
 
+export class MaxRoundReachedError extends Error {
+  constructor(readonly maxRounds: number) {
+    super(`Task aborted: maximum number of rounds reached (${maxRounds}).`);
+    this.name = "AbortError";
+  }
+}
+
+export class MaxRetryReachedError extends Error {
+  constructor(readonly maxRetries: number) {
+    super(`Task aborted: maximum number of retries reached (${maxRetries}).`);
+    this.name = "AbortError";
+  }
+}
+
 /**
  * A step of the runner loop.
  * The runner loads the task, processes messages, then sends results to the server.
@@ -40,7 +54,7 @@ export class StepCount implements StepInfo {
 
   throwIfReachedMaxSteps() {
     if (this.step >= this.maxSteps) {
-      throw new Error(`Reached max rounds (${this.maxSteps}).`);
+      throw new MaxRoundReachedError(this.maxSteps);
     }
   }
 
@@ -52,7 +66,7 @@ export class StepCount implements StepInfo {
 
   throwIfReachedMaxRetries() {
     if (this.retry >= this.maxRetries) {
-      throw new Error(`Reached max retries (${this.maxRetries}).`);
+      throw new MaxRetryReachedError(this.maxRetries);
     }
   }
 

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -203,6 +203,7 @@ export class TaskRunner {
     } catch (e) {
       const error = toError(e);
       logger.trace("Failed:", error);
+      this.chatKit.markAsFailed(error);
     }
   }
 

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -224,6 +224,16 @@ export class LiveChatKit<
     );
   };
 
+  markAsFailed = (error: Error) => {
+    this.store.commit(
+      events.taskFailed({
+        id: this.taskId,
+        error: toTaskError(error),
+        updatedAt: new Date(),
+      }),
+    );
+  };
+
   private readonly onStart: OnStartCallback = async ({
     messages,
     environment,

--- a/packages/livekit/src/livestore/schema.ts
+++ b/packages/livekit/src/livestore/schema.ts
@@ -139,6 +139,14 @@ export const events = {
       ),
     }),
   }),
+  taskFailed: Events.synced({
+    name: "v1.TaskFailed",
+    schema: Schema.Struct({
+      id: Schema.String,
+      error: TaskError,
+      updatedAt: Schema.Date,
+    }),
+  }),
   chatStreamStarted: Events.synced({
     name: "v1.ChatStreamStarted",
     schema: Schema.Struct({
@@ -230,6 +238,15 @@ const materializers = State.SQLite.materializers(events, {
           }),
         ]
       : []),
+  ],
+  "v1.TaskFailed": ({ id, error, updatedAt }) => [
+    tables.tasks
+      .update({
+        status: "failed",
+        error,
+        updatedAt,
+      })
+      .where({ id }),
   ],
   "v1.ChatStreamStarted": ({ id, data, todos, git, title, updatedAt }) => [
     tables.tasks


### PR DESCRIPTION
## Summary
- Add MaxRoundReachedError and MaxRetryReachedError classes for better error handling
- Update StepCount to use the new error types instead of generic Error
- Add markAsFailed method to LiveChatKit to track task failures
- Add taskFailed event to schema with materializer to update task status

## Test plan
- [x] Verify that the new error types are properly thrown when limits are reached
- [x] Check that the taskFailed event correctly updates task status in the database
- [x] Ensure existing tests pass with the new error handling

🤖 Generated with [Pochi](https://getpochi.com)