### PR TITLE
fix(cli): prevent CLI from stuck initializing with disabled MCP servers

### DIFF
--- a/packages/cli/src/mcp/initializer.ts
+++ b/packages/cli/src/mcp/initializer.ts
@@ -25,12 +25,15 @@ export async function initializeMcp(program: Command) {
     const readyConnections = connections.filter(
       (conn) => conn.status === "ready",
     ).length;
+    const stoppedConnections = connections.filter(
+      (conn) => conn.status === "stopped",
+    ).length;
     const errorConnections = connections.filter(
       (conn) => conn.status === "error",
     ).length;
 
     // Wait for ALL non-error connections to be ready
-    if (readyConnections >= connections.length) {
+    if (readyConnections + stoppedConnections >= connections.length) {
       break;
     }
 


### PR DESCRIPTION
## Summary
- Fix CLI initialization hanging when there are disabled MCP servers in config
- Add tracking for stopped connections in MCP initializer
- Update initialization condition to include both ready and stopped connections

## Test plan
- Verified the fix resolves the CLI hanging issue during initialization
- Tested with various combinations of ready, stopped, and error MCP server states

🤖 Generated with [Pochi](https://getpochi.com)