### PR TITLE
fix(livestore): fix the potential recreation of livestore adaptor

### DIFF
--- a/packages/vscode-webui/ambient.d.ts
+++ b/packages/vscode-webui/ambient.d.ts
@@ -1,4 +1,12 @@
-declare namespace globalThis {
-  // biome-ignore lint/style/noVar: <explanation>
+import type {
+  makeInMemoryAdapter,
+  makePersistedAdapter,
+} from "@livestore/adapter-web";
+
+declare global {
   var POCHI_WEBVIEW_KIND: "sidebar" | "pane";
+  var POCHI_LIVEKIT_ADAPTER:
+    | ReturnType<typeof makePersistedAdapter>
+    | ReturnType<typeof makeInMemoryAdapter>
+    | undefined;
 }

--- a/packages/vscode-webui/src/livestore-provider.tsx
+++ b/packages/vscode-webui/src/livestore-provider.tsx
@@ -19,14 +19,21 @@ import { usePochiCredentials } from "./lib/hooks/use-pochi-credentials";
 import { setActiveStore, vscodeHost } from "./lib/vscode";
 import LiveStoreWorker from "./livestore.worker.ts?worker&inline";
 
-const adapter =
-  globalThis.POCHI_WEBVIEW_KIND === "sidebar"
-    ? makePersistedAdapter({
-        storage: { type: "opfs" },
-        worker: LiveStoreWorker,
-        sharedWorker: LiveStoreSharedWorker,
-      })
-    : makeInMemoryAdapter();
+const adapter = (() => {
+  if (!globalThis.POCHI_LIVEKIT_ADAPTER) {
+    globalThis.POCHI_LIVEKIT_ADAPTER =
+      globalThis.POCHI_WEBVIEW_KIND === "sidebar"
+        ? makePersistedAdapter({
+            storage: { type: "opfs" },
+            worker: LiveStoreWorker,
+            sharedWorker: LiveStoreSharedWorker,
+          })
+        : makeInMemoryAdapter();
+  }
+  return globalThis.POCHI_LIVEKIT_ADAPTER as ReturnType<
+    typeof makePersistedAdapter
+  >;
+})();
 
 interface StoreDateContextType {
   storeDate: Date;


### PR DESCRIPTION
the global adaptor in vscode-webui may be recreate when the ui refresh while the LiveStoreSharedWorker still alive, making the extension return the following error, this PR save the adaptor to global namespace to avoid recreation of adaptor

<img width="1632" height="2190" alt="CleanShot 2025-10-13 at 23 32 00@2x" src="https://github.com/user-attachments/assets/cc29b1e1-e3da-4ab1-98e2-89c4513def2a" />
