### PR TITLE
refactor(vscode-webui): extract useThirdPartyMcp hook to separate file

### DIFF
--- a/packages/vscode-webui/src/lib/hooks/use-third-party-mcp.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-third-party-mcp.ts
@@ -1,0 +1,22 @@
+import { vscodeHost } from "@/lib/vscode";
+import { useQuery } from "@tanstack/react-query";
+
+export interface McpConfigPath {
+  name: string;
+  description: string;
+  path: string;
+}
+
+export function useThirdPartyMcp() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["thirdPartyMcpConfigs"],
+    queryFn: async () => {
+      return await vscodeHost.fetchAvailableThirdPartyMcpConfigs();
+    },
+  });
+
+  return {
+    ...data,
+    isLoading,
+  };
+}

--- a/packages/vscode-webui/src/providers.tsx
+++ b/packages/vscode-webui/src/providers.tsx
@@ -23,7 +23,8 @@ export const Providers: React.FC<{ children: React.ReactNode }> = ({
 
               const cacheQuery =
                 query.queryKey[0] === "session" ||
-                query.queryKey[0] === "mcpConnectTools";
+                query.queryKey[0] === "mcpConnectTools" ||
+                query.queryKey[0] === "thirdPartyMcpConfigs";
 
               return isSuccess && cacheQuery;
             },


### PR DESCRIPTION
## Summary
- Extracted useThirdPartyMcp hook from mcp-section.tsx to its own file
- Updated import paths in mcp-section.tsx to use the new hook location
- Added thirdPartyMcpConfigs to query cache in providers.tsx
- Improved loading state logic in McpSection component

This change improves code organization by separating the third-party MCP hook into its own module and ensures proper caching of the configuration data.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>