### PR TITLE
feat(vertex): add timeout configuration for Google Vertex model

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -303,11 +303,17 @@
                       "modelUrl": {
                         "default": "",
                         "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Timeout in milliseconds when requesting model api",
+                        "default": 900000,
+                        "type": "number"
                       }
                     },
                     "required": [
                       "issueUrl",
-                      "modelUrl"
+                      "modelUrl",
+                      "timeout"
                     ],
                     "additionalProperties": false
                   }

--- a/packages/common/src/configuration/model.ts
+++ b/packages/common/src/configuration/model.ts
@@ -70,6 +70,13 @@ export const GoogleVertexModel = z.union([
   z.object({
     issueUrl: z.string().default(process.env.POCHI_VERTEX_ISSUE_URL ?? ""),
     modelUrl: z.string().default(process.env.POCHI_VERTEX_MODEL_URL ?? ""),
+    timeout: z
+      .number()
+      // By default timeout is 15min
+      .default(
+        Number.parseInt(process.env.POCHI_VERTEX_MODEL_TIMEOUT ?? "900000"),
+      )
+      .describe("Timeout in milliseconds when requesting model api"),
   }),
 ]);
 

--- a/packages/common/src/google-vertex-utils.ts
+++ b/packages/common/src/google-vertex-utils.ts
@@ -89,7 +89,7 @@ export function createVertexModel(vertex: GoogleVertexModel, modelId: string) {
   }
 
   if ("issueUrl" in vertex) {
-    const { issueUrl, modelUrl } = vertex;
+    const { issueUrl, modelUrl, timeout } = vertex;
     return createVertexWithoutCredentials({
       project: "placeholder",
       location: "placeholder",
@@ -122,7 +122,11 @@ export function createVertexModel(vertex: GoogleVertexModel, modelId: string) {
 
         const headers = new Headers(requestInit?.headers);
         headers.append("Authorization", `Bearer ${accessToken}`);
-        return fetch(`${modelUrl}/${lastSegment}`, { ...requestInit, headers });
+        return fetch(`${modelUrl}/${lastSegment}`, {
+          ...requestInit,
+          headers,
+          signal: AbortSignal.timeout(timeout),
+        });
       },
     })(modelId);
   }


### PR DESCRIPTION
## Summary
- Add a configurable timeout option for Google Vertex model requests to prevent hanging requests
- The timeout defaults to 15 minutes (900000ms) and can be configured via the POCHI_VERTEX_MODEL_TIMEOUT environment variable
- Update the configuration schema to include the new timeout property
- Implement the timeout in the Google Vertex utilities using AbortSignal.timeout()

## Test plan
- Verified that the changes pass all existing tests
- Confirmed that the configuration schema is properly updated
- Verified that the timeout is correctly applied to model requests

🤖 Generated with [Pochi](https://getpochi.com)