### PR TITLE
feat(uri-handler): use base64url to decode new task request to avoid encoding issues

### DIFF
--- a/packages/vscode/src/integrations/uri-handler.ts
+++ b/packages/vscode/src/integrations/uri-handler.ts
@@ -60,7 +60,11 @@ class RagdollUriHandler implements vscode.UriHandler, vscode.Disposable {
       );
     } else if (eventParam) {
       await this.safeExecute(() => {
-        const decodedEvent = JSON.parse(decodeURIComponent(eventParam));
+        const decodedEvent = JSON.parse(
+          decodeURIComponent(
+            Buffer.from(eventParam, "base64url").toString("utf8"),
+          ),
+        );
         const event = WebsiteTaskCreateEvent.parse(decodedEvent);
         return this.handleNewProjectTask(event);
       }, "Failed to process task event");


### PR DESCRIPTION
it would break the redirect query params when user input prompt or image url contained special chars like `&`.

this PR use base64url to decode the event param, safely escape all special chars.