### PR TITLE
feat(cli): redirect console output to stderr for CLI

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env bun
+
+// Override global console to stderr
+import "./logger";
+
 // Workaround for https://github.com/oven-sh/bun/issues/18145
 import "@livestore/wa-sqlite/dist/wa-sqlite.node.wasm" with { type: "file" };
 

--- a/packages/cli/src/json-renderer.ts
+++ b/packages/cli/src/json-renderer.ts
@@ -1,8 +1,12 @@
+import { Console } from "node:console";
 import { type Message, StoreBlobProtocol, catalog } from "@getpochi/livekit";
 import type { Store } from "@livestore/livestore";
 import * as R from "remeda";
 import type { NodeChatState } from "./livekit/chat.node";
 import type { TaskRunner } from "./task-runner";
+
+// JsonRenderer shall output stdout
+const console = new Console(process.stdout);
 
 export class JsonRenderer {
   private outputMessageIds = new Set<string>();

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -1,0 +1,3 @@
+import { Console } from "node:console";
+
+globalThis.console = new Console(process.stderr);


### PR DESCRIPTION
## Summary
- Redirects console output to stderr instead of stdout to separate application output from logging/debugging information
- Creates a new logger module that overrides global console to stderr
- Updates JSON renderer to explicitly use stdout for its output
- Ensures CLI command output goes to stderr while structured data goes to stdout

## Test plan
- [x] Verify that console.log/warn/error now go to stderr
- [x] Verify that JSON renderer output still goes to stdout
- [x] Verify CLI commands work correctly with the new output routing

🤖 Generated with [Pochi](https://getpochi.com)