### PR TITLE
refactor(vscode-webui): centralize tool call status logic

### DIFF
--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
@@ -1,4 +1,3 @@
-import { isAutoSuccessToolName } from "@getpochi/tools";
 import { useToolCallLifeCycle } from "../lib/chat-state";
 
 interface UseChatStatusProps {
@@ -20,11 +19,7 @@ export function useChatStatus({
   isUploadingAttachments,
   newCompactTaskPending,
 }: UseChatStatusProps) {
-  const { executingToolCalls, previewingToolCalls } = useToolCallLifeCycle();
-  const isExecuting = executingToolCalls.length > 0;
-  const isPreviewing =
-    previewingToolCalls.filter((x) => !isAutoSuccessToolName(x.toolName))
-      .length > 0;
+  const { isExecuting, isPreviewing } = useToolCallLifeCycle();
 
   const isBusyCore = isModelsLoading || newCompactTaskPending;
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -4,7 +4,7 @@ import { prepareMessageParts } from "@/lib/message-utils";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { getLogger } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
-import { isAutoSuccessToolName } from "@getpochi/tools";
+
 import type React from "react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -42,10 +42,9 @@ export function useChatSubmit({
   setQueuedMessages,
 }: UseChatSubmitProps) {
   const autoApproveGuard = useAutoApproveGuard();
-  const { executingToolCalls, previewingToolCalls } = useToolCallLifeCycle();
+  const { executingToolCalls, previewingToolCalls, isExecuting, isPreviewing } =
+    useToolCallLifeCycle();
   const { t } = useTranslation();
-  const isExecuting = executingToolCalls.length > 0;
-  const isPreviewing = (previewingToolCalls?.length ?? 0) > 0;
 
   const abortExecutingToolCalls = useCallback(() => {
     for (const toolCall of executingToolCalls) {
@@ -55,9 +54,7 @@ export function useChatSubmit({
 
   const abortPreviewingToolCalls = useCallback(() => {
     for (const toolCall of previewingToolCalls || []) {
-      if (!isAutoSuccessToolName(toolCall.toolName)) {
-        toolCall.abort();
-      }
+      toolCall.abort();
     }
   }, [previewingToolCalls]);
 

--- a/packages/vscode-webui/src/features/chat/lib/chat-state/index.tsx
+++ b/packages/vscode-webui/src/features/chat/lib/chat-state/index.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+
 import { ChatContext, type ChatState } from "./types";
 
 function useChatState(): ChatState {
@@ -24,11 +25,16 @@ export function useToolCallLifeCycle() {
     previewingToolCalls,
     completeToolCalls,
   } = useChatState();
+
+  const isExecuting = executingToolCalls.length > 0;
+  const isPreviewing = previewingToolCalls.length > 0;
   return {
     getToolCallLifeCycle,
     executingToolCalls,
     previewingToolCalls,
     completeToolCalls,
+    isExecuting,
+    isPreviewing,
   };
 }
 

--- a/packages/vscode-webui/src/features/chat/lib/use-tool-call-life-cycles.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-tool-call-life-cycles.ts
@@ -1,3 +1,4 @@
+import { isAutoSuccessToolName } from "@getpochi/tools";
 import { useStore } from "@livestore/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import type { ToolCallLifeCycleKey } from "./chat-state/types";
@@ -39,9 +40,10 @@ export function useToolCallLifeCycles(abortSignal: AbortSignal) {
     const previewing = [];
     for (const lifecycle of toolCallLifeCycles.values()) {
       if (
-        lifecycle.status === "init" ||
-        lifecycle.status === "pending" ||
-        lifecycle.status === "ready"
+        (lifecycle.status === "init" ||
+          lifecycle.status === "pending" ||
+          lifecycle.status === "ready") &&
+        !isAutoSuccessToolName(lifecycle.toolName)
       ) {
         previewing.push(lifecycle);
       }


### PR DESCRIPTION
refactor(vscode-webui): centralize tool call status logic

Move isExecuting and isPreviewing logic into useToolCallLifeCycle hook to centralize tool call status management. This simplifies the consumer hooks and ensures consistent status handling. Also, consolidate isAutoSuccessToolName check for previewing tool calls.

🤖 Generated with [Pochi](https://getpochi.com)