### PR TITLE
refactor(vscode-webui): simplify reasoning part headline logic

### DIFF
--- a/packages/vscode-webui/src/components/reasoning-part.tsx
+++ b/packages/vscode-webui/src/components/reasoning-part.tsx
@@ -1,10 +1,9 @@
 import { Dot, Lightbulb } from "lucide-react";
 
 import { MessageMarkdown } from "@/components/message/markdown";
-import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { cn, tw } from "@/lib/utils";
 import type { ReasoningUIPart } from "ai";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { ExpandableToolContainer } from "./tool-invocation/tool-container";
 
 interface ReasoningPartUIProps {
@@ -19,40 +18,16 @@ export function ReasoningPartUI({
   isLoading,
 }: ReasoningPartUIProps) {
   const iconClass = tw`text-blue-700 dark:text-blue-300`;
-  const [headline, setHeadline] = useDebounceState("Thinking ...", 1000);
-  const [isHeadlineChanging, setIsHeadlineChanging] = useState(false);
-  const [displayHeadline, setDisplayHeadline] = useState(headline);
-
   const headlineFromMarkdown = useMemo(
     () => extractThinkingHeadline(part.text),
     [part.text],
   );
 
+  const headline = useMemo(
+    () => headlineFromMarkdown || "Thinking ...",
+    [headlineFromMarkdown],
+  );
   const finishHeadline = `Thought for ${part.text.length} characters`;
-
-  useEffect(() => {
-    if (headlineFromMarkdown) {
-      setHeadline(headlineFromMarkdown);
-    }
-  }, [headlineFromMarkdown, setHeadline]);
-
-  // Handle fade animation when headline changes
-  useEffect(() => {
-    if (headline !== displayHeadline) {
-      setIsHeadlineChanging(true);
-      // Fade out current headline
-      const fadeOutTimer = setTimeout(() => {
-        setDisplayHeadline(headline);
-        // Fade in new headline
-        const fadeInTimer = setTimeout(() => {
-          setIsHeadlineChanging(false);
-        }, 50);
-        return () => clearTimeout(fadeInTimer);
-      }, 250);
-      return () => clearTimeout(fadeOutTimer);
-    }
-  }, [headline, displayHeadline]);
-
   const title = (
     <span className="flex items-center gap-2">
       {isLoading ? (
@@ -65,13 +40,8 @@ export function ReasoningPartUI({
       ) : (
         <Lightbulb className={cn("size-4 scale-90", iconClass)} />
       )}
-      <span
-        className={cn(
-          "font-medium italic transition-opacity duration-300 ease-in-out",
-          isHeadlineChanging && isLoading ? "opacity-0" : "opacity-100",
-        )}
-      >
-        {isLoading ? displayHeadline : finishHeadline}
+      <span className="font-medium italic">
+        {isLoading ? headline : finishHeadline}
       </span>
     </span>
   );


### PR DESCRIPTION
## Summary
- Simplified the headline logic in `packages/vscode-webui/src/components/reasoning-part.tsx`.
- Removed `useDebounceState`, `useState`, and `useEffect` hooks related to headline animation.
- Directly derived `headline` from `headlineFromMarkdown`.

## Test plan
- Verify that the reasoning part headline updates correctly without animation.

🤖 Generated with [Pochi](https://getpochi.com)