### PR TITLE
fix(vendor/pochi): improve content type handling for models

### DIFF
--- a/packages/vendor-pochi/src/content-type.ts
+++ b/packages/vendor-pochi/src/content-type.ts
@@ -1,0 +1,70 @@
+const ContentType = {
+  gemini: [
+    // https://ai.google.dev/gemini-api/docs/image-understanding#supported-formats
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/heic",
+    "image/heif",
+
+    // https://ai.google.dev/gemini-api/docs/video-understanding#supported-formats
+    "video/mp4",
+    "video/mpeg",
+    "video/mov",
+    "video/avi",
+    "video/x-flv",
+    "video/mpg",
+    "video/webm",
+    "video/wmv",
+    "video/3gpp",
+
+    // https://ai.google.dev/gemini-api/docs/audio#supported-formats
+    "audio/wav",
+    "audio/mp3",
+    "audio/aiff",
+    "audio/aac",
+    "audio/ogg",
+    "audio/flac",
+
+    // https://ai.google.dev/gemini-api/docs/document-processing#document-types
+    "application/pdf",
+  ],
+  claude: [
+    // https://docs.claude.com/en/docs/build-with-claude/vision#ensuring-image-quality
+    // https://docs.claude.com/en/api/messages-examples#vision
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+
+    // https://docs.claude.com/en/docs/build-with-claude/pdf-support#option-2%3A-base64-encoded-pdf-document
+    "application/pdf",
+  ],
+  gpt: [
+    // https://platform.openai.com/docs/guides/images-vision#image-input-requirements
+    // https://platform.openai.com/docs/models/gpt-5-codex
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+
+    // https://platform.openai.com/docs/guides/pdf-files#base64-encoded-files
+    "application/pdf",
+  ],
+
+  // other pochi models only support text input, e.g., kimi-k2, glm-4.6, qwen3-coder and grok-code-fask-1
+};
+
+export const getContentTypesForModel = (
+  modelId: string,
+): string[] | undefined => {
+  if (modelId.includes("google/gemini")) {
+    return ContentType.gemini;
+  }
+  if (modelId.includes("anthropic/claude")) {
+    return ContentType.claude;
+  }
+  if (modelId.includes("openai/gpt")) {
+    return ContentType.gpt;
+  }
+};

--- a/packages/vendor-pochi/src/vendor.ts
+++ b/packages/vendor-pochi/src/vendor.ts
@@ -16,6 +16,7 @@ import { jwtClient } from "better-auth/client/plugins";
 import { createAuthClient as createAuthClientImpl } from "better-auth/react";
 import { hc } from "hono/client";
 import * as jose from "jose";
+import { getContentTypesForModel } from "./content-type";
 import { getPochiCredentials, updatePochiCredentials } from "./credentials";
 import type { PochiApi, PochiApiClient } from "./pochi-api";
 import { makeWebFetch, makeWebSearch } from "./tools";
@@ -50,40 +51,9 @@ export class Pochi extends VendorBase {
           x.id,
           {
             contextWindow: x.contextWindow,
-            useToolCallMiddleware: x.id.includes("google/"),
+            useToolCallMiddleware: x.id.includes("google"),
             label: x.costType === "basic" ? "swift" : "super",
-            contentType: x.id.includes("google/")
-              ? [
-                  // https://ai.google.dev/gemini-api/docs/image-understanding#supported-formats
-                  "image/png",
-                  "image/jpeg",
-                  "image/webp",
-                  "image/heic",
-                  "image/heif",
-
-                  // https://ai.google.dev/gemini-api/docs/video-understanding#supported-formats
-                  "video/mp4",
-                  "video/mpeg",
-                  "video/mov",
-                  "video/avi",
-                  "video/x-flv",
-                  "video/mpg",
-                  "video/webm",
-                  "video/wmv",
-                  "video/3gpp",
-
-                  // https://ai.google.dev/gemini-api/docs/audio#supported-formats
-                  "audio/wav",
-                  "audio/mp3",
-                  "audio/aiff",
-                  "audio/aac",
-                  "audio/ogg",
-                  "audio/flac",
-
-                  // https://ai.google.dev/gemini-api/docs/document-processing#document-types
-                  "application/pdf",
-                ]
-              : undefined,
+            contentType: getContentTypesForModel(x.id),
           } satisfies ModelOptions,
         ]),
       );


### PR DESCRIPTION
## Summary
- Extract content type logic to a dedicated content-type.ts file
- Add comprehensive content type support for different model vendors:
  * Google Gemini: images, videos, audio, and PDF documents
  * Anthropic Claude: images and PDF documents
  * OpenAI GPT: images and PDF documents
- Simplify model ID matching logic for Google models
- Remove hardcoded content types in vendor.ts in favor of dynamic lookup

This change makes the content type handling more maintainable and extensible for future model additions.

🤖 Generated with [Pochi](https://getpochi.com)