### PR TITLE
chore(cli): optimize mcp toolcall output in cli

### DIFF
--- a/packages/cli/src/output-renderer.ts
+++ b/packages/cli/src/output-renderer.ts
@@ -267,7 +267,7 @@ function renderToolPart(part: ToolUIPart<UITools>): {
     };
   }
   return {
-    text: `Tool ${getToolName(part)}`,
+    text: `🛠️ Tool ${getToolName(part)}`,
     stop: hasError ? "fail" : "succeed",
     error: errorText,
   };

--- a/packages/common/src/mcp-utils/mcp-connection.ts
+++ b/packages/common/src/mcp-utils/mcp-connection.ts
@@ -285,7 +285,6 @@ export class McpConnection implements Disposable {
                 }
                 return await tool.execute(args, options);
               } catch (error) {
-                this.logger.warn(`Error while executing tool ${name}`, error);
                 this.handleError(error);
                 throw error;
               }


### PR DESCRIPTION
before:
<img width="2560" height="2162" alt="CleanShot 2025-10-23 at 16 01 53@2x" src="https://github.com/user-attachments/assets/90c36c51-541d-4c91-81bb-168704d02859" />

after:
<img width="2564" height="520" alt="CleanShot 2025-10-23 at 16 05 15@2x" src="https://github.com/user-attachments/assets/9609b4c3-17e3-4204-9191-c16effac7e4f" />
