### PR TITLE
fix(vendor-pochi): fix the type mismatch when extract headers

### DIFF
--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -6,7 +6,6 @@ import {
 import {
   EventSourceParserStream,
   convertToBase64,
-  extractResponseHeaders,
 } from "@ai-sdk/provider-utils";
 import type { CreateModelOptions } from "@getpochi/common/vendor/edge";
 import {
@@ -80,12 +79,18 @@ export function createPochiModel({
       );
 
       if (!resp.ok || !resp.body) {
+        // Convert Hono ClientResponse headers to standard Headers format
+        const responseHeaders: Record<string, string> = {};
+        resp.headers.forEach((value, key) => {
+          responseHeaders[key] = value;
+        });
+
         throw new APICallError({
           message: `Failed to fetch: ${resp.status} ${resp.statusText}`,
           statusCode: resp.status,
           url: apiClient.api.chat.stream.$url().toString(),
           requestBodyValues: data,
-          responseHeaders: extractResponseHeaders(resp),
+          responseHeaders,
         });
       }
 


### PR DESCRIPTION
fix the error:

@getpochi/livekit-cf:tsc: ../vendor-pochi/src/model.ts:88:51 - error TS2345: Argument of type 'ClientResponse<{}, StatusCode, string>' is not assignable to parameter of type 'Response'.
@getpochi/livekit-cf:tsc:   The types returned by 'clone().json()' are incompatible between these types.
@getpochi/livekit-cf:tsc:     Type 'Promise<unknown>' is not assignable to type 'Promise<T>'.
@getpochi/livekit-cf:tsc:       Type 'unknown' is not assignable to type 'T'.
@getpochi/livekit-cf:tsc:         'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.
@getpochi/livekit-cf:tsc:
@getpochi/livekit-cf:tsc: 88           responseHeaders: extractResponseHeaders(resp),
@getpochi/livekit-cf:tsc:                                                      ~~~~
@getpochi/livekit-cf:tsc:
@getpochi/livekit-cf:tsc:
@getpochi/livekit-cf:tsc: Found 1 error in ../vendor-pochi/src/model.ts:88
@getpochi/livekit-cf:tsc:
@getpochi/livekit-cf:tsc: ERROR: command finished with error: command (/Users/kw/code/work/pochi/packages/livekit-cf) /Users/kw/.bun/bin/bun run tsc exited (2)
@getpochi/livekit-cf#tsc: command (/Users/kw/code/work/pochi/packages/livekit-cf) /Users/kw/.bun/bin/bun run tsc exited (2)
