### PR TITLE
feat: default sidebar to task list and update icons

### DIFF
--- a/packages/vscode-webui/src/main.tsx
+++ b/packages/vscode-webui/src/main.tsx
@@ -22,6 +22,10 @@ import reportWebVitals from "./reportWebVitals.ts";
 
 const hashHistory = createHashHistory();
 
+if (window.POCHI_WEBVIEW_KIND === "sidebar") {
+  hashHistory.push("/tasks");
+}
+
 // Create a new router instance
 const router = createRouter({
   routeTree,

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -81,7 +81,7 @@
       {
         "command": "pochi.webui.navigate.taskList",
         "title": "Show All Tasks",
-        "icon": "$(history)",
+        "icon": "$(code)",
         "category": "Pochi"
       },
       {
@@ -189,11 +189,6 @@
         }
       ],
       "view/title": [
-        {
-          "command": "pochi.webui.navigate.newTask",
-          "when": "view == pochiSidebar",
-          "group": "navigation@0"
-        },
         {
           "command": "pochi.webui.navigate.taskList",
           "when": "view == pochiSidebar",


### PR DESCRIPTION
## Summary
- Set sidebar webui to navigate to /tasks by default
- Change task list icon from history to code
- Remove newTask navigation from sidebar title

## Test plan
- Open sidebar in VSCode extension
- Verify it defaults to task list view
- Check that task list icon is now code icon
- Confirm new task navigation is removed from title bar