### PR TITLE
fix(slash-command): Auto-switch model when selecting a slash command

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/context-mention/mention-list.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/context-mention/mention-list.tsx
@@ -8,6 +8,7 @@ import {
   useImperativeHandle,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import type { MentionListActions } from "../shared";
 import {
   useMentionItems,
@@ -35,9 +36,9 @@ export interface MentionListProps {
  */
 export const MentionList = forwardRef<MentionListActions, MentionListProps>(
   ({ items: initialItems, command, query, fetchItems }, ref) => {
+    const { t } = useTranslation();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const items = useMentionItems(initialItems, query, fetchItems);
-
     // Reset selected index when items change to prevent out-of-bounds access
     useEffect(() => {
       if (selectedIndex >= items.length) {
@@ -66,7 +67,9 @@ export const MentionList = forwardRef<MentionListActions, MentionListProps>(
         <ScrollArea viewportClassname="max-h-[300px] px-2">
           {items.length === 0 ? (
             <div className="px-2 py-1.5 text-muted-foreground text-xs">
-              {query ? "No results found" : "Type to search..."}
+              {query
+                ? t("mentionList.noResultsFound")
+                : t("mentionList.typeToSearch")}
             </div>
           ) : (
             <div className="grid gap-0.5">

--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -51,7 +51,6 @@ import {
   type SlashCandidate,
   SlashMentionList,
   type SlashMentionListProps,
-  type WorkflowData,
 } from "./slash-mention/mention-list";
 import { SubmitHistoryExtension } from "./submit-history-extension";
 
@@ -146,9 +145,15 @@ export function FormEditor({
   // State for drag overlay UI
   const [isDragOver, setIsDragOver] = useState(false);
 
-  const onSelectWorkflow = useCallback(
-    (workflow: WorkflowData) => {
-      const foundModel = resolveModelFromId(workflow.frontmatter.model, models);
+  const onSelectSlashCandidate = useCallback(
+    (data: SlashCandidate) => {
+      let model: string | undefined;
+      if (data.type === "workflow") {
+        model = data.rawData.frontmatter.model;
+      } else if (data.type === "custom-agent") {
+        model = data.rawData.model;
+      }
+      const foundModel = resolveModelFromId(model, models);
       if (foundModel) {
         updateSelectedModelId(foundModel.id);
       }
@@ -326,7 +331,7 @@ export function FormEditor({
                     props: {
                       ...props,
                       fetchItems,
-                      onSelectWorkflow,
+                      onSelect: onSelectSlashCandidate,
                     },
                     editor: props.editor,
                   });

--- a/packages/vscode-webui/src/components/prompt-form/slash-mention/mention-list.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/slash-mention/mention-list.tsx
@@ -10,6 +10,7 @@ import {
   useImperativeHandle,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import type { MentionListActions } from "../shared";
 import {
   useMentionItems,
@@ -46,21 +47,21 @@ export interface SlashMentionListProps {
   command: (item: SlashCandidate) => void;
   query?: string;
   fetchItems?: (query?: string) => Promise<SlashCandidate[]>;
-  onSelect?: (workflow: SlashCandidate) => void;
+  onSelect?: (data: SlashCandidate) => void;
 }
 
 /**
- * A React component for the workflow dropdown list.
+ * A React component for the slash dropdown list.
  * Displays when a user types '/...' and suggestions are fetched.
- * Reads the file content when a workflow is selected.
+ * Reads the file content when a slash command candidate is selected.
  */
 export const SlashMentionList = forwardRef<
   MentionListActions,
   SlashMentionListProps
 >(({ items: initialItems, command, query, fetchItems, onSelect }, ref) => {
+  const { t } = useTranslation();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const items = useMentionItems(initialItems, query, fetchItems);
-
   // Reset selected index when items change to prevent out-of-bounds access
   useEffect(() => {
     if (selectedIndex >= items.length) {
@@ -106,7 +107,9 @@ export const SlashMentionList = forwardRef<
       <ScrollArea viewportClassname="max-h-[300px] px-2">
         {items.length === 0 ? (
           <div className="px-2 py-3 text-muted-foreground text-xs">
-            {query ? "No workflows found" : "Type to search workflows..."}
+            {query
+              ? t("mentionList.noResultsFound")
+              : t("mentionList.typeToSearch")}
           </div>
         ) : (
           <div className="grid gap-0.5">
@@ -141,6 +144,7 @@ const CandidateItemView = memo(function SlashCandidateItemView({
   data,
   ...rest
 }: CandidateItemViewProps) {
+  const { t } = useTranslation();
   const ref = useScrollIntoView(isSelected);
 
   return (
@@ -158,7 +162,9 @@ const CandidateItemView = memo(function SlashCandidateItemView({
         </span>
       </div>
       <span className="text-muted-foreground text-xs">
-        {data.type === "workflow" ? "workflow" : "agent"}
+        {data.type === "workflow"
+          ? t("mentionList.workflow")
+          : t("mentionList.agent")}
       </span>
     </div>
   );

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -274,7 +274,9 @@
   },
   "mentionList": {
     "noResultsFound": "No results found",
-    "typeToSearch": "Type to search..."
+    "typeToSearch": "Type to search...",
+    "workflow": "workflow",
+    "agent": "agent"
   },
   "subtask": {
     "back": "Back",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -273,7 +273,9 @@
   },
   "mentionList": {
     "noResultsFound": "結果が見つかりません",
-    "typeToSearch": "入力して検索..."
+    "typeToSearch": "入力して検索...",
+    "workflow": "ワークフロー",
+    "agent": "エージェント"
   },
   "subtask": {
     "back": "戻る",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -273,7 +273,9 @@
   },
   "mentionList": {
     "noResultsFound": "결과를 찾을 수 없습니다",
-    "typeToSearch": "입력하여 검색..."
+    "typeToSearch": "입력하여 검색...",
+    "workflow": "워크플로",
+    "agent": "에이전트"
   },
   "subtask": {
     "back": "뒤로",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -272,7 +272,9 @@
   },
   "mentionList": {
     "noResultsFound": "未找到结果",
-    "typeToSearch": "输入以搜索..."
+    "typeToSearch": "输入以搜索...",
+    "workflow": "工作流",
+    "agent": "代理"
   },
   "subtask": {
     "back": "返回",


### PR DESCRIPTION
## Summary

This PR fixes a bug where the model was not automatically switching when a user selected a slash command that has a specific model defined in its frontmatter. The `onSelectSlashCandidate` function has been updated to ensure the model is switched as expected.

## Screenshot
https://jam.dev/c/19e13f97-e9c6-4e24-b597-6018a24fbb65

## Test plan

1.  Define a workflow with a `model` in its frontmatter.
2.  Open the slash command menu by typing `/`.
3.  Select the workflow.
4.  Verify that the model selector in the UI updates to the model specified in the workflow's frontmatter.

🤖 Generated with [Pochi](https://getpochi.com)