### PR TITLE
refactor(vscode): standardize edit diff metadata field naming

### DIFF
--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -17,7 +17,6 @@ export type { SessionState, WorkspaceState } from "./types/session";
 export type {
   TaskIdParams,
   NewTaskParams,
-  TaskDataParams,
   TaskData,
 } from "./types/task";
 export type {

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -15,14 +15,6 @@ export interface NewTaskParams {
   uid: undefined;
 }
 
-export interface TaskDataParams<T extends TaskData = TaskData> {
-  uid: string;
-  /**
-   * @link packages/vscode-webui/src/livestore-provider.tsx#TaskSyncData
-   */
-  task: T;
-}
-
 /**
  * only include fields that are used in the webview and node process
  */

--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -95,12 +95,10 @@ export class PochiWebviewPanel
       existingPanel?.panel.reveal();
       logger.info(`Revealed existing Pochi panel: ${sessionId}`);
       logger.info(`Opening task ${uid} in existing panel`);
-      if (uid) {
-        existingPanel?.webviewHost?.openTask({
-          uid,
-          parentId,
-        });
-      }
+      existingPanel?.webviewHost?.openTask({
+        uid,
+        parentId,
+      });
       return;
     }
 
@@ -142,12 +140,10 @@ export class PochiWebviewPanel
 
     PochiWebviewPanel.panels.set(sessionId, pochiPanel);
 
-    if (uid) {
-      pochiPanel.onWebviewReady(() => {
-        logger.info(`Webview ready, opening task ${uid} in new panel`);
-        pochiPanel.webviewHost?.openTask({ uid, parentId });
-      });
-    }
+    pochiPanel.onWebviewReady(() => {
+      logger.info(`Webview ready, opening task ${uid} in new panel`);
+      pochiPanel.webviewHost?.openTask({ uid, parentId });
+    });
 
     logger.info(`Created new Pochi panel: ${sessionId}`);
   }

--- a/packages/vscode/src/lib/write-text-document.ts
+++ b/packages/vscode/src/lib/write-text-document.ts
@@ -71,7 +71,7 @@ export async function writeTextDocument(
   );
 
   const editSummary = getEditSummary(preEditContent, postSaveContent);
-  const edits = createPrettyPatch(path, preEditContent, postSaveContent);
+  const editDiff = createPrettyPatch(path, preEditContent, postSaveContent);
 
   logger.debug(
     `Wrote to ${path}, content length: ${postSaveContent.length}, edit summary: +${editSummary.added} -${editSummary.removed}`,
@@ -79,7 +79,7 @@ export async function writeTextDocument(
   return {
     autoFormattingEdits,
     newProblems,
-    _meta: { edits, editSummary },
+    _meta: { edit: editDiff, editSummary },
   };
 }
 

--- a/packages/vscode/src/tools/apply-diff.ts
+++ b/packages/vscode/src/tools/apply-diff.ts
@@ -48,8 +48,8 @@ export const previewApplyDiff: PreviewToolFunctionType<
 
     if (nonInteractive) {
       const editSummary = getEditSummary(fileContent, updatedContent);
-      const edits = createPrettyPatch(path, fileContent, updatedContent);
-      return { success: true, _meta: { edits, editSummary } };
+      const edit = createPrettyPatch(path, fileContent, updatedContent);
+      return { success: true, _meta: { edit, editSummary } };
     }
 
     const diffView = await DiffView.getOrCreate(toolCallId, path, cwd);

--- a/packages/vscode/src/tools/multi-apply-diff.ts
+++ b/packages/vscode/src/tools/multi-apply-diff.ts
@@ -35,8 +35,8 @@ export const previewMultiApplyDiff: PreviewToolFunctionType<
 
     if (nonInteractive) {
       const editSummary = getEditSummary(fileContent, updatedContent);
-      const edits = createPrettyPatch(path, fileContent, updatedContent);
-      return { success: true, _meta: { edits, editSummary } };
+      const edit = createPrettyPatch(path, fileContent, updatedContent);
+      return { success: true, _meta: { edit, editSummary } };
     }
 
     const diffView = await DiffView.getOrCreate(toolCallId, path, cwd);

--- a/packages/vscode/src/tools/write-to-file.ts
+++ b/packages/vscode/src/tools/write-to-file.ts
@@ -30,8 +30,8 @@ export const previewWriteToFile: PreviewToolFunctionType<
       const fileBuffer = await vscode.workspace.fs.readFile(fileUri);
       const fileContent = fileBuffer.toString();
       const editSummary = getEditSummary(fileContent, processedContent);
-      const edits = createPrettyPatch(path, fileContent, processedContent);
-      return { success: true, _meta: { edits, editSummary } };
+      const edit = createPrettyPatch(path, fileContent, processedContent);
+      return { success: true, _meta: { edit, editSummary } };
     }
 
     const diffView = await DiffView.getOrCreate(toolCallId, path, cwd);


### PR DESCRIPTION
## Summary
- Rename `edits` to `edit` in tool result metadata for consistency across apply-diff, multi-apply-diff, and write-to-file tools
- Remove unused `TaskDataParams` type from vscode-webui-bridge
- Simplify webview panel task opening logic by removing unnecessary uid check
- Update write-text-document to use consistent `edit` field name

## Test plan
- [ ] Verify that file editing tools (apply-diff, multi-apply-diff, write-to-file) still work correctly
- [ ] Confirm that diff highlighting still displays properly in the webview
- [ ] Test task opening in webview panel

🤖 Generated with [Pochi](https://getpochi.com)