### PR TITLE
feat(vscode-webui): implement inline diff expand functionality

### DIFF
--- a/packages/vscode-webui/src/components/tool-invocation/tools/apply-diff.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/apply-diff.tsx
@@ -65,14 +65,12 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
 
   const details = [];
 
-  const displayEdit = result?._meta?.edit || previewInfo?.edit;
-
-  if (displayEdit) {
+  if (result?._meta?.edit) {
     details.push(
       <ModelEdits
         key="model-edits"
-        edit={displayEdit}
-        isPreview={result?._meta?.edit === undefined}
+        edit={result?._meta?.edit}
+        isPreview={false}
       />,
     );
   }
@@ -89,11 +87,16 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
 
   const expandableDetail = details.length > 0 ? <>{details}</> : undefined;
 
+  const detail = previewInfo?.edit ? (
+    <ModelEdits edit={previewInfo.edit} isPreview={true} />
+  ) : null;
+
   return (
     <ExpandableToolContainer
       title={title}
       expandableDetail={expandableDetail}
       expandableDetailIcon={result?.newProblems && <NewProblemsIcon />}
+      detail={detail}
     />
   );
 };

--- a/packages/vscode-webui/src/components/tool-invocation/tools/multi-apply-diff.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/multi-apply-diff.tsx
@@ -68,14 +68,12 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
 
   const details = [];
 
-  const displayEdit = result?._meta?.edit || previewInfo?.edit;
-
-  if (displayEdit) {
+  if (result?._meta?.edit) {
     details.push(
       <ModelEdits
         key="model-edits"
-        edit={displayEdit}
-        isPreview={result?._meta?.edit === undefined}
+        edit={result?._meta?.edit}
+        isPreview={false}
       />,
     );
   }
@@ -92,11 +90,16 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
 
   const expandableDetail = details.length > 0 ? <>{details}</> : undefined;
 
+  const detail = previewInfo?.edit ? (
+    <ModelEdits edit={previewInfo.edit} isPreview={true} />
+  ) : null;
+
   return (
     <ExpandableToolContainer
       title={title}
       expandableDetail={expandableDetail}
       expandableDetailIcon={result?.newProblems && <NewProblemsIcon />}
+      detail={detail}
     />
   );
 };

--- a/packages/vscode-webui/src/components/tool-invocation/tools/write-to-file.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/write-to-file.tsx
@@ -65,14 +65,12 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
 
   const details = [];
 
-  const displayEdit = result?._meta?.edit || previewInfo?.edit;
-
-  if (displayEdit) {
+  if (result?._meta?.edit) {
     details.push(
       <ModelEdits
         key="model-edits"
-        edit={displayEdit}
-        isPreview={result?._meta?.edit === undefined}
+        edit={result?._meta?.edit}
+        isPreview={false}
       />,
     );
   }
@@ -89,11 +87,16 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
 
   const expandableDetail = details.length > 0 ? <>{details}</> : undefined;
 
+  const detail = previewInfo?.edit ? (
+    <ModelEdits edit={previewInfo.edit} isPreview={true} />
+  ) : null;
+
   return (
     <ExpandableToolContainer
       title={title}
       expandableDetail={expandableDetail}
       expandableDetailIcon={result?.newProblems && <NewProblemsIcon />}
+      detail={detail}
     />
   );
 };


### PR DESCRIPTION
## Summary
- Show model edits in the expandable detail section
- Show preview edits in the main detail section
- Remove the confusing displayEdit logic that was combining both

This provides a cleaner UI where users can see preview changes immediately and expand to see model-applied changes.

🤖 Generated with [Pochi](https://getpochi.com)