### PR TITLE
fix(config): fix cannot write config file when value contains undefined

### DIFF
--- a/packages/common/src/configuration/config-file.ts
+++ b/packages/common/src/configuration/config-file.ts
@@ -91,7 +91,8 @@ export class PochiConfigFile {
         )?.trim() || "{}";
 
       // Apply changes.
-      content = fleece.patch(content, this.cfg.value);
+      const current = JSON.parse(JSON.stringify(this.cfg.value)); // remove keys with undefined values
+      content = fleece.patch(content, current);
 
       // Formatting.
       const edits = JSONC.format(content, undefined, {


### PR DESCRIPTION
## Summary

This PR fixes a bug where the config file could not be saved if it contained `undefined` values. This was caused by `JSON.stringify` which throws an error when it encounters `undefined`.

The fix is to use `JSON.parse(JSON.stringify(value))` to remove any keys with `undefined` values before patching the config file.

## Screenshot

![Screenshot from 2025-10-29 00-18-12.png](https://pochi-file-uploads.getpochi.com/Screenshot%20from%202025-10-29%2000-18-12-1761759189659.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20251029%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20251029T173311Z&X-Amz-Expires=561600&X-Amz-Signature=9d5158e0cdf8a2b7701985de2915759a12689146e112bbc785f265d7c2e41dfd&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>