### PR TITLE
fix(vscode): add project and location placeholders for vertex model creation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,6 @@
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.0",
-        "jose": "catalog:",
         "listr2": "^9.0.3",
         "ora": "^8.2.0",
         "remeda": "catalog:",
@@ -257,6 +256,7 @@
       "name": "pochi",
       "version": "0.11.0-dev",
       "dependencies": {
+        "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",
         "@getpochi/vendor-claude-code": "workspace:*",
         "@getpochi/vendor-codex": "workspace:*",

--- a/packages/vscode/src/nes/client/pochi.ts
+++ b/packages/vscode/src/nes/client/pochi.ts
@@ -6,6 +6,8 @@ const ModelId = "654670113898758144";
 
 export function createPochiModel() {
   const vertexModel = createVertexWithoutCredentials({
+    project: "placeholder",
+    location: "placeholder",
     baseURL:
       "https://api-gateway.getpochi.com/https/us-central1-aiplatform.googleapis.com/v1/projects/gen-lang-client-0005535210/locations/us-central1/publishers/google",
     fetch: async (


### PR DESCRIPTION
## Summary
- Added required project and location placeholders when creating vertex model in pochi provider
- Updated bun.lock with @ai-sdk/google-vertex dependency

## Test plan
- [x] Verified the changes fix the issue with creating vertex model in pochi provider

🤖 Generated with [Pochi](https://getpochi.com)