### PR TITLE
refactor(vscode): streamline task opening by removing unnecessary sidebar focus

### DIFF
--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -69,14 +69,11 @@ export class CommandManager implements vscode.Disposable {
     openTaskParams: TaskIdParams | NewTaskParams,
     requestId?: string,
   ) {
-    await vscode.commands.executeCommand("pochiSidebar.focus");
-
     if (githubTemplateUrl) {
       await prepareProject(workspaceUri, githubTemplateUrl, progress);
     }
 
-    const webviewHost = await this.pochiWebviewSidebar.retrieveWebviewHost();
-    webviewHost.openTask(openTaskParams);
+    this.openTaskOnWorkspaceFolder(openTaskParams);
 
     if (requestId) {
       await this.newProjectRegistry.set(requestId, workspaceUri);
@@ -226,9 +223,7 @@ export class CommandManager implements vscode.Disposable {
           async (progress) => {
             progress.report({ message: "Pochi: Opening task..." });
             await vscode.commands.executeCommand("pochiSidebar.focus");
-            const webviewHost =
-              await this.pochiWebviewSidebar.retrieveWebviewHost();
-            webviewHost.openTask({ uid });
+            this.openTaskOnWorkspaceFolder({ uid });
           },
         );
       }),
@@ -456,7 +451,7 @@ export class CommandManager implements vscode.Disposable {
         "pochi.createTaskOnWorktree",
         async () => {
           if ((await this.worktreeManager.isGitRepository()) === false) {
-            this.createTaskOnWorkspace();
+            this.openTaskOnWorkspaceFolder();
             return;
           }
           const worktrees = await this.worktreeManager.getWorktrees();
@@ -574,7 +569,7 @@ export class CommandManager implements vscode.Disposable {
     );
   }
 
-  createTaskOnWorkspace() {
+  openTaskOnWorkspaceFolder(params?: TaskIdParams | NewTaskParams) {
     const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     if (!cwd) {
       vscode.window.showErrorMessage(
@@ -586,6 +581,7 @@ export class CommandManager implements vscode.Disposable {
     PochiWebviewPanel.createOrShow(
       workspaceContainer,
       this.context.extensionUri,
+      params,
     );
   }
 

--- a/packages/vscode/src/integrations/uri-handler.ts
+++ b/packages/vscode/src/integrations/uri-handler.ts
@@ -34,8 +34,6 @@ class RagdollUriHandler implements vscode.UriHandler, vscode.Disposable {
   }
 
   private async handleUriImpl(uri: vscode.Uri) {
-    await vscode.commands.executeCommand("pochiSidebar.focus");
-
     /**
      * Supported URI formats:
      * - vscode://tabbyml.pochi/?token=<device_link_token> - Device link authentication

--- a/packages/vscode/src/lib/post-install-actions.ts
+++ b/packages/vscode/src/lib/post-install-actions.ts
@@ -91,7 +91,6 @@ class OpenTaskFromEnvAction implements Action {
     const uid = process.env.POCHI_TASK_ID;
     if (uid) {
       logger.info(`Opening task from POCHI_TASK_ID: ${uid}`);
-      await vscode.commands.executeCommand("pochiSidebar.focus");
       await new Promise((resolve) => setTimeout(resolve, 500));
       await vscode.commands.executeCommand("pochi.openTask", uid);
     }


### PR DESCRIPTION
## Summary

This PR refactors the task opening logic in the VSCode extension by:
- Removing unnecessary `pochiSidebar.focus` calls before opening tasks
- Consolidating task opening logic by replacing `createTaskOnWorkspace()` with `openTaskOnWorkspaceFolder()`
- Passing parameters directly to `PochiWebviewPanel.createOrShow()` instead of retrieving webview host first

## Changes

- **command.ts**: Simplified `openTaskAndPrepareProject()` and URI handler by removing sidebar focus commands and using the unified `openTaskOnWorkspaceFolder()` method
- **uri-handler.ts**: Removed redundant sidebar focus call before handling URI actions
- **post-install-actions.ts**: Removed sidebar focus call when opening task from `POCHI_TASK_ID` environment variable

## Benefits

- Cleaner code with reduced redundancy
- More direct task opening flow
- Better separation of concerns between webview host retrieval and task opening

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>