### PR TITLE
feat(vscode-webui): remove date from empty state on tasks page

### DIFF
--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -169,7 +169,7 @@
   },
   "tasksPage": {
     "emptyState": {
-      "title": "No tasks found for {{date}}",
+      "title": "No tasks found",
       "description": "Create a new task to get started with Pochi",
       "createButton": "New Task"
     },

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -163,7 +163,7 @@
   },
   "tasksPage": {
     "emptyState": {
-      "title": "{{date}} のタスクが見つかりません",
+      "title": "タスクが見つかりません",
       "description": "Pochi を始めるために新しいタスクを作成してください",
       "createButton": "新しいタスクを作成"
     },

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -163,7 +163,7 @@
   },
   "tasksPage": {
     "emptyState": {
-      "title": "{{date}}에 대한 작업을 찾을 수 없습니다",
+      "title": "작업을 찾을 수 없습니다",
       "description": "Pochi를 시작하려면 새 작업을 만드세요",
       "createButton": "새 작업 만들기"
     },

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -162,7 +162,7 @@
   },
   "tasksPage": {
     "emptyState": {
-      "title": "未找到 {{date}} 的任务",
+      "title": "未找到任务",
       "description": "创建一个新任务以开始使用 Pochi",
       "createButton": "创建新任务"
     },

--- a/packages/vscode-webui/src/routes/index.tsx
+++ b/packages/vscode-webui/src/routes/index.tsx
@@ -223,7 +223,7 @@ function Tasks() {
         <CreateTaskInput cwd={cwd} attachmentUpload={attachmentUpload} />
       </div>
       {tasks.length === 0 ? (
-        <EmptyTaskPlaceholder date={new Date()} />
+        <EmptyTaskPlaceholder />
       ) : (
         <div className="min-h-0 flex-1 pt-4">
           <ScrollArea className="h-full">
@@ -269,14 +269,14 @@ function Tasks() {
   );
 }
 
-function EmptyTaskPlaceholder({ date }: { date: Date }) {
+function EmptyTaskPlaceholder() {
   const { t } = useTranslation();
 
   return (
     <div className="flex h-full select-none flex-col items-center justify-center p-5 text-center text-gray-500 dark:text-gray-300">
       <h2 className="mb-2 flex items-center gap-3 font-semibold text-2xl text-gray-700 dark:text-gray-100">
         <TerminalIcon />
-        {t("tasksPage.emptyState.title", { date: date.toLocaleDateString() })}
+        {t("tasksPage.emptyState.title")}
       </h2>
       <p className="mb-4 leading-relaxed">
         {t("tasksPage.emptyState.description")}


### PR DESCRIPTION
## Summary

- Removes the date from the empty state message on the tasks page to simplify the UI.

This change includes:
- Updating the `EmptyTaskPlaceholder` component to no longer accept a `date` prop.
- Removing the date variable from the `tasksPage.emptyState.title` translation key in the `en.json`, `jp.json`, `ko.json`, and `zh.json` locale files.

## Screenshot
<img width="934" height="1302" alt="image" src="https://github.com/user-attachments/assets/3b87ccbd-4652-431c-bc61-dde4ab0bd522" />


🤖 Generated with [Pochi](https://getpochi.com)