### PR TITLE
feat(vscode-webui): sanitize livestore storeId with cwd

### DIFF
--- a/packages/vscode-webui/src/livestore-task-provider.tsx
+++ b/packages/vscode-webui/src/livestore-task-provider.tsx
@@ -13,11 +13,13 @@ const adapter = makePersistedAdapter({
 });
 
 export function LiveStoreTaskProvider({
+  cwd,
   children,
-}: { children: React.ReactNode }) {
+}: { children: React.ReactNode; cwd: string }) {
+  const storeId = sanitizeStoreId(isDev ? `dev-tasks-${cwd}` : `tasks-${cwd}`);
   return (
     <LiveStoreProvider
-      storeId={isDev ? "dev-tasks" : "tasks"}
+      storeId={storeId}
       schema={taskCatalog.schema}
       adapter={adapter}
       renderLoading={(_) => <></>}
@@ -26,4 +28,9 @@ export function LiveStoreTaskProvider({
       {children}
     </LiveStoreProvider>
   );
+}
+
+// Only alphanumeric characters, underscores, and hyphens are allowed.
+function sanitizeStoreId(str: string) {
+  return str.replace(/[^a-zA-Z0-9_-]/g, "-");
 }

--- a/packages/vscode-webui/src/routes/index.tsx
+++ b/packages/vscode-webui/src/routes/index.tsx
@@ -172,7 +172,7 @@ function App() {
     return;
   }
 
-  if (!currentWorkspace) {
+  if (!currentWorkspace?.cwd) {
     return (
       <div className="flex h-screen w-full flex-col items-center justify-center">
         <WorkspaceRequiredPlaceholder isFetching={isFetchingWorkspace} />
@@ -181,7 +181,7 @@ function App() {
   }
 
   return (
-    <LiveStoreTaskProvider>
+    <LiveStoreTaskProvider cwd={currentWorkspace.cwd}>
       <Tasks />
     </LiveStoreTaskProvider>
   );


### PR DESCRIPTION
## Summary
- Sanitize the `storeId` used by `LiveStoreTaskProvider` in `vscode-webui` by incorporating the current working directory (cwd).
- Ensures that the `storeId` is unique per workspace, preventing conflicts when multiple VSCode instances are open with different workspaces.
- Introduces a new `sanitizeStoreId` function to clean the cwd string, allowing only alphanumeric characters, underscores, and hyphens.

## Test plan
- Verify that tasks are correctly stored and retrieved when opening multiple VSCode instances with different workspaces.
- Check that the `storeId` generated is unique for each workspace and contains only allowed characters.

🤖 Generated with [Pochi](https://getpochi.com)