### PR TITLE
chore(vscode-webui): optimize display with branch and worktree having same name

### DIFF
--- a/packages/vscode-webui/src/routes/index.tsx
+++ b/packages/vscode-webui/src/routes/index.tsx
@@ -432,8 +432,12 @@ function GitBadge({
       variant="outline"
       className={cn("border-none p-0 text-foreground", className)}
     >
-      <GitBranch className="shrink-0" />
-      <span className="truncate">{git.branch}</span>
+      {git.branch && git.branch !== worktreeName && (
+        <>
+          <GitBranch className="shrink-0" />
+          <span className="truncate">{git.branch}</span>
+        </>
+      )}
       {worktreeName && (
         <>
           <ListTreeIcon className="ml-1 shrink-0" />


### PR DESCRIPTION
optimize display with branch and worktree having same name

## Screenshots

#### Main workspace
<img width="1068" height="856" alt="image" src="https://github.com/user-attachments/assets/3fb3cd30-2999-4b77-aee6-bf96f261fd58" />


#### Worktree workspace
<img width="1348" height="984" alt="image" src="https://github.com/user-attachments/assets/edd0ec12-ee93-44f7-8d0b-4b542f537ea6" />


🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>