### PR TITLE
fix(vscode): use absolute path for tab state

### DIFF
--- a/packages/vscode/src/integrations/editor/tab-state.ts
+++ b/packages/vscode/src/integrations/editor/tab-state.ts
@@ -1,9 +1,7 @@
-import { asRelativePath } from "@/lib/fs";
-// biome-ignore lint/style/useImportType: needed for dependency injection
-import { WorkspaceScope } from "@/lib/workspace-scoped";
 import { signal } from "@preact/signals-core";
 import { injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
+import { PochiTaskEditorProvider } from "../webview/webview-panel";
 
 export type FileSelection = {
   filepath: string;
@@ -28,9 +26,9 @@ export class TabState implements vscode.Disposable {
 
   private disposables: vscode.Disposable[] = [];
 
-  constructor(private readonly workspaceScope: WorkspaceScope) {
-    this.activeSelection.value = getActiveSelection(this.workspaceScope.cwd);
-    this.activeTabs.value = listOpenTabs(this.workspaceScope.cwd);
+  constructor() {
+    this.activeSelection.value = getActiveSelection();
+    this.activeTabs.value = listOpenTabs();
     this.setupEventListeners();
   }
 
@@ -67,10 +65,10 @@ export class TabState implements vscode.Disposable {
    */
   private onTabChanged = () => {
     // Update the existing signal value instead of creating a new signal
-    const newOpenTabs = listOpenTabs(this.workspaceScope.cwd);
+    const newOpenTabs = listOpenTabs();
     this.activeTabs.value = newOpenTabs;
 
-    const newSelection = getActiveSelection(this.workspaceScope.cwd);
+    const newSelection = getActiveSelection();
     if (newSelection) {
       this.activeSelection.value = newSelection;
     } else if (this.activeSelection.value) {
@@ -89,7 +87,7 @@ export class TabState implements vscode.Disposable {
   };
 
   private onSelectionChanged = () => {
-    const newSelection = getActiveSelection(this.workspaceScope.cwd);
+    const newSelection = getActiveSelection();
     if (newSelection !== undefined) {
       this.activeSelection.value = newSelection;
     }
@@ -106,16 +104,12 @@ export class TabState implements vscode.Disposable {
   }
 }
 
-function getActiveSelection(cwd: string | null): FileSelection | undefined {
-  if (!cwd) {
-    return undefined;
-  }
+function getActiveSelection(): FileSelection | undefined {
   const activeEditor = vscode.window.activeTextEditor;
   if (activeEditor?.document && activeEditor.document.uri.scheme === "file") {
     const selection = activeEditor.selection;
-    const relativePath = asRelativePath(activeEditor.document.uri, cwd);
     return {
-      filepath: relativePath,
+      filepath: activeEditor.document.uri.fsPath,
       range: {
         start: {
           line: selection.start.line,
@@ -133,7 +127,6 @@ function getActiveSelection(cwd: string | null): FileSelection | undefined {
   const activeNotebookEditor = vscode.window.activeNotebookEditor;
   if (activeNotebookEditor?.notebook) {
     const notebook = activeNotebookEditor.notebook;
-    const relativePath = asRelativePath(notebook.uri, cwd);
 
     // Get the active cell selection
     const activeCell = activeNotebookEditor.selection?.start;
@@ -155,7 +148,7 @@ function getActiveSelection(cwd: string | null): FileSelection | undefined {
           : cellDocument.getText();
 
         return {
-          filepath: relativePath,
+          filepath: notebook.uri.fsPath,
           range: {
             start: {
               line: selection.start.line,
@@ -179,22 +172,17 @@ function getActiveSelection(cwd: string | null): FileSelection | undefined {
   return undefined;
 }
 
-function listOpenTabs(
-  cwd: string | null,
-): { filepath: string; isDir: boolean }[] {
-  if (!cwd) {
-    return [];
-  }
+function listOpenTabs(): { filepath: string; isDir: boolean }[] {
   const currentOpenTabFiles: { filepath: string; isDir: boolean }[] = [];
   const processedFilepaths = new Set<string>(); // To ensure uniqueness by final relative filepath
 
   // Prioritize active editor
   const activeEditor = vscode.window.activeTextEditor;
   if (activeEditor?.document) {
-    const relativePath = asRelativePath(activeEditor.document.uri, cwd);
-    if (!processedFilepaths.has(relativePath)) {
-      currentOpenTabFiles.push({ filepath: relativePath, isDir: false });
-      processedFilepaths.add(relativePath);
+    const filepath = activeEditor.document.uri.fsPath;
+    if (!processedFilepaths.has(filepath)) {
+      currentOpenTabFiles.push({ filepath: filepath, isDir: false });
+      processedFilepaths.add(filepath);
     }
   }
 
@@ -210,16 +198,19 @@ function listOpenTabs(
         uri = tab.input.uri;
       } else if (tab.input instanceof vscode.TabInputNotebookDiff) {
         uri = tab.input.modified;
-      } else if (tab.input instanceof vscode.TabInputCustom) {
+      } else if (
+        tab.input instanceof vscode.TabInputCustom &&
+        tab.input.uri.scheme !== PochiTaskEditorProvider.scheme
+      ) {
         uri = tab.input.uri;
       }
       // Other tab input types like vscode.TabInputWebview or vscode.TabInputTerminal are generally not considered file-backed code editors.
 
       if (uri) {
-        const relativePath = asRelativePath(uri, cwd);
-        if (!processedFilepaths.has(relativePath)) {
-          currentOpenTabFiles.push({ filepath: relativePath, isDir: false });
-          processedFilepaths.add(relativePath);
+        const filepath = uri.fsPath;
+        if (!processedFilepaths.has(filepath)) {
+          currentOpenTabFiles.push({ filepath: filepath, isDir: false });
+          processedFilepaths.add(filepath);
         }
       }
     }


### PR DESCRIPTION
## Summary

Previously, the tab state was using relative paths, which could cause issues when the current working directory changed. This commit changes the tab state to use absolute paths to ensure that the filepaths are always correct, regardless of the current working directory. In `VSCodeHostImpl`, the absolute paths are converted back to relative paths before being sent to the webview to maintain the existing behavior.

## Test plan

- Verified that the extension continues to function as expected after the changes.
- Manually tested that active tabs and selections are correctly reported to the webview.

🤖 Generated with [Pochi](https://getpochi.com)