### PR TITLE
fix(vscode-webui): Navigate to task page on load in pane webview

### DIFF
--- a/packages/vscode-webui/src/main.tsx
+++ b/packages/vscode-webui/src/main.tsx
@@ -60,6 +60,8 @@ declare module "@tanstack/react-router" {
   }
 }
 
+// In the "pane" webview, navigate to the task page on load.
+// Avoid setting window.location.hash globally because other scripts may modify it.
 if (window.POCHI_WEBVIEW_KIND === "pane") {
   const params = window.POCHI_TASK_PARAMS;
   if (params) {
@@ -73,11 +75,10 @@ if (window.POCHI_WEBVIEW_KIND === "pane") {
 function InnerApp() {
   const { isLoading } = useUserStorage();
 
-  if (
-    isLoading &&
-    isVSCodeEnvironment() &&
-    window.POCHI_WEBVIEW_KIND !== "pane"
-  ) {
+  if (isLoading && isVSCodeEnvironment()) {
+    if (window.POCHI_WEBVIEW_KIND === "pane") {
+      return null;
+    }
     return (
       <div className="flex h-screen w-screen items-center justify-center">
         <Loader2 className="animate-spin" />


### PR DESCRIPTION
## Summary
- This PR fixes an issue where the task page would not load correctly in the `pane` webview.
- It ensures that when the webview is of kind `pane`, it navigates to the task page on load if task parameters are available.
- The loading logic is also simplified.

## Test plan
N/A

🤖 Generated with [Pochi](https://getpochi.com)