### PR TITLE
fix(vscode-webui): switch model automatically when workflow is selected in sidebar

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -29,6 +29,7 @@ import {
 } from "./context-mention/mention-list";
 import "./prompt-form.css";
 import { useSelectedModels } from "@/features/settings";
+import { useLatest } from "@/lib/hooks/use-latest";
 import { cn } from "@/lib/utils";
 import { resolveModelFromId } from "@/lib/utils/resolve-model-from-id";
 import { isValidCustomAgentFile } from "@getpochi/common/vscode-webui-bridge";
@@ -145,21 +146,18 @@ export function FormEditor({
   // State for drag overlay UI
   const [isDragOver, setIsDragOver] = useState(false);
 
-  const onSelectSlashCandidate = useCallback(
-    (data: SlashCandidate) => {
-      let model: string | undefined;
-      if (data.type === "workflow") {
-        model = data.rawData.frontmatter.model;
-      } else if (data.type === "custom-agent") {
-        model = data.rawData.model;
-      }
-      const foundModel = resolveModelFromId(model, models);
-      if (foundModel) {
-        updateSelectedModelId(foundModel.id);
-      }
-    },
-    [models, updateSelectedModelId],
-  );
+  const onSelectSlashCandidate = useLatest((data: SlashCandidate) => {
+    let model: string | undefined;
+    if (data.type === "workflow") {
+      model = data.rawData.frontmatter.model;
+    } else if (data.type === "custom-agent") {
+      model = data.rawData.model;
+    }
+    const foundModel = resolveModelFromId(model, models);
+    if (foundModel) {
+      updateSelectedModelId(foundModel.id);
+    }
+  });
 
   const editor = useEditor(
     {
@@ -331,7 +329,7 @@ export function FormEditor({
                     props: {
                       ...props,
                       fetchItems,
-                      onSelect: onSelectSlashCandidate,
+                      onSelect: onSelectSlashCandidate.current,
                     },
                     editor: props.editor,
                   });


### PR DESCRIPTION
## Summary
- Fixes a bug where selecting a workflow in the sidebar would not automatically switch the model
- The issue was that the onSelectSlashCandidate function was not properly using the latest state due to closure issues
- Wrapped the function with useLatest to ensure it always has access to the current models and updateSelectedModelId references

## Test plan
- [x] Verify that selecting a workflow in the sidebar properly switches the model
- [x] Verify that selecting a custom agent in the slash command menu still works correctly
- [x] Run existing tests to ensure no regressions

🤖 Generated with [Pochi](https://getpochi.com)