### PR TITLE
feat(vscode-webui): Handle auto approve properly in each session

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -108,6 +108,7 @@ interface FormEditorProps {
   onPaste?: (e: ClipboardEvent) => void;
   enableSubmitHistory?: boolean;
   onFileDrop?: (files: File[]) => boolean;
+  onFocus?: (event: FocusEvent) => void;
   messageContent?: string;
   isSubTask: boolean;
 }
@@ -123,6 +124,7 @@ export function FormEditor({
   editorRef,
   autoFocus = true,
   onPaste,
+  onFocus,
   enableSubmitHistory = true,
   onFileDrop,
   messageContent = "",
@@ -482,6 +484,9 @@ export function FormEditor({
       },
       onPaste: (e) => {
         onPaste?.(e);
+      },
+      onFocus(props) {
+        onFocus?.(props.event);
       },
     },
     [],

--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -18,6 +18,7 @@ interface ChatInputFormProps {
   onQueueMessage: (message: string) => void;
   isLoading: boolean;
   onPaste: (event: ClipboardEvent) => void;
+  onFocus?: (event: FocusEvent) => void;
   pendingApproval: ReturnType<typeof useApprovalAndRetry>["pendingApproval"];
   status: UseChatHelpers<Message>["status"];
   onFileDrop?: (files: File[]) => boolean;
@@ -35,6 +36,7 @@ export function ChatInputForm({
   onQueueMessage,
   isLoading,
   onPaste,
+  onFocus,
   pendingApproval,
   status,
   onFileDrop,
@@ -59,6 +61,7 @@ export function ChatInputForm({
       onFileDrop={onFileDrop}
       messageContent={messageContent}
       isSubTask={isSubTask}
+      onFocus={onFocus}
     >
       <ActiveSelectionBadge
         onClick={() => {

--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/hover-card";
 
 import { WorktreeSelect } from "@/components/worktree-select";
-import { useSelectedModels } from "@/features/settings";
+import { useSelectedModels, useSettingsStore } from "@/features/settings";
 import type { useAttachmentUpload } from "@/lib/hooks/use-attachment-upload";
 import { useWorktrees } from "@/lib/hooks/use-worktrees";
 import { vscodeHost } from "@/lib/vscode";
@@ -83,6 +83,10 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
     return worktreesData.data?.filter((x) => x.path === workspaceFolder) ?? [];
   }, [isOpenMainWorktree, worktreesData.data, workspaceFolder]);
 
+  const onFocus = () => {
+    useSettingsStore.persist.rehydrate();
+  };
+
   const handleSubmit = useCallback(
     async (e?: React.FormEvent<HTMLFormElement>) => {
       e?.preventDefault();
@@ -148,6 +152,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
         isSubTask={false}
         onQueueMessage={noop}
         onRemoveQueuedMessage={noop}
+        onFocus={onFocus}
       >
         {files.length > 0 && (
           <div className="px-3">

--- a/packages/vscode-webui/src/features/settings/components/auto-approve-menu.tsx
+++ b/packages/vscode-webui/src/features/settings/components/auto-approve-menu.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import {
@@ -9,6 +10,7 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import {
   Blocks,
+  CheckIcon,
   Eye,
   FileEdit,
   type LucideIcon,
@@ -20,7 +22,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAutoApprove } from "../hooks/use-auto-approve";
 import { useSubtaskOffhand } from "../hooks/use-subtask-offhand";
-import type { AutoApprove } from "../store";
+import { type AutoApprove, GlobalStateStorage } from "../store";
 
 interface CoreActionSetting {
   id: keyof Omit<AutoApprove, "default">;
@@ -92,6 +94,28 @@ export function AutoApproveMenu({ isSubTask }: { isSubTask: boolean }) {
     setCurrentMaxRetry(autoApproveSettings.maxRetryLimit.toString());
   };
 
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handlePersistSettings = async () => {
+    if (isSaving) return;
+    setIsSaving(true);
+    await GlobalStateStorage.persist({
+      autoApproveActive,
+      autoApproveSettings,
+      subtaskOffhand,
+    });
+    setTimeout(() => {
+      setIsSaving(false);
+      setIsDirty(false);
+      // After persisting, the current state is the new "initial" state
+      setInitialSettings({
+        autoApproveActive,
+        autoApproveSettings,
+        subtaskOffhand,
+      });
+    }, 1000);
+  };
+
   const getCoreActionCheckedState = (
     id: keyof Omit<AutoApprove, "default">,
   ): boolean => {
@@ -106,8 +130,53 @@ export function AutoApproveMenu({ isSubTask }: { isSubTask: boolean }) {
   ];
 
   const { subtaskOffhand, toggleSubtaskOffhand } = useSubtaskOffhand();
+
+  const [isDirty, setIsDirty] = useState(false);
+  type SettingsSnapshot = {
+    autoApproveActive: boolean;
+    autoApproveSettings: AutoApprove;
+    subtaskOffhand: boolean;
+  };
+  const [initialSettings, setInitialSettings] =
+    useState<SettingsSnapshot | null>(null);
+
+  useEffect(() => {
+    if (isSubTask || !initialSettings) return;
+
+    const currentSnapshot = {
+      autoApproveActive,
+      autoApproveSettings,
+      subtaskOffhand,
+    };
+    const hasChanges =
+      JSON.stringify(currentSnapshot) !== JSON.stringify(initialSettings);
+    setIsDirty(hasChanges);
+  }, [
+    autoApproveActive,
+    autoApproveSettings,
+    subtaskOffhand,
+    initialSettings,
+    isSubTask,
+  ]);
+
+  const onOpenChange = (open: boolean) => {
+    if (isSubTask) return;
+
+    if (open) {
+      setInitialSettings({
+        autoApproveActive,
+        autoApproveSettings,
+        subtaskOffhand,
+      });
+    } else {
+      // When closing, just reset dirty tracking. Unsaved changes remain in the store.
+      setInitialSettings(null);
+      setIsDirty(false);
+    }
+  };
+
   return (
-    <Popover>
+    <Popover onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>
         <div
           className={cn(
@@ -150,96 +219,114 @@ export function AutoApproveMenu({ isSubTask }: { isSubTask: boolean }) {
         </div>
       </PopoverTrigger>
       <PopoverContent
-        className="grid grid-cols-1 gap-2.5 [@media(min-width:400px)]:w-[400px] [@media(min-width:400px)]:grid-cols-2"
+        className="[@media(min-width:400px)]:w-[400px]"
         side="top"
       >
-        {coreActionSettings.map((setting) => (
-          <div key={setting.id} className="flex items-center">
-            <label
-              htmlFor={`core-action-dialog-${setting.id}`}
-              className={
-                "flex flex-1 cursor-pointer select-none items-center pl-1 text-foreground text-sm"
-              }
-            >
-              <Checkbox
-                id={`core-action-dialog-${setting.id}`}
-                checked={getCoreActionCheckedState(setting.id)}
-                onCheckedChange={(checked) =>
-                  handleCoreActionToggle(setting.id, !!checked)
-                }
-              />
-              <span className="ml-4 flex items-center gap-2 font-semibold">
-                <setting.iconClass className="size-4 shrink-0" />
-                {setting.label}
-              </span>
-            </label>
-          </div>
-        ))}
-
-        {/* Max Attempts Section - Always visible */}
-        <div className="mt-1 border-gray-200/30 border-t pt-2 [@media(min-width:400px)]:col-span-2">
-          <div className="flex h-7 items-center pl-1">
-            <Checkbox
-              id="retry-actions-trigger-dialog"
-              checked={autoApproveSettings.retry}
-              onCheckedChange={(checked) =>
-                handleCoreActionToggle("retry", !!checked)
-              }
-            />
-            <label
-              className="flex cursor-pointer items-center gap-3 px-3"
-              htmlFor={
-                autoApproveSettings.retry
-                  ? "retry-actions-max-attempts"
-                  : "retry-actions-trigger-dialog"
-              }
-            >
-              <span className="ml-3.5 flex items-center gap-2 font-semibold">
-                <RotateCcw className="size-4 shrink-0" />
-                <span className="whitespace-nowrap text-foreground text-sm">
-                  {autoApproveSettings.retry
-                    ? `${t("settings.autoApprove.maxAttempts")}:`
-                    : t("settings.autoApprove.retryActions")}
-                </span>
-              </span>
-            </label>
-            {autoApproveSettings.retry && (
-              <Input
-                id="retry-actions-max-attempts"
-                type="number"
-                min="1"
-                max="10"
-                value={currentMaxRetry}
-                onChange={(e) => handleRetryLimitChange(e.target.value)}
-                onBlur={handleRetryLimitBlur}
-                className="h-7 w-full text-xs [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                onClick={(e) => e.stopPropagation()}
-              />
+        {isDirty && !isSubTask && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handlePersistSettings}
+            disabled={isSaving}
+            className="mb-3"
+          >
+            {isSaving ? (
+              <CheckIcon className="size-4" />
+            ) : (
+              t("settings.autoApprove.applyChangesToDefault")
             )}
-          </div>
-
-          {!isSubTask && (
-            <div className="mt-1 flex h-7 items-center">
-              <Switch
-                id="subtask-toggle-offhand"
-                checked={subtaskOffhand}
-                onCheckedChange={toggleSubtaskOffhand}
-              />
+          </Button>
+        )}
+        <div className="grid grid-cols-1 gap-2.5 [@media(min-width:400px)]:grid-cols-2">
+          {coreActionSettings.map((setting) => (
+            <div key={setting.id} className="flex items-center">
               <label
-                className="flex cursor-pointer items-center gap-3 px-3"
-                htmlFor={"subtask-toggle-offhand"}
+                htmlFor={`core-action-dialog-${setting.id}`}
+                className={
+                  "flex flex-1 cursor-pointer select-none items-center pl-1 text-foreground text-sm"
+                }
               >
-                <span className="ml-1.5 flex items-center gap-2 font-semibold">
-                  <SquareChevronRightIcon className="size-4 shrink-0" />
-                  <span className="whitespace-nowrap text-foreground text-sm">
-                    {subtaskOffhand
-                      ? t("settings.autoApprove.subtaskOffhand")
-                      : t("settings.autoApprove.subtaskManual")}
-                  </span>
+                <Checkbox
+                  id={`core-action-dialog-${setting.id}`}
+                  checked={getCoreActionCheckedState(setting.id)}
+                  onCheckedChange={(checked) =>
+                    handleCoreActionToggle(setting.id, !!checked)
+                  }
+                />
+                <span className="ml-4 flex items-center gap-2 font-semibold">
+                  <setting.iconClass className="size-4 shrink-0" />
+                  {setting.label}
                 </span>
               </label>
             </div>
-          )}
+          ))}
+
+          {/* Max Attempts Section - Always visible */}
+          <div className="mt-1 border-gray-200/30 border-t pt-2 [@media(min-width:400px)]:col-span-2">
+            <div className="flex h-7 items-center pl-1">
+              <Checkbox
+                id="retry-actions-trigger-dialog"
+                checked={autoApproveSettings.retry}
+                onCheckedChange={(checked) =>
+                  handleCoreActionToggle("retry", !!checked)
+                }
+              />
+              <label
+                className="flex cursor-pointer items-center gap-3 px-3"
+                htmlFor={
+                  autoApproveSettings.retry
+                    ? "retry-actions-max-attempts"
+                    : "retry-actions-trigger-dialog"
+                }
+              >
+                <span className="ml-3.5 flex items-center gap-2 font-semibold">
+                  <RotateCcw className="size-4 shrink-0" />
+                  <span className="whitespace-nowrap text-foreground text-sm">
+                    {autoApproveSettings.retry
+                      ? `${t("settings.autoApprove.maxAttempts")}:`
+                      : t("settings.autoApprove.retryActions")}
+                  </span>
+                </span>
+              </label>
+              {autoApproveSettings.retry && (
+                <Input
+                  id="retry-actions-max-attempts"
+                  type="number"
+                  min="1"
+                  max="10"
+                  value={currentMaxRetry}
+                  onChange={(e) => handleRetryLimitChange(e.target.value)}
+                  onBlur={handleRetryLimitBlur}
+                  className="h-7 w-full text-xs [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              )}
+            </div>
+
+            {!isSubTask && (
+              <div className="mt-1 flex h-7 items-center">
+                <Switch
+                  id="subtask-toggle-offhand"
+                  checked={subtaskOffhand}
+                  onCheckedChange={toggleSubtaskOffhand}
+                />
+                <label
+                  className="flex cursor-pointer items-center gap-3 px-3"
+                  htmlFor={"subtask-toggle-offhand"}
+                >
+                  <span className="ml-1.5 flex items-center gap-2 font-semibold">
+                    <SquareChevronRightIcon className="size-4 shrink-0" />
+                    <span className="whitespace-nowrap text-foreground text-sm">
+                      {subtaskOffhand
+                        ? t("settings.autoApprove.subtaskOffhand")
+                        : t("settings.autoApprove.subtaskManual")}
+                    </span>
+                  </span>
+                </label>
+              </div>
+            )}
+          </div>
         </div>
       </PopoverContent>
     </Popover>

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -121,7 +121,8 @@
       "mcp": "MCP",
       "retry": "Retry",
       "subtaskOffhand": "Subtask - Offhand",
-      "subtaskManual": "Subtask - Manual"
+      "subtaskManual": "Subtask - Manual",
+      "applyChangesToDefault": "Apply changes to default"
     },
     "customAgents": {
       "title": "Agents",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -115,7 +115,8 @@
       "mcp": "MCP",
       "retry": "再試行",
       "subtaskOffhand": "サブタスク - 自動",
-      "subtaskManual": "サブタスク - 手動"
+      "subtaskManual": "サブタスク - 手動",
+      "applyChangesToDefault": "デフォルトに変更を適用"
     },
     "customAgents": {
       "title": "エージェント",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -115,7 +115,8 @@
       "mcp": "MCP",
       "retry": "재시도",
       "subtaskOffhand": "하위 작업 - 자동",
-      "subtaskManual": "하위 작업 - 수동"
+      "subtaskManual": "하위 작업 - 수동",
+      "applyChangesToDefault": "기본값에 변경 사항 적용"
     },
     "customAgents": {
       "title": "에이전트",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -115,7 +115,8 @@
       "mcp": "MCP",
       "retry": "重试",
       "subtaskOffhand": "子任务 - 自动",
-      "subtaskManual": "子任务 - 手动"
+      "subtaskManual": "子任务 - 手动",
+      "applyChangesToDefault": "将更改应用于默认设置"
     },
     "customAgents": {
       "title": "代理",


### PR DESCRIPTION
## Summary
This pull request refactors the `autoApprove` state management in the VS Code Web UI. The `autoApprove` state has been moved from a persistent store to a session-based state. This ensures that the auto-approve setting is reset for each new session, preventing unintended tool execution approvals across different tasks.

Key changes include:
- Removal of `autoApprove` from the persistent settings store.
- Introduction of a new session-based store for `autoApprove`.
- Updates to components to utilize the new session-based state.
- Addition of i18n for new UI text.

This change enhances security and user experience by ensuring that the auto-approve setting is intentionally configured for each session.

## Test plan
1. Run the VS Code extension.
2. Open the settings and enable "Auto Approve".
3. Start a new task and verify that "Auto Approve" is disabled by default.
4. Enable "Auto Approve" for the current task.
5. Close the task and start a new one.
6. Verify that "Auto Approve" is disabled again for the new task.

🤖 Generated with [Pochi](https://getpochi.com)