### PR TITLE
chore(vscode): prepare extension for 0.13.0-dev

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -254,7 +254,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.11.0-dev",
+      "version": "0.13.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.11.0-dev",
+  "version": "0.13.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- bump the VS Code extension package metadata to 0.13.0-dev for the upcoming release

## Test plan
- [ ] Not run (version bump only)

🤖 Generated with [Pochi](https://getpochi.com)