### PR TITLE
fix(vscode-webui): Foreground subtask completion should not trigger notification

### DIFF
--- a/packages/vscode-webui/src/features/approval/components/approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/approval-button.tsx
@@ -43,6 +43,7 @@ export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
         <RetryApprovalButton
           task={task}
           pendingApproval={pendingApproval}
+          isSubTask={isSubTask}
           retry={retry}
         />
       ) : (

--- a/packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx
@@ -13,12 +13,14 @@ interface RetryApprovalButtonProps {
   pendingApproval: PendingRetryApproval;
   retry: (error: Error) => void;
   task: Task | undefined;
+  isSubTask: boolean;
 }
 
 export const RetryApprovalButton: React.FC<RetryApprovalButtonProps> = ({
   pendingApproval,
   retry,
   task,
+  isSubTask,
 }) => {
   const { t } = useTranslation();
 
@@ -47,19 +49,25 @@ export const RetryApprovalButton: React.FC<RetryApprovalButtonProps> = ({
   }, [setShowRetry]);
 
   useEffect(() => {
+    const uid = isSubTask ? task?.parentId : task?.id;
     if (
-      task?.id &&
       showRetry &&
-      task.status === "failed" &&
+      uid &&
+      task?.status === "failed" &&
       (pendingApproval.attempts === undefined ||
         pendingApproval.countdown === undefined)
     ) {
-      sendNotification("failed", { cwd: task.cwd, uid: task.id });
+      sendNotification("failed", {
+        cwd: task.cwd,
+        uid,
+      });
     }
   }, [
     showRetry,
     sendNotification,
     pendingApproval,
+    isSubTask,
+    task?.parentId,
     task?.id,
     task?.cwd,
     task?.status,

--- a/packages/vscode-webui/src/features/approval/components/tool-call-approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/tool-call-approval-button.tsx
@@ -181,10 +181,20 @@ export const ToolCallApprovalButton: React.FC<ToolCallApprovalButtonProps> = ({
   const showAccept = !isAutoApproved && isReady;
 
   useEffect(() => {
-    if (showAccept && task?.cwd && task?.id) {
-      sendNotification("pending-tool", { cwd: task.cwd, uid: task.id });
+    if (showAccept) {
+      const uid = isSubTask ? task?.parentId : task?.id;
+      if (uid) {
+        sendNotification("pending-tool", { cwd: task?.cwd, uid });
+      }
     }
-  }, [showAccept, sendNotification, task?.cwd, task?.id]);
+  }, [
+    showAccept,
+    sendNotification,
+    isSubTask,
+    task?.parentId,
+    task?.cwd,
+    task?.id,
+  ]);
 
   if (showAccept) {
     return (


### PR DESCRIPTION
## Summary
This PR fixes a bug where notifications were being triggered for foreground subtasks. The changes ensure that notifications are only shown for top-level tasks.

- The `isSubTask` prop is now passed down to `ApprovalButton` and `RetryApprovalButton`.
- The logic for sending notifications now correctly uses the `parentId` for subtasks to identify the root task.

## Test plan
- Manually tested in the VS Code extension.
- Verified that no notifications appear for foreground subtasks that require approval or have failed.

🤖 Generated with [Pochi](https://getpochi.com)