### PR TITLE
feat(vscode): auto unlock editor group when pochi task editor is closed

### DIFF
--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -122,6 +122,8 @@ export class PochiTaskEditorProvider
 
     setAutoLockGroupsConfig();
 
+    disposables.push(autoCleanTabGroupLock());
+
     return vscode.Disposable.from(...disposables);
   }
 
@@ -388,4 +390,23 @@ async function openTaskInColumn(uri: vscode.Uri) {
     PochiTaskEditorProvider.viewType,
     { preview: false, viewColumn },
   );
+}
+
+function autoCleanTabGroupLock() {
+  return vscode.window.tabGroups.onDidChangeTabs((event) => {
+    if (vscode.window.tabGroups.all.length > 1) {
+      return;
+    }
+
+    if (
+      event.closed.length > 0 &&
+      event.closed.some(
+        (tab) =>
+          tab.input instanceof vscode.TabInputCustom &&
+          tab.input.viewType === PochiTaskEditorProvider.viewType,
+      )
+    ) {
+      vscode.commands.executeCommand("workbench.action.unlockEditorGroup");
+    }
+  });
 }


### PR DESCRIPTION
## Summary
This PR introduces a new feature that automatically unlocks the editor group when the Pochi task editor is closed. This improves the user experience by preventing the editor group from remaining locked after the task is completed.

## Test plan
1. Open a Pochi task.
2. The editor group should be locked.
3. Close the Pochi task editor.
4. The editor group should be automatically unlocked.

🤖 Generated with [Pochi](https://getpochi.com)