### PR TITLE
feat(vscode): improve auto unlock editor group logic

### DIFF
--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -394,10 +394,23 @@ async function openTaskInColumn(uri: vscode.Uri) {
 
 function autoCleanTabGroupLock() {
   return vscode.window.tabGroups.onDidChangeTabs((event) => {
+    // if we have more than one tab group, do nothing. vscode will close tab group when it has no tab
     if (vscode.window.tabGroups.all.length > 1) {
       return;
     }
 
+    // if the tab group still have pochi tab, do nothing
+    if (
+      vscode.window.tabGroups.all[0].tabs.filter(
+        (tab) =>
+          tab.input instanceof vscode.TabInputCustom &&
+          tab.input.viewType === PochiTaskEditorProvider.viewType,
+      ).length > 0
+    ) {
+      return;
+    }
+
+    // if closed tabs contain pochi tab, unlock this tab group
     if (
       event.closed.length > 0 &&
       event.closed.some(


### PR DESCRIPTION
## Summary
- Enhance the autoCleanTabGroupLock function to prevent unlocking editor groups when there are multiple tab groups
- Prevent unlocking editor groups when the tab group still contains Pochi task editor tabs
- This ensures more precise control over when editor groups are unlocked

## Test plan
- [x] Verify that editor groups with Pochi tabs are not unlocked prematurely
- [x] Verify that editor groups are still properly unlocked when all Pochi tabs are closed
- [x] Verify that multiple tab group scenarios work correctly

🤖 Generated with [Pochi](https://getpochi.com)