### PR TITLE
fix(vscode-webui): prevent unnecessary notification after new task submit

### DIFF
--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -136,11 +136,10 @@ export function useChatSubmit({
           const parts = prepareMessageParts(t, text, uploadedAttachments);
           logger.debug("Sending message with files");
 
+          autoApproveGuard.current = "auto";
           await sendMessage({
             parts,
           });
-
-          autoApproveGuard.current = "auto";
         } catch (error) {
           // Error is already handled by the hook
           return;
@@ -148,10 +147,11 @@ export function useChatSubmit({
       } else if (allMessages.length > 0) {
         clearUploadError();
         const parts = prepareMessageParts(t, text, []);
+
+        autoApproveGuard.current = "auto";
         await sendMessage({
           parts,
         });
-        autoApproveGuard.current = "auto";
       }
     },
     [


### PR DESCRIPTION
## Summary
- Fixes a bug where unnecessary notifications were sent after submitting a new task
- Repositions the autoApproveGuard assignment to ensure it's set before calling sendMessage
- Prevents race conditions that could trigger unwanted notifications

## Test plan
- Verify that chat submit functionality works as expected
- Confirm that no unnecessary notifications are triggered after task submission

🤖 Generated with [Pochi](https://getpochi.com)