### PR TITLE
fix(vscode-nes): improve checking for reverting recent edits

### DIFF
--- a/packages/vscode/src/nes/client/chat-model-client.ts
+++ b/packages/vscode/src/nes/client/chat-model-client.ts
@@ -118,6 +118,6 @@ function extractResult(text: string, segments: NESPromptSegments) {
 }
 
 const SystemPromptTemplate =
-  "You are an AI coding assistant that helps with code completion and editing. You will be given a code snippet with an editable region marked.\nYour task is to complete or modify the code within that region based on the following events that happened in past.\nYou should not undo or revert the edits. \n\nUser edits:\n\n```diff\n{{edits}}\n```\n";
+  "You are an AI coding assistant that helps with code completion and editing. You will be given a code snippet with an editable region marked.\nYour task is to complete or modify the code within that region based on the following events that happened in past. \nNOTE: DO NOT undo or revert the user edits. \n\nUser edits:\n\n```diff\n{{edits}}\n```\n";
 const UserPromptTemplate =
   "```{{filepath}}\n{{prefix}}<|editable_region_start|>{{editableRegionPrefix}}<|user_cursor_is_here|>{{editableRegionSuffix}}<|editable_region_end|>{{suffix}}\n```";

--- a/packages/vscode/src/nes/solution/item-filters.ts
+++ b/packages/vscode/src/nes/solution/item-filters.ts
@@ -1,4 +1,5 @@
 import type { NESRequestContext } from "@/nes/contexts";
+import { applyEdit } from "../utils";
 import type { NESSolutionItem } from "./item";
 
 export function isRevertingRecentEdits(
@@ -7,9 +8,22 @@ export function isRevertingRecentEdits(
 ): boolean {
   const editSteps = context.documentContext.editHistory;
   const targetText = item.target.getText();
+  // For every EditStep, check the state of start
   for (const editStep of editSteps) {
     if (targetText === editStep.getBefore().getText()) {
       return true;
+    }
+  }
+  // For the last EditStep, check every change
+  if (editSteps.length > 0) {
+    const lastEditStep = editSteps[editSteps.length - 1];
+    let before = lastEditStep.getBefore().getText();
+    for (const edit of lastEditStep.getEdits()) {
+      const { text } = applyEdit(before, edit);
+      if (targetText === text) {
+        return true;
+      }
+      before = text;
     }
   }
   return false;


### PR DESCRIPTION
This commit improves the logic for checking if a given solution is reverting recent user edits. It now checks against intermediate states of the last edit step, in addition to the start and end states of all previous edit steps.

It also refines the system prompt to be more explicit about not reverting user edits.