### PR TITLE
fix(webui): always display todoWrite tool with todo list

### DIFF
--- a/packages/vscode-webui/src/components/tool-invocation/index.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/index.tsx
@@ -1,5 +1,4 @@
 import { useToolCallLifeCycle } from "@/features/chat";
-import { useIsDevMode } from "@/features/settings";
 import { cn } from "@/lib/utils";
 import type { Message, UITools } from "@getpochi/livekit";
 import { type ToolUIPart, getToolName } from "ai";
@@ -43,10 +42,6 @@ export function ToolInvocationPart({
   });
   const isExecuting = lifecycle.status.startsWith("execute");
   const C = Tools[toolName];
-  const [isDevMode] = useIsDevMode();
-  if (toolName === "todoWrite" && !isDevMode) {
-    return null; // Skip rendering the todoWrite tool in non-dev mode
-  }
 
   return (
     <div className={cn("flex flex-col gap-1", className)}>


### PR DESCRIPTION
## Summary
- Remove the condition that was hiding the todoWrite tool in non-dev mode
- Ensure that the todo list is always visible to users regardless of their dev mode setting
- Fix an issue where the todoWrite tool was not displaying correctly for users

## Test plan
- [x] Verify that the todoWrite tool is now visible in both dev and non-dev modes
- [x] Confirm that the todo list displays correctly with all its functionality

🤖 Generated with [Pochi](https://getpochi.com)