### PR TITLE
fix(vscode-webui): distinguish task and sub task completed notification

### DIFF
--- a/packages/vscode-webui/src/features/chat/lib/use-send-task-notification.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-send-task-notification.ts
@@ -8,7 +8,11 @@ export function useSendTaskNotification() {
   const sendNotification = useCallback(
     async (
       kind: "failed" | "completed" | "pending-tool" | "pending-input",
-      openTaskParams: { uid: string; cwd: string | null | undefined },
+      openTaskParams: {
+        uid: string;
+        cwd: string | null | undefined;
+        isSubTask?: boolean;
+      },
     ) => {
       clearTimeout(timer.current);
 
@@ -31,7 +35,9 @@ export function useSendTaskNotification() {
             renderMessage = "Pochi is waiting for your input to continue.";
             break;
           case "completed":
-            renderMessage = "Pochi has completed the task.";
+            renderMessage = openTaskParams.isSubTask
+              ? "Pochi has completed the sub task."
+              : "Pochi has completed the task.";
             break;
           case "failed":
             renderMessage = "Pochi is running into error, please take a look.";

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -161,7 +161,11 @@ function Chat({ user, uid, prompt, files }: ChatProps) {
           });
 
           if (!autoApproved) {
-            sendNotification("pending-tool", { uid: taskUid, cwd: data.cwd });
+            sendNotification("pending-tool", {
+              uid: taskUid,
+              cwd: data.cwd,
+              isSubTask,
+            });
           }
         }
       }
@@ -179,12 +183,20 @@ function Chat({ user, uid, prompt, files }: ChatProps) {
           retryLimit === 0 ||
           (retryCount?.count !== undefined && retryCount.count >= retryLimit)
         ) {
-          sendNotification("pending-input", { uid: taskUid, cwd: data.cwd });
+          sendNotification("pending-input", {
+            uid: taskUid,
+            cwd: data.cwd,
+            isSubTask,
+          });
         }
       }
 
       if (data.status === "completed") {
-        sendNotification("completed", { uid: taskUid, cwd: data.cwd });
+        sendNotification("completed", {
+          uid: taskUid,
+          cwd: data.cwd,
+          isSubTask,
+        });
       }
     },
   );
@@ -208,7 +220,7 @@ function Chat({ user, uid, prompt, files }: ChatProps) {
         retryLimit === 0 ||
         (retryCount?.count !== undefined && retryCount.count >= retryLimit)
       ) {
-        sendNotification("failed", { uid: taskUid, cwd });
+        sendNotification("failed", { uid: taskUid, cwd, isSubTask });
       }
     },
   );


### PR DESCRIPTION
## Summary
- Modified the notification system to differentiate between completed tasks and completed sub tasks
- When a sub task is completed, the notification message will now indicate "Pochi has completed the sub task" instead of "Pochi has completed the task"
- This improves clarity for users when working with complex tasks that have multiple sub tasks

## Screenshot
<img width="1012" height="306" alt="image" src="https://github.com/user-attachments/assets/482b54f0-51b7-47bb-b0bf-f8f5cb86c2b7" />


## Test plan
- [x] Verify that task completion notifications still work correctly
- [x] Verify that sub task completion notifications show the correct message
- [x] Ensure no regressions in other notification types (pending-tool, pending-input, failed)

🤖 Generated with [Pochi](https://getpochi.com)