### PR TITLE
fix(vscode-webui): disallow submission without a selected model

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -94,6 +94,9 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       // Uploading / Compacting is not allowed to be stopped.
       if (isUploadingAttachments) return;
 
+      // If no valid model is selected, submission is not allowed.
+      if (!selectedModel) return;
+
       const content = input.trim();
 
       // Disallow empty submissions
@@ -127,6 +130,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       }
     },
     [
+      selectedModel,
       files.length,
       input,
       clearUploadError,


### PR DESCRIPTION
## Summary
This PR prevents the user from submitting a task if no valid model is selected. It adds a check to ensure `selectedModel` exists before proceeding with the submission, and also adds `selectedModel` to the dependency array of the `submit` function.

## Test plan
1. Run the extension.
2. Open the chat view.
3. Try to submit a task without selecting a model.
4. Verify that the submission is not allowed.
5. Select a model.
6. Submit a task.
7. Verify that the submission is successful.

🤖 Generated with [Pochi](https://getpochi.com)