### PR TITLE
chore: bump vscode version

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.13.0-dev",
+  "version": "0.15.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Updates the VSCode extension version from 0.13.0-dev to 0.15.0-dev
- Fixes formatting in package.json by standardizing array formatting using pre-commit hooks
- Reformats activationEvents, filenamePatterns, and required fields to single-line format

## Test plan
- [ ] Verify the version bump is correct
- [ ] Ensure package.json formatting follows project standards
- [ ] Confirm VSCode extension builds correctly with these changes

🤖 Generated with [Pochi](https://getpochi.com)