### PR TITLE
fix: Prevent task panel flickering when creating new tasks in VSCode

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-area.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.tsx
@@ -10,6 +10,7 @@ interface ChatAreaProps {
   user?: { name: string; image?: string | null };
   messagesContainerRef: React.RefObject<HTMLDivElement | null>;
   className?: string;
+  hideEmptyPlaceholder?: boolean;
 }
 
 export function ChatArea({
@@ -18,11 +19,14 @@ export function ChatArea({
   user,
   messagesContainerRef,
   className,
+  hideEmptyPlaceholder,
 }: ChatAreaProps) {
   const resourceUri = useResourceURI();
   return (
     <>
-      {messages.length === 0 && <EmptyChatPlaceholder />}
+      {!hideEmptyPlaceholder && messages.length === 0 && (
+        <EmptyChatPlaceholder />
+      )}
       {messages.length > 0 && <div className="h-4" />}
       <MessageList
         messages={messages}

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -85,6 +85,8 @@ function Chat({ user, uid, prompt, files }: ChatProps) {
   const subtask = useSubtaskInfo(uid, task?.parentId);
   const isSubTask = !!subtask;
 
+  const isNewTaskWithContent = !!prompt || !!files?.length;
+
   useEffect(() => {
     if (task) {
       vscodeHost.onTaskUpdated(
@@ -342,6 +344,7 @@ function Chat({ user, uid, prompt, files }: ChatProps) {
           // Leave more space for errors as errors / approval button are absolutely positioned
           "pb-14": !!displayError,
         })}
+        hideEmptyPlaceholder={isNewTaskWithContent}
       />
       <div className="relative flex flex-col px-4">
         {!isWorkspaceActive ? (


### PR DESCRIPTION
## Summary
This commit addresses the issue where the task panel flickers when a new task is created in the VSCode extension.

## Screen recording
https://jam.dev/c/b1ad557b-8281-4b64-9a40-9bec02558447


🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>