### PR TITLE
refactor: Add Pochi client and use case headers

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -69,6 +69,7 @@ import { TaskRunner } from "./task-runner";
 import { checkForUpdates, registerUpgradeCommand } from "./upgrade";
 
 const logger = getLogger("Pochi");
+globalThis.POCHI_CLIENT = `PochiCli/${packageJson.version}`;
 logger.debug(`pochi v${packageJson.version}`);
 
 const parsePositiveInt = (input: string): number => {

--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -12,3 +12,5 @@ export const DefaultContextWindow = 100_000;
 export const DefaultMaxOutputTokens = 4096;
 
 export const PochiTaskIdHeader = "x-pochi-task-id";
+export const PochiClientHeader = "x-pochi-client";
+export const PochiRequestUseCaseHeader = "x-pochi-request-use-case";

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -1,3 +1,5 @@
+import { z } from "zod/v4";
+
 export { attachTransport, getLogger } from "./logger";
 
 export { formatters, type LLMFormatterOptions } from "./formatters";
@@ -14,3 +16,17 @@ export {
 export { WebsiteTaskCreateEvent } from "./event";
 
 export { toErrorMessage } from "./error";
+
+export const PochiProviderOptions = z.object({
+  taskId: z.string(),
+  client: z.string(),
+  useCase: z.union([
+    z.literal("agent"),
+    z.literal("output-schema"),
+    z.literal("repair-tool-call"),
+    z.literal("generate-task-title"),
+    z.literal("compact-task"),
+  ]),
+});
+
+export type PochiProviderOptions = z.infer<typeof PochiProviderOptions>;

--- a/packages/common/src/vendor/edge.ts
+++ b/packages/common/src/vendor/edge.ts
@@ -21,4 +21,5 @@ export function createModel(vendorId: string, opts: CreateModelOptions) {
 
 declare global {
   var POCHI_CORS_PROXY_PORT: string;
+  var POCHI_CLIENT: string;
 }

--- a/packages/livekit/ambient.d.ts
+++ b/packages/livekit/ambient.d.ts
@@ -3,4 +3,6 @@
 declare namespace globalThis {
   // biome-ignore lint/style/noVar: <explanation>
   var POCHI_CORS_PROXY_PORT: string;
+  // biome-ignore lint/style/noVar: <explanation>
+  var POCHI_CLIENT: string;
 }

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -1,5 +1,5 @@
 import { getErrorMessage } from "@ai-sdk/provider";
-import type { Environment } from "@getpochi/common";
+import type { Environment, PochiProviderOptions } from "@getpochi/common";
 import { formatters, prompts } from "@getpochi/common";
 import * as R from "remeda";
 
@@ -175,7 +175,9 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       providerOptions: {
         pochi: {
           taskId: chatId,
-        },
+          client: globalThis.POCHI_CLIENT,
+          useCase: "agent",
+        } satisfies PochiProviderOptions,
       },
       system: prompts.system(
         environment?.info?.customRules,

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -76,6 +76,8 @@ async function createSummary(
     providerOptions: {
       pochi: {
         taskId,
+        version: globalThis.POCHI_CLIENT,
+        useCase: "compact-task",
       },
     },
     model,

--- a/packages/livekit/src/chat/llm/generate-task-title.ts
+++ b/packages/livekit/src/chat/llm/generate-task-title.ts
@@ -116,6 +116,8 @@ async function generateTitle(
     providerOptions: {
       pochi: {
         taskId,
+        version: globalThis.POCHI_CLIENT,
+        useCase: "generate-task-title",
       },
     },
     model,

--- a/packages/livekit/src/chat/llm/repair-tool-call.ts
+++ b/packages/livekit/src/chat/llm/repair-tool-call.ts
@@ -24,6 +24,8 @@ export const makeRepairToolCall: (
       providerOptions: {
         pochi: {
           taskId,
+          version: globalThis.POCHI_CLIENT,
+          useCase: "repair-tool-call",
         },
       },
       model,

--- a/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
@@ -99,6 +99,8 @@ async function ensureOutputSchema(
       providerOptions: {
         pochi: {
           taskId,
+          version: globalThis.POCHI_CLIENT,
+          useCase: "output-schema",
         },
       },
       model,

--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -7,7 +7,7 @@ import {
   EventSourceParserStream,
   convertToBase64,
 } from "@ai-sdk/provider-utils";
-import { constants } from "@getpochi/common";
+import { constants, PochiProviderOptions } from "@getpochi/common";
 import type { CreateModelOptions } from "@getpochi/common/vendor/edge";
 import {
   type PochiCredentials,
@@ -32,12 +32,17 @@ export function createPochiModel({
       providerOptions,
       ...options
     }) => {
-      const headers =
-        typeof providerOptions?.pochi?.taskId === "string"
-          ? {
-              [constants.PochiTaskIdHeader]: providerOptions.pochi.taskId,
-            }
-          : undefined;
+      const headers: Record<string, string> = {};
+      const parsedOptions = PochiProviderOptions.safeParse(
+        providerOptions?.pochi,
+      );
+      if (parsedOptions.success) {
+        headers[constants.PochiTaskIdHeader] = parsedOptions.data.taskId;
+        headers[constants.PochiClientHeader] = parsedOptions.data.client;
+        headers[constants.PochiRequestUseCaseHeader] =
+          parsedOptions.data.useCase;
+      }
+
       const apiClient = createApiClient(getCredentials);
       const resp = await apiClient.api.chat.$post(
         {
@@ -69,12 +74,17 @@ export function createPochiModel({
       providerOptions,
     }) => {
       const apiClient = createApiClient(getCredentials);
-      const headers =
-        typeof providerOptions?.pochi?.taskId === "string"
-          ? {
-              [constants.PochiTaskIdHeader]: providerOptions.pochi.taskId,
-            }
-          : undefined;
+      const headers: Record<string, string> = {};
+      const parsedOptions = PochiProviderOptions.safeParse(
+        providerOptions?.pochi,
+      );
+      if (parsedOptions.success) {
+        headers[constants.PochiTaskIdHeader] = parsedOptions.data.taskId;
+        headers[constants.PochiClientHeader] = parsedOptions.data.client;
+        headers[constants.PochiRequestUseCaseHeader] =
+          parsedOptions.data.useCase;
+      }
+
       const data = {
         model: modelId,
         callOptions: {

--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -95,6 +95,7 @@ export abstract class WebviewBase implements vscode.Disposable {
 
     const nonce = getNonce();
     const injectGlobalVars = `<script type="module" nonce="${nonce}">
+      window.POCHI_CLIENT = "Pochi/${this.context.extension.packageJSON.version}"
       window.POCHI_CORS_PROXY_PORT = "${getCorsProxyPort()}";
       window.POCHI_LOG = "${this.pochiConfiguration.advancedSettings.value.webviewLogLevel || ""}";
       window.POCHI_WEBVIEW_KIND = "${kind}";


### PR DESCRIPTION
This commit introduces new headers for Pochi client and use case information,
and refactors the `PochiProviderOptions` to include this data.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>