### PR TITLE
docs: Add status bar item section to tab completion docs.

### DIFF
--- a/packages/docs/content/docs/tab-completion.mdx
+++ b/packages/docs/content/docs/tab-completion.mdx
@@ -47,8 +47,15 @@ Just start typing. Pochi will surface suggestions automatically. The more you us
 | `Alt + ]` | Next suggestion (if multiple available) |
 | `Alt + [` | Previous suggestion (if multiple available) |
 
+## Status Bar Item
 
-## Feature Conflicts
+The status bar item shows the status of Pochi Tab Completion. It indicates whether the feature is enabled, disabled, or if any errors have occurred.
+
+### Disable/Enable
+
+You can click the status bar item to toggle Pochi Tab Completion on and off.
+
+### Feature Conflicts
 
 Pochi's Tab Completion feature may conflict with other extensions that provide code completions, such as GitHub Copilot. If you encounter issues, you can disable conflicting features to use Pochi Tab Completion.
 


### PR DESCRIPTION
## Summary
- Added a new section for the status bar item in the tab completion documentation.
- Explained how to disable/enable tab completion via the status bar item.

## Test plan
- Verified the changes locally by checking the generated documentation.

🤖 Generated with [Pochi](https://getpochi.com)