### PR TITLE
fix(common): Ensure workflow content does not include frontmatter

### DIFF
--- a/packages/cli/src/lib/__tests__/workflow-loader.test.ts
+++ b/packages/cli/src/lib/__tests__/workflow-loader.test.ts
@@ -78,7 +78,7 @@ describe("loadWorkflows", () => {
     const workflows = await loadWorkflows(projectDir);
     const duplicate = workflows.find((w) => w.id === "duplicate");
     expect(duplicate).toBeDefined();
-    expect(duplicate?.content).toBe("Project duplicate content");
+    expect(duplicate?.content).toBe("Project duplicate content\n");
   });
 
   it("should only load project workflows when includeGlobalWorkflows is false", async () => {
@@ -96,4 +96,3 @@ describe("loadWorkflows", () => {
     expect(projectWorkflow?.frontmatter.model).toBe("project-model");
   });
 });
-

--- a/packages/cli/src/lib/workflow-loader.ts
+++ b/packages/cli/src/lib/workflow-loader.ts
@@ -2,10 +2,7 @@ import * as fs from "node:fs/promises";
 import { homedir } from "node:os";
 import * as path from "node:path";
 import { constants } from "@getpochi/common";
-import {
-  isFileExists,
-  parseWorkflowFrontmatter,
-} from "@getpochi/common/tool-utils";
+import { isFileExists, parseWorkflow } from "@getpochi/common/tool-utils";
 import { uniqueBy } from "remeda";
 
 export interface Workflow {
@@ -34,13 +31,13 @@ async function readWorkflowsFromDir(dir: string): Promise<Workflow[]> {
         const id = fileName.replace(/\.md$/, "");
         const filePath = path.join(dir, fileName);
         try {
-          const content = await fs.readFile(filePath, "utf-8");
-          const frontmatter = await parseWorkflowFrontmatter(content);
+          const fileContent = await fs.readFile(filePath, "utf-8");
+          const { frontmatter, content } = await parseWorkflow(fileContent);
           workflows.push({
             id,
             pathName: getWorkflowPath(id),
             content,
-            frontmatter: { model: frontmatter.model },
+            frontmatter,
           });
         } catch (e) {
           // ignore file read errors

--- a/packages/common/src/tool-utils/__tests__/workflow-parser.test.ts
+++ b/packages/common/src/tool-utils/__tests__/workflow-parser.test.ts
@@ -1,86 +1,72 @@
 import { describe, expect, it } from "vitest";
-import { parseWorkflowFrontmatter } from "../workflow-parser";
+import { parseWorkflow } from "../workflow-parser";
 
-describe("parseWorkflowFrontmatter", () => {
+describe("parseWorkflow", () => {
   it("should parse a valid workflow file with frontmatter", async () => {
-    const content = `---
-model: gpt-4
----
-This is the system prompt for the workflow.
-`;
-    const result = await parseWorkflowFrontmatter(content);
+    const content = `---\nmodel: gpt-4\n---\nThis is the system prompt for the workflow.\n`;
+    const result = await parseWorkflow(content);
     expect(result).toEqual({
-      model: "gpt-4",
+      frontmatter: { model: "gpt-4" },
+      content: "This is the system prompt for the workflow.\n",
     });
   });
 
   it("should handle missing model field in frontmatter", async () => {
-    const content = `---
-name: my-workflow
----
-Minimal prompt.
-`;
-    const result = await parseWorkflowFrontmatter(content);
+    const content = `---\nname: my-workflow\n---\nMinimal prompt.\n`;
+    const result = await parseWorkflow(content);
     expect(result).toEqual({
-      model: undefined,
+      frontmatter: { model: undefined },
+      content: "Minimal prompt.\n",
     });
   });
 
   it("should return undefined model when no frontmatter is present", async () => {
     const content = "This is a system prompt without any frontmatter.";
-    const result = await parseWorkflowFrontmatter(content);
+    const result = await parseWorkflow(content);
     expect(result).toEqual({
-      model: undefined,
+      frontmatter: { model: undefined },
+      content: "This is a system prompt without any frontmatter.\n",
     });
   });
 
   it("should handle empty frontmatter", async () => {
-    const content = `---
----
-System prompt with empty frontmatter.
-`;
-    const result = await parseWorkflowFrontmatter(content);
+    const content = `---\n---\nSystem prompt with empty frontmatter.\n`;
+    const result = await parseWorkflow(content);
     expect(result).toEqual({
-      model: undefined,
+      frontmatter: { model: undefined },
+      content: "System prompt with empty frontmatter.\n",
     });
   });
 
   it("should return an error for invalid YAML in frontmatter", async () => {
-    const content = `---
-model: an unclosed: { string
----
-Prompt.
-`;
-    const result = await parseWorkflowFrontmatter(content);
+    const content = `---\nmodel: an unclosed: { string\n---\nPrompt.\n`;
+    const result = await parseWorkflow(content);
     expect(result.error).toBe("parseError");
     expect(result.message).toBeDefined();
+    expect(result.frontmatter).toEqual({ model: undefined });
+    expect(result.content).toBe(content);
   });
 
   it("should return an error for invalid frontmatter schema", async () => {
-    const content = `---
-model: 12345
----
-Prompt.
-`;
-    const result = (await parseWorkflowFrontmatter(content)) as {
-      model: undefined;
-      error: string;
-      message: string;
-    };
-    expect(result.model).toBeUndefined();
+    const content = `---\nmodel: 12345\n---\nPrompt.\n`;
+    const result = await parseWorkflow(content);
     expect(result.error).toBe("validationError");
     expect(result.message).toBeDefined();
+    expect(result.frontmatter).toEqual({ model: undefined });
+    expect(result.content).toBe("Prompt.\n");
   });
 
   it("should handle null or empty content", async () => {
-    const nullResult = await parseWorkflowFrontmatter(null);
+    const nullResult = await parseWorkflow(null);
     expect(nullResult).toEqual({
-      model: undefined,
+      frontmatter: { model: undefined },
+      content: "",
     });
 
-    const emptyResult = await parseWorkflowFrontmatter("");
+    const emptyResult = await parseWorkflow("");
     expect(emptyResult).toEqual({
-      model: undefined,
+      frontmatter: { model: undefined },
+      content: "",
     });
   });
 });

--- a/packages/common/src/tool-utils/index.ts
+++ b/packages/common/src/tool-utils/index.ts
@@ -29,7 +29,7 @@ export {
   buildShellCommand,
 } from "./shell";
 export { parseAgentFile } from "./agent-parser";
-export { parseWorkflowFrontmatter } from "./workflow-parser";
+export { parseWorkflow } from "./workflow-parser";
 export {
   type NotebookCell,
   type NotebookContent,

--- a/packages/common/src/tool-utils/workflow-parser.ts
+++ b/packages/common/src/tool-utils/workflow-parser.ts
@@ -10,35 +10,57 @@ const WorkflowFrontmatter = z.object({
   model: z.string().optional(),
 });
 
+type ParsedWorkflow = {
+  frontmatter: { model: string | undefined };
+  content: string;
+  error?: string;
+  message?: string;
+};
+
 /**
- * Parse a workflow file frontmatter
+ * Parse a workflow file
  */
-export async function parseWorkflowFrontmatter(content: string | null) {
-  if (!content) return { model: undefined };
+export async function parseWorkflow(
+  content: string | null,
+): Promise<ParsedWorkflow> {
+  if (!content) {
+    return { frontmatter: { model: undefined }, content: "" };
+  }
   let vfile: VFile;
   try {
     vfile = await remark()
       .use(remarkFrontmatter, [{ type: "yaml", marker: "-" }])
       .use(() => (_tree, file) => matter(file))
+      .use(() => (tree) => {
+        // Remove frontmatter nodes from the tree
+        if ("children" in tree && Array.isArray(tree.children)) {
+          tree.children = tree.children.filter((node) => node.type !== "yaml");
+        }
+      })
       .process(content);
   } catch (error) {
     return {
-      model: undefined,
+      frontmatter: { model: undefined },
+      content: content,
       error: "parseError",
       message: toErrorMessage(error),
     };
   }
 
+  const contentWithoutFrontmatter = String(vfile);
+
   if (!vfile.data.matter || Object.keys(vfile.data.matter).length === 0) {
     return {
-      model: undefined,
+      frontmatter: { model: undefined },
+      content: contentWithoutFrontmatter,
     };
   }
 
   const parseResult = WorkflowFrontmatter.safeParse(vfile.data.matter);
   if (!parseResult.success) {
     return {
-      model: undefined,
+      frontmatter: { model: undefined },
+      content: contentWithoutFrontmatter,
       error: "validationError",
       message: z.prettifyError(parseResult.error),
     };
@@ -47,6 +69,7 @@ export async function parseWorkflowFrontmatter(content: string | null) {
   const frontmatterData = parseResult.data;
 
   return {
-    model: frontmatterData.model,
+    frontmatter: { model: frontmatterData.model },
+    content: contentWithoutFrontmatter,
   };
 }

--- a/packages/vscode/src/lib/__test__/env.test.ts
+++ b/packages/vscode/src/lib/__test__/env.test.ts
@@ -745,7 +745,7 @@ describe("env.ts", () => {
       assert.strictEqual(workflow.id, "duplicate-workflow", "Workflow ID should be correct");
       
       // Check that the content is from the workspace workflow
-      assert.strictEqual(workflow.content, workspaceWorkflowContent, "Should use the content from the workspace workflow");
+      assert.strictEqual(workflow.content, "# Workspace Version\n\nThis is the workspace version\n", "Should use the content from the workspace workflow");
 
       // Check that the path is the workspace path, not the global one
       assert.ok(!workflow.path.startsWith("~"), "Path should be the workspace path, not global");

--- a/packages/vscode/src/lib/env.ts
+++ b/packages/vscode/src/lib/env.ts
@@ -5,7 +5,7 @@ import {
   collectAllRuleFiles as commonCollectAllRuleFiles,
   collectCustomRules as commonCollectCustomRules,
   getSystemInfo as getSystemInfoImpl,
-  parseWorkflowFrontmatter,
+  parseWorkflow,
 } from "@getpochi/common/tool-utils";
 import type { RuleFile } from "@getpochi/common/vscode-webui-bridge";
 import { uniqueBy } from "remeda";
@@ -137,8 +137,8 @@ export async function collectWorkflows(
             const fileUri = vscode.Uri.joinPath(workflowsDir, name);
             const absolutePath = fileUri.fsPath;
 
-            const content = await readFileContent(absolutePath);
-            const frontmatter = await parseWorkflowFrontmatter(content);
+            const fileContent = await readFileContent(absolutePath);
+            const { frontmatter, content } = await parseWorkflow(fileContent);
             // e.g., "workflow1.md" -> "workflow1"
             const fileName = name.replace(/\.md$/i, "");
 
@@ -153,7 +153,7 @@ export async function collectWorkflows(
             return {
               id: fileName,
               path: file,
-              content: content || "",
+              content,
               frontmatter,
             };
           }),


### PR DESCRIPTION
## Summary
This PR addresses an issue where the workflow parser was incorrectly including frontmatter in the workflow content. The `parseWorkflow` function has been updated to correctly separate the frontmatter from the content.

- Updates `parseWorkflow` to remove frontmatter from the content.
- Adjusts related tests in `packages/cli` and `packages/vscode` to account for the corrected parsing and newline behavior.

## Screenshot

### Before
<img width="1698" height="894" alt="image" src="https://github.com/user-attachments/assets/d921660d-9397-4145-ad53-594dfc63ecfc" />

### After
<img width="1936" height="952" alt="image" src="https://github.com/user-attachments/assets/a5d49ff7-9835-49fb-8a36-543d41c720cc" />


## Test plan
- All existing tests pass.
- Manually verified that workflows are loaded correctly without frontmatter in the content.

🤖 Generated with [Pochi](https://getpochi.com)