### PR TITLE
fix: Display correct Pochi server errors

### DIFF
--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -112,8 +112,21 @@ export function createPochiModel({
           responseHeaders[key] = value;
         });
 
+        let message = `Failed to fetch: ${resp.status} ${resp.statusText}`;
+
+        if (
+          resp.status >= 400 &&
+          resp.status < 600 &&
+          responseHeaders["content-type"]?.includes("text/plain")
+        ) {
+          const errorMessage = await resp.text();
+          if (errorMessage) {
+            message = errorMessage;
+          }
+        }
+
         throw new APICallError({
-          message: `Failed to fetch: ${resp.status} ${resp.statusText}`,
+          message,
           statusCode: resp.status,
           url: apiClient.api.chat.stream.$url().toString(),
           requestBodyValues: data,


### PR DESCRIPTION
This PR improves the display of error messages from the Pochi server.
Previously, generic 'Failed to fetch' messages were shown.
Now, if the server returns a text/plain error message with a 4xx or 5xx status code, the specific error message from the server will be displayed to the user.

## Screenshot

### Before
<img width="1198" height="406" alt="image" src="https://github.com/user-attachments/assets/d40ba016-856b-4cbf-a8f6-a78f74c201f0" />

### After
<img width="1412" height="354" alt="image" src="https://github.com/user-attachments/assets/0b5413f1-6fc6-45d1-a45d-49bf0637a2ef" />

🤖 Generated with [Pochi](https://getpochi.com)