### PR TITLE
fix: Display command in start background job panel when pending approval

### DIFF
--- a/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/command-execution-panel.tsx
@@ -130,7 +130,7 @@ const BackgroundJobIdButton: FC<{
 };
 
 export const CommandPanelContainer: FC<{
-  icon?: React.ReactNode;
+  icon: React.ReactNode;
   title: React.ReactNode;
   expanded?: boolean;
   actions?: React.ReactNode;

--- a/packages/vscode-webui/src/components/tool-invocation/tools/start-background-job.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/start-background-job.tsx
@@ -49,11 +49,7 @@ export const StartBackgroundJobTool: React.FC<
           <BackgroundJobPanel backgroundJobId={backgroundJobId} />
         ) : command ? (
           <CommandPanelContainer
-            icon={
-              <div className="flex size-[16px] items-center justify-between">
-                <TerminalIcon className="size-4" />
-              </div>
-            }
+            icon={<TerminalIcon className="mt-[2px] size-4 flex-shrink-0" />}
             title={command}
             actions={<CopyCommandButton command={command} />}
           />


### PR DESCRIPTION
This commit exports the `CopyCommandButton` and `CommandPanelContainer`
components from `command-execution-panel.tsx` to be used in
`start-background-job.tsx`. This allows the command to be displayed
in the `start-background-job` panel even when the job is pending approval.

## Screenshot

### Before
<img width="530" height="720" alt="image" src="https://github.com/user-attachments/assets/98eb7ac8-6ccb-4870-b835-c6b86b5ac209" />

### After
<img width="530" height="720" alt="image" src="https://github.com/user-attachments/assets/850f7f50-cd37-4a7e-a715-4549aeceb327" />



🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>