### PR TITLE
fix: Adjust task status display text in sidebar.

### DIFF
--- a/packages/vscode-webui/src/components/task-row/index.tsx
+++ b/packages/vscode-webui/src/components/task-row/index.tsx
@@ -5,7 +5,7 @@ import { parseTitle } from "@getpochi/common/message-utils";
 import { encodeStoreId } from "@getpochi/common/store-id-utils";
 import type { Task, UITools } from "@getpochi/livekit";
 import type { ToolUIPart } from "ai";
-import { GitBranch } from "lucide-react";
+import { GitBranch, Loader2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { useTranslation as UseTranslation } from "react-i18next";
@@ -135,6 +135,7 @@ function TaskStatusView({
     case "pending-tool": {
       return (
         <span className="flex items-center gap-2">
+          <Loader2 className="size-3.5 shrink-0 animate-spin" />
           <span>{t("tasksPage.taskStatus.planning")}</span>
         </span>
       );

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -201,7 +201,7 @@
     "cancel": "Cancel",
     "delete": "Delete",
     "taskStatus": {
-      "planning": "Planning next moves ...",
+      "planning": "Planning next moves",
       "error": "Error encountered",
       "finished": "Finished in {{duration}}"
     }

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -195,7 +195,7 @@
     "cancel": "キャンセル",
     "delete": "削除",
     "taskStatus": {
-      "planning": "次の動作を計画中...",
+      "planning": "次の動作を計画中",
       "error": "エラーが発生しました",
       "finished": "{{duration}} で完了"
     }

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -195,7 +195,7 @@
     "cancel": "취소",
     "delete": "삭제",
     "taskStatus": {
-      "planning": "다음 작업 계획 중...",
+      "planning": "다음 작업 계획 중",
       "error": "오류 발생",
       "finished": "{{duration}} 만에 완료"
     }

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -194,7 +194,7 @@
     "cancel": "取消",
     "delete": "删除",
     "taskStatus": {
-      "planning": "正在规划下一步操作...",
+      "planning": "正在规划下一步操作",
       "error": "遇到错误",
       "finished": "已完成，耗时 {{duration}}"
     }


### PR DESCRIPTION
## Summary
- Adjust task status display text in sidebar.

## Screenshot
<img width="780" height="420" alt="image" src="https://github.com/user-attachments/assets/e77b7d1b-717e-41e5-8df9-6261840d5d7a" />


## Test plan
- Verify that the task status display text in the sidebar is correctly adjusted.

🤖 Generated with [Pochi](https://getpochi.com)