### PR TITLE
fix(vscode-webui): ensure task title exists before updating task

### DIFF
--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -274,7 +274,7 @@ function Chat({ user, uid, prompt, files }: ChatProps) {
         : pendingToolApproval.tools
       : undefined;
 
-    if (task) {
+    if (task?.title) {
       vscodeHost.onTaskUpdated(
         Schema.encodeSync(taskCatalog.events.tastUpdated.schema)(
           taskCatalog.events.tastUpdated({


### PR DESCRIPTION
## Summary
Check \`task?.title\` instead of just \`task\` to prevent updates with missing titles.

## Test plan
- Verified that the code compiles and tests pass.

🤖 Generated with [Pochi](https://getpochi.com)