### PR TITLE
fix(vscode-webui): adjust worktree select max width

### DIFF
--- a/packages/vscode-webui/src/components/worktree-select.tsx
+++ b/packages/vscode-webui/src/components/worktree-select.tsx
@@ -82,7 +82,7 @@ export function WorktreeSelect({
             <Button
               variant="ghost"
               className={cn(
-                "!px-1 button-focus h-6 max-w-full items-center py-0 font-normal",
+                "!px-1 button-focus h-6 max-w-[40vw] items-center py-0 font-normal",
                 triggerClassName,
               )}
             >


### PR DESCRIPTION
## Summary
- Adjust the maximum width of the worktree select component to 40vw to prevent it from taking up too much space.

## Screenshot
<img width="720" height="389" alt="image" src="https://github.com/user-attachments/assets/0a2c3b67-bf95-4378-a00b-90c83d72be11" />


## Test plan
- Verify that the worktree select component has a maximum width of 40vw in the UI.

🤖 Generated with [Pochi](https://getpochi.com)