### PR TITLE
feat(worktree): add prunable state handling and default branch retrieval

### DIFF
--- a/packages/common/src/vscode-webui-bridge/types/git.ts
+++ b/packages/common/src/vscode-webui-bridge/types/git.ts
@@ -3,4 +3,5 @@ export interface GitWorktree {
   branch?: string;
   commit: string;
   isMain: boolean;
+  prunable?: string;
 }

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -35,7 +35,7 @@ import * as vscode from "vscode";
 import { PochiConfiguration } from "./configuration";
 import { DiffChangesContentProvider } from "./editor/diff-changes-content-provider";
 // biome-ignore lint/style/useImportType: needed for dependency injection
-import { WorktreeManager, showWorktreeDiff } from "./git/worktree";
+import { WorktreeManager } from "./git/worktree";
 import { PochiTaskEditorProvider } from "./webview/webview-panel";
 const logger = getLogger("CommandManager");
 
@@ -479,7 +479,7 @@ export class CommandManager implements vscode.Disposable {
             activeTab.input.uri,
           );
           if (params?.cwd) {
-            await showWorktreeDiff(params.cwd);
+            await this.worktreeManager.showWorktreeDiff(params.cwd);
           }
         }
       }),
@@ -488,7 +488,7 @@ export class CommandManager implements vscode.Disposable {
         "pochi.worktree.openDiff",
         async (worktreePath: string) => {
           if (worktreePath) {
-            await showWorktreeDiff(worktreePath);
+            await this.worktreeManager.showWorktreeDiff(worktreePath);
           }
         },
       ),

--- a/packages/vscode/src/integrations/git/__tests__/worktree.test.ts
+++ b/packages/vscode/src/integrations/git/__tests__/worktree.test.ts
@@ -209,5 +209,31 @@ branch refs/heads/master
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0].isMain, true);
     });
+
+    it("should parse prunable worktree correctly", () => {
+      const output = `worktree /path/to/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /path/to/worktrees/old-feature
+HEAD def456
+branch refs/heads/old-feature
+prunable gitdir file points to non-existent location
+
+`;
+
+      // @ts-ignore - accessing private method for testing
+      const result = worktreeManager.parseWorktreePorcelain(output);
+
+      assert.strictEqual(result.length, 2);
+      assert.strictEqual(result[0].isMain, true);
+      assert.strictEqual(result[0].prunable, undefined);
+      assert.strictEqual(result[1].isMain, false);
+      assert.strictEqual(result[1].path, "/path/to/worktrees/old-feature");
+      assert.strictEqual(
+        result[1].prunable,
+        "gitdir file points to non-existent location",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add prunable state handling to GitWorktree interface to identify worktrees that can be removed
- Implement default branch retrieval functionality to get the correct base branch for worktree diffs
- Update worktree parsing to handle prunable worktrees and filter them out from the worktree list
- Move showWorktreeDiff function to WorktreeManager class and update references
- Add tests for prunable worktree parsing

## Test plan
- Verify that prunable worktrees are properly identified and filtered from the worktree list
- Test that default branch is correctly retrieved for worktree diffs
- Run existing tests to ensure no regressions

🤖 Generated with [Pochi](https://getpochi.com)