### PR TITLE
fix(vscode-webui): adjust worktree and task row ui

### DIFF
--- a/packages/vscode-webui/src/components/task-row/index.tsx
+++ b/packages/vscode-webui/src/components/task-row/index.tsx
@@ -28,7 +28,7 @@ export function TaskRow({
     <div
       className={cn(
         "group cursor-pointer rounded-lg border border-border/50 bg-card transition-all duration-200 hover:border-border hover:bg-card/90 hover:shadow-md",
-        "border-l-4",
+        "border-l-2",
         getStatusBorderColor(task.status),
       )}
     >

--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useTaskReadStatusStore } from "@/features/chat";
 import { useWorktrees } from "@/lib/hooks/use-worktrees";
+import { cn } from "@/lib/utils";
 import { getWorktreeNameFromWorktreePath } from "@getpochi/common/git-utils";
 import type { Task } from "@getpochi/livekit";
 import {
@@ -189,10 +190,10 @@ function WorktreeSection({
     <Collapsible
       open={isExpanded}
       onOpenChange={setIsExpanded}
-      className="mb-2 rounded-lg border shadow-sm"
+      className="mb-2"
     >
       <div
-        className="flex items-center justify-between px-3 py-1"
+        className="group flex h-6 items-center gap-2 px-1"
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => {
           setIsHovered(false);
@@ -201,23 +202,30 @@ function WorktreeSection({
       >
         {group.isDeleted ? (
           <CollapsibleTrigger asChild>
-            <div className="flex cursor-pointer select-none items-center gap-2">
+            <div className="flex cursor-pointer select-none items-center gap-2 truncate font-medium text-sm">
               {isExpanded ? (
                 <ChevronDown className="size-4" />
               ) : (
                 <ChevronRight className="size-4" />
               )}
-              <span className="font-semibold">{group.name}</span>
+              <span>{group.name}</span>
             </div>
           </CollapsibleTrigger>
         ) : (
-          <div className="flex items-center truncate">
-            <span className="font-semibold">{group.name}</span>
+          <div className="flex items-center truncate font-bold">
+            <span>{group.name}</span>
           </div>
         )}
 
-        <div className="flex items-center gap-1">
-          {!group.isDeleted && isHovered && (
+        <div
+          className={cn(
+            "flex items-center gap-1 transition-opacity duration-200",
+            !isHovered && !showDeleteConfirm
+              ? "pointer-events-none opacity-0"
+              : "opacity-100",
+          )}
+        >
+          {!group.isDeleted && (
             <>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -340,7 +348,7 @@ function WorktreeSection({
       </div>
 
       <CollapsibleContent>
-        <ScrollArea viewportClassname="max-h-[200px] border-t px-1 py-1">
+        <ScrollArea viewportClassname="max-h-[230px] px-1 py-1">
           {group.tasks.length > 0 ? (
             group.tasks.map((task) => {
               const isRead = !unreadTaskIds.has(task.id);
@@ -352,7 +360,7 @@ function WorktreeSection({
               );
             })
           ) : (
-            <div className="py-1 text-center text-muted-foreground text-xs">
+            <div className="py-1 text-muted-foreground text-xs">
               {t("tasksPage.emptyState.description")}
             </div>
           )}

--- a/packages/vscode-webui/src/routes/index.tsx
+++ b/packages/vscode-webui/src/routes/index.tsx
@@ -85,7 +85,7 @@ function Tasks() {
       ) : (
         <div className="min-h-0 flex-1 pt-4">
           <ScrollArea className="h-full">
-            <div className="flex flex-col gap-4 p-4 pb-6">
+            <div className="flex flex-col gap-4 px-4 pb-6">
               <WorktreeList tasks={[...tasks]} />
             </div>
           </ScrollArea>


### PR DESCRIPTION

<img width="768" height="1406" alt="image" src="https://github.com/user-attachments/assets/8e251d07-cff5-4239-a423-9dbf4ad72ac7" />


- reduce task row left border width
- refine worktree section styles for a cleaner look
- improve hover effects and layout in worktree list

🤖 Generated with [Pochi](https://getpochi.com)