### PR TITLE
fix(vscode): fix handle delete created file in checkpoint

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
+++ b/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
@@ -272,8 +272,6 @@ export class CheckpointService implements vscode.Disposable {
         } else {
           result.push(file);
         }
-      } else {
-        result.push(file);
       }
     }
 


### PR DESCRIPTION
This commit removes a redundant `else` block in `CheckpointService`.

🤖 Generated with [Pochi](https://getpochi.com)