### PR TITLE
fix(vscode-webui): adjust diff summary and todo list styling

### DIFF
--- a/packages/vscode-webui/src/components/diff-summary.tsx
+++ b/packages/vscode-webui/src/components/diff-summary.tsx
@@ -7,10 +7,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useTaskChangedFiles } from "@/features/chat";
+import type { useTaskChangedFiles } from "@/features/chat";
 import { cn } from "@/lib/utils";
 import { vscodeHost } from "@/lib/vscode";
-import type { Message } from "@getpochi/livekit";
 import {
   Check,
   ChevronDown,
@@ -34,26 +33,21 @@ const collapsibleSectionVariants = {
   },
 };
 
-export interface DiffSummaryProps {
-  messages: Message[];
-  taskId: string;
-  className?: string;
+export interface DiffSummaryProps
+  extends ReturnType<typeof useTaskChangedFiles> {
   actionEnabled: boolean;
+  className?: string;
 }
 
 export function DiffSummary({
-  messages,
-  taskId,
-  className,
+  visibleChangedFiles,
+  showFileChanges,
+  revertFileChanges,
+  acceptChangedFile,
   actionEnabled,
+  className,
 }: DiffSummaryProps) {
   const { t } = useTranslation();
-  const {
-    visibleChangedFiles,
-    showFileChanges,
-    revertFileChanges,
-    acceptChangedFile,
-  } = useTaskChangedFiles(taskId, messages, actionEnabled);
 
   const [collapsed, setCollapsed] = useState(true);
 
@@ -105,7 +99,7 @@ export function DiffSummary({
             variant="default"
             size="xs"
             onClick={() => acceptChangedFile()}
-            className="h-7 gap-1.5"
+            className="h-6 gap-1.5"
           >
             {t("diffSummary.keep")}
           </Button>
@@ -114,7 +108,7 @@ export function DiffSummary({
             variant="outline"
             size="xs"
             onClick={() => revertFileChanges()}
-            className="h-7 gap-1.5"
+            className="h-6 gap-1.5"
           >
             {t("diffSummary.undo")}
           </Button>

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -13,7 +13,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { ApprovalButton, type useApprovalAndRetry } from "@/features/approval";
-import { useAutoApproveGuard } from "@/features/chat";
+import { useAutoApproveGuard, useTaskChangedFiles } from "@/features/chat";
 import { useSelectedModels } from "@/features/settings";
 import { AutoApproveMenu } from "@/features/settings";
 import { TodoList, useTodos } from "@/features/todo";
@@ -190,6 +190,13 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     [messages],
   );
 
+  const diffSummaryActionEnabled = !isLoading && !isExecuting;
+  const useTaskChangedFilesHelpers = useTaskChangedFiles(
+    task?.id as string,
+    messages,
+    diffSummaryActionEnabled,
+  );
+
   return (
     <>
       <div className="-translate-y-full -top-2 absolute left-0 w-full px-4 pt-1">
@@ -205,26 +212,24 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           />
         </div>
       </div>
-      <div
-        className={cn("mt-1.5 rounded-md ", {
-          "border border-border": todos.length > 0,
-        })}
-      >
-        {todos && todos.length > 0 && (
-          <TodoList todos={todos}>
-            <TodoList.Header />
-            <TodoList.Items viewportClassname="max-h-48" />
-          </TodoList>
-        )}
-        <DiffSummary
-          messages={messages}
-          taskId={task?.id as string}
-          actionEnabled={!isLoading && !isExecuting}
-          className={cn({
-            "border-border border-t": todos.length > 0,
-          })}
-        />
-      </div>
+      {(todos.length > 0 ||
+        useTaskChangedFilesHelpers.changedFiles.length > 0) && (
+        <div className={cn("mt-1.5 rounded-md border border-border")}>
+          {todos.length > 0 && (
+            <TodoList todos={todos}>
+              <TodoList.Header />
+              <TodoList.Items viewportClassname="max-h-48" />
+            </TodoList>
+          )}
+          <DiffSummary
+            {...useTaskChangedFilesHelpers}
+            actionEnabled={diffSummaryActionEnabled}
+            className={cn({
+              "border-border border-t": todos.length > 0,
+            })}
+          />
+        </div>
+      )}
       <AutoApproveMenu isSubTask={isSubTask} />
       {files.length > 0 && (
         <AttachmentPreviewList

--- a/packages/vscode-webui/src/features/todo/components/todo-list.tsx
+++ b/packages/vscode-webui/src/features/todo/components/todo-list.tsx
@@ -223,14 +223,14 @@ function TodoListItems({
         variants={collapsibleSectionVariants}
         className="overflow-hidden"
       >
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-0.5">
           <AnimatePresence mode="popLayout">
             {displayTodos.map((todo, idx) => (
               <motion.div
                 id={`todo-item-${todo.id}`}
                 key={todo.id}
                 className={cn(
-                  "flex items-start space-x-2.5 rounded-sm p-1 transition-colors",
+                  "flex items-start space-x-2.5 rounded-sm px-1 py-0.5 transition-colors",
                   "hover:bg-accent/5",
                 )}
                 variants={todoItemVariants}


### PR DESCRIPTION
## Summary
- Reduce vertical padding of keep / undo buttons in diff summary.
- Adjust changed summary styling and conditional rendering in chat toolbar.
- Reduce gap and padding in todo list items.

## Screenshot

### Before
<img width="1044" height="178" alt="image" src="https://github.com/user-attachments/assets/613b9a8d-354a-44ff-8c4e-b545c4a7f384" />

### After
<img width="1044" height="180" alt="image" src="https://github.com/user-attachments/assets/fd462bb1-b329-4fca-a593-b4483eacf8f7" />


## Test plan
- Verify the visual changes in the diff summary component (smaller buttons).
- Verify the todo list items spacing.
- Check the chat toolbar changed files summary appearance.

🤖 Generated with [Pochi](https://getpochi.com)