### PR TITLE
fix(vscode): reduce log verbosity and optimize workspace job queue

### DIFF
--- a/packages/vscode/src/lib/workspace-job.ts
+++ b/packages/vscode/src/lib/workspace-job.ts
@@ -55,6 +55,10 @@ export class WorkspaceJobQueue implements vscode.Disposable {
       [],
     );
 
+    if (allJobs.length === 0) {
+      return;
+    }
+
     logger.trace(`Running workspace job queue with ${allJobs.length} jobs.`);
 
     const currentWorkspaceJobs: WorkspaceJob[] = [];

--- a/packages/vscode/src/nes/decoration-manager.ts
+++ b/packages/vscode/src/nes/decoration-manager.ts
@@ -386,9 +386,9 @@ export class NESDecorationManager implements vscode.Disposable {
   }
 
   async accept() {
-    logger.debug("Accepting the current edit suggestion");
+    logger.trace("Accepting the current edit suggestion");
     if (!this.current) {
-      logger.debug("No current edit suggestion to accept");
+      logger.trace("No current edit suggestion to accept");
       return;
     }
     const { editor, solution } = this.current;
@@ -423,18 +423,18 @@ export class NESDecorationManager implements vscode.Disposable {
   }
 
   reject() {
-    logger.debug("Rejecting the current edit suggestion");
+    logger.trace("Rejecting the current edit suggestion");
     this.hide();
   }
 
   dismiss() {
-    logger.debug("Dismissing the current edit suggestion");
+    logger.trace("Dismissing the current edit suggestion");
     this.hide();
   }
 
   private hide() {
     if (!this.current) {
-      logger.debug("No current edit suggestion to hide");
+      logger.trace("No current edit suggestion to hide");
       return;
     }
     const { editor } = this.current;

--- a/packages/vscode/src/nes/index.ts
+++ b/packages/vscode/src/nes/index.ts
@@ -76,13 +76,13 @@ export class NESProvider implements vscode.Disposable {
       return undefined;
     }
 
-    logger.debug("Begin provide NES");
-
     const editHistory = this.editHistoryTracker.getEditSteps(document);
     if (!editHistory || editHistory.length === 0) {
       logger.debug("The current document is not being edited.");
       return undefined;
     }
+
+    logger.debug("Begin provide NES");
 
     const context = await buildNESRequestContext({
       document,
@@ -135,7 +135,8 @@ export class NESProvider implements vscode.Disposable {
           token,
         );
         if (result) {
-          logger.debug("Result received", result);
+          logger.debug("Result received");
+          logger.trace("Result: ", result);
           responseItem = result;
         } else {
           logger.debug("No result received");
@@ -147,7 +148,7 @@ export class NESProvider implements vscode.Disposable {
         const added = solution.addItem(responseItem);
         if (added) {
           this.cache.set(context.hash, responseItem);
-          logger.debug("Result cached", responseItem);
+          logger.debug("Result cached");
         }
         return solution;
       }
@@ -237,7 +238,7 @@ class NESInlineCompletionProvider
       }
       this.cancellationTokenSource = tokenSource;
 
-      logger.debug(
+      logger.trace(
         `Trigger NES from InlineCompletionProvider, document: ${document.uri.toString()}`,
       );
       const version = document.version;
@@ -334,7 +335,7 @@ class NESEditorListener implements vscode.Disposable {
             const tokenSource = new vscode.CancellationTokenSource();
             this.cancellationTokenSource = tokenSource;
 
-            logger.debug(
+            logger.trace(
               `Trigger NES from TextEditorSelectionChange, document: ${document.uri.toString()}`,
             );
             const version = document.version;


### PR DESCRIPTION
## Summary
- Change log level from debug to trace for NES decoration manager and provider to reduce noise.
- Add early return in workspace job queue when there are no jobs to optimize performance.

## Test plan
- Verify that NES logs are less verbose in trace mode.
- Verify that workspace job queue processes correctly and returns early when empty.
- Existing tests passed.

🤖 Generated with [Pochi](https://getpochi.com)