### PR TITLE
fix(vscode-webui): filter out non-current worktree files in mention suggestions

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -181,7 +181,7 @@ export function FormEditor({
 
               return fuzzySearchFiles(query, {
                 files: data.files,
-                activeTabs: activeTabsRef.current,
+                activeTabs: getActiveTabsInCwd(activeTabsRef.current),
               });
             },
             render: () => {
@@ -198,7 +198,7 @@ export function FormEditor({
 
                 return fuzzySearchFiles(query, {
                   files: data.files,
-                  activeTabs: activeTabsRef.current,
+                  activeTabs: getActiveTabsInCwd(activeTabsRef.current),
                 });
               };
 
@@ -681,3 +681,12 @@ export const debouncedListSlashCommand = debounceWithCachedValue(
     leading: true,
   },
 );
+
+const getActiveTabsInCwd = (
+  activeTabs: {
+    filepath: string;
+    isDir: boolean;
+  }[],
+) => {
+  return activeTabs.filter((x) => !x.filepath.startsWith("../"));
+};


### PR DESCRIPTION
## Summary
Filters out files that are not in the current working directory (starting with `../`) from the active tabs suggestions in the mention menu.

## Test plan
Verify that when mentioning files, only files within the current workspace/worktree are suggested.

🤖 Generated with [Pochi](https://getpochi.com)