### PR TITLE
fix(vscode-webui): When both todolist / diff summary exist, their divide border should be straight line

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -225,7 +225,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             {...useTaskChangedFilesHelpers}
             actionEnabled={diffSummaryActionEnabled}
             className={cn({
-              "border-border border-t": todos.length > 0,
+              "rounded-t-none border-border border-t": todos.length > 0,
             })}
           />
         </div>


### PR DESCRIPTION
## Summary
- Added `rounded-t-none` to the `ChatToolbar` class list when todos are present to ensure the border between the todolist and diff summary is a straight line.

## Screenshot
<img width="1068" height="644" alt="image" src="https://github.com/user-attachments/assets/7ec99374-6b6e-43ba-9141-f91f9cfff634" />

----

<img width="1034" height="252" alt="image" src="https://github.com/user-attachments/assets/74ceb7f2-e19a-4c19-98af-7f7274f5d149" />


## Test plan
- Verify that the border between the todolist and diff summary in the chat toolbar is a straight line when both are visible.

🤖 Generated with [Pochi](https://getpochi.com)