### PR TITLE
feat(vscode-webui): improve worktree list handling when no worktrees exist

### DIFF
--- a/packages/vscode/src/integrations/git/git-state.ts
+++ b/packages/vscode/src/integrations/git/git-state.ts
@@ -32,7 +32,11 @@ export class GitStateMonitor implements vscode.Disposable {
 
   private gitExtension: GitExtension | undefined;
   private gitAPI: API | undefined;
-  private repositories = new Map<string, GitRepositoryState>();
+  private repositoryState = new Map<string, GitRepositoryState>();
+
+  get repositories(): string[] {
+    return Array.from(this.repositoryState.keys());
+  }
 
   readonly #onDidChangeGitState =
     new vscode.EventEmitter<GitStateChangeEvent>();
@@ -148,7 +152,7 @@ export class GitStateMonitor implements vscode.Disposable {
       }
 
       // Remove repository state
-      this.repositories.delete(repoKey);
+      this.repositoryState.delete(repoKey);
     } catch (error) {
       logger.debug("Failed to handle repository closed event:", error);
     }
@@ -159,10 +163,10 @@ export class GitStateMonitor implements vscode.Disposable {
   ): Promise<void> {
     try {
       const repoKey = repository.rootUri.toString();
-      const previousState = this.repositories.get(repoKey);
+      const previousState = this.repositoryState.get(repoKey);
       const currentState = this.buildRepositoryState(repository);
 
-      this.repositories.set(repoKey, currentState);
+      this.repositoryState.set(repoKey, currentState);
 
       if (
         previousState &&
@@ -208,7 +212,7 @@ export class GitStateMonitor implements vscode.Disposable {
     for (const disposable of this.disposables) {
       disposable.dispose();
     }
-    this.repositories.clear();
+    this.repositoryState.clear();
 
     logger.debug("Git state monitor disposed");
   }


### PR DESCRIPTION
## Summary
- Add fallback to show current workspace as default worktree when no git worktrees exist
- Add loading state handling in WorktreeList component
- Rename repositories map to repositoryState in GitStateMonitor for clarity
- Ensure worktree order matches VSCode's repository order
- Filter out non-text files from diff display

## Test plan
- [ ] Verify that worktree list displays properly when no git worktrees exist
- [ ] Check that the current workspace is shown as the default worktree
- [ ] Test that loading states are properly handled
- [ ] Confirm that worktree ordering matches VSCode's repository order
- [ ] Verify that non-text files are properly filtered from diff display

🤖 Generated with [Pochi](https://getpochi.com)