### PR TITLE
fix(vscode-webui): prevent branch name overlap in task row

### DIFF
--- a/packages/vscode-webui/src/components/task-row/index.tsx
+++ b/packages/vscode-webui/src/components/task-row/index.tsx
@@ -113,7 +113,7 @@ function GitBadge({
   if (!git?.origin || !git?.branch) return null;
 
   return (
-    <div className="inline-flex items-center gap-1 text-muted-foreground/80 text-sm">
+    <div className="flex min-w-0 items-center gap-1 text-muted-foreground/80 text-sm">
       <GitBranch className="size-3 shrink-0" />
       <span className="truncate">{git.branch}</span>
     </div>


### PR DESCRIPTION

<img width="436" height="188" alt="image" src="https://github.com/user-attachments/assets/4e11a468-d4af-48a4-a093-9d980b36c9a4" />



## Summary
- Fixes layout issue in task row component where long branch names would cause overlap with edit summary
- Updates GitBadge component to use `flex min-w-0` instead of `inline-flex` to allow proper truncation

## Test plan
- [ ] Verify that long branch names are properly truncated without overlapping other elements
- [ ] Confirm that the edit summary remains visible and correctly positioned
- [ ] Test with various branch name lengths to ensure responsive behavior

🤖 Generated with [Pochi](https://getpochi.com)