### PR TITLE
fix(vscode): fix not switching to new worktree after creation

### DIFF
--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -106,7 +106,7 @@ export class WorktreeManager implements vscode.Disposable {
     await vscode.commands.executeCommand("git.createWorktree");
 
     // Get worktrees again to find the new one
-    const updatedWorktrees = await this.getWorktrees();
+    const updatedWorktrees = await this.getWorktrees(true);
     // Find the new worktree by comparing with previous worktrees
     const newWorktree = updatedWorktrees.find(
       (updated) =>
@@ -152,14 +152,16 @@ export class WorktreeManager implements vscode.Disposable {
     await showWorktreeDiff(cwd, baseBranch);
   }
 
-  async getWorktrees(): Promise<GitWorktree[]> {
+  async getWorktrees(skipVSCodeFilter?: boolean): Promise<GitWorktree[]> {
     try {
-      const vscodeRepos = this.gitStateMonitor.repositories.map(
-        (uri) => vscode.Uri.parse(uri).fsPath,
-      );
       const result = await this.git.raw(["worktree", "list", "--porcelain"]);
       const worktrees = this.parseWorktreePorcelain(result).filter(
         (wt) => wt.prunable === undefined,
+      );
+      if (skipVSCodeFilter) return worktrees;
+
+      const vscodeRepos = this.gitStateMonitor.repositories.map(
+        (uri) => vscode.Uri.parse(uri).fsPath,
       );
       // keep the worktree order and number same as vscode
       return vscodeRepos


### PR DESCRIPTION
## Summary
- Fixed an issue where the VSCode extension was not switching to the newly created worktree.

## Screen recording
https://jam.dev/c/c42eaa02-5465-4cd7-a42b-20de704554d6

## Test plan
- [ ] Create a new worktree and verify that the extension switches to it automatically.

🤖 Generated with [Pochi](https://getpochi.com)