### PR TITLE
fix(vscode): revert add timeout after worktree creation

### DIFF
--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -105,9 +105,6 @@ export class WorktreeManager implements vscode.Disposable {
 
     await vscode.commands.executeCommand("git.createWorktree");
 
-    // FIXME(zhanba): Wait for a moment to let Git finish creating the worktree
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
     // Get worktrees again to find the new one
     const updatedWorktrees = await this.getWorktrees();
     // Find the new worktree by comparing with previous worktrees


### PR DESCRIPTION
Reverts TabbyML/pochi#783