### PR TITLE
fix(vscode): remove unnecessary timeout after worktree creation

### DIFF
--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -105,9 +105,6 @@ export class WorktreeManager implements vscode.Disposable {
 
     await vscode.commands.executeCommand("git.createWorktree");
 
-    // FIXME(zhanba): Wait for a moment to let Git finish creating the worktree
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
     // Get worktrees again to find the new one
     const updatedWorktrees = await this.getWorktrees(true);
     // Find the new worktree by comparing with previous worktrees


### PR DESCRIPTION
## Summary
- Remove the hardcoded 1-second timeout that was waiting for Git to finish creating the worktree
- Remove the FIXME comment that indicated this was a temporary solution
- The timeout and comment were no longer needed as the underlying issue has been resolved

## Test plan
- [ ] Verify that worktree creation still functions properly without the timeout
- [ ] Ensure no regressions in the git worktree functionality
- [ ] Confirm that the extension tests pass

🤖 Generated with [Pochi](https://getpochi.com)