### PR TITLE
refactor(livekit-cf): make webhook secret required and update URL handling

### DIFF
--- a/packages/livekit-cf/src/do/livestore-client/do.ts
+++ b/packages/livekit-cf/src/do/livestore-client/do.ts
@@ -38,8 +38,12 @@ export class LiveStoreClientDO
 
   async signalKeepAlive(storeId: string): Promise<void> {
     this.storeId = storeId;
-    if (this.env.WEBHOOK_URL && !this.webhook) {
-      this.webhook = new WebhookDelivery(this.storeId, this.env.WEBHOOK_URL);
+    if (this.env.WEBHOOK_URL && this.env.WEBHOOK_SECRET && !this.webhook) {
+      this.webhook = new WebhookDelivery(
+        this.storeId,
+        this.env.WEBHOOK_URL,
+        this.env.WEBHOOK_SECRET,
+      );
     }
 
     await this.subscribeToStoreUpdates();

--- a/packages/livekit-cf/src/lib/webhook-delivery.ts
+++ b/packages/livekit-cf/src/lib/webhook-delivery.ts
@@ -5,6 +5,7 @@ export class WebhookDelivery {
   constructor(
     private readonly storeId: string,
     private readonly url: string,
+    private readonly secret: string,
   ) {}
 
   async onTaskUpdated(
@@ -30,6 +31,7 @@ export class WebhookDelivery {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${this.secret}`,
       },
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(1500),

--- a/packages/livekit-cf/src/types.ts
+++ b/packages/livekit-cf/src/types.ts
@@ -10,6 +10,7 @@ export type Env = {
   ENVIRONMENT: "dev" | "prod" | undefined;
   ASSETS: CfTypes.Fetcher;
   WEBHOOK_URL?: string;
+  WEBHOOK_SECRET?: string;
   CACHE: CfTypes.KVNamespace;
 };
 


### PR DESCRIPTION
This PR refactors the webhook delivery logic in `packages/livekit-cf`.

## Summary
- Made `WEBHOOK_SECRET` a required environment variable for `WebhookDelivery`.
- Updated `WebhookDelivery` constructor to strictly use the provided `secret` for authorization.
- Modified `LiveStoreClientDO` to only instantiate `WebhookDelivery` if both `WEBHOOK_URL` and `WEBHOOK_SECRET` are present.
- Removed automatic appending of `/livekit-cf` to the webhook URL within `WebhookDelivery`, relying on the environment variable to contain the full and correct URL.

## Test plan
- Unit tests for `WebhookDelivery` were created and passed, covering URL usage and authorization header logic.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>