### PR TITLE
refactor: remove non-interactive mode references from tools and tests

### DIFF
--- a/packages/cli/src/tools/apply-diff.ts
+++ b/packages/cli/src/tools/apply-diff.ts
@@ -4,9 +4,6 @@ import { resolvePath, validateTextFile } from "@getpochi/common/tool-utils";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 import { ensureFileDirectoryExists } from "../lib/fs";
 
-/**
- * Apply a diff to a file using DiffView
- */
 export const applyDiff =
   (): ToolFunctionType<ClientTools["applyDiff"]> =>
   async (

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -60,7 +60,6 @@ export interface VSCodeHostApi {
       toolCallId: string;
       state: "partial-call" | "call" | "result";
       abortSignal?: ThreadAbortSignalSerialization;
-      nonInteractive?: boolean;
     },
   ): Promise<PreviewReturnType>;
 
@@ -79,7 +78,6 @@ export interface VSCodeHostApi {
     options: {
       toolCallId: string;
       abortSignal: ThreadAbortSignalSerialization;
-      nonInteractive?: boolean;
       contentType?: string[];
     },
   ): Promise<unknown>;

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -11,7 +11,6 @@ import type { EditFileOutputSchema } from "./constants";
 export type ToolFunctionType<T extends Tool> = (
   input: InferToolInput<T>,
   options: ToolCallOptions & {
-    nonInteractive?: boolean;
     cwd: string;
     contentType?: string[];
   },
@@ -29,6 +28,5 @@ export type PreviewToolFunctionType<T extends Tool> = (
     state: "partial-call" | "call" | "result";
     abortSignal?: AbortSignal;
     cwd: string;
-    nonInteractive?: boolean;
   },
 ) => Promise<PreviewReturnType>;

--- a/packages/vscode-webui/src/components/tool-invocation/tools/new-task/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/components/tool-invocation/tools/new-task/use-live-sub-task.tsx
@@ -122,7 +122,6 @@ export function useLiveSubTask(
           abortSignal: ThreadAbortSignal.serialize(
             abortController.current.signal,
           ),
-          nonInteractive: true,
           contentType: customAgentModel?.contentType,
         },
       );

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -218,7 +218,6 @@ export class ManagedToolCallLifeCycle
         state: convertState(state),
         toolCallId: this.toolCallId,
         abortSignal: ThreadAbortSignal.serialize(abortSignal),
-        nonInteractive: globalThis.POCHI_WEBVIEW_KIND === "pane",
       })
       .then((result) => {
         this.transitTo("ready", {
@@ -258,7 +257,6 @@ export class ManagedToolCallLifeCycle
         state: convertState(state),
         toolCallId: this.toolCallId,
         abortSignal: ThreadAbortSignal.serialize(abortSignal),
-        nonInteractive: globalThis.POCHI_WEBVIEW_KIND === "pane",
       });
     };
 
@@ -326,7 +324,6 @@ export class ManagedToolCallLifeCycle
         toolCallId: this.toolCallId,
         abortSignal: ThreadAbortSignal.serialize(abortSignal),
         contentType: options?.contentType,
-        nonInteractive: globalThis.POCHI_WEBVIEW_KIND === "pane",
       });
     }
 

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -365,7 +365,6 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       options: {
         toolCallId: string;
         abortSignal: ThreadAbortSignalSerialization;
-        nonInteractive?: boolean;
         contentType?: string[];
       },
     ) => {
@@ -397,7 +396,6 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
           abortSignal,
           messages: [],
           toolCallId: options.toolCallId,
-          nonInteractive: options.nonInteractive,
           cwd: this.cwd,
           contentType: options.contentType,
         }),
@@ -437,7 +435,6 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
         toolCallId: string;
         state: "partial-call" | "call" | "result";
         abortSignal?: ThreadAbortSignalSerialization;
-        nonInteractive?: boolean;
       },
     ) => {
       const tool = ToolPreviewMap[toolName];
@@ -465,7 +462,6 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
           ...options,
           abortSignal,
           cwd: this.cwd,
-          nonInteractive: options.nonInteractive,
         }),
       );
     },

--- a/packages/vscode/src/tools/__test__/apply-diff.test.ts
+++ b/packages/vscode/src/tools/__test__/apply-diff.test.ts
@@ -88,7 +88,6 @@ describe("applyDiff Tool", () => {
         toolCallId: "test-call-id-123",
         messages: [],
         cwd: testSuiteRootTempDir.fsPath,
-        nonInteractive: true,
       },
     );
 
@@ -115,7 +114,6 @@ describe("applyDiff Tool", () => {
         toolCallId: "test-call-id-123",
         messages: [],
         cwd: testSuiteRootTempDir.fsPath,
-        nonInteractive: true,
       },
     );
 
@@ -126,4 +124,3 @@ describe("applyDiff Tool", () => {
     );
   });
 });
-

--- a/packages/vscode/src/tools/__test__/write-to-file.test.ts
+++ b/packages/vscode/src/tools/__test__/write-to-file.test.ts
@@ -73,7 +73,7 @@ describe("writeToFile Tool", () => {
   });
 
   describe("writeToFile", () => {
-    it("should create a new file in non-interactive mode", async () => {
+    it("should create a new file", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "new-file.txt",
@@ -90,7 +90,6 @@ describe("writeToFile Tool", () => {
           toolCallId: "test-call-id-123",
           messages: [],
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -99,7 +98,7 @@ describe("writeToFile Tool", () => {
       assert.strictEqual(fileContent.toString(), content);
     });
 
-    it("should overwrite existing file in non-interactive mode", async () => {
+    it("should overwrite existing file", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "existing-file.txt",
@@ -119,7 +118,6 @@ describe("writeToFile Tool", () => {
           toolCallId: "test-call-id-123",
           messages: [],
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -147,7 +145,6 @@ describe("writeToFile Tool", () => {
           toolCallId: "test-call-id-123",
           messages: [],
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -156,7 +153,7 @@ describe("writeToFile Tool", () => {
       assert.strictEqual(fileContent.toString(), content);
     });
 
-    it("should handle absolute paths in non-interactive mode", async () => {
+    it("should handle absolute paths", async () => {
       const absoluteFilePath = _path.join(
         currentTestTempDirUri.fsPath,
         "absolute-path-file.txt",
@@ -173,7 +170,6 @@ describe("writeToFile Tool", () => {
           toolCallId: "test-call-id-123",
           messages: [],
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -182,7 +178,7 @@ describe("writeToFile Tool", () => {
       assert.strictEqual(fileContent.toString(), content);
     });
 
-    it("should preserve line endings in non-interactive mode", async () => {
+    it("should preserve line endings", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "line-endings.txt",
@@ -199,7 +195,6 @@ describe("writeToFile Tool", () => {
           toolCallId: "test-call-id-123",
           messages: [],
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -210,7 +205,7 @@ describe("writeToFile Tool", () => {
       assert.ok(fileContent.toString().includes("Line 3"));
     });
 
-    it("should handle empty content in non-interactive mode", async () => {
+    it("should handle empty content", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "empty-file.txt",
@@ -227,7 +222,6 @@ describe("writeToFile Tool", () => {
           toolCallId: "test-call-id-123",
           messages: [],
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -237,7 +231,7 @@ describe("writeToFile Tool", () => {
       assert.strictEqual(fileContent.toString().length, 0);
     });
 
-    it("should include edit metadata in non-interactive mode", async () => {
+    it("should include edit metadata", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "metadata-file.txt",
@@ -257,7 +251,6 @@ describe("writeToFile Tool", () => {
           toolCallId: "test-call-id-123",
           messages: [],
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -269,7 +262,7 @@ describe("writeToFile Tool", () => {
       assert.ok(result._meta.editSummary.removed > 0);
     });
 
-    it("should handle Unicode content in non-interactive mode", async () => {
+    it("should handle Unicode content", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "unicode-file.txt",
@@ -286,7 +279,6 @@ describe("writeToFile Tool", () => {
           toolCallId: "test-call-id-123",
           messages: [],
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -297,7 +289,7 @@ describe("writeToFile Tool", () => {
   });
 
   describe("previewWriteToFile", () => {
-    it("should preview creating a new file in non-interactive mode", async () => {
+    it("should preview creating a new file", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "preview-new-file.txt",
@@ -313,7 +305,6 @@ describe("writeToFile Tool", () => {
           state: "call",
           toolCallId: "test-call-id-123",
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -324,7 +315,7 @@ describe("writeToFile Tool", () => {
       assert.ok("_meta" in result && result._meta?.editSummary);
     });
 
-    it("should preview overwriting an existing file in non-interactive mode", async () => {
+    it("should preview overwriting an existing file", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "preview-existing-file.txt",
@@ -344,7 +335,6 @@ describe("writeToFile Tool", () => {
           state: "call",
           toolCallId: "test-call-id-123",
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -358,7 +348,7 @@ describe("writeToFile Tool", () => {
       assert.strictEqual(fileContent.toString(), originalContent);
     });
 
-    it("should preview with correct edit summary for new file in non-interactive mode", async () => {
+    it("should preview with correct edit summary for new file", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "preview-new-with-summary.txt",
@@ -374,7 +364,6 @@ describe("writeToFile Tool", () => {
           state: "call",
           toolCallId: "test-call-id-123",
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -388,7 +377,7 @@ describe("writeToFile Tool", () => {
       }
     });
 
-    it("should preview with correct edit summary for modified file in non-interactive mode", async () => {
+    it("should preview with correct edit summary for modified file", async () => {
       const filePath = _path.join(
         currentTestTempDirRelativePath,
         "preview-modified-with-summary.txt",
@@ -408,7 +397,6 @@ describe("writeToFile Tool", () => {
           state: "call",
           toolCallId: "test-call-id-123",
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -422,7 +410,7 @@ describe("writeToFile Tool", () => {
       }
     });
 
-    it("should return error when path is undefined in non-interactive mode", async () => {
+    it("should return error when path is undefined", async () => {
       const result = await previewWriteToFileWithMock(
         {
           path: undefined,
@@ -432,7 +420,6 @@ describe("writeToFile Tool", () => {
           state: "call",
           toolCallId: "test-call-id-123",
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -444,7 +431,7 @@ describe("writeToFile Tool", () => {
       );
     });
 
-    it("should return error when content is undefined in non-interactive mode", async () => {
+    it("should return error when content is undefined", async () => {
       const result = await previewWriteToFileWithMock(
         {
           path: "test.txt",
@@ -454,7 +441,6 @@ describe("writeToFile Tool", () => {
           state: "call",
           toolCallId: "test-call-id-123",
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 
@@ -486,7 +472,6 @@ describe("writeToFile Tool", () => {
           state: "call",
           toolCallId: "test-call-id-123",
           cwd: testSuiteRootTempDir.fsPath,
-          nonInteractive: true,
         },
       );
 


### PR DESCRIPTION
https://app.getpochi.com/share/p-f788b5512e454f27ae6107eed7d5cf92

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
