### PR TITLE
feat(vscode): remove pochi.diffWorktree command

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -149,12 +149,6 @@
         "icon": "$(terminal)"
       },
       {
-        "command": "pochi.diffWorktree",
-        "title": "Review Changes",
-        "category": "Pochi",
-        "icon": "$(diff-multiple)"
-      },
-      {
         "command": "pochi.openCustomModelSettings",
         "title": "Open Custom Model Settings",
         "category": "Pochi"
@@ -187,11 +181,6 @@
         },
         {
           "command": "pochi.openTerminal",
-          "when": "resourceScheme == 'pochi-task'",
-          "group": "navigation"
-        },
-        {
-          "command": "pochi.diffWorktree",
           "when": "resourceScheme == 'pochi-task'",
           "group": "navigation"
         }

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -468,22 +468,6 @@ export class CommandManager implements vscode.Disposable {
         }
       }),
 
-      vscode.commands.registerCommand("pochi.diffWorktree", async () => {
-        const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
-        if (
-          activeTab &&
-          activeTab.input instanceof vscode.TabInputCustom &&
-          activeTab.input.viewType === PochiTaskEditorProvider.viewType
-        ) {
-          const params = PochiTaskEditorProvider.parseTaskUri(
-            activeTab.input.uri,
-          );
-          if (params?.cwd) {
-            await this.worktreeManager.showWorktreeDiff(params.cwd);
-          }
-        }
-      }),
-
       vscode.commands.registerCommand(
         "pochi.worktree.openDiff",
         async (worktreePath: string) => {


### PR DESCRIPTION
Removes the `pochi.diffWorktree` command from the VS Code extension to reduce confusion, as a diff summary feature is now available.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>