### PR TITLE
chore(vscode-webui): adjust task row time display styling

### DIFF
--- a/packages/vscode-webui/src/components/task-row/index.tsx
+++ b/packages/vscode-webui/src/components/task-row/index.tsx
@@ -42,7 +42,7 @@ export function TaskRow({
                 )}
               </h3>
               <div className="flex shrink-0 items-center gap-2">
-                <div className="text-muted-foreground text-sm">
+                <div className="text-sm italic">
                   {formatTimeAgo(task.createdAt)}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Adjusted the styling for the task row in the web UI.
- This change specifically targets the time display within the task row.

## Screenshot
#### Before
<img width="824" height="288" alt="image" src="https://github.com/user-attachments/assets/a1878a02-5e83-48ea-82d1-7cff7e4d2b4f" />

#### After
<img width="812" height="288" alt="image" src="https://github.com/user-attachments/assets/1395f763-66be-464a-9a03-2dbb16d45774" />


## Test plan
- Verify that the task row time display is correctly formatted and styled.

🤖 Generated with [Pochi](https://getpochi.com)