### PR TITLE
feat(vscode): Improve task layout behavior with worktree attachment control

### DIFF
--- a/packages/vscode/src/integrations/layout.ts
+++ b/packages/vscode/src/integrations/layout.ts
@@ -13,6 +13,7 @@ export class LayoutManager implements vscode.Disposable {
   async toggleTaskFocusLayout(task: TaskParams) {
     const layout = getTaskFocusLayout(task);
     if (isCurrentLayoutMatched(layout)) {
+      PochiTaskEditorProvider.attachToSameWorktree = true;
       await this.restoreLayout();
 
       await vscode.commands.executeCommand("workbench.action.focusSideBar");
@@ -24,6 +25,7 @@ export class LayoutManager implements vscode.Disposable {
         "workbench.action.focusFirstEditorGroup",
       );
     } else {
+      PochiTaskEditorProvider.attachToSameWorktree = false;
       if (shouldSaveLayout()) {
         await this.saveLayout();
       }


### PR DESCRIPTION
## Summary
- Added PochiTaskEditorProvider.attachToSameWorktree flag to control whether tasks should be attached to the same worktree
- Modified getPochiTaskColumn function to accept an optional attachWorktree parameter for more flexible column assignment
- Updated layout management logic to set the attachment flag based on whether we're toggling task focus layout or restoring normal layout
- Added getFirstPochiTaskColumn helper function to find the first column with a Pochi task

## Test plan
- [ ] Verify that tasks behave correctly when toggling task focus layout
- [ ] Verify that tasks are placed in the correct columns based on worktree settings
- [ ] Verify that the new attachment control flag works as expected

🤖 Generated with [Pochi](https://getpochi.com)