### PR TITLE
refactor(vscode-webui): Remove uid and storeId params from openTaskInPanel

### DIFF
--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -480,8 +480,6 @@ async function forkTaskFromCheckPoint(
   // Create new task
   await vscodeHost.openTaskInPanel({
     cwd,
-    uid: crypto.randomUUID(),
-    storeId: undefined,
     initMessages: JSON.stringify(initMessages),
     disablePendingModelAutoStart: true,
   });


### PR DESCRIPTION
This commit aligns the openTaskInPanel call with the updated signature that no longer requires uid and storeId.

References #812

🤖 Generated with [Pochi](https://getpochi.com)