### PR TITLE
feat(vscode-webui): Add messageId to forkTask for checkpoint restore

### DIFF
--- a/packages/vscode-webui/src/components/checkpoint-ui.tsx
+++ b/packages/vscode-webui/src/components/checkpoint-ui.tsx
@@ -23,13 +23,15 @@ export const CheckpointUI: React.FC<{
   isLoading: boolean;
   className?: string;
   hideBorderOnHover?: boolean;
-  forkTask?: (commitId: string) => Promise<void>;
+  forkTask?: (commitId: string, messageId?: string) => Promise<void>;
+  restoreMessageId?: string;
 }> = ({
   checkpoint,
   isLoading,
   className,
   hideBorderOnHover = true,
   forkTask,
+  restoreMessageId,
 }) => {
   const { t } = useTranslation();
   const [isDevMode] = useIsDevMode();
@@ -44,6 +46,7 @@ export const CheckpointUI: React.FC<{
     mutationFn: async (params: {
       action: ActionType;
       commitId: string;
+      messageId?: string;
     }) => {
       const actions = {
         compare: () =>
@@ -53,7 +56,7 @@ export const CheckpointUI: React.FC<{
         restore: () => vscodeHost.restoreCheckpoint(params.commitId),
         fork: async () => {
           if (forkTask) {
-            await forkTask(params.commitId);
+            await forkTask(params.commitId, params.messageId);
           }
         },
       };
@@ -80,6 +83,7 @@ export const CheckpointUI: React.FC<{
     executeAction({
       action,
       commitId: checkpoint.commit,
+      messageId: restoreMessageId,
     });
   };
 

--- a/packages/vscode-webui/src/features/chat/components/chat-area.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.tsx
@@ -11,7 +11,7 @@ interface ChatAreaProps {
   messagesContainerRef: React.RefObject<HTMLDivElement | null>;
   className?: string;
   hideEmptyPlaceholder?: boolean;
-  forkTask?: (commitId: string) => Promise<void>;
+  forkTask?: (commitId: string, messageId?: string) => Promise<void>;
 }
 
 export function ChatArea({


### PR DESCRIPTION
## Summary
- Modified the `forkTask` signature in `CheckpointUI`, `MessageList`, and `ChatArea` to accept an optional `messageId`.
- Updated the `forkTaskFromCheckPoint` function to handle the new `messageId` parameter, allowing restoration to a specific message.

## Test plan
- Manual testing of checkpoint restore functionality with and without messageId.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>