### PR TITLE
fix(vscode-webui): Add tooltip to create-pr button

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -585,9 +585,7 @@ function CreatePrDropdown({
               </span>
             </TooltipTrigger>
             {!isGhCliReady && (
-              <TooltipContent align="end" side="right">
-                {ghTooltipMessage}
-              </TooltipContent>
+              <TooltipContent>{ghTooltipMessage}</TooltipContent>
             )}
           </Tooltip>
           <Tooltip>
@@ -606,9 +604,7 @@ function CreatePrDropdown({
               </DropdownMenuItem>
             </TooltipTrigger>
             {!isGhCliReady && (
-              <TooltipContent align="end" side="right">
-                {ghTooltipMessage}
-              </TooltipContent>
+              <TooltipContent>{ghTooltipMessage}</TooltipContent>
             )}
           </Tooltip>
           <DropdownMenuItem asChild disabled={!manualPrUrl}>


### PR DESCRIPTION
## Summary
- Added a tooltip to the create-pr button in the VSCode web UI.

## Screenshot
<img width="592" height="234" alt="image" src="https://github.com/user-attachments/assets/1387f3fd-cdd2-4a7e-a3b2-95586f1843ce" />

----

<img width="742" height="260" alt="image" src="https://github.com/user-attachments/assets/059bbcb6-d861-4f31-9c0e-f7d4ed8d634d" />


## Test plan
- Verify that hovering over the create-pr button displays the tooltip.

🤖 Generated with [Pochi](https://getpochi.com)