### PR TITLE
fix(vscode-webui): Fix PR checks display styling issues

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -670,7 +670,10 @@ function PrStatusDisplay({
   const allChecksPassed = prChecks && passedCheckCount === prChecks.length;
   const allChecksFailed = prChecks && failedCheckCount === prChecks.length;
 
-  const getChecksStatusText = () => {
+  const getChecksStatusText = (short = false) => {
+    if (short) {
+      return `${passedCheckCount}/${prChecks?.length || 0}`;
+    }
     if (allChecksPassed) {
       return t("worktree.allChecksPassed");
     }
@@ -697,7 +700,12 @@ function PrStatusDisplay({
         <HoverCard openDelay={200} closeDelay={100}>
           <HoverCardTrigger asChild>
             <span className="cursor-pointer truncate whitespace-nowrap text-xs">
-              {getChecksStatusText()}
+              <span className="hidden truncate whitespace-nowrap min-[300px]:inline">
+                {getChecksStatusText()}
+              </span>
+              <span className="truncate whitespace-nowrap min-[300px]:hidden">
+                {getChecksStatusText(true)}
+              </span>
             </span>
           </HoverCardTrigger>
           <HoverCardContent


### PR DESCRIPTION
## Summary
- Add `flex-1 overflow-x-hidden` to the container of the PR checks status text to ensure proper truncation and layout.
- Remove the unnecessary wrapper div around `HoverCard` in `PrStatusDisplay` to fix styling issues with PR checks display.

## Screenshot
<img width="442" height="180" alt="image" src="https://github.com/user-attachments/assets/be7a7197-3d99-49ba-8801-c31ca61210a0" />

## Screen recording
https://jam.dev/c/7adf4e94-18de-45e3-96e4-d47f83743bf9


## Test plan
Verify the PR checks display in the VSCode WebUI. Ensure that long check names are truncated correctly and the layout is as expected.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>