### PR TITLE
fix(vscode-webui): hide create pr dropdown for deleted worktree groups

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -357,7 +357,7 @@ function WorktreeSection({
                 prUrl={prUrl}
                 prChecks={pullRequest.checks}
               />
-            ) : hasEdit ? (
+            ) : hasEdit && !group.isDeleted ? (
               <CreatePrDropdown
                 worktreePath={group.path}
                 branch={group.branch}


### PR DESCRIPTION
## Summary
- Hide the 'Create PR' dropdown in the worktree list when the worktree group is marked as deleted.

## Test plan
- Verify that the 'Create PR' dropdown does not appear for deleted worktree groups.

🤖 Generated with [Pochi](https://getpochi.com)