### PR TITLE
refactor(vscode): Refactor task state management to use rootTaskId

### DIFF
--- a/packages/vscode/src/integrations/editor/pochi-task-state.ts
+++ b/packages/vscode/src/integrations/editor/pochi-task-state.ts
@@ -68,13 +68,12 @@ export class PochiTaskState implements vscode.Disposable {
       status?: string;
     };
     const uid = taskData.id;
-    const topTaskUid = taskData.parentId || taskData.id;
+    const rootTaskId = taskData.parentId || taskData.id;
 
-    if (!topTaskUid) return;
+    if (!rootTaskId) return;
 
     const newState = R.clone(this.state.value);
-    const current = newState[topTaskUid] || {};
-    current.unread = !current.active;
+    const current = newState[rootTaskId] || {};
 
     // If status indicates the task is no longer running, clear the running flag
     if (
@@ -85,9 +84,12 @@ export class PochiTaskState implements vscode.Disposable {
         `Task ${uid} is no longer running (status: ${taskData.status})`,
       );
       current.running = false;
+
+      // Only change unread to be true (if current.active = false) when running ends
+      current.unread = !current.active;
     }
 
-    newState[topTaskUid] = current;
+    newState[rootTaskId] = current;
     this.saveState(newState);
   };
 


### PR DESCRIPTION
## Summary
- Refactored `PochiTaskState` to use `rootTaskId` for improved clarity and consistency in task state management.
- Ensured the `unread` flag is correctly set when a task finishes.

## Test plan
- Verify that task state updates correctly in VSCode.
- Check that `unread` status behaves as expected after task completion.

🤖 Generated with [Pochi](https://getpochi.com)