### PR TITLE
docs: fixing link on independent page

### DIFF
--- a/packages/docs/content/docs/developer-updates/context-management-in-your-editor.mdx
+++ b/packages/docs/content/docs/developer-updates/context-management-in-your-editor.mdx
@@ -6,7 +6,7 @@ image: "/og-image/nes-part-2-og-image.png"
 
 # NES Series (Part 2): Real-Time Context Management in Your Code Editor
 
-In [Part 1](./how-we-created-nes-model/), we covered how we trained our **NES model**, including topics such as the special tokens we use, the LoRA-based fine-tuning on Gemini Flash Lite, and how we utilized a judge LLM to evaluate the model.
+In [Part 1](https://docs.getpochi.com/developer-updates/how-we-created-nes-model/), we covered how we trained our **NES model**, including topics such as the special tokens we use, the LoRA-based fine-tuning on Gemini Flash Lite, and how we utilized a judge LLM to evaluate the model.
 
 However, the end experience is far more than just building a good model. To make NES feel “intent-aware” inside your editor, we needed to give the model the right context at the right moment.
 


### PR DESCRIPTION
the link was: Part 1(`./how-we-created-nes-model/`), and it rendered fine on the `/developer-updates` page, but while inside the (`https://docs.getpochi.com/developer-updates/context-management-in-your-editor/`) page, the link broke since it was not in the same file directory.


so I've just updated the link parameter to be: Part 1(`https://docs.getpochi.com/developer-updates/how-we-created-nes-model/`), so that it renders well on both pages for now