### PR TITLE
fix(vscode): truncate long worktree names in display

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -327,30 +327,26 @@ function WorktreeSection({
       >
         {/* worktree name & branch */}
         <div className="flex h-6 items-center gap-2">
-          <div className="flex items-center gap-2 overflow-x-hidden">
-            {group.isDeleted ? (
-              <CollapsibleTrigger asChild>
-                <div className="flex w-full flex-1 cursor-pointer select-none items-center gap-2 font-medium text-sm">
-                  {isExpanded ? (
-                    <ChevronDown className="size-4 shrink-0" />
-                  ) : (
-                    <ChevronRight className="size-4 shrink-0" />
-                  )}
-                  <span className="truncate">
-                    {prefixWorktreeName(group.name)}
-                  </span>
-                </div>
-              </CollapsibleTrigger>
-            ) : (
-              <div className="flex items-center font-bold">
+          {group.isDeleted ? (
+            <CollapsibleTrigger asChild>
+              <div className="flex w-full flex-1 cursor-pointer select-none items-center gap-2 font-medium text-sm">
+                {isExpanded ? (
+                  <ChevronDown className="size-4 shrink-0" />
+                ) : (
+                  <ChevronRight className="size-4 shrink-0" />
+                )}
                 <span className="truncate">
                   {prefixWorktreeName(group.name)}
                 </span>
               </div>
-            )}
-          </div>
+            </CollapsibleTrigger>
+          ) : (
+            <span className="items-center truncate font-bold">
+              {prefixWorktreeName(group.name)}
+            </span>
+          )}
 
-          <div className="mt-[1px] flex-1 overflow-x-hidden">
+          <div className="mt-[1px] flex-1">
             {pullRequest ? (
               <PrStatusDisplay
                 prNumber={pullRequest.id}
@@ -552,74 +548,70 @@ function CreatePrDropdown({
   }, [gitOriginUrl, branch]);
 
   return (
-    <div className="flex items-center">
-      <DropdownMenu>
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 shrink-0 gap-1"
+            >
+              <GitPullRequest className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{t("worktree.createPr")}</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        align="start"
+        className="bg-background text-xs"
+        side="right"
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
         <Tooltip>
           <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-6 w-6 gap-1">
-                <GitPullRequest className="size-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent>{t("worktree.createPr")}</TooltipContent>
-        </Tooltip>
-        <DropdownMenuContent
-          align="start"
-          className="bg-background text-xs"
-          side="right"
-          onCloseAutoFocus={(e) => e.preventDefault()}
-        >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span>
-                <DropdownMenuItem
-                  onSelect={(e) => {
-                    if (!isGhCliReady) {
-                      e.preventDefault();
-                    } else {
-                      onCreatePr();
-                    }
-                  }}
-                  className={cn(
-                    !isGhCliReady && "cursor-not-allowed opacity-50",
-                  )}
-                >
-                  {t("worktree.createPr")}
-                </DropdownMenuItem>
-              </span>
-            </TooltipTrigger>
-            {!isGhCliReady && (
-              <TooltipContent>{ghTooltipMessage}</TooltipContent>
-            )}
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
+            <span>
               <DropdownMenuItem
                 onSelect={(e) => {
                   if (!isGhCliReady) {
                     e.preventDefault();
                   } else {
-                    onCreatePr(true);
+                    onCreatePr();
                   }
                 }}
                 className={cn(!isGhCliReady && "cursor-not-allowed opacity-50")}
               >
-                {t("worktree.createDraftPr")}
+                {t("worktree.createPr")}
               </DropdownMenuItem>
-            </TooltipTrigger>
-            {!isGhCliReady && (
-              <TooltipContent>{ghTooltipMessage}</TooltipContent>
-            )}
-          </Tooltip>
-          <DropdownMenuItem asChild disabled={!manualPrUrl}>
-            <a href={manualPrUrl} target="_blank" rel="noopener noreferrer">
-              {t("worktree.createPrManually")}
-            </a>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+            </span>
+          </TooltipTrigger>
+          {!isGhCliReady && <TooltipContent>{ghTooltipMessage}</TooltipContent>}
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuItem
+              onSelect={(e) => {
+                if (!isGhCliReady) {
+                  e.preventDefault();
+                } else {
+                  onCreatePr(true);
+                }
+              }}
+              className={cn(!isGhCliReady && "cursor-not-allowed opacity-50")}
+            >
+              {t("worktree.createDraftPr")}
+            </DropdownMenuItem>
+          </TooltipTrigger>
+          {!isGhCliReady && <TooltipContent>{ghTooltipMessage}</TooltipContent>}
+        </Tooltip>
+        <DropdownMenuItem asChild disabled={!manualPrUrl}>
+          <a href={manualPrUrl} target="_blank" rel="noopener noreferrer">
+            {t("worktree.createPrManually")}
+          </a>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 


### PR DESCRIPTION
## Summary
- Truncate long worktree names to prevent UI overflow.
- Ensures proper display of worktree names in the UI.

## Screenshot

### Before
<img width="630" height="314" alt="image" src="https://github.com/user-attachments/assets/ab4be4f6-9c04-4e38-ac1c-652f35af8b40" />


### After
<img width="552" height="334" alt="image" src="https://github.com/user-attachments/assets/46f1349b-6301-46d2-aa5e-fcde934ed135" />


🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>