### PR TITLE
fix(vscode-webui): resolve subtask message conversion issue during task forking

### DIFF
--- a/packages/vscode-webui/src/features/chat/lib/__tests__/convert-subtask-messages.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/convert-subtask-messages.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { convertSubtaskMessages } from "../convert-subtask-messages";
+import type { Message } from "@getpochi/livekit";
+import type { TFunction } from "i18next";
+
+describe("convertSubtaskMessages", () => {
+  const mockT = vi.fn((key: string) => key) as unknown as TFunction<"translation", undefined>;
+
+  it("should return messages as is if no tool-newTask part is present", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      },
+    ];
+    const result = convertSubtaskMessages(messages, mockT);
+    expect(result).toEqual(messages);
+  });
+
+  it("should convert tool-newTask part with output-available and result", () => {
+    const messages: Message[] = [
+      {
+        id: "2",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-newTask",
+            toolCallId: "tool-call-id-1",
+            state: "output-available",
+            input: { agentType: "explore", description: "Explore codebase", prompt: "explore" },
+            output: { result: "Codebase explored successfully" },
+          },
+        ],
+      },
+    ];
+    const result = convertSubtaskMessages(messages, mockT);
+    expect(result[0].parts[0]).toEqual({
+      type: "text",
+      text: "#### [explore] Explore codebase  \nforkTask.subTaskSummary.completed  \nCodebase explored successfully",
+    });
+  });
+
+  it("should convert tool-newTask part with output-available and error in output", () => {
+    const messages: Message[] = [
+      {
+        id: "3",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-newTask",
+            toolCallId: "tool-call-id-2",
+            state: "output-available",
+            input: { agentType: "debugger", description: "Debug issue", prompt: "debug" },
+            output: { error: "Debugging failed" } as any,
+          },
+        ],
+      },
+    ];
+    const result = convertSubtaskMessages(messages, mockT);
+    expect(result[0].parts[0]).toEqual({
+      type: "text",
+      text: "#### [debugger] Debug issue  \nforkTask.subTaskSummary.error \nDebugging failed",
+    });
+  });
+
+  it("should convert tool-newTask part with output-error state", () => {
+    const messages: Message[] = [
+      {
+        id: "4",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-newTask",
+            toolCallId: "tool-call-id-3",
+            state: "output-error",
+            input: { description: "Perform task", prompt: "task" },
+            errorText: "Task execution failed",
+          },
+        ],
+      },
+    ];
+    const result = convertSubtaskMessages(messages, mockT);
+    expect(result[0].parts[0]).toEqual({
+      type: "text",
+      text: "#### [Subtask] Perform task  \nforkTask.subTaskSummary.error \nTask execution failed",
+    });
+  });
+
+  it("should handle multiple parts and messages", () => {
+    const messages: Message[] = [
+      {
+        id: "6",
+        role: "user",
+        parts: [{ type: "text", text: "First message" }],
+      },
+      {
+        id: "7",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Before subtask" },
+          {
+            type: "tool-newTask",
+            toolCallId: "tool-call-id-4",
+            state: "output-available",
+            input: { description: "Another subtask", prompt: "another subtask" },
+            output: { result: "Subtask done" },
+          },
+          { type: "text", text: "After subtask" },
+        ],
+      },
+    ];
+    const result = convertSubtaskMessages(messages, mockT);
+    expect(result[0]).toEqual(messages[0]);
+    expect(result[1].parts[0]).toEqual(messages[1].parts[0]);
+    expect(result[1].parts[1]).toEqual({
+      type: "text",
+      text: "#### [Subtask] Another subtask  \nforkTask.subTaskSummary.completed  \nSubtask done",
+    });
+    expect(result[1].parts[2]).toEqual(messages[1].parts[2]);
+  });
+});

--- a/packages/vscode-webui/src/features/chat/lib/convert-subtask-messages.ts
+++ b/packages/vscode-webui/src/features/chat/lib/convert-subtask-messages.ts
@@ -1,0 +1,47 @@
+import type { Message } from "@getpochi/livekit";
+import type { ClientTools } from "@getpochi/tools";
+import type { InferToolInput } from "ai";
+import type { TFunction } from "i18next";
+
+export function convertSubtaskMessages(
+  messages: Message[],
+  t: TFunction<"translation", undefined>,
+) {
+  return messages.map((message) => {
+    return {
+      ...message,
+      parts: message.parts.map((part) => {
+        if (part.type === "tool-newTask") {
+          const input = part.input as InferToolInput<ClientTools["newTask"]>;
+          const error =
+            part.state === "output-available" &&
+            typeof part.output === "object" &&
+            part.output !== null &&
+            "error" in part.output &&
+            typeof part.output.error === "string"
+              ? part.output.error
+              : part.state === "output-error"
+                ? part.errorText
+                : undefined;
+          const output =
+            part.state === "output-available" && !error
+              ? part.output.result
+              : undefined;
+
+          return {
+            type: "text",
+            text: [
+              `#### [${input.agentType ?? "Subtask"}] ${input.description}`,
+              output
+                ? `${t("forkTask.subTaskSummary.completed")}  \n${output}`
+                : error
+                  ? `${t("forkTask.subTaskSummary.error")} \n${error}`
+                  : t("forkTask.subTaskSummary.noOutput"),
+            ].join("  \n"),
+          };
+        }
+        return part;
+      }),
+    };
+  });
+}

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -26,6 +26,7 @@ import { useLatest } from "@/lib/hooks/use-latest";
 import { useMcp } from "@/lib/hooks/use-mcp";
 import { cn } from "@/lib/utils";
 import { Schema } from "@livestore/utils/effect";
+import type { TFunction } from "i18next";
 import { useApprovalAndRetry } from "../approval";
 import { getReadyForRetryError } from "../retry/hooks/use-ready-for-retry-error";
 import {
@@ -50,6 +51,7 @@ import {
   useChatAbortController,
   useRetryCount,
 } from "./lib/chat-state";
+import { convertSubtaskMessages } from "./lib/convert-subtask-messages";
 import { onOverrideMessages } from "./lib/on-override-messages";
 import { useLiveChatKitGetters } from "./lib/use-live-chat-kit-getters";
 import { useSendTaskNotification } from "./lib/use-send-task-notification";
@@ -393,14 +395,15 @@ function Chat({
       if (task?.cwd && task.title) {
         await forkTaskFromCheckPoint(
           messages,
+          t,
           commitId,
           task.cwd,
-          t("forkTask.forkedTaskTitle", { taskTitle: task.title }),
+          task.title,
           messageId,
         );
       }
     },
-    [messages, task?.cwd, task?.title, t],
+    [messages, task, t],
   );
 
   return (
@@ -472,6 +475,7 @@ function fromTaskError(task?: Task) {
 
 async function forkTaskFromCheckPoint(
   messages: Message[],
+  t: TFunction<"translation", undefined>,
   commitId: string,
   cwd: string,
   title: string,
@@ -514,8 +518,8 @@ async function forkTaskFromCheckPoint(
   // Create new task
   await vscodeHost.openTaskInPanel({
     cwd,
-    initTitle: title,
-    initMessages: JSON.stringify(initMessages),
+    initTitle: t("forkTask.forkedTaskTitle", { taskTitle: title }),
+    initMessages: JSON.stringify(convertSubtaskMessages(initMessages, t)),
     disablePendingModelAutoStart: true,
   });
 }

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -405,6 +405,11 @@
     "openFile": "Open file"
   },
   "forkTask": {
-    "forkedTaskTitle": "Forked from {{taskTitle}}"
+    "forkedTaskTitle": "Forked from {{taskTitle}}",
+    "subTaskSummary": {
+      "noOutput": "✘ No Output Available",
+      "completed": "✔ Task Completed",
+      "error": "✘ Error Encountered"
+    }
   }
 }

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -407,6 +407,11 @@
     "openFile": "ファイルを開く"
   },
   "forkTask": {
-    "forkedTaskTitle": "フォーク 元: {{taskTitle}}"
+    "forkedTaskTitle": "フォーク 元: {{taskTitle}}",
+    "subTaskSummary": {
+      "noOutput": "✘ 出力がありません",
+      "completed": "✔ タスク完了",
+      "error": "✘ エラーが発生しました"
+    }
   }
 }

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -402,6 +402,11 @@
     "openFile": "파일 열기"
   },
   "forkTask": {
-    "forkedTaskTitle": "포크됨 원본: {{taskTitle}}"
+    "forkedTaskTitle": "포크됨 원본: {{taskTitle}}",
+    "subTaskSummary": {
+      "noOutput": "✘ 사용 가능한 출력 없음",
+      "completed": "✔ 작업 완료",
+      "error": "✘ 오류 발생"
+    }
   }
 }

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -406,6 +406,11 @@
     "openFile": "打开文件"
   },
   "forkTask": {
-    "forkedTaskTitle": "任务分支自：{{taskTitle}}"
+    "forkedTaskTitle": "任务分支自：{{taskTitle}}",
+    "subTaskSummary": {
+      "noOutput": "✘ 无可用输出",
+      "completed": "✔ 任务完成",
+      "error": "✘ 遇到错误"
+    }
   }
 }


### PR DESCRIPTION
This commit addresses a bug where forking tasks containing subtask tool-calls would fail due to improper message handling.
The fix introduces a new utility function, `convertSubtaskMessages`, which transforms subtask tool-calls into a text representation
before creating a forked task. This ensures that subtask content is correctly preserved and displayed in the new task.

Additionally, this change includes internationalization updates for subtask summaries in English, Japanese, Korean, and Chinese,
providing clearer status messages for users.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>