### PR TITLE
feat(vscode): make worktree info provider methods async and add run-exclusive

### DIFF
--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -228,15 +228,18 @@ export class CommandManager implements vscode.Disposable {
           }
 
           // Clear the GitHub data for the main worktree
-          this.worktreeInfoProvider.updateGithubIssues(mainWorktree.path, {
-            data: [],
-            updatedAt: undefined,
-            processedAt: undefined,
-            pageOffset: undefined,
-          });
+          await this.worktreeInfoProvider.updateGithubIssues(
+            mainWorktree.path,
+            {
+              data: [],
+              updatedAt: undefined,
+              processedAt: undefined,
+              pageOffset: undefined,
+            },
+          );
 
           // Also clear pull request data if it exists
-          this.worktreeInfoProvider.updateGithubPullRequest(
+          await this.worktreeInfoProvider.updateGithubPullRequest(
             mainWorktree.path,
             undefined,
           );

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -136,7 +136,6 @@ export class WorktreeManager implements vscode.Disposable {
     if (newWorktree) {
       logger.debug(`New worktree created at: ${newWorktree.path}`);
       this.updateWorktrees();
-      this.worktreeInfoProvider.initialize(newWorktree.path);
       setupWorktree(newWorktree.path);
       return newWorktree;
     }

--- a/packages/vscode/src/integrations/github/issue.ts
+++ b/packages/vscode/src/integrations/github/issue.ts
@@ -136,7 +136,7 @@ export class GithubIssues implements vscode.Disposable {
         }
 
         if (hasMore) {
-          this.worktreeInfoProvider.updateGithubIssues(worktreePath, {
+          await this.worktreeInfoProvider.updateGithubIssues(worktreePath, {
             pageOffset: page,
             data: updatedIssues,
           });
@@ -145,7 +145,7 @@ export class GithubIssues implements vscode.Disposable {
           );
         } else {
           const now = new Date().toISOString();
-          this.worktreeInfoProvider.updateGithubIssues(worktreePath, {
+          await this.worktreeInfoProvider.updateGithubIssues(worktreePath, {
             updatedAt: currentIssuesData?.processedAt ?? now,
             processedAt: now,
             pageOffset: 0,

--- a/packages/vscode/src/integrations/github/pull-request-monitor.ts
+++ b/packages/vscode/src/integrations/github/pull-request-monitor.ts
@@ -40,7 +40,7 @@ export class GithubPullRequestMonitor implements vscode.Disposable {
     this.disposables.push(
       this.gitStateMonitor.onDidChangeGitState(async (e) => {
         if (e.type === "branch-changed" && e.currentBranch !== undefined) {
-          this.worktreeInfoProvider.updateGithubPullRequest(
+          await this.worktreeInfoProvider.updateGithubPullRequest(
             e.repository,
             undefined,
           );
@@ -162,7 +162,7 @@ export class GithubPullRequestMonitor implements vscode.Disposable {
     const newPrInfo = prInfo ?? undefined;
 
     if (JSON.stringify(currentPrInfo) !== JSON.stringify(newPrInfo)) {
-      this.worktreeInfoProvider.updateGithubPullRequest(
+      await this.worktreeInfoProvider.updateGithubPullRequest(
         worktree.path,
         newPrInfo,
       );

--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -172,7 +172,7 @@ export class PochiTaskEditorProvider
           : {
               ...params,
               uid: crypto.randomUUID(),
-              displayId: getNextDisplayId(params.cwd),
+              displayId: await getNextDisplayId(params.cwd),
             };
       const uri = PochiTaskEditorProvider.createTaskUri(taskParams);
       PochiTaskEditorProvider.taskParamsCache.set(uri.toString(), taskParams);
@@ -323,13 +323,13 @@ export class PochiTaskEditorProvider
   }
 }
 
-function getNextDisplayId(cwd: string) {
+async function getNextDisplayId(cwd: string) {
   const worktreeManager = container.resolve(WorktreeManager);
   const mainWorktreeCwd = worktreeManager.worktrees.value.find(
     (wt) => wt.isMain,
   )?.path;
   const worktreeInfoProvider = container.resolve(GitWorktreeInfoProvider);
-  return worktreeInfoProvider.getNextDisplayId(mainWorktreeCwd ?? cwd);
+  return await worktreeInfoProvider.getNextDisplayId(mainWorktreeCwd ?? cwd);
 }
 
 function setAutoLockGroupsConfig() {


### PR DESCRIPTION
## Summary
- Convert GitWorktreeInfoProvider methods to async to properly handle await operations in the global state updates
- Add run-exclusive to prevent race conditions when updating GitHub issues and pull request data
- Update all call sites to properly await async operations
- Remove redundant initialization call in WorktreeManager

## Test plan
- [ ] Verify that GitHub issues and pull requests are still properly updated in the UI
- [ ] Check that race conditions are prevented when updating worktree info concurrently
- [ ] Confirm that display IDs are still assigned correctly for new tasks

🤖 Generated with [Pochi](https://getpochi.com)