### PR TITLE
feat(vscode): enhance github issue sorting and add query limits

### DIFF
--- a/packages/vscode/src/integrations/github/issue.ts
+++ b/packages/vscode/src/integrations/github/issue.ts
@@ -25,6 +25,7 @@ const PageSize = 50;
 const PollIntervalMS = 60 * 1000; // 1 minute
 const OneYearAgoMS = 365 * 24 * 60 * 60 * 1000;
 const MaxIssues = 3000;
+const QueryLimit = 50;
 
 @singleton()
 @injectable()
@@ -198,7 +199,7 @@ export class GithubIssues implements vscode.Disposable {
           searchQuery += " is:open";
         }
         searchQuery += ` updated:>=${updatedAt}`;
-        searchQuery += " sort:updated-desc";
+        searchQuery += " sort:created-desc";
 
         command = `gh api "/search/issues?q=${encodeURIComponent(searchQuery)}&per_page=${PageSize}&page=${page}" --jq '.items[] | {number: .number, title: .title, url: .html_url, state: .state}'`;
       }
@@ -276,7 +277,7 @@ export class GithubIssues implements vscode.Disposable {
       }
     }
 
-    return filteredIssues;
+    return filteredIssues.sort((a, b) => b.id - a.id);
   }
 
   private scheduleNextCheck() {
@@ -310,7 +311,7 @@ export class GithubIssues implements vscode.Disposable {
       const issues = issuesData.data;
 
       if (!query) {
-        return issues.slice(0, 10);
+        return issues.slice(0, QueryLimit);
       }
 
       // Check for fuzzy match by issue ID (substring match)
@@ -346,7 +347,7 @@ export class GithubIssues implements vscode.Disposable {
         ),
       ];
 
-      return allMatches.slice(0, 10);
+      return allMatches.slice(0, QueryLimit);
     } catch (error) {
       logger.warn(`Failed to query issues: ${toErrorMessage(error)}`);
       return [];


### PR DESCRIPTION

<img width="1470" height="852" alt="image" src="https://github.com/user-attachments/assets/90289231-6c84-4365-83ac-9df0b4de8af6" />


## Summary
- Change issue sort order from updated-desc to created-desc
- Add client-side sorting by issue ID in descending order
- Introduce QueryLimit constant (50) to replace hardcoded limits
- Apply query limit consistently across issue query functions

## Test plan
- [ ] Verify that GitHub issues are now sorted by creation date instead of update date
- [ ] Confirm that issue queries return results with proper client-side sorting
- [ ] Test that the query limit of 50 is applied consistently across different issue query functions

🤖 Generated with [Pochi](https://getpochi.com)