### PR TITLE
fix(vscode-webui): prevent unexpected popup dismissal when webview is not focused

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -697,9 +697,24 @@ export function FormEditor({
 
   // Auto focus when document is focused.
   useEffect(() => {
-    window.addEventListener("focus", focusEditor);
+    const handleFocus = () => {
+      setTimeout(() => {
+        const activeElement = document.activeElement;
+        if (
+          activeElement &&
+          (activeElement.tagName === "BUTTON" ||
+            activeElement.tagName === "A" ||
+            activeElement.closest('[data-slot="tooltip-trigger"]') ||
+            activeElement.closest('[data-slot="popover-trigger"]'))
+        ) {
+          return;
+        }
+        focusEditor();
+      }, 0);
+    };
+    window.addEventListener("focus", handleFocus);
     return () => {
-      window.removeEventListener("focus", focusEditor);
+      window.removeEventListener("focus", handleFocus);
     };
   }, [focusEditor]);
 

--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -419,13 +419,15 @@ function WorktreeSection({
                     <Tooltip>
                       <PopoverTrigger asChild>
                         <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 w-6 p-0"
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
+                          <span>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-6 w-6 p-0"
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          </span>
                         </TooltipTrigger>
                       </PopoverTrigger>
                       <TooltipContent>


### PR DESCRIPTION
## Summary
- This commit addresses an issue where clicking the action button in the worktree list would unexpectedly dismiss the popup if the webview did not have focus.
- The fix resolves a race condition related to focus management.

## Screen recording

### Before
https://jam.dev/c/af8f311f-1d9e-433c-98f3-f256496e87fe

### After
https://jam.dev/c/2004a000-d6cd-4ae2-9f7e-2562c095379a

## Test plan
- Verify that clicking worktree action buttons no longer dismisses popups when the webview is not focused.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>