### PR TITLE
fix(vscode-webui): fix mention popup width overflow issue

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -767,9 +767,9 @@ export function FormEditor({
         })}
       >
         {isAutoCompleteHintVisible && (
-          <div className="flex items-center text-muted-foreground text-xs">
+          <div className="flex flex-nowrap items-center truncate whitespace-nowrap text-muted-foreground text-xs">
             {t("formEditor.autoCompleteHintPrefix")}{" "}
-            <ArrowRightToLine className="mr-1.5 ml-0.5 size-4" />{" "}
+            <ArrowRightToLine className="mr-1.5 ml-0.5 size-4 shrink-0" />{" "}
             {t("formEditor.autoCompleteHintSuffix")}
           </div>
         )}

--- a/packages/vscode-webui/src/components/prompt-form/slash-mention/mention-list.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/slash-mention/mention-list.tsx
@@ -103,7 +103,7 @@ export const SlashMentionList = forwardRef<
   useImperativeHandle(ref, () => keyboardNavigation);
 
   return (
-    <div className="relative flex w-[240px] max-w-full flex-col overflow-hidden py-1">
+    <div className="relative flex w-[80vw] max-w-[240px] flex-col overflow-hidden py-1 sm:w-[240px]">
       <ScrollArea viewportClassname="max-h-[300px] px-2">
         {items.length === 0 ? (
           <div className="px-2 py-3 text-muted-foreground text-xs">


### PR DESCRIPTION
## Summary
- Fixed an issue where the mention popup width would overflow.

## Screenshot

### Before
<img width="480" height="666" alt="image" src="https://github.com/user-attachments/assets/378e07a8-d2e2-4a73-a167-a0ccb8f94ab2" />


### After
<img width="478" height="418" alt="image" src="https://github.com/user-attachments/assets/ae7a2dd3-7eac-4593-a427-c67e98af440e" />


## Test plan
- Verify that the mention popup now has a constrained width and does not overflow.

🤖 Generated with [Pochi](https://getpochi.com)