### PR TITLE
fix(vscode-webui): always display create pr icon

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -291,11 +291,6 @@ function WorktreeSection({
   const pochiTasks = usePochiTabs();
 
   const pullRequest = group.data?.github?.pullRequest;
-  const hasEdit = group.tasks.some(
-    (task) =>
-      task.lineChanges &&
-      (task.lineChanges?.added !== 0 || task.lineChanges?.removed !== 0),
-  );
 
   const prUrl = useMemo(() => {
     if (!gitOriginUrl || !pullRequest?.id) return "#";
@@ -353,7 +348,7 @@ function WorktreeSection({
                 prUrl={prUrl}
                 prChecks={pullRequest.checks}
               />
-            ) : hasEdit && !group.isDeleted ? (
+            ) : !group.isDeleted ? (
               <CreatePrDropdown
                 worktreePath={group.path}
                 branch={group.branch}


### PR DESCRIPTION
## Summary
- Always display the \"Create PR\" icon in the worktree list, even if there are no local edits.
- This allows users to create a PR for a branch that has been pushed but has no further local changes.

## Test plan
1. Open the worktree list in VSCode WebUI.
2. Verify that the \"Create PR\" icon appears for worktrees that are not deleted, regardless of whether they have modified files.

🤖 Generated with [Pochi](https://getpochi.com)