### PR TITLE
feat(vscode): add create task button in worktree section

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -48,6 +48,7 @@ import {
   GitCompare,
   GitPullRequest,
   Loader2,
+  Plus,
   Terminal,
   Trash2,
   X,
@@ -373,6 +374,23 @@ function WorktreeSection({
           >
             {!group.isDeleted && (
               <>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 w-6 p-0"
+                      asChild
+                    >
+                      <a
+                        href={`command:pochi.worktree.newTask?${encodeURIComponent(JSON.stringify([group.path]))}`}
+                      >
+                        <Plus className="size-4" />
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t("tasksPage.newTask")}</TooltipContent>
+                </Tooltip>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button


### PR DESCRIPTION
<img width="554" height="123" alt="image" src="https://github.com/user-attachments/assets/4a4b58a1-9685-43fb-b6e2-b8c01247dda4" />

## Summary
- Add plus button to worktree list item to create new task
- Enhance pochi.worktree.newTask command to handle missing arguments by inferring context

## Test plan
- Verify that a plus button appears next to worktree items in the sidebar
- Click the plus button and verify it opens a new task in that worktree
- Run the command `pochi.worktree.newTask` from command palette without arguments and verify it infers the correct worktree from active editor or workspace

🤖 Generated with [Pochi](https://getpochi.com)