### PR TITLE
fix(vscode): improve cwd logic for pochi layout

### DIFF
--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -505,29 +505,11 @@ export class CommandManager implements vscode.Disposable {
         if (arg0 instanceof vscode.Uri) {
           taskUri = arg0;
         }
-        // Try find active group's active tab
+        // Try find active task tab
         if (taskUri === undefined) {
-          const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
-          if (activeTab && isPochiTaskTab(activeTab)) {
+          const activeTab = findActivePochiTaskTab();
+          if (activeTab) {
             taskUri = activeTab.input.uri;
-          }
-        }
-        // Otherwise find active tab in other groups
-        if (taskUri === undefined) {
-          const group = getSortedCurrentTabGroups().find(
-            (group) => group.activeTab && isPochiTaskTab(group.activeTab),
-          );
-          if (group?.activeTab && isPochiTaskTab(group.activeTab)) {
-            taskUri = group.activeTab.input.uri;
-          }
-        }
-        // Otherwise find first task tab
-        if (taskUri === undefined) {
-          const tab = getSortedCurrentTabGroups()
-            .flatMap((group) => group.tabs)
-            .find((tab) => isPochiTaskTab(tab));
-          if (tab) {
-            taskUri = tab.input.uri;
           }
         }
         // No task found
@@ -585,6 +567,16 @@ export class CommandManager implements vscode.Disposable {
             const workspace = vscode.workspace.getWorkspaceFolder(arg0);
             if (workspace) {
               cwd = workspace.uri.fsPath;
+            }
+          }
+          // Try find active task tab
+          if (!cwd) {
+            const activeTab = findActivePochiTaskTab();
+            if (activeTab) {
+              const params = PochiTaskEditorProvider.parseTaskUri(
+                activeTab.input.uri,
+              );
+              cwd = params?.cwd;
             }
           }
           // Use workspace
@@ -669,4 +661,33 @@ export class CommandManager implements vscode.Disposable {
     }
     this.disposables = [];
   }
+}
+
+function findActivePochiTaskTab():
+  | (vscode.Tab & {
+      input: vscode.TabInputCustom & {
+        viewType: typeof PochiTaskEditorProvider.viewType;
+      };
+    })
+  | undefined {
+  // Try find active tab in active group
+  const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+  if (activeTab && isPochiTaskTab(activeTab)) {
+    return activeTab;
+  }
+  // Otherwise find active tab in other groups
+  const group = getSortedCurrentTabGroups().find(
+    (group) => group.activeTab && isPochiTaskTab(group.activeTab),
+  );
+  if (group?.activeTab && isPochiTaskTab(group.activeTab)) {
+    return group.activeTab;
+  }
+  // Otherwise find first task tab
+  const tab = getSortedCurrentTabGroups()
+    .flatMap((group) => group.tabs)
+    .find((tab) => isPochiTaskTab(tab));
+  if (tab) {
+    return tab;
+  }
+  return undefined;
 }

--- a/packages/vscode/src/integrations/layout.ts
+++ b/packages/vscode/src/integrations/layout.ts
@@ -203,9 +203,10 @@ export async function applyPochiLayout(params: { cwd: string | undefined }) {
   if (getSortedCurrentTabGroups()[2].tabs.length === 0) {
     await vscode.commands.executeCommand(
       "pochi.openTerminal",
-      userFocusTab && isPochiTaskTab(userFocusTab)
-        ? userFocusTab.input.uri
-        : undefined,
+      params.cwd ??
+        (userFocusTab && isPochiTaskTab(userFocusTab)
+          ? userFocusTab.input.uri
+          : undefined),
     );
   }
 


### PR DESCRIPTION
This change improves finding cwd logic when applying pochi layout.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>

-----

Improve finding cwd logic when invoking `Pochi: Pochi Layout` without args (aka from command palette)
Before: use workspaceFolders[0]
After: find active PochiTaskTab first, fallback to workspaceFolders[0]