### PR TITLE
feat(vscode): support open task diff along with task tab

### DIFF
--- a/packages/vscode-webui/src/components/diff-summary.tsx
+++ b/packages/vscode-webui/src/components/diff-summary.tsx
@@ -5,8 +5,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { useTaskChangedFiles } from "@/features/chat";
 import { EditSummary, FileIcon } from "@/features/tools";
+import type { useTaskChangedFiles } from "@/lib/hooks/use-task-changed-files";
 import { cn } from "@/lib/utils";
 import { vscodeHost } from "@/lib/vscode";
 import { Check, ChevronDown, ChevronRight } from "lucide-react";

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -13,12 +13,13 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { ApprovalButton, type useApprovalAndRetry } from "@/features/approval";
-import { useAutoApproveGuard, useTaskChangedFiles } from "@/features/chat";
+import { useAutoApproveGuard } from "@/features/chat";
 import { useSelectedModels } from "@/features/settings";
 import { AutoApproveMenu } from "@/features/settings";
 import { TodoList, useTodos } from "@/features/todo";
 import { useAddCompleteToolCalls } from "@/lib/hooks/use-add-complete-tool-calls";
 import type { useAttachmentUpload } from "@/lib/hooks/use-attachment-upload";
+import { useTaskChangedFiles } from "@/lib/hooks/use-task-changed-files";
 import { cn } from "@/lib/utils";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { constants } from "@getpochi/common";

--- a/packages/vscode-webui/src/features/chat/index.ts
+++ b/packages/vscode-webui/src/features/chat/index.ts
@@ -22,5 +22,3 @@ export type { ToolCallLifeCycle } from "./lib/tool-call-life-cycle";
 export { ChatPage } from "./page";
 
 export { CreateTaskInput } from "./components/create-task-input";
-
-export { useTaskChangedFiles } from "./lib/use-task-changed-files";

--- a/packages/vscode-webui/src/features/chat/lib/on-override-messages.ts
+++ b/packages/vscode-webui/src/features/chat/lib/on-override-messages.ts
@@ -1,3 +1,4 @@
+import { getTaskChangedFileStore } from "@/lib/hooks/use-task-changed-files";
 import { vscodeHost } from "@/lib/vscode";
 import { prompts } from "@getpochi/common";
 import { extractWorkflowBashCommands } from "@getpochi/common/message-utils";
@@ -6,7 +7,6 @@ import { type Message, catalog } from "@getpochi/livekit";
 import type { Store } from "@livestore/livestore";
 import { ThreadAbortSignal } from "@quilted/threads";
 import { unique } from "remeda";
-import { getTaskChangedFileStore } from "./use-task-changed-files";
 
 /**
  * Handles the onOverrideMessages event by appending a checkpoint to the last message.

--- a/packages/vscode-webui/src/lib/hooks/use-task-changed-files.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-task-changed-files.ts
@@ -1,10 +1,97 @@
 import { fileChangeEvent, vscodeHost } from "@/lib/vscode";
+import { getLogger } from "@getpochi/common";
 import type { TaskChangedFile } from "@getpochi/common/vscode-webui-bridge";
 import type { Message } from "@getpochi/livekit";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { create, useStore } from "zustand";
-import { persist } from "zustand/middleware";
+import {
+  type StateStorage,
+  createJSONStorage,
+  persist,
+} from "zustand/middleware";
 
+const logger = getLogger("task-changed-files");
+
+/**
+ * Custom storage adapter for Zustand persist middleware that uses VS Code's
+ * global state API instead of localStorage. This ensures state is shared
+ * across all webviews (sidebar and task panels).
+ */
+const vscodeStorage: StateStorage = {
+  getItem: async (name: string): Promise<string | null> => {
+    try {
+      const value = await vscodeHost.getGlobalState(name);
+      logger.trace(`getItem: ${name}`, value ? "found" : "not found");
+      return value ? JSON.stringify(value) : null;
+    } catch (error) {
+      logger.error(`Failed to get item: ${name}`, error);
+      return null;
+    }
+  },
+  setItem: async (name: string, value: string): Promise<void> => {
+    try {
+      const parsed = JSON.parse(value);
+      logger.trace(`setItem: ${name}`, parsed);
+      await vscodeHost.setGlobalState(name, parsed);
+    } catch (error) {
+      logger.error(`Failed to set item: ${name}`, error);
+    }
+  },
+  removeItem: async (name: string): Promise<void> => {
+    try {
+      logger.trace(`removeItem: ${name}`);
+      await vscodeHost.setGlobalState(name, undefined);
+    } catch (error) {
+      logger.error(`Failed to remove item: ${name}`, error);
+    }
+  },
+};
+
+/**
+ * Migrates data from localStorage to VS Code global state.
+ * This is needed when switching from the default localStorage storage
+ * to the custom VS Code global state storage.
+ */
+async function migrateFromLocalStorage(storeName: string): Promise<void> {
+  try {
+    // Check if we're in a browser environment with localStorage
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
+
+    // Check if data exists in localStorage
+    const localStorageData = window.localStorage.getItem(storeName);
+    if (!localStorageData) {
+      logger.trace(
+        `No migration needed for ${storeName} - no localStorage data`,
+      );
+      return;
+    }
+
+    // Check if data already exists in global state
+    const globalStateData = await vscodeHost.getGlobalState(storeName);
+    if (globalStateData) {
+      logger.trace(
+        `No migration needed for ${storeName} - global state already has data`,
+      );
+      // Clean up localStorage since global state is the source of truth now
+      window.localStorage.removeItem(storeName);
+      return;
+    }
+
+    // Migrate data from localStorage to global state
+    logger.info(`Migrating ${storeName} from localStorage to global state`);
+    const parsedData = JSON.parse(localStorageData);
+    await vscodeHost.setGlobalState(storeName, parsedData);
+
+    // Clean up localStorage after successful migration
+    window.localStorage.removeItem(storeName);
+    logger.info(`Successfully migrated ${storeName}`);
+  } catch (error) {
+    logger.error(`Failed to migrate ${storeName}:`, error);
+    // Don't throw - migration failure shouldn't break the app
+  }
+}
 export type ChangedFileContent =
   | {
       type: "text";
@@ -83,18 +170,50 @@ const createChangedFileStore = (taskId: string) =>
           },
         };
       },
-      { name: `changed-file-store-${taskId}` },
+      {
+        name: `changed-file-store-${taskId}`,
+        storage: createJSONStorage(() => vscodeStorage),
+      },
     ),
   );
 
 const taskStores = new Map<string, ReturnType<typeof createChangedFileStore>>();
+const migrationPromises = new Map<string, Promise<void>>();
+
 export const getTaskChangedFileStore = (taskId: string) => {
   if (taskStores.has(taskId)) {
     return taskStores.get(taskId) as ReturnType<typeof createChangedFileStore>;
   }
+
+  const storeName = `changed-file-store-${taskId}`;
   const storeHook = createChangedFileStore(taskId);
   taskStores.set(taskId, storeHook);
+
+  // Trigger migration from localStorage if needed (async, don't block)
+  if (!migrationPromises.has(taskId)) {
+    const migrationPromise = migrateFromLocalStorage(storeName).then(() => {
+      // After migration, trigger rehydration to load the migrated data
+      return storeHook.persist.rehydrate();
+    });
+    migrationPromises.set(taskId, migrationPromise);
+  }
+
   return storeHook;
+};
+
+/**
+ * Wait for the store to complete migration and hydration.
+ * Should be called before reading changed files from the store.
+ */
+export const waitForTaskStoreReady = async (taskId: string): Promise<void> => {
+  // Ensure store is created (triggers migration if needed)
+  getTaskChangedFileStore(taskId);
+
+  // Wait for migration to complete
+  const migrationPromise = migrationPromises.get(taskId);
+  if (migrationPromise) {
+    await migrationPromise;
+  }
 };
 
 export const useTaskChangedFiles = (


### PR DESCRIPTION
## Summary
- Adds support for opening task diff along with task tab in VS Code
- Implements proper handling of changed files in VS Code task panels
- Migrates task changed file stores from localStorage to VS Code global state for better cross-tab sharing
- Adds a new task button in the worktree section
- Improves VS Code layout management for terminals and task panels

## Test plan
- [ ] Verify that task diff can be opened from task tabs
- [ ] Check that changed files are properly tracked across different VS Code webviews
- [ ] Ensure the new task button in worktree section works correctly
- [ ] Confirm VS Code layout management improvements work as expected

🤖 Generated with [Pochi](https://getpochi.com)