### PR TITLE
feat(vscode-webui): extract router error boundary component with i18n support

### DIFF
--- a/packages/vscode-webui/src/components/router-error-boundary.tsx
+++ b/packages/vscode-webui/src/components/router-error-boundary.tsx
@@ -1,0 +1,42 @@
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+interface RouterErrorBoundaryProps {
+  error: Error;
+}
+
+export function RouterErrorBoundary({ error }: RouterErrorBoundaryProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-background p-4">
+      <div className="flex max-w-md flex-col items-center text-center">
+        <h1 className="mb-8 flex items-center gap-2 font-semibold text-2xl tracking-tight">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <AlertCircle
+                className="size-5 shrink-0 cursor-help text-yellow-500"
+                strokeWidth={2}
+              />
+            </TooltipTrigger>
+            <TooltipContent
+              side="top"
+              className="max-w-md whitespace-pre-wrap break-words"
+            >
+              {error.message || String(error)}
+            </TooltipContent>
+          </Tooltip>
+          <span>{t("error.somethingWentWrong")}</span>
+        </h1>
+        <a
+          href="command:workbench.action.reloadWindow"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 font-medium text-primary-foreground shadow-lg transition-all hover:scale-105 hover:bg-primary/90 hover:shadow-xl"
+        >
+          <RefreshCw className="size-4" />
+          {t("error.reloadWindow")}
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -5,6 +5,10 @@
     "account": "Account",
     "help": "Help"
   },
+  "error": {
+    "somethingWentWrong": "Something went wrong",
+    "reloadWindow": "Reload Window"
+  },
   "placeholder": {
     "title": "What can I help you ship?",
     "subtitle": "Pochi is powered by AI, so errors may occur.",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -5,6 +5,10 @@
     "account": "アカウント",
     "help": "ヘルプ"
   },
+  "error": {
+    "somethingWentWrong": "問題が発生しました",
+    "reloadWindow": "ウィンドウを再読み込み"
+  },
   "placeholder": {
     "title": "何をお手伝いしましょうか？",
     "subtitle": "Pochi は AI によって動作しているため、エラーが発生する可能性があります。",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -5,6 +5,10 @@
     "account": "계정",
     "help": "도움말"
   },
+  "error": {
+    "somethingWentWrong": "문제가 발생했습니다",
+    "reloadWindow": "창 새로고침"
+  },
   "placeholder": {
     "title": "무엇을 도와드릴까요?",
     "subtitle": "Pochi는 AI로 구동되므로 오류가 발생할 수 있습니다.",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -5,6 +5,10 @@
     "account": "账户",
     "help": "帮助"
   },
+  "error": {
+    "somethingWentWrong": "出错了",
+    "reloadWindow": "重新加载窗口"
+  },
   "placeholder": {
     "title": "我能帮您实现什么？",
     "subtitle": "Pochi 由 AI 驱动，可能会出现错误。",

--- a/packages/vscode-webui/src/main.tsx
+++ b/packages/vscode-webui/src/main.tsx
@@ -14,12 +14,8 @@ import ReactDOM from "react-dom/client";
 import { routeTree } from "./routeTree.gen";
 
 import "./styles.css";
-import { AlertCircle, Loader2, RefreshCw } from "lucide-react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "./components/ui/tooltip";
+import { Loader2 } from "lucide-react";
+import { RouterErrorBoundary } from "./components/router-error-boundary";
 import { useUserStorage } from "./lib/hooks/use-user-storage.ts";
 import { isVSCodeEnvironment, vscodeHost } from "./lib/vscode";
 import { Providers } from "./providers.tsx";
@@ -36,40 +32,7 @@ const router = createRouter({
   defaultStructuralSharing: true,
   defaultPreloadStaleTime: 0,
   history: hashHistory,
-  defaultErrorComponent: ({ error }) => {
-    return (
-      <div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-background p-4">
-        {/* eslint-disable i18next/no-literal-string */}
-        <div className="flex max-w-md flex-col items-center text-center">
-          <h1 className="mb-8 flex items-center gap-2 font-semibold text-2xl tracking-tight">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <AlertCircle
-                  className="size-5 shrink-0 cursor-help text-yellow-500"
-                  strokeWidth={2}
-                />
-              </TooltipTrigger>
-              <TooltipContent
-                side="top"
-                className="max-w-md whitespace-pre-wrap break-words"
-              >
-                {error.message || String(error)}
-              </TooltipContent>
-            </Tooltip>
-            <span>Something went wrong</span>
-          </h1>
-          <a
-            href="command:workbench.action.reloadWindow"
-            className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 font-medium text-primary-foreground shadow-lg transition-all hover:scale-105 hover:bg-primary/90 hover:shadow-xl"
-          >
-            <RefreshCw className="size-4" />
-            Reload Window
-          </a>
-        </div>
-        {/* eslint-enable i18next/no-literal-string */}
-      </div>
-    );
-  },
+  defaultErrorComponent: ({ error }) => <RouterErrorBoundary error={error} />,
 });
 
 declare global {


### PR DESCRIPTION
## Summary
- Extract defaultErrorComponent into a separate RouterErrorBoundary component
- Add i18n support for error messages in English, Chinese, Japanese, and Korean
- Update main.tsx to use the new component instead of inline implementation
- Follow project conventions for naming and structure

## Test plan
- [ ] Verify that error boundary still works correctly when router errors occur
- [ ] Check that translations work in all supported languages
- [ ] Ensure no functionality is lost compared to the original implementation

🤖 Generated with [Pochi](https://getpochi.com)