### PR TITLE
fix(vscode): pass true parameter to getWorktrees in WorktreeManager

### DIFF
--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -89,7 +89,7 @@ export class WorktreeManager implements vscode.Disposable {
     if ((await this.isGitRepository()) === false) {
       return null;
     }
-    const worktrees = await this.getWorktrees();
+    const worktrees = await this.getWorktrees(true);
 
     if (worktrees.length >= this.maxWorktrees) {
       vscode.window.showErrorMessage(


### PR DESCRIPTION
## Summary
- Fixed an issue in the WorktreeManager where the refresh parameter was not being passed to getWorktrees() function
- This ensures the worktrees list is properly updated when checking if the maximum worktrees limit is reached

## Test plan
- [ ] Verify that worktree functionality works as expected
- [ ] Confirm that the maximum worktrees limit check functions properly with the updated parameter

🤖 Generated with [Pochi](https://getpochi.com)