### PR TITLE
feat(vscode): improve worktree and PR integration

### DIFF
--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -30,6 +30,8 @@ export class WorktreeManager implements vscode.Disposable {
   worktrees = signal<GitWorktree[]>([]);
   inited = new Deferred<void>();
 
+  defaultBranch = "origin/main";
+
   private workspacePath: string | undefined;
   private git: ReturnType<typeof simpleGit>;
 
@@ -64,6 +66,7 @@ export class WorktreeManager implements vscode.Disposable {
     this.disposables.push(
       this.gitState.onDidChangeRepository(onWorktreeChanged),
     );
+    this.defaultBranch = await this.getDefaultBranch();
     this.inited.resolve();
   }
 
@@ -175,8 +178,7 @@ export class WorktreeManager implements vscode.Disposable {
   }
 
   async showWorktreeDiff(cwd: string) {
-    const baseBranch = await this.getDefaultBranch();
-    await showWorktreeDiff(cwd, baseBranch);
+    await showWorktreeDiff(cwd, this.defaultBranch);
   }
 
   async updateWorktrees() {

--- a/packages/vscode/src/integrations/github/github-pull-request-state.ts
+++ b/packages/vscode/src/integrations/github/github-pull-request-state.ts
@@ -36,6 +36,7 @@ export class GithubPullRequestState implements vscode.Disposable {
   }
 
   async init() {
+    await this.worktreeManager.inited.promise;
     this.queueCheck();
     this.disposables.push(
       this.gitState.onDidChangeBranch(async (e) => {
@@ -143,6 +144,16 @@ export class GithubPullRequestState implements vscode.Disposable {
   }
 
   async fetchWorktreePrInfo(worktree: GitWorktree) {
+    logger.info(
+      `Fetching GitHub PR info for worktree at ${worktree.path} (branch: ${worktree.branch}), default branch: ${this.worktreeManager.defaultBranch}`,
+    );
+    if (
+      worktree.branch ===
+      this.worktreeManager.defaultBranch.split(/\/(.+)/, 2).pop()
+    ) {
+      return;
+    }
+
     if (!this.gh.value.authorized) {
       return;
     }


### PR DESCRIPTION
## Summary
- Add defaultBranch property to WorktreeManager to store the default branch
- Initialize defaultBranch during WorktreeManager initialization
- Use cached defaultBranch when showing worktree diffs instead of fetching each time
- Wait for worktree manager to be initialized before initializing GitHub PR state
- Add logging for GitHub PR info fetching
- Skip PR info fetching for the default branch to avoid unnecessary API calls

## Test plan
- [ ] Verify that worktree diffs still work correctly
- [ ] Check that GitHub PR state initializes properly
- [ ] Confirm that PR info fetching is skipped for the default branch
- [ ] Ensure no unnecessary API calls are made

🤖 Generated with [Pochi](https://getpochi.com)