### PR TITLE
fix(vscode-webui): handle null subtask messages in useInlinedSubTask hook

### DIFF
--- a/packages/vscode-webui/src/features/tools/hooks/use-inlined-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-inlined-sub-task.tsx
@@ -14,7 +14,7 @@ export function useInlinedSubTask(
 
   const { todos } = useTodos({
     initialTodos: subtask?.todos as Readonly<Todo[]> | undefined,
-    messages: subtask?.messages as Message[],
+    messages: (subtask?.messages ?? []) as Message[],
     todosRef,
   });
 


### PR DESCRIPTION
## Summary
- Add nullish coalescing operator to handle cases where subtask.messages might be undefined
- This prevents potential runtime errors when accessing subtask messages in the useInlinedSubTask hook

## Test plan
- [ ] Verify that the fix resolves potential null reference errors
- [ ] Ensure existing functionality remains intact

🤖 Generated with [Pochi](https://getpochi.com)