### PR TITLE
feat(vscode-webui): enhance worktree select component to support auto create worktree

### DIFF
--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -51,6 +51,7 @@ export {
   prefixTaskDisplayId,
   prefixWorktreeName,
   getTaskDisplayTitle,
+  WorktreePrefix,
 } from "./task-utils";
 
 const isPochiDev = process.env.POCHI_LOCAL_SERVER === "true";

--- a/packages/common/src/vscode-webui-bridge/task-utils.ts
+++ b/packages/common/src/vscode-webui-bridge/task-utils.ts
@@ -1,4 +1,4 @@
-const WorktreePrefix = "⎇";
+export const WorktreePrefix = "⎇";
 export const prefixWorktreeName = (name: string) => `${WorktreePrefix} ${name}`;
 export const prefixTaskDisplayId = (displayId: number) =>
   `${String(displayId).padStart(3, "0")}`;

--- a/packages/vscode-webui/src/components/worktree-select.tsx
+++ b/packages/vscode-webui/src/components/worktree-select.tsx
@@ -10,20 +10,30 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { vscodeHost } from "@/lib/vscode";
 import { getWorktreeNameFromWorktreePath } from "@getpochi/common/git-utils";
-import type { GitWorktree } from "@getpochi/common/vscode-webui-bridge";
+import {
+  type GitWorktree,
+  WorktreePrefix,
+} from "@getpochi/common/vscode-webui-bridge";
 import { DropdownMenuPortal } from "@radix-ui/react-dropdown-menu";
-import { CheckIcon, FolderGit2, PlusIcon } from "lucide-react";
+import { CheckIcon, CirclePlus, PlusIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+
+export type CreateWorktreeType = GitWorktree | "new-worktree" | undefined;
 
 interface WorktreeSelectProps {
   cwd: string;
   worktrees: GitWorktree[];
   showCreateWorktree?: boolean;
-  value: GitWorktree | undefined;
-  onChange: (v: GitWorktree) => void;
+  value: CreateWorktreeType;
+  onChange: (v: CreateWorktreeType) => void;
   isLoading?: boolean;
   triggerClassName?: string;
 }
@@ -49,19 +59,10 @@ export function WorktreeSelect({
 }: WorktreeSelectProps) {
   const { t } = useTranslation();
   const onCreateWorkTree = async () => {
-    try {
-      const newWorktree = await vscodeHost.createWorktree();
-      if (newWorktree) {
-        setTimeout(() => {
-          onChange(newWorktree);
-        }, 1000);
-      }
-    } catch (e) {
-      // ignore
-    }
+    onChange("new-worktree");
   };
 
-  const isMainWorkspace = value?.path === cwd;
+  const isNewWorktree = value === "new-worktree";
   return (
     <LoadingWrapper
       loading={isLoading}
@@ -71,35 +72,55 @@ export function WorktreeSelect({
         </div>
       }
     >
-      <div className="h-6 select-none overflow-hidden">
+      <div className="h-6 select-none overflow-visible">
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              className={cn(
-                "!px-1 button-focus h-6 max-w-[40vw] items-center py-0 font-normal",
-                triggerClassName,
-              )}
-            >
-              <span
-                className={cn(
-                  "truncate whitespace-nowrap transition-colors duration-200",
-                  !value && "text-muted-foreground",
-                )}
-              >
-                {isMainWorkspace
-                  ? "\b"
-                  : (getWorktreeName(value) ??
-                    t("worktreeSelect.selectWorktree"))}
-              </span>
-              <FolderGit2
-                className={cn(
-                  "size-4 shrink-0 scale-110 transition-colors duration-200",
-                  !value && "text-muted-foreground",
-                )}
-              />
-            </Button>
-          </DropdownMenuTrigger>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className={cn(
+                      "!px-1 button-focus h-6 max-w-[40vw] items-center overflow-visible py-0 font-normal",
+                      triggerClassName,
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "truncate whitespace-nowrap transition-colors duration-200",
+                        !value && "text-muted-foreground",
+                      )}
+                    >
+                      {value === "new-worktree" || value?.path === cwd
+                        ? "\b"
+                        : (getWorktreeName(value) ??
+                          t("worktreeSelect.selectWorktree"))}
+                    </span>
+                    <div
+                      className={cn("relative inline-flex items-center", {
+                        "pr-2": isNewWorktree,
+                      })}
+                    >
+                      <span
+                        className={cn(
+                          "font-bold text-base leading-none",
+                          !value && "text-muted-foreground",
+                        )}
+                      >
+                        {WorktreePrefix}
+                      </span>
+                      {isNewWorktree && (
+                        <CirclePlus className="-right-0.5 -top-1 absolute size-3" />
+                      )}
+                    </div>
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{t("worktreeSelect.selectWorktree")}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <DropdownMenuPortal>
             <DropdownMenuContent
               onCloseAutoFocus={(e) => e.preventDefault()}
@@ -108,8 +129,34 @@ export function WorktreeSelect({
               alignOffset={-6}
               className="dropdown-menu max-h-[32vh] min-w-[18rem] max-w-[80vw] animate-in overflow-y-auto overflow-x-hidden rounded-md border bg-background p-2 text-popover-foreground shadow"
             >
+              {showCreateWorktree && (
+                <>
+                  <DropdownMenuItem
+                    onClick={onCreateWorkTree}
+                    className="cursor-pointer py-2 pl-2"
+                  >
+                    {isNewWorktree ? (
+                      <CheckIcon
+                        className={cn("mr-2 shrink-0", "opacity-100")}
+                      />
+                    ) : (
+                      <PlusIcon className="mr-2 shrink-0" />
+                    )}
+                    <div>
+                      <div className="font-semibold">
+                        {t("worktreeSelect.createWorktree")}
+                      </div>
+                      <div className="text-muted-foreground text-xs">
+                        {t("worktreeSelect.createWorktreeDescription")}
+                      </div>
+                    </div>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </>
+              )}
               {worktrees?.map((item: GitWorktree) => {
-                const isSelected = item.path === value?.path;
+                const isSelected =
+                  value === "new-worktree" ? false : item.path === value?.path;
                 return (
                   <DropdownMenuItem
                     onClick={(e: React.MouseEvent) => {
@@ -141,25 +188,6 @@ export function WorktreeSelect({
                   </DropdownMenuItem>
                 );
               })}
-              {showCreateWorktree && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={onCreateWorkTree}
-                    className="cursor-pointer py-2 pl-2"
-                  >
-                    <PlusIcon className="mr-2 shrink-0" />
-                    <div>
-                      <div className="font-semibold">
-                        {t("worktreeSelect.createWorktree")}
-                      </div>
-                      <div className="text-muted-foreground text-xs">
-                        {t("worktreeSelect.createWorktreeDescription")}
-                      </div>
-                    </div>
-                  </DropdownMenuItem>
-                </>
-              )}
             </DropdownMenuContent>
           </DropdownMenuPortal>
         </DropdownMenu>

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -61,7 +61,7 @@
   },
   "worktreeSelect": {
     "selectWorktree": "Select Worktree",
-    "createWorktree": "Create Git worktree",
+    "createWorktree": "New worktree",
     "createWorktreeDescription": "Start task in a new Git worktree"
   },
   "worktree": {

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -61,7 +61,7 @@
   },
   "worktreeSelect": {
     "selectWorktree": "ワークツリーを選択",
-    "createWorktree": "Git ワークツリーを作成",
+    "createWorktree": "新しいワークツリー",
     "createWorktreeDescription": "新しい Git ワークツリーでタスクを開始"
   },
   "worktree": {

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -61,7 +61,7 @@
   },
   "worktreeSelect": {
     "selectWorktree": "워크트리 선택",
-    "createWorktree": "Git 워크트리 생성",
+    "createWorktree": "새 워크트리",
     "createWorktreeDescription": "새 Git 워크트리에서 작업 시작"
   },
   "worktree": {

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -61,7 +61,7 @@
   },
   "worktreeSelect": {
     "selectWorktree": "选择工作树",
-    "createWorktree": "创建 Git 工作树",
+    "createWorktree": "新工作树",
     "createWorktreeDescription": "在新的 Git 工作树中启动任务"
   },
   "worktree": {

--- a/packages/vscode-webui/src/routes/index.tsx
+++ b/packages/vscode-webui/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { WelcomeScreen } from "@/components/welcome-screen";
 import { WorkspaceRequiredPlaceholder } from "@/components/workspace-required-placeholder";
 import { WorktreeList } from "@/components/worktree-list";
+import type { CreateWorktreeType } from "@/components/worktree-select";
 import { CreateTaskInput } from "@/features/chat";
 import { useAttachmentUpload } from "@/lib/hooks/use-attachment-upload";
 import { useCurrentWorkspace } from "@/lib/hooks/use-current-workspace";
@@ -9,7 +10,6 @@ import { useModelList } from "@/lib/hooks/use-model-list";
 import { useUserStorage } from "@/lib/hooks/use-user-storage";
 import { useOptimisticWorktreeDelete } from "@/lib/hooks/use-worktrees";
 import { setActiveStore } from "@/lib/vscode";
-import type { GitWorktree } from "@getpochi/common/vscode-webui-bridge";
 import { taskCatalog } from "@getpochi/livekit";
 import { useStore } from "@livestore/react";
 import { createFileRoute } from "@tanstack/react-router";
@@ -61,7 +61,7 @@ function Tasks() {
   const { store } = useStore();
   const { data: currentWorkspace } = useCurrentWorkspace();
   const cwd = currentWorkspace?.cwd || "default";
-  const workspaceFolder = currentWorkspace?.workspacePath;
+  const workspacePath = currentWorkspace?.workspacePath;
   // Fetch all tasks
   const tasks = store.useQuery(taskCatalog.queries.makeTasksQuery(cwd));
 
@@ -74,16 +74,18 @@ function Tasks() {
 
   const attachmentUpload = useAttachmentUpload();
 
-  const [userSelectedWorktree, setUserSelectedWorktree] = useState<
-    GitWorktree | undefined
-  >();
+  const [userSelectedWorktree, setUserSelectedWorktree] =
+    useState<CreateWorktreeType>();
 
   const { deleteWorktree, deletingWorktreePaths } =
     useOptimisticWorktreeDelete();
 
   const onDeleteWorktree = (wt: string) => {
     deleteWorktree(wt);
-    if (userSelectedWorktree?.path === wt) {
+    if (
+      typeof userSelectedWorktree !== "string" &&
+      userSelectedWorktree?.path === wt
+    ) {
       setUserSelectedWorktree(undefined);
     }
   };
@@ -93,7 +95,7 @@ function Tasks() {
       <div className="w-full px-4 pt-3">
         <CreateTaskInput
           cwd={cwd}
-          workspaceFolder={workspaceFolder}
+          workspacePath={workspacePath}
           attachmentUpload={attachmentUpload}
           userSelectedWorktree={userSelectedWorktree}
           setUserSelectedWorktree={setUserSelectedWorktree}

--- a/packages/vscode/src/integrations/git/__tests__/worktree.test.ts
+++ b/packages/vscode/src/integrations/git/__tests__/worktree.test.ts
@@ -367,8 +367,8 @@ prunable gitdir file points to non-existent location
         prompt: "create feature",
       });
 
-      assert.ok(result.branchName.startsWith("branch/"));
-      assert.ok(result.worktreePath.startsWith("/path/to/worktrees/branch-"));
+      assert.ok(result.branchName.startsWith("worktree/"));
+      assert.ok(result.worktreePath.startsWith("/path/to/worktrees/worktree-"));
     });
 
     it("should fallback to timestamp if generation fails", async () => {
@@ -394,8 +394,8 @@ prunable gitdir file points to non-existent location
         prompt: "create feature",
       });
 
-      assert.ok(result.branchName.startsWith("branch/"));
-      assert.ok(result.worktreePath.startsWith("/path/to/worktrees/branch-"));
+      assert.ok(result.branchName.startsWith("worktree/"));
+      assert.ok(result.worktreePath.startsWith("/path/to/worktrees/worktree-"));
     });
 
     it("should use workspace folder parent for worktree path if no worktrees", async () => {

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -333,7 +333,7 @@ export class WorktreeManager implements vscode.Disposable {
     }
     if (!branchName) {
       // Fallback to timestamp
-      branchName = `branch/${getTimestampString()}`;
+      branchName = `worktree/${getTimestampString()}`;
     }
 
     const worktreeName = branchName.replace(/\//g, "-");


### PR DESCRIPTION
https://jam.dev/c/55ab1c83-450a-4644-9591-cbc5b580b778

## Summary
- Add tooltip to worktree select component for better UX
- Introduce 'new-worktree' option type to allow creating new worktrees directly from the select dropdown
- Update worktree creation flow to handle the new option type
- Replace FolderGit2 icon with CirclePlus for new worktree indicator
- Update i18n translations for worktree creation
- Export WorktreePrefix constant for reuse across components
- Update branch naming convention from 'branch/' to 'worktree/' for clarity

## Test plan
- [x] Verify worktree select component shows tooltip on hover
- [x] Verify new worktree option appears in dropdown
- [x] Verify clicking new worktree option triggers worktree creation
- [x] Verify branch naming uses 'worktree/' prefix instead of 'branch/' prefix
- [x] Run tests to ensure all functionality works as expected

🤖 Generated with [Pochi](https://getpochi.com)