### PR TITLE
feat(vscode-webui): add storybook story for router error boundary component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -256,7 +256,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.19.0-dev",
+      "version": "0.21.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/vscode-webui/src/components/__stories__/router-error-boundary.stories.tsx
+++ b/packages/vscode-webui/src/components/__stories__/router-error-boundary.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { RouterErrorBoundary } from "../router-error-boundary";
+
+const meta: Meta<typeof RouterErrorBoundary> = {
+  title: "Pochi/RouterErrorBoundary",
+  component: RouterErrorBoundary,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    error: new Error(
+      "This is a test error message that might be long and contain details about what went wrong in the application routing.",
+    ),
+  },
+  parameters: {
+    backgrounds: { disable: true },
+  },
+};


### PR DESCRIPTION
## Summary
- Create RouterErrorBoundary story in Storybook
- Enable viewing the error boundary component in isolation
- Facilitates easier testing and development of error states

## Test plan
- [ ] Verify the new story appears in Storybook
- [ ] Check that the error boundary component renders correctly in Storybook
- [ ] Confirm the story displays different error states properly

🤖 Generated with [Pochi](https://getpochi.com)