### PR TITLE
fix(vscode-webui): handle create worktree fail properly

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -152,14 +152,17 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
                 },
               })
             : selectedWorktree;
-        vscodeHost.openTaskInPanel({
-          type: "new-task",
-          cwd: worktree?.path || cwd,
-          prompt: content,
-          files: uploadedFiles,
-        });
-
-        clearFiles();
+        if (worktree) {
+          vscodeHost.openTaskInPanel({
+            type: "new-task",
+            cwd: worktree?.path || cwd,
+            prompt: content,
+            files: uploadedFiles,
+          });
+          clearFiles();
+          // Clear input content after unfreeze
+          setTimeout(clearDraft, 50);
+        }
       } else if (content.length > 0) {
         clearUploadError();
 
@@ -171,19 +174,21 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
                 },
               })
             : selectedWorktree;
-        vscodeHost.openTaskInPanel({
-          type: "new-task",
-          cwd: worktree?.path || cwd,
-          prompt: content,
-        });
+        if (worktree) {
+          vscodeHost.openTaskInPanel({
+            type: "new-task",
+            cwd: worktree?.path || cwd,
+            prompt: content,
+          });
+          // Clear input content after unfreeze
+          setTimeout(clearDraft, 50);
+        }
       }
 
       // Set isCreatingTask state false
       // Hide loading and unfreeze input
       setIsCreatingTask(false);
       setDebouncedIsCreatingTask(false);
-      // Clear input content after unfreeze
-      setTimeout(clearDraft, 50);
     },
     [
       cwd,


### PR DESCRIPTION
## Summary
- Add null check for worktree before opening task in panel
- Prevent errors when worktree is undefined/null
- Move clearDraft timeout inside worktree check to avoid issues

## Test plan
- [ ] Verify that tasks can still be created properly when worktree exists
- [ ] Verify that no errors occur when worktree is undefined/null
- [ ] Verify that the input content is cleared properly after task creation

Fixes: #851

🤖 Generated with [Pochi](https://getpochi.com)