### PR TITLE
refactor: simplify chat page initialization and deprecate displayId in events

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -22,7 +22,6 @@ const logger = getLogger("LiveChatKit");
 
 export type LiveChatKitOptions<T> = {
   taskId: string;
-  displayId?: number;
 
   abortSignal?: AbortSignal;
 
@@ -101,7 +100,6 @@ export class LiveChatKit<
 
   constructor({
     taskId,
-    displayId,
     abortSignal,
     store,
     chatClass,
@@ -117,7 +115,6 @@ export class LiveChatKit<
     ...chatInit
   }: LiveChatKitOptions<T>) {
     this.taskId = taskId;
-    this.displayId = displayId;
     this.store = store;
     this.onStreamStart = onStreamStart;
     this.onStreamFinish = onStreamFinish;
@@ -320,7 +317,6 @@ export class LiveChatKit<
           git: toTaskGitInfo(environment?.workspace.gitStatus),
           updatedAt: new Date(),
           modelId: llm.id,
-          displayId: this.displayId,
         }),
       );
 

--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -131,6 +131,7 @@ export const events = {
       git: Schema.optional(Git),
       updatedAt: Schema.Date,
       modelId: Schema.optional(Schema.String),
+      // @deprecated, use displayId in init instead.
       displayId: Schema.optional(Schema.Number),
     }),
   }),


### PR DESCRIPTION
## Summary
- Simplified the chat page initialization by removing the workspace-required check and using `info.cwd` directly.
- Removed `displayId` from `LiveChatKit` options and constructor, moving it to initialization-time parameters for better consistency.
- Deprecated `displayId` in `default-schema.ts` events in favor of the initialization-time value.
- Updated `useLiveChatKit` in `packages/vscode-webui` to reflect these changes and ensure correct type checking.

## Test plan
- Verified that the project builds and passes type checks with `bun tsc`.
- Verified that existing tests pass.
- Manual verification of chat page initialization and display ID handling.

🤖 Generated with [Pochi](https://getpochi.com)