### PR TITLE
fix(livekit): remove max_tokens when mapping to max_completion_tokens

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ragdoll",

--- a/packages/livekit/src/chat/models/openai.ts
+++ b/packages/livekit/src/chat/models/openai.ts
@@ -81,6 +81,7 @@ function overrideMaxOutputToken(body: string): string | undefined {
     // Apply the transformation safely
     if (parsed.max_tokens) {
       parsed.max_completion_tokens = parsed.max_tokens;
+      parsed.max_tokens = undefined;
     }
 
     return JSON.stringify(parsed);


### PR DESCRIPTION
## Summary
When `max_tokens` is present in the request body, we map it to `max_completion_tokens` for OpenAI compatibility. However, sending both might cause issues with some models or validators. This change ensures `max_tokens` is removed (set to undefined) after mapping.

## Test plan
Verified that `max_tokens` is removed from the request body when `max_completion_tokens` is set.

🤖 Generated with [Pochi](https://getpochi.com)

Before:

<img width="1446" height="258" alt="CleanShot 2025-12-19 at 14 25 55@2x" src="https://github.com/user-attachments/assets/10c6e724-5f06-4ee1-a530-882523837a24" />

<img width="1444" height="322" alt="CleanShot 2025-12-19 at 14 25 41@2x" src="https://github.com/user-attachments/assets/ee7753f4-e6b9-4fe7-aabe-22e401ac8e4d" />

After:
<img width="1466" height="866" alt="CleanShot 2025-12-19 at 14 30 35@2x" src="https://github.com/user-attachments/assets/5d6b1776-4d1d-46eb-b71c-6ac3a220eaa4" />
