### PR TITLE
fix(vscode-webui): update create worktree label translation

### DIFF
--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -61,7 +61,7 @@
   },
   "worktreeSelect": {
     "selectWorktree": "Select Worktree",
-    "createWorktree": "New worktree",
+    "createWorktree": "Auto create worktree",
     "createWorktreeDescription": "Start task in a new Git worktree"
   },
   "worktree": {

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -61,7 +61,7 @@
   },
   "worktreeSelect": {
     "selectWorktree": "ワークツリーを選択",
-    "createWorktree": "新しいワークツリー",
+    "createWorktree": "ワークツリー自動作成",
     "createWorktreeDescription": "新しい Git ワークツリーでタスクを開始"
   },
   "worktree": {

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -61,7 +61,7 @@
   },
   "worktreeSelect": {
     "selectWorktree": "워크트리 선택",
-    "createWorktree": "새 워크트리",
+    "createWorktree": "워크트리 자동 생성",
     "createWorktreeDescription": "새 Git 워크트리에서 작업 시작"
   },
   "worktree": {

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -61,7 +61,7 @@
   },
   "worktreeSelect": {
     "selectWorktree": "选择工作树",
-    "createWorktree": "新工作树",
+    "createWorktree": "自动创建工作树",
     "createWorktreeDescription": "在新的 Git 工作树中启动任务"
   },
   "worktree": {


### PR DESCRIPTION
## Summary
- Update the \`createWorktree\` label translation in \`en\`, \`jp\`, \`ko\`, and \`zh\` locales to \"Auto create worktree\" (and corresponding translations) to better reflect the action.

## Test plan
- Verify the new label appears in the UI when selecting a worktree.

🤖 Generated with [Pochi](https://getpochi.com)