### PR TITLE
fix: update spinner state to reflect completion of todos

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/todo-write.tsx
+++ b/packages/vscode-webui/src/features/tools/components/todo-write.tsx
@@ -18,9 +18,12 @@ export const todoWriteTool: React.FC<ToolProps<"todoWrite">> = ({
     return [];
   }, [tool]);
 
+  // Check if all todos are completed
+  const allCompleted = todos.length > 0 && todos.every((t) => t.status === "completed");
+
   const title = (
     <>
-      <StatusIcon isExecuting={isExecuting} tool={tool} />
+      <StatusIcon isExecuting={isExecuting && !allCompleted} tool={tool} />
       <span className="ml-2" />
       {t("toolInvocation.updatingToDos")}
     </>


### PR DESCRIPTION
# Fix: Show Completed State When All Todos Are Done

This pull request introduces a targeted fix to the `todoWrite` tool component to ensure the status icon correctly reflects the completion state of all todo items.


## Problem Statement

The current implementation had the following issues:

- **Issue 1**: The `todoWrite` tool in the message list continues to show the "executing" state (spinner) even after all items in the todo list are marked as completed.

- **Issue 2**: The `StatusIcon` component receives `isExecuting={true}` regardless of whether all todos are done, causing incorrect visual feedback to users.

- **Impact**: Users see a perpetual loading spinner even when all tasks are complete, leading to confusion about whether the operation has finished.

Fixes #914 

## Solution

- Added a check to determine if all todos in the list have a status of `"completed"`
- Modified the `isExecuting` prop passed to `StatusIcon` to return `false` when all todos are completed
- Ensured alignment with project-wide conventions and best practices

The solution was designed to be minimal, focused, and easy to review.

## Changes Introduced

- Updated `packages/vscode-webui/src/features/tools/components/todo-write.tsx`
- Added `allCompleted` variable to check if all todos are completed:
  ```tsx
  const allCompleted = todos.length > 0 && todos.every((t) => t.status === "completed");

- Fixed `StatusIcon` prop to stop showing spinner when all todos are done:
  ```tsx
  <StatusIcon isExecuting={isExecuting && !allCompleted} tool={tool} />

## Testing & Verification

- Local testing using existing test cases
- Manual validation of critical scenarios:
     -✅ Spinner shows when todos are in progress
     -✅ Check icon appears when all todos are completed
     -✅ Empty todos array handled correctly
     -✅ Partial completion continues showing spinner