### PR TITLE
fix(task): generate displayId if not existed when open task

### DIFF
--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -168,7 +168,7 @@ export class PochiTaskEditorProvider
           params.uid) ||
         crypto.randomUUID();
       const displayId =
-        params.type === "open-task"
+        params.type === "open-task" && params.displayId
           ? params.displayId
           : await getNextDisplayId(params.cwd);
       const taskInfo: PochiTaskInfo = {


### PR DESCRIPTION
Ensure that for open-task requests, we only use the provided displayId if it is truthy. Otherwise, we generate a new displayId.

🤖 Generated with [Pochi](https://getpochi.com)

Co-Authored-By: Pochi <noreply@getpochi.com>

---
fix the issue that the local tasks created in website did not gain a displayId

<img width="4802" height="814" alt="Google Chrome 2025-12-22 21 49 03" src="https://github.com/user-attachments/assets/902a9108-4dfe-4c46-a4ff-f99871b78654" />
