### PR TITLE
fix: improve new problem detection for file writing tool calls

### DIFF
--- a/packages/tools/src/constants.ts
+++ b/packages/tools/src/constants.ts
@@ -43,4 +43,13 @@ export const EditFileOutputSchema = z.object({
     .describe(
       "Metadata that would be removed before sending to the LLM (e.g. UI specific data).",
     ),
+
+  _transient: z
+    .object({
+      resolvedProblems: z
+        .string()
+        .optional()
+        .describe("The problems resolved after writing the file, if any."),
+    })
+    .optional(),
 });

--- a/packages/vscode/src/integrations/editor/__test__/diff-view.test.ts
+++ b/packages/vscode/src/integrations/editor/__test__/diff-view.test.ts
@@ -147,7 +147,7 @@ describe("DiffView with real file system", () => {
 
     diagnosticStubs = {
       diagnosticsToProblemsString: sinon.stub().returns(""),
-      getNewDiagnostics: sinon.stub().returns([]),
+      compareDiagnostics: sinon.stub().returns({ newProblems: [], resolvedProblems: [] }),
     };
     
     // A basic constructor stub for TabInputTextDiff for `instanceof` checks


### PR DESCRIPTION
## Summary
This PR improves how Pochi detects and tracks problems reported by file writing tools (`writeToFile` and `applyDiff`). It introduces a mechanism to track resolved problems and refine the problem list in the UI, ensuring that fixed problems are no longer displayed.

- Update `compareDiagnostics` to return both new and resolved problems.
- Add `_transient.resolvedProblems` to tool outputs.
- Implement `refineDetectedNewPromblems` in message formatters to clean up the problem list.
- Add unit tests for the new refinement logic.

Fixes #915

## Review of `refineDetectedNewPromblems` function
The function iterates through `UIMessage` objects to clean up lists of detected problems. When a tool part indicates that a problem has been resolved (via a `_transient.resolvedProblems` property), this function finds the original tool part that reported the problem and removes it from its `newProblems` list. This ensures the UI doesn't show problems that have already been fixed in subsequent steps.

## Test plan
- Verified with new unit tests in `packages/common/src/base/__tests__/formatters.test.ts`.
- Verified that `compareDiagnostics` correctly identifies new and resolved problems in `packages/vscode/src/lib/__test__/diagnostic.test.ts`.
- Run `bun run test` in the root directory to ensure all tests pass.

🤖 Generated with [Pochi](https://getpochi.com)


---


<img width="6144" height="3456" alt="Screenshot from 2025-12-23 17-29-39" src="https://github.com/user-attachments/assets/f31d1897-43cb-4889-b3c4-28a6c5101464" />

