### PR TITLE
fix: add filter completion tools middleware

### DIFF
--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -30,6 +30,7 @@ import type { Message, Metadata, RequestData } from "../types";
 import { makeRepairToolCall } from "./llm";
 import { parseMcpToolSet } from "./mcp-utils";
 import {
+  createFilterCompletionToolsMiddleware,
   createNewTaskMiddleware,
   createReasoningMiddleware,
   createToolCallMiddleware,
@@ -112,6 +113,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
 
     const model = createModel({ llm });
     const middlewares = [];
+
+    middlewares.push(createFilterCompletionToolsMiddleware());
 
     if (!this.isSubTask) {
       middlewares.push(

--- a/packages/livekit/src/chat/middlewares/__tests__/filter-completion-tools-middleware.test.ts
+++ b/packages/livekit/src/chat/middlewares/__tests__/filter-completion-tools-middleware.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { createFilterCompletionToolsMiddleware } from "../filter-completion-tools-middleware";
+import type {
+  LanguageModelV2StreamPart,
+} from "@ai-sdk/provider";
+
+describe("filterCompletionToolsMiddleware", () => {
+  const middleware = createFilterCompletionToolsMiddleware();
+
+  async function processStream(parts: LanguageModelV2StreamPart[]) {
+    const readableStream = new ReadableStream<LanguageModelV2StreamPart>({
+      start(controller) {
+        for (const part of parts) {
+          controller.enqueue(part);
+        }
+        controller.close();
+      },
+    });
+
+    const doStream = vi.fn().mockResolvedValue({
+      stream: readableStream,
+      rawCall: {},
+      rawResponse: {},
+    });
+
+    const result = await (middleware as any).wrapStream({
+      doStream,
+      params: {},
+    });
+
+    const reader = result.stream.getReader();
+    const output: LanguageModelV2StreamPart[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output.push(value);
+    }
+    return output;
+  }
+
+  it("should allow todoWrite and then attemptCompletion", async () => {
+    const input: LanguageModelV2StreamPart[] = [
+      { type: "tool-input-start", toolName: "todoWrite", id: "1" },
+      { type: "tool-input-delta", id: "1", delta: "{}" },
+      { type: "tool-call", toolCallId: "1", toolName: "todoWrite", input: "{}" },
+      { type: "tool-input-start", toolName: "attemptCompletion", id: "2" },
+      { type: "tool-input-delta", id: "2", delta: "{}" },
+      { type: "tool-call", toolCallId: "2", toolName: "attemptCompletion", input: "{}" },
+    ];
+
+    const output = await processStream(input);
+    expect(output).toEqual(input);
+  });
+
+  it("should filter out attemptCompletion if other tools are already present", async () => {
+    const input: LanguageModelV2StreamPart[] = [
+      { type: "tool-input-start", toolName: "executeCommand", id: "1" },
+      { type: "tool-input-delta", id: "1", delta: "{}" },
+      { type: "tool-call", toolCallId: "1", toolName: "executeCommand", input: "{}" },
+      { type: "tool-input-start", toolName: "attemptCompletion", id: "2" },
+      { type: "tool-input-delta", id: "2", delta: "{}" },
+      { type: "tool-call", toolCallId: "2", toolName: "attemptCompletion", input: "{}" },
+    ];
+
+    const output = await processStream(input);
+    expect(output).toHaveLength(3);
+    expect(output[0]).toEqual(input[0]);
+    expect(output[1]).toEqual(input[1]);
+    expect(output[2]).toEqual(input[2]);
+    expect(output.find(p => (p as any).id === "2" || (p as any).toolCallId === "2")).toBeUndefined();
+  });
+
+  it("should filter out subsequent tools if attemptCompletion is already present", async () => {
+    const input: LanguageModelV2StreamPart[] = [
+      { type: "tool-input-start", toolName: "attemptCompletion", id: "1" },
+      { type: "tool-input-delta", id: "1", delta: "{}" },
+      { type: "tool-call", toolCallId: "1", toolName: "attemptCompletion", input: "{}" },
+      { type: "tool-input-start", toolName: "executeCommand", id: "2" },
+      { type: "tool-input-delta", id: "2", delta: "{}" },
+      { type: "tool-call", toolCallId: "2", toolName: "executeCommand", input: "{}" },
+    ];
+
+    const output = await processStream(input);
+    expect(output).toHaveLength(3);
+    expect(output[0]).toEqual(input[0]);
+    expect(output[1]).toEqual(input[1]);
+    expect(output[2]).toEqual(input[2]);
+    expect(output.find(p => (p as any).id === "2" || (p as any).toolCallId === "2")).toBeUndefined();
+  });
+});

--- a/packages/livekit/src/chat/middlewares/filter-completion-tools-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/filter-completion-tools-middleware.ts
@@ -1,0 +1,106 @@
+import type {
+  LanguageModelV2Middleware,
+  LanguageModelV2StreamPart,
+} from "@ai-sdk/provider";
+import { isUserInputToolName } from "@getpochi/tools";
+
+// Middleware rules:
+// 1. If there are already any tool calls (todoWrite excluded) in the current step, attemptCompletion/askFollowupQuestions are not allowed.
+// 2. If there is already an attemptCompletion/askFollowupQuestions in the current step, further tool calls are not allowed.
+
+export function createFilterCompletionToolsMiddleware(): LanguageModelV2Middleware {
+  return {
+    middlewareVersion: "v2",
+    wrapStream: async ({ doStream }) => {
+      const { stream, ...rest } = await doStream();
+
+      let stepState: undefined | "hasOtherTools" | "hasCompletionTool" =
+        undefined;
+      let completionToolId: string | undefined = undefined;
+      const filterOutToolIds: string[] = [];
+
+      const transformedStream = stream.pipeThrough(
+        new TransformStream<
+          LanguageModelV2StreamPart,
+          LanguageModelV2StreamPart
+        >({
+          async transform(chunk, controller) {
+            // attempt to update state
+            if (stepState === undefined && chunk.type === "tool-input-start") {
+              if (isUserInputToolName(chunk.toolName)) {
+                stepState = "hasCompletionTool";
+                completionToolId = getToolCallId(chunk);
+              } else if (chunk.toolName !== "todoWrite") {
+                stepState = "hasOtherTools";
+              }
+            }
+
+            // filter out futher toolcalls when already has completion tool
+            if (
+              stepState === "hasCompletionTool" &&
+              chunk.type === "tool-input-start" &&
+              getToolCallId(chunk) !== completionToolId
+            ) {
+              const toolcallId = getToolCallId(chunk);
+              if (!filterOutToolIds.includes(toolcallId)) {
+                filterOutToolIds.push(toolcallId);
+              }
+              return;
+            }
+
+            // filter out attemptCompletion/askFollowupQuestions toolcalls when already has other tools
+            if (
+              stepState === "hasOtherTools" &&
+              chunk.type === "tool-input-start" &&
+              isUserInputToolName(chunk.toolName)
+            ) {
+              const toolcallId = getToolCallId(chunk);
+              if (!filterOutToolIds.includes(toolcallId)) {
+                filterOutToolIds.push(toolcallId);
+              }
+              return;
+            }
+
+            if (
+              (chunk.type === "tool-input-delta" ||
+                chunk.type === "tool-input-end" ||
+                chunk.type === "tool-call") &&
+              filterOutToolIds.includes(getToolCallId(chunk))
+            ) {
+              // filter out
+              return;
+            }
+
+            controller.enqueue(chunk);
+          },
+        }),
+      );
+
+      return {
+        stream: transformedStream,
+        ...rest,
+      };
+    },
+  };
+}
+
+function getToolCallId(
+  part: Extract<
+    LanguageModelV2StreamPart,
+    | { type: "tool-input-start" }
+    | { type: "tool-input-delta" }
+    | { type: "tool-input-end" }
+    | { type: "tool-call" }
+  >,
+): string {
+  switch (part.type) {
+    case "tool-input-start":
+      return part.id;
+    case "tool-input-delta":
+      return part.id;
+    case "tool-input-end":
+      return part.id;
+    case "tool-call":
+      return part.toolCallId;
+  }
+}

--- a/packages/livekit/src/chat/middlewares/index.ts
+++ b/packages/livekit/src/chat/middlewares/index.ts
@@ -1,3 +1,4 @@
 export { createReasoningMiddleware } from "./reasoning-middleware";
 export { createNewTaskMiddleware } from "./new-task-middleware";
 export { createToolCallMiddleware } from "./tool-call-middleware";
+export { createFilterCompletionToolsMiddleware } from "./filter-completion-tools-middleware";

--- a/packages/tools/src/ask-followup-question.ts
+++ b/packages/tools/src/ask-followup-question.ts
@@ -10,6 +10,8 @@ Use this tool in the following scenarios:
 1. The user's request is ambiguous or unclear and requires clarification.
 2. You need more details to proceed effectively.
 3. You have made several unsuccessful attempts to solve the issue and need user guidance to move forward.
+
+IMPORTANT: This tool CANNOT be used in combination with other tools (except todoWrite) in a single step. If you need to use other tools, you must do so in a separate step before calling this tool.
 `.trim(),
   inputSchema: z.object({
     question: z.string().describe("The question to ask the user."),

--- a/packages/tools/src/attempt-completion.ts
+++ b/packages/tools/src/attempt-completion.ts
@@ -15,6 +15,8 @@ const toolDef = {
 
 You MUST NOT generate any text before this tool call. All conclusion text must be included within the result parameter of the attemptCompletion tool.
 Never use this tool with a question or request to engage in further conversation! Formulate the end of your result in a way that is final and does not require further input from the user.
+
+IMPORTANT: This tool CANNOT be used in combination with other tools (except todoWrite) in a single step. If you need to use other tools, you must do so in a separate step before calling this tool.
 `.trim(),
   inputSchema: attemptCompletionSchema,
   outputSchema: z.object({


### PR DESCRIPTION
## Summary
- Implemented `FilterCompletionToolsMiddleware` to restrict the usage of completion tools (`askFollowupQuestion` and `attemptCompletion`) when other tools are being called.
- Updated tool descriptions for `askFollowupQuestion` and `attemptCompletion` to explicitly state they cannot be combined with other tools in a single step.
- Registered the new middleware in `FlexibleChatTransport`.

## Test plan
- Verified that the middleware correctly filters out completion tools when multiple tools are present in a single request.
- Ensured the tool descriptions are updated in the generated schema.

🤖 Generated with [Pochi](https://getpochi.com)