### PR TITLE
fix: enforce single-tool usage for completion tools

### DIFF
--- a/packages/livekit/src/chat/__tests__/filter-completion-tools.test.ts
+++ b/packages/livekit/src/chat/__tests__/filter-completion-tools.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { filterCompletionTools } from "../filter-completion-tools";
+import type { Message } from "../../types";
+
+describe("filterCompletionTools", () => {
+  it("should return the same message if only completion tools are present in the last step", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { 
+          type: "tool-attemptCompletion", 
+          toolCallId: "tool-1", 
+          state: "input-available", 
+          input: {} as any 
+        },
+      ] as any,
+    } as any;
+
+    const result = filterCompletionTools(message);
+    expect(result).toEqual(message);
+  });
+
+  it("should return the same message if only other tools are present in the last step", () => {
+    const message: Message = {
+      id: "2",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { 
+          type: "tool-executeCommand", 
+          toolCallId: "tool-1", 
+          state: "input-available", 
+          input: {} as any 
+        },
+      ] as any,
+    } as any;
+
+    const result = filterCompletionTools(message);
+    expect(result).toEqual(message);
+  });
+
+  it("should filter out completion tools if both completion and other tools are present in the last step", () => {
+    const message: Message = {
+      id: "3",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { 
+          type: "tool-executeCommand", 
+          toolCallId: "tool-1", 
+          state: "input-available", 
+          input: {} as any 
+        },
+        { 
+          type: "tool-attemptCompletion", 
+          toolCallId: "tool-2", 
+          state: "input-available", 
+          input: {} as any 
+        },
+      ] as any,
+    } as any;
+
+    const result = filterCompletionTools(message);
+    expect(result.parts).toHaveLength(2);
+    expect(result.parts[0]).toEqual({ type: "step-start" });
+    expect(result.parts[1]).toEqual({ 
+      type: "tool-executeCommand", 
+      toolCallId: "tool-1", 
+      state: "input-available", 
+      input: {} 
+    });
+  });
+
+  it("should ignore todoWrite when deciding whether to filter", () => {
+    const message: Message = {
+      id: "4",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { 
+          type: "tool-todoWrite", 
+          toolCallId: "tool-1", 
+          state: "input-available", 
+          input: {} as any 
+        },
+        { 
+          type: "tool-attemptCompletion", 
+          toolCallId: "tool-2", 
+          state: "input-available", 
+          input: {} as any 
+        },
+      ] as any,
+    } as any;
+
+    const result = filterCompletionTools(message);
+    expect(result).toEqual(message);
+  });
+
+  it("should handle multiple steps and only filter the last step", () => {
+    const message: Message = {
+      id: "5",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { 
+          type: "tool-executeCommand", 
+          toolCallId: "tool-1", 
+          state: "input-available", 
+          input: {} as any 
+        },
+        { 
+          type: "tool-attemptCompletion", 
+          toolCallId: "tool-2", 
+          state: "input-available", 
+          input: {} as any 
+        },
+        { type: "step-start" },
+        { 
+          type: "tool-executeCommand", 
+          toolCallId: "tool-3", 
+          state: "input-available", 
+          input: {} as any 
+        },
+        { 
+          type: "tool-askFollowupQuestion", 
+          toolCallId: "tool-4", 
+          state: "input-available", 
+          input: {} as any 
+        },
+      ] as any,
+    } as any;
+
+    const result = filterCompletionTools(message);
+    expect(result.parts).toHaveLength(5);
+    expect(result.parts[result.parts.length - 1]).toEqual({
+      type: "tool-executeCommand",
+      toolCallId: "tool-3",
+      state: "input-available",
+      input: {},
+    });
+  });
+});

--- a/packages/livekit/src/chat/filter-completion-tools.ts
+++ b/packages/livekit/src/chat/filter-completion-tools.ts
@@ -1,0 +1,46 @@
+import type { Message } from "../types";
+
+// type A: attemptCompletion/askFollowupQuestion
+// type B: toolcalls exclude todoWrite and attemptCompletion/askFollowupQuestion
+
+// Rules:
+// If there are both type A and B tool calls in the last step, remove all type A tool calls
+
+export function filterCompletionTools(message: Message): Message {
+  const lastStepStartIndex = message.parts.findLastIndex(
+    (part) => part.type === "step-start",
+  );
+  const parts =
+    lastStepStartIndex > 0
+      ? message.parts.slice(lastStepStartIndex)
+      : message.parts;
+
+  const hasCompletionTools = parts.some(
+    (part) =>
+      part.type === "tool-attemptCompletion" ||
+      part.type === "tool-askFollowupQuestion",
+  );
+  const hasOtherTools = parts.some(
+    (part) =>
+      part.type.startsWith("tool-") &&
+      part.type !== "tool-todoWrite" &&
+      part.type !== "tool-attemptCompletion" &&
+      part.type !== "tool-askFollowupQuestion",
+  );
+
+  if (hasCompletionTools && hasOtherTools) {
+    const lastStepParts = parts.filter(
+      (part) =>
+        part.type !== "tool-attemptCompletion" &&
+        part.type !== "tool-askFollowupQuestion",
+    );
+    const prevStepsParts =
+      lastStepStartIndex > 0 ? message.parts.slice(0, lastStepStartIndex) : [];
+    return {
+      ...message,
+      parts: [...prevStepsParts, ...lastStepParts],
+    };
+  }
+
+  return message;
+}

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -10,6 +10,7 @@ import { toTaskError, toTaskGitInfo, toTaskStatus } from "../task";
 
 import type { Message, Task } from "../types";
 import { scheduleGenerateTitleJob } from "./background-job";
+import { filterCompletionTools } from "./filter-completion-tools";
 import {
   FlexibleChatTransport,
   type OnStartCallback,
@@ -327,7 +328,7 @@ export class LiveChatKit<
   };
 
   private readonly onFinish: ChatOnFinishCallback<Message> = ({
-    message,
+    message: originalMessage,
     isAbort,
     isError,
   }) => {
@@ -339,6 +340,9 @@ export class LiveChatKit<
     }
 
     if (isError) return; // handled in onError already.
+
+    const message = filterCompletionTools(originalMessage);
+    this.chat.messages = [...this.chat.messages.slice(0, -1), message];
 
     const { store } = this;
     if (message.metadata?.kind !== "assistant") {

--- a/packages/tools/src/ask-followup-question.ts
+++ b/packages/tools/src/ask-followup-question.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { NoOtherToolsReminderPrompt } from "./constants";
 import { defineClientTool } from "./types";
 
 const toolDef = {
@@ -10,6 +11,8 @@ Use this tool in the following scenarios:
 1. The user's request is ambiguous or unclear and requires clarification.
 2. You need more details to proceed effectively.
 3. You have made several unsuccessful attempts to solve the issue and need user guidance to move forward.
+
+${NoOtherToolsReminderPrompt}
 `.trim(),
   inputSchema: z.object({
     question: z.string().describe("The question to ask the user."),

--- a/packages/tools/src/attempt-completion.ts
+++ b/packages/tools/src/attempt-completion.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { NoOtherToolsReminderPrompt } from "./constants";
 import { defineClientTool } from "./types";
 
 export const attemptCompletionSchema = z.object({
@@ -15,6 +16,8 @@ const toolDef = {
 
 You MUST NOT generate any text before this tool call. All conclusion text must be included within the result parameter of the attemptCompletion tool.
 Never use this tool with a question or request to engage in further conversation! Formulate the end of your result in a way that is final and does not require further input from the user.
+
+${NoOtherToolsReminderPrompt}
 `.trim(),
   inputSchema: attemptCompletionSchema,
   outputSchema: z.object({

--- a/packages/tools/src/constants.ts
+++ b/packages/tools/src/constants.ts
@@ -53,3 +53,6 @@ export const EditFileOutputSchema = z.object({
     })
     .optional(),
 });
+
+export const NoOtherToolsReminderPrompt =
+  "IMPORTANT: This tool CANNOT be used in combination with other tools (except todoWrite) in a single step. If you need to use other tools, you must do so in a separate step before calling this tool.";


### PR DESCRIPTION
## Summary
- Add `NoOtherToolsReminderPrompt` to `askFollowupQuestion` and `attemptCompletion` tools to remind the model that these tools cannot be used with others.
- Implement `filterCompletionTools` in `LiveChatKit` to ensure these tools are not mixed with other tool calls (except `todoWrite`) in a single step.
- Add comprehensive unit tests for the tool filtering logic.

## Test plan
- [x] Run unit tests for `filterCompletionTools`: `bun test packages/livekit/src/chat/__tests__/filter-completion-tools.test.ts`
- [x] Verify pre-push hooks passed during branch push.

🤖 Generated with [Pochi](https://getpochi.com)