### PR TITLE
fix: remove redundant sidebar reset commands in layout application

### DIFF
--- a/packages/vscode/src/integrations/layout.ts
+++ b/packages/vscode/src/integrations/layout.ts
@@ -33,11 +33,7 @@ export async function applyPochiLayout(params: { cwd: string | undefined }) {
   const userFocusTab = vscode.window.tabGroups.activeTabGroup.activeTab;
   const userActiveTerminal = vscode.window.activeTerminal;
 
-  // Reset pochiSidebar location to primary sidebar, move all bottom panels to secondary sidebar
-  await vscode.commands.executeCommand("pochiSidebar.resetViewLocation");
-  await vscode.commands.executeCommand(
-    "workbench.view.extension.pochi.resetViewContainerLocation",
-  );
+  // Move all bottom panels to secondary sidebar
   await vscode.commands.executeCommand("workbench.action.movePanelToSidePanel");
 
   // Make all groups horizontal, so we can move them left/right, then join groups if needed


### PR DESCRIPTION
## Summary
- Removed redundant `pochiSidebar.resetViewLocation` and `workbench.view.extension.pochi.resetViewContainerLocation` commands from `applyPochiLayout`.
- These resets are no longer necessary when applying the Pochi layout and were causing unnecessary UI shifts.

## Test plan
- Verified that applying the Pochi layout still works correctly.
- Ensured that the bottom panels are still moved to the secondary sidebar as expected.

🤖 Generated with [Pochi](https://getpochi.com)