### PR TITLE
fix(vscode-webui): remove unexpected line when no todos and diffs

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -225,7 +225,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
         </div>
       </div>
       {(todos.length > 0 ||
-        useTaskChangedFilesHelpers.changedFiles.length > 0) && (
+        useTaskChangedFilesHelpers.visibleChangedFiles.length > 0) && (
         <div className={cn("mt-1.5 rounded-sm border border-border")}>
           {todos.length > 0 && (
             <TodoList todos={todos}>


### PR DESCRIPTION
## Summary
- Fixes an issue where an empty border (unexpected line) would appear in the chat toolbar when there are no todos and no visible changed files.
- Updated the condition to use `visibleChangedFiles` instead of `changedFiles`.

## Test plan
- Verify that the chat toolbar does not show an empty border container when there are no tasks and no file changes.
- Verify that the container still appears correctly when there are active todos or visible file changes.

🤖 Generated with [Pochi](https://getpochi.com)