### PR TITLE
feat: highlight the current selected task in the task list

### DIFF
--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -71,6 +71,7 @@ export interface TaskState {
   unread?: boolean;
   active?: boolean;
   running?: boolean;
+  focused?: boolean;
 }
 
 export type TaskStates = Record<string, TaskState>;

--- a/packages/vscode-webui/src/components/task-row.tsx
+++ b/packages/vscode-webui/src/components/task-row.tsx
@@ -32,7 +32,10 @@ export function TaskRow({
   const content = (
     <div
       className={cn(
-        "group cursor-pointer rounded-lg border border-border/50 bg-card/60 transition-all duration-200 hover:border-border hover:bg-card hover:shadow-md",
+        "group cursor-pointer rounded-lg border border-border/50 bg-card/60 transition-all duration-200 hover:bg-card hover:shadow-md",
+        {
+          "border-primary/85": state?.focused,
+        },
       )}
     >
       <div className="px-2 py-1">
@@ -44,7 +47,7 @@ export function TaskRow({
                   {prefixTaskDisplayId(task.displayId)}
                 </span>
               )}
-              <div className="line-clamp-2 flex flex-1 items-center font-medium text-foreground leading-relaxed transition-colors duration-200">
+              <div className="line-clamp-2 flex flex-1 items-center font-medium text-foreground leading-relaxed">
                 <div className="truncate">{title}</div>
                 {state?.unread && (
                   <div className="ml-2 h-2 w-2 shrink-0 rounded-full bg-primary" />


### PR DESCRIPTION
## Summary
- Add `focused` property to `TaskState` to track which task is currently focused in the editor.
- Update `PochiTaskState` in VS Code extension to detect and sync the focused task based on the active tab group.
- Highlight the focused task in the task list UI with a primary border for better visual feedback.

## Demo
https://jam.dev/c/576e2931-9350-4837-ab39-e0e534bcb216

## Test plan
1. Open multiple tasks in the editor.
2. Switch between task tabs.
3. Verify that the task list in the webview correctly highlights the task corresponding to the active editor tab.

🤖 Generated with [Pochi](https://getpochi.com)