### PR TITLE
chore: Hide create-pr button when it is not a git repo

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -229,14 +229,14 @@ function WorktreeSection({
                 prUrl={prUrl}
                 prChecks={pullRequest.checks}
               />
-            ) : (
+            ) : gitOriginUrl ? (
               <CreatePrDropdown
                 worktreePath={group.path}
                 branch={group.branch}
                 gitOriginUrl={gitOriginUrl}
                 gh={gh}
               />
-            )}
+            ) : null}
           </div>
 
           <div


### PR DESCRIPTION
## Summary
- Hide the `CreatePrDropdown` component in the worktree list when `gitOriginUrl` is not available.
- This prevents showing the 'Create PR' button for local repositories that are not associated with a remote git host.

## Screenshot
<img width="724" height="194" alt="image" src="https://github.com/user-attachments/assets/48673c98-c2a8-49e3-9385-f63af5407fb0" />


## Test plan
- Verified that the button is hidden when no git origin URL is present.
- Ensured existing functionality remains for repositories with a valid origin URL.

🤖 Generated with [Pochi](https://getpochi.com)