### PR TITLE
fix: reveal range when clicking on review item

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -295,7 +295,7 @@ const VSCodeHostStub = {
 
   openReview: async (
     _review: Review,
-    _options?: { focusCommentsPanel?: boolean },
+    _options?: { focusCommentsPanel?: boolean; revealRange?: boolean },
   ) => {},
 
   getGlobalState: async (): Promise<unknown> => {

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -340,7 +340,7 @@ export interface VSCodeHostApi {
 
   openReview(
     review: Review,
-    options?: { focusCommentsPanel?: boolean },
+    options?: { focusCommentsPanel?: boolean; revealRange?: boolean },
   ): Promise<void>;
 }
 

--- a/packages/vscode-webui/src/components/message/reviews.tsx
+++ b/packages/vscode-webui/src/components/message/reviews.tsx
@@ -89,7 +89,11 @@ function ReviewFileGroup({ uri, reviews }: ReviewFileGroupProps) {
   const onFileClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!reviews.length) return;
-    vscodeHost.openReview(reviews[0], { focusCommentsPanel: false });
+    vscodeHost.openReview(reviews[0]);
+  };
+
+  const onReviewClick = (review: Review) => {
+    vscodeHost.openReview(review, { revealRange: true });
   };
 
   const displayUri = convertReviewThreadUri(uri);
@@ -120,12 +124,16 @@ function ReviewFileGroup({ uri, reviews }: ReviewFileGroupProps) {
       </div>
       <CollapsibleContent>
         <div
-          className={cn("ml-6 flex flex-col gap-2 px-3 py-1", {
+          className={cn("flex flex-col gap-2", {
             "mb-1": isOpen,
           })}
         >
           {reviews.map((review) => (
-            <ReviewItem key={review.id} review={review} />
+            <ReviewItem
+              onClick={() => onReviewClick(review)}
+              key={review.id}
+              review={review}
+            />
           ))}
         </div>
       </CollapsibleContent>
@@ -135,14 +143,18 @@ function ReviewFileGroup({ uri, reviews }: ReviewFileGroupProps) {
 
 interface ReviewItemProps {
   review: Review;
+  onClick: () => void;
 }
 
-function ReviewItem({ review }: ReviewItemProps) {
+function ReviewItem({ review, onClick }: ReviewItemProps) {
   const mainComment = review.comments[0];
   const replies = review.comments.slice(1);
 
   return (
-    <div className="flex justify-between gap-2 text-sm">
+    <div
+      className="flex cursor-pointer justify-between gap-2 py-1 pr-3 pl-9 text-sm hover:bg-border/30"
+      onClick={onClick}
+    >
       <div className="flex min-w-0 flex-1 gap-1.5">
         <MessageSquare className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
         <div className="flex min-w-0 flex-1 flex-col gap-1">

--- a/packages/vscode-webui/src/components/prompt-form/review-badges.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/review-badges.tsx
@@ -30,7 +30,10 @@ export const ReviewBadges: React.FC<Props> = ({ reviews }) => {
 
   const onBadgeClick = (review: Review) => {
     if (!review) return;
-    vscodeHost.openReview(review, { focusCommentsPanel: true });
+    vscodeHost.openReview(review, {
+      focusCommentsPanel: true,
+      revealRange: true,
+    });
   };
 
   return (

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -978,7 +978,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
 
   openReview = async (
     review: Review,
-    options?: { focusCommentsPanel?: boolean },
+    options?: { focusCommentsPanel?: boolean; revealRange?: boolean },
   ): Promise<void> => {
     if (options?.focusCommentsPanel) {
       vscode.commands.executeCommand("workbench.action.focusCommentsPanel");
@@ -986,14 +986,15 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
 
     const uri = vscode.Uri.parse(review.uri);
     vscode.commands.executeCommand("vscode.open", uri, {
-      selection: review.range
-        ? new vscode.Selection(
-            review.range.start.line,
-            review.range.start.character,
-            review.range.start.line,
-            review.range.start.character,
-          )
-        : undefined,
+      selection:
+        review.range && options?.revealRange
+          ? new vscode.Selection(
+              review.range.start.line - 1,
+              0,
+              review.range.start.line - 1,
+              0,
+            )
+          : undefined,
     });
 
     this.reviewController.expandThread(review.id);


### PR DESCRIPTION
## Summary
- Added `revealRange` option to the `openReview` API in both the bridge and host implementation.
- Updated `ReviewItem` in the webview to handle clicks and call `openReview` with `revealRange: true` to enable navigation to the specific code range.
- Adjusted `VSCodeHostImpl` to correctly handle the VS Code selection range (converting 1-based line numbers to 0-based) when `revealRange` is enabled.
- Improved the UI of `ReviewItem` with a cursor-pointer and hover effect to indicate interactivity.

## Recording
https://jam.dev/c/6ca2f53b-0c60-44c9-b495-3fb71aa630e5

## Test plan
- Manually verified that clicking on a review item in the Reviews section now opens the corresponding file and scrolls to the correct line/range.
- Verified that clicking on the file header still opens the file without necessarily revealing a specific range (or using the first review's range as before).
- Verified that review badges in the prompt form still work as expected with the new option.

🤖 Generated with [Pochi](https://getpochi.com)