### PR TITLE
refactor(tools): improve expand/collapse behavior in FileBadge

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/apply-diff.tsx
+++ b/packages/vscode-webui/src/features/tools/components/apply-diff.tsx
@@ -1,6 +1,6 @@
 import { useToolCallLifeCycle } from "@/features/chat";
 import { getToolName } from "ai";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ModelEdits } from "./code-edits";
 import { FileBadge } from "./file-badge";
@@ -15,6 +15,7 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
   changes,
 }) => {
   const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
   const { path } = tool.input || {};
   const lifecycle = useToolCallLifeCycle().getToolCallLifeCycle({
     toolName: getToolName(tool),
@@ -31,8 +32,12 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
   }, [tool.state, lifecycle.status]);
 
   const handleClick = useCallback(() => {
-    lifecycle.preview(tool.input, tool.state);
-  }, [tool.input, tool.state, lifecycle.preview]);
+    if (shouldPreview) {
+      lifecycle.preview(tool.input, tool.state);
+    } else {
+      setIsExpanded((prev) => !prev);
+    }
+  }, [shouldPreview, tool.input, tool.state, lifecycle.preview]);
 
   const result =
     tool.state === "output-available" && !("error" in tool.output)
@@ -55,7 +60,7 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
         <FileBadge
           className="ml-1"
           path={path}
-          onClick={shouldPreview ? handleClick : undefined}
+          onClick={handleClick}
           editSummary={result?._meta?.editSummary ?? previewInfo?.editSummary}
           changes={result?.success ? changes : undefined}
         />
@@ -87,6 +92,8 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
       expandableDetail={expandableDetail}
       expandableDetailIcon={result?.newProblems && <NewProblemsIcon />}
       detail={detail}
+      isExpanded={isExpanded}
+      onToggle={setIsExpanded}
     />
   );
 };

--- a/packages/vscode-webui/src/features/tools/components/multi-apply-diff.tsx
+++ b/packages/vscode-webui/src/features/tools/components/multi-apply-diff.tsx
@@ -1,7 +1,7 @@
 import { useToolCallLifeCycle } from "@/features/chat";
 
 import { getToolName } from "ai";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ModelEdits } from "./code-edits";
 import { FileBadge } from "./file-badge";
@@ -16,6 +16,7 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
   changes,
 }) => {
   const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
   const { path } = tool.input || {};
 
   const lifecycle = useToolCallLifeCycle().getToolCallLifeCycle({
@@ -32,8 +33,12 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
   }, [tool.state, lifecycle.status]);
 
   const handleClick = useCallback(() => {
-    lifecycle.preview(tool.input, tool.state);
-  }, [tool.input, tool.state, lifecycle.preview]);
+    if (shouldPreview) {
+      lifecycle.preview(tool.input, tool.state);
+    } else {
+      setIsExpanded((prev) => !prev);
+    }
+  }, [shouldPreview, tool.input, tool.state, lifecycle.preview]);
 
   const result =
     tool.state === "output-available" &&
@@ -58,7 +63,7 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
         <FileBadge
           className="ml-1"
           path={path}
-          onClick={shouldPreview ? handleClick : undefined}
+          onClick={handleClick}
           editSummary={result?._meta?.editSummary ?? previewInfo?.editSummary}
           changes={result?.success ? changes : undefined}
         />
@@ -90,6 +95,8 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
       expandableDetail={expandableDetail}
       expandableDetailIcon={result?.newProblems && <NewProblemsIcon />}
       detail={detail}
+      isExpanded={isExpanded}
+      onToggle={setIsExpanded}
     />
   );
 };

--- a/packages/vscode-webui/src/features/tools/components/tool-container.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-container.tsx
@@ -50,14 +50,28 @@ export const ExpandableToolContainer: React.FC<{
   expandableDetail?: React.ReactNode;
   expandableDetailIcon?: React.ReactNode;
   detail?: React.ReactNode;
+  isExpanded?: boolean;
   onToggle?: (expand: boolean) => void;
-}> = ({ title, expandableDetail, expandableDetailIcon, detail, onToggle }) => {
-  const [showDetails, setShowDetails] = useState(false);
+}> = ({
+  title,
+  expandableDetail,
+  expandableDetailIcon,
+  detail,
+  isExpanded: controlledExpanded,
+  onToggle,
+}) => {
+  const [internalExpanded, setInternalExpanded] = useState(false);
+
+  const isExpanded =
+    controlledExpanded !== undefined ? controlledExpanded : internalExpanded;
 
   const handleToggle = () => {
-    setShowDetails(!showDetails);
+    const newExpanded = !isExpanded;
+    if (controlledExpanded === undefined) {
+      setInternalExpanded(newExpanded);
+    }
     if (onToggle) {
-      onToggle(!showDetails);
+      onToggle(newExpanded);
     }
   };
 
@@ -72,13 +86,13 @@ export const ExpandableToolContainer: React.FC<{
         )}
         {expandableDetail && (
           <ExpandIcon
-            isExpanded={showDetails}
+            isExpanded={isExpanded}
             onClick={handleToggle}
             className="cursor-pointer"
           />
         )}
       </ToolTitle>
-      {showDetails && expandableDetail}
+      {isExpanded && expandableDetail}
       {detail}
     </ToolContainer>
   );

--- a/packages/vscode-webui/src/features/tools/components/write-to-file.tsx
+++ b/packages/vscode-webui/src/features/tools/components/write-to-file.tsx
@@ -1,6 +1,6 @@
 import { useToolCallLifeCycle } from "@/features/chat";
 import { getToolName } from "ai";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ModelEdits } from "./code-edits";
 import { FileBadge } from "./file-badge";
@@ -15,6 +15,7 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
   changes,
 }) => {
   const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
   const lifecycle = useToolCallLifeCycle().getToolCallLifeCycle({
     toolName: getToolName(tool),
     toolCallId: tool.toolCallId,
@@ -29,8 +30,12 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
   }, [tool.state, lifecycle.status]);
 
   const handleClick = useCallback(() => {
-    lifecycle.preview(tool.input, tool.state);
-  }, [tool.input, tool.state, lifecycle.preview]);
+    if (shouldPreview) {
+      lifecycle.preview(tool.input, tool.state);
+    } else {
+      setIsExpanded((prev) => !prev);
+    }
+  }, [shouldPreview, tool.input, tool.state, lifecycle.preview]);
 
   const { path } = tool.input || {};
 
@@ -55,7 +60,7 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
         <FileBadge
           className="ml-1"
           path={path}
-          onClick={shouldPreview ? handleClick : undefined}
+          onClick={handleClick}
           editSummary={result?._meta?.editSummary ?? previewInfo?.editSummary}
           changes={result?.success ? changes : undefined}
         />
@@ -87,6 +92,8 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
       expandableDetail={expandableDetail}
       expandableDetailIcon={result?.newProblems && <NewProblemsIcon />}
       detail={detail}
+      isExpanded={isExpanded}
+      onToggle={setIsExpanded}
     />
   );
 };


### PR DESCRIPTION
## Summary
- Enhanced `ExpandableToolContainer` to support both controlled and uncontrolled expansion states
- Improved UX by allowing users to toggle expanded view even after tool execution completes
- File badges now remain clickable for expanding/collapsing content, not just for preview

## Changes
- **ExpandableToolContainer**: Added optional `isExpanded` prop to support controlled state management
- **File edit tools** (applyDiff, multiApplyDiff, writeToFile): 
  - Added local expansion state management
  - Modified click handlers to toggle expansion when preview is not available
  - Preserved original preview behavior when tool is in preview-able state

## Benefits
- Better UX: Users can expand/collapse tool details after execution completes
- More flexible component API: Supports both controlled and uncontrolled modes
- Consistent interaction: File badges remain interactive throughout the tool lifecycle

## Test plan
- [ ] Test clicking file badge before tool execution (should trigger preview)
- [ ] Test clicking file badge after tool execution (should toggle expanded view)
- [ ] Test expand icon behavior remains unchanged
- [ ] Verify all three tools (applyDiff, multiApplyDiff, writeToFile) work correctly

🤖 Generated with [Pochi](https://getpochi.com)