### PR TITLE
fix(vscode-webui): persist worktree selection when creating task

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -171,6 +171,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
               })
             : selectedWorktree;
         if (worktree) {
+          setUserSelectedWorktree(worktree);
           vscodeHost.openTaskInPanel({
             type: "new-task",
             cwd: worktree?.path || cwd,
@@ -195,6 +196,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
               })
             : selectedWorktree;
         if (worktree) {
+          setUserSelectedWorktree(worktree);
           vscodeHost.openTaskInPanel({
             type: "new-task",
             cwd: worktree?.path || cwd,
@@ -227,6 +229,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       setDebouncedIsCreatingTask,
       baseBranch,
       reviews,
+      setUserSelectedWorktree,
     ],
   );
 


### PR DESCRIPTION
## Summary
- Add `setUserSelectedWorktree()` call when opening a task in the panel to persist the selected worktree across task creation flows
- This prevents the worktree selection from being reset unexpectedly when creating tasks

## Changes
- Updated `CreateTaskInput` component to call `setUserSelectedWorktree()` in two locations before opening tasks in the panel
- Added `setUserSelectedWorktree` to the dependency array of the `createTask` callback

## Test plan
- Verify that worktree selection persists when creating tasks through different flows
- Ensure the selected worktree is maintained across task creation operations

🤖 Generated with [Pochi](https://getpochi.com)