### PR TITLE
refactor(vscode-webui): introduce useBlockingOperations hook

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -30,6 +30,10 @@ import { PaperclipIcon, SendHorizonal, StopCircleIcon } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  type BlockingOperation,
+  useBlockingOperations,
+} from "../hooks/use-blocking-operations";
 import { useChatStatus } from "../hooks/use-chat-status";
 import { useChatSubmit } from "../hooks/use-chat-submit";
 import { useInlineCompactTask } from "../hooks/use-inline-compact-task";
@@ -110,6 +114,16 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     compact,
   });
 
+  const blockingOperations: BlockingOperation[] = [
+    {
+      id: "new-compact-task",
+      isBusy: newCompactTaskPending,
+      label: t("tokenUsage.compacting"),
+    },
+  ];
+
+  const blockingState = useBlockingOperations(blockingOperations);
+
   const {
     isExecuting,
     isBusyCore,
@@ -124,7 +138,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     isFilesEmpty: files.length === 0,
     isReviewsEmpty: reviews.length === 0,
     isUploadingAttachments,
-    newCompactTaskPending,
+    blockingState,
   });
 
   const compactEnabled = !(
@@ -141,7 +155,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     isSubmitDisabled,
     isLoading,
     pendingApproval,
-    newCompactTaskPending,
+    blockingState,
     queuedMessages,
     setQueuedMessages,
     reviews,
@@ -182,7 +196,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   ]);
 
   // Only allow adding tool results when not loading
-  const allowAddToolResult = !(isLoading || newCompactTaskPending);
+  const allowAddToolResult = !(isLoading || blockingState.isBusy);
   useAddCompleteToolCalls({
     messages,
     enable: allowAddToolResult,

--- a/packages/vscode-webui/src/features/chat/hooks/use-blocking-operations.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-blocking-operations.ts
@@ -1,0 +1,26 @@
+export interface BlockingOperation {
+  id: "new-compact-task";
+  isBusy: boolean;
+  label?: string; // e.g., "Compacting...", "Indexing..."
+}
+
+export interface BlockingState {
+  isBusy: boolean;
+  busyLabel: string | undefined;
+  activeOperation: BlockingOperation | undefined;
+}
+
+export function useBlockingOperations(
+  operations: BlockingOperation[],
+): BlockingState {
+  const activeOperation = operations.find((op) => op.isBusy);
+
+  const isBusy = !!activeOperation;
+  const busyLabel = activeOperation?.label;
+
+  return {
+    isBusy,
+    busyLabel,
+    activeOperation,
+  };
+}

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
@@ -1,4 +1,5 @@
 import { useToolCallLifeCycle } from "../lib/chat-state";
+import type { BlockingState } from "./use-blocking-operations";
 
 interface UseChatStatusProps {
   isModelsLoading: boolean;
@@ -8,7 +9,7 @@ interface UseChatStatusProps {
   isFilesEmpty: boolean;
   isReviewsEmpty: boolean;
   isUploadingAttachments: boolean;
-  newCompactTaskPending: boolean;
+  blockingState: BlockingState;
 }
 
 export function useChatStatus({
@@ -19,11 +20,11 @@ export function useChatStatus({
   isFilesEmpty,
   isReviewsEmpty,
   isUploadingAttachments,
-  newCompactTaskPending,
+  blockingState,
 }: UseChatStatusProps) {
   const { isExecuting, isPreviewing } = useToolCallLifeCycle();
 
-  const isBusyCore = isModelsLoading || newCompactTaskPending;
+  const isBusyCore = isModelsLoading || blockingState.isBusy;
 
   const showEditTodos = !isBusyCore;
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -10,6 +10,7 @@ import type React from "react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useAutoApproveGuard, useToolCallLifeCycle } from "../lib/chat-state";
+import type { BlockingState } from "./use-blocking-operations";
 
 const logger = getLogger("UseChatSubmit");
 
@@ -24,7 +25,7 @@ interface UseChatSubmitProps {
   attachmentUpload: UseAttachmentUploadReturn;
   isSubmitDisabled: boolean;
   isLoading: boolean;
-  newCompactTaskPending: boolean;
+  blockingState: BlockingState;
   pendingApproval: PendingApproval | undefined;
   queuedMessages: string[];
   setQueuedMessages: React.Dispatch<React.SetStateAction<string[]>>;
@@ -38,7 +39,7 @@ export function useChatSubmit({
   attachmentUpload,
   isSubmitDisabled,
   isLoading,
-  newCompactTaskPending,
+  blockingState,
   pendingApproval,
   queuedMessages,
   setQueuedMessages,
@@ -72,7 +73,7 @@ export function useChatSubmit({
 
   const handleStop = useCallback(() => {
     // Compacting is not allowed to be stopped.
-    if (newCompactTaskPending) return;
+    if (blockingState.isBusy) return;
 
     if (isPreviewing) {
       abortPreviewingToolCalls();
@@ -87,7 +88,7 @@ export function useChatSubmit({
       pendingApproval.stopCountdown();
     }
   }, [
-    newCompactTaskPending,
+    blockingState.isBusy,
     isExecuting,
     isPreviewing,
     isLoading,
@@ -108,7 +109,7 @@ export function useChatSubmit({
       logger.debug("handleSubmit");
 
       // Uploading / Compacting is not allowed to be stopped.
-      if (newCompactTaskPending || isUploading) return;
+      if (blockingState.isBusy || isUploading) return;
 
       const allMessages = [...queuedMessages];
       // Clear queued messages after adding them to allMessages
@@ -175,7 +176,7 @@ export function useChatSubmit({
       sendMessage,
       setInput,
       clearUploadError,
-      newCompactTaskPending,
+      blockingState.isBusy,
       queuedMessages,
       setQueuedMessages,
       isUploading,


### PR DESCRIPTION
## Summary
Refactors the chat blocking mechanism to be more generic. Replaces the specific `newCompactTaskPending` state with a `blockingState` derived from a list of `BlockingOperation`s. This allows for easier addition of other blocking operations in the future.

## Test plan
- Verify that the chat input is disabled when a compact task is running.
- Verify that tool results cannot be added when a compact task is running.
- Verify that the UI behaves as expected during normal chat operations.

🤖 Generated with [Pochi](https://getpochi.com)