### PR TITLE
refactor(vscode): make diff editor modified content editable

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
+++ b/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
@@ -13,8 +13,8 @@ import type {
 } from "@getpochi/common/vscode-webui-bridge";
 import { Lifecycle, inject, injectable, scoped } from "tsyringe";
 import type * as vscode from "vscode";
+import type { FileChange } from "../editor/diff-changes-editor";
 import { ShadowGitRepo } from "./shadow-git-repo";
-import type { GitDiff } from "./types";
 import { filterGitChanges, processGitChangesToFileEdits } from "./util";
 
 const logger = getLogger("CheckpointService");
@@ -178,7 +178,7 @@ export class CheckpointService implements vscode.Disposable {
   getCheckpointChanges = async (
     from: string,
     to?: string,
-  ): Promise<GitDiff[]> => {
+  ): Promise<FileChange[]> => {
     await this.ensureInitialized();
     if (!this.shadowGit) {
       throw new Error("Shadow Git repository not initialized");
@@ -233,7 +233,7 @@ export class CheckpointService implements vscode.Disposable {
 
     const result: TaskChangedFile[] = [];
     for (const file of changedFiles) {
-      let changes: GitDiff[] = [];
+      let changes: FileChange[] = [];
       if (file.content?.type === "checkpoint") {
         changes = await this.shadowGit.getDiff(file.content.commit, undefined, [
           file.filepath,
@@ -287,13 +287,13 @@ export class CheckpointService implements vscode.Disposable {
 
   getChangedFilesChanges = async (
     changedFiles: TaskChangedFile[],
-  ): Promise<GitDiff[]> => {
+  ): Promise<FileChange[]> => {
     await this.ensureInitialized();
     if (!this.shadowGit) {
       throw new Error("Shadow Git repository not initialized");
     }
 
-    const changes: GitDiff[] = [];
+    const changes: FileChange[] = [];
     for (const file of changedFiles) {
       if (file.content?.type === "checkpoint") {
         const diffResult = await this.shadowGit.getDiff(

--- a/packages/vscode/src/integrations/checkpoint/shadow-git-repo.ts
+++ b/packages/vscode/src/integrations/checkpoint/shadow-git-repo.ts
@@ -4,8 +4,8 @@ import { getLogger, toErrorMessage } from "@getpochi/common";
 import { isFileExists } from "@getpochi/common/tool-utils";
 import simpleGit, { type SimpleGit } from "simple-git";
 import type * as vscode from "vscode";
+import type { FileChange } from "../editor/diff-changes-editor";
 import { writeExcludesFile } from "./shadow-git-excludes";
-import type { GitDiff } from "./types";
 
 const logger = getLogger("ShadowGitRepo");
 
@@ -304,7 +304,7 @@ export class ShadowGitRepo implements vscode.Disposable {
     from: string,
     to?: string,
     files?: string[],
-  ): Promise<GitDiff[]> {
+  ): Promise<FileChange[]> {
     const diffRange = to ? `${from}..${to}` : from;
     // For bare repository with worktree, use --work-tree flag like in reset method
     let command = [
@@ -320,7 +320,7 @@ export class ShadowGitRepo implements vscode.Disposable {
     const diffSummaryOutput = await this.git.raw(command);
 
     const parsedDiffs = this.parseDiffOutput(diffSummaryOutput);
-    const result: GitDiff[] = [];
+    const result: FileChange[] = [];
 
     for (const diffEntry of parsedDiffs) {
       const { status, filepath, oldFilepath } = diffEntry;
@@ -387,7 +387,6 @@ export class ShadowGitRepo implements vscode.Disposable {
         filepath,
         before: beforeContent,
         after: afterContent,
-        status,
       });
     }
     return result;

--- a/packages/vscode/src/integrations/checkpoint/types.ts
+++ b/packages/vscode/src/integrations/checkpoint/types.ts
@@ -1,9 +1,0 @@
-export type GitDiff = {
-  // Relative filepath to cwd
-  filepath: string;
-  // if null, the file was created
-  before: string | null;
-  // if null, the file was deleted
-  after: string | null;
-  status?: string;
-};

--- a/packages/vscode/src/integrations/checkpoint/util.ts
+++ b/packages/vscode/src/integrations/checkpoint/util.ts
@@ -4,7 +4,7 @@ import type {
 } from "@getpochi/common/vscode-webui-bridge";
 import { diffLines } from "diff";
 import { isNonNullish } from "remeda";
-import type { GitDiff } from "./types";
+import type { FileChange } from "../editor/diff-changes-editor";
 
 interface DiffResult {
   content: string;
@@ -74,7 +74,7 @@ export function generateDiffContent(
  * @returns Array of FileDiff objects, or null if no valid changes
  */
 export function processGitChangesToFileEdits(
-  changes: GitDiff[],
+  changes: FileChange[],
   options?: DiffCheckpointOptions,
 ): Array<FileDiff> | null {
   // Filter out binary files and files that exceed size limits
@@ -115,12 +115,12 @@ export function processGitChangesToFileEdits(
  *
  * @param changes - Array of git diff changes
  * @param maxSizeLimit - Maximum allowed size for file content in bytes (default 8KB)
- * @returns Filtered array of GitDiff changes
+ * @returns Filtered array of FileChange changes
  */
 export function filterGitChanges(
-  changes: GitDiff[],
+  changes: FileChange[],
   maxSizeLimit?: number,
-): GitDiff[] {
+): FileChange[] {
   const nullbyte = "\u0000";
 
   return changes.filter((change) => {

--- a/packages/vscode/src/integrations/editor/diff-changes-editor.ts
+++ b/packages/vscode/src/integrations/editor/diff-changes-editor.ts
@@ -1,0 +1,76 @@
+import * as vscode from "vscode";
+import { DiffChangesContentProvider } from "./diff-changes-content-provider";
+
+export type FileChange = {
+  // Relative filepath to cwd
+  filepath: string;
+  // if null, the file was created
+  before: string | null;
+  // if null, the file was deleted
+  after: string | null;
+};
+
+export async function showDiffChanges(
+  changedFiles: FileChange[],
+  title: string,
+  cwd: string,
+  readModifiedFromFile = false, // set to true if the modified content is the same as the file on disk, will make modified editor editable
+): Promise<boolean> {
+  if (changedFiles.length === 0) {
+    return false;
+  }
+
+  const getFileUri = (filepath: string) =>
+    vscode.Uri.joinPath(vscode.Uri.parse(cwd ?? ""), filepath);
+
+  if (changedFiles.length === 1) {
+    const changedFile = changedFiles[0];
+
+    await vscode.commands.executeCommand(
+      "vscode.diff",
+      DiffChangesContentProvider.encode({
+        filepath: getFileUri(changedFile.filepath).fsPath,
+        content: changedFile.before ?? "",
+        cwd: cwd,
+        type: "original",
+      }),
+      readModifiedFromFile
+        ? getFileUri(changedFile.filepath)
+        : DiffChangesContentProvider.encode({
+            filepath: getFileUri(changedFile.filepath).fsPath,
+            content: changedFile.after ?? "",
+            cwd: cwd,
+            type: "modified",
+          }),
+      title,
+      {
+        preview: true,
+        preserveFocus: true,
+      },
+    );
+    return true;
+  }
+
+  await vscode.commands.executeCommand(
+    "vscode.changes",
+    title,
+    changedFiles.map((file) => [
+      getFileUri(file.filepath),
+      DiffChangesContentProvider.encode({
+        filepath: getFileUri(file.filepath).fsPath,
+        content: file.before ?? "",
+        cwd: cwd ?? "",
+        type: "original",
+      }),
+      readModifiedFromFile
+        ? getFileUri(file.filepath)
+        : DiffChangesContentProvider.encode({
+            filepath: getFileUri(file.filepath).fsPath,
+            content: file.after ?? "",
+            cwd: cwd ?? "",
+            type: "modified",
+          }),
+    ]),
+  );
+  return true;
+}

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -91,10 +91,9 @@ import { Lifecycle, inject, injectable, scoped } from "tsyringe";
 import * as vscode from "vscode";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { CheckpointService } from "../checkpoint/checkpoint-service";
-import type { GitDiff } from "../checkpoint/types";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { PochiConfiguration } from "../configuration";
-import { DiffChangesContentProvider } from "../editor/diff-changes-content-provider";
+import { showDiffChanges } from "../editor/diff-changes-editor";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { PochiTaskState } from "../editor/pochi-task-state";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -767,7 +766,12 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
           )
         : changedFiles;
 
-      return await showDiff(displayFiles, title, this.cwd);
+      return await showDiffChanges(
+        displayFiles,
+        title,
+        this.cwd,
+        checkpoint.modified === undefined,
+      );
     },
   );
 
@@ -786,7 +790,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       if (!this.cwd) {
         return false;
       }
-      return await showDiff(changes, title, this.cwd);
+      return await showDiffChanges(changes, title, this.cwd, true);
     },
   );
 
@@ -1042,56 +1046,3 @@ const ToolPreviewMap: Record<
   writeToFile: previewWriteToFile,
   applyDiff: previewApplyDiff,
 };
-
-async function showDiff(displayFiles: GitDiff[], title: string, cwd: string) {
-  if (displayFiles.length === 0) {
-    return false;
-  }
-
-  if (displayFiles.length === 1) {
-    const changedFile = displayFiles[0];
-
-    await vscode.commands.executeCommand(
-      "vscode.diff",
-      DiffChangesContentProvider.encode({
-        filepath: changedFile.filepath,
-        content: changedFile.before ?? "",
-        cwd: cwd,
-        type: "original",
-      }),
-      DiffChangesContentProvider.encode({
-        filepath: changedFile.filepath,
-        content: changedFile.after ?? "",
-        cwd: cwd,
-        type: "modified",
-      }),
-      title,
-      {
-        preview: true,
-        preserveFocus: true,
-      },
-    );
-    return true;
-  }
-
-  await vscode.commands.executeCommand(
-    "vscode.changes",
-    title,
-    displayFiles.map((file) => [
-      vscode.Uri.joinPath(vscode.Uri.parse(cwd ?? ""), file.filepath),
-      DiffChangesContentProvider.encode({
-        filepath: file.filepath,
-        content: file.before ?? "",
-        cwd: cwd ?? "",
-        type: "original",
-      }),
-      DiffChangesContentProvider.encode({
-        filepath: file.filepath,
-        content: file.after ?? "",
-        cwd: cwd ?? "",
-        type: "modified",
-      }),
-    ]),
-  );
-  return true;
-}


### PR DESCRIPTION
## Summary
- Created a new unified `showDiffChanges` function and `FileChange` type to consolidate diff viewer functionality
- Replaced the `GitDiff` type with `FileChange` throughout the checkpoint system
- Added `readModifiedFromFile` parameter to make the modified side of diff editors editable when appropriate (when modified content matches disk)
- Removed duplicate `showDiff` implementation from `vscode-host-impl.ts`
- Deleted the now-unused `types.ts` file in checkpoint module

## Benefits
- **Improved UX**: Users can now edit the modified side of diff editors when viewing current file changes, allowing them to make quick adjustments without switching editors
- **Better code organization**: Consolidated two separate implementations of diff viewing logic into a single, reusable function
- **Type clarity**: Removed the unused `status` field from the type, making it clearer what data is actually used

## Test plan
- [x] All existing tests pass (157 passing)
- [ ] Manually verify that checkpoint diff views work correctly
- [ ] Manually verify that worktree diff views work correctly  
- [ ] Verify that the modified editor is editable for worktree diffs
- [ ] Verify that the modified editor is editable for checkpoint diffs when no modified commit is specified
- [ ] Verify that the modified editor is read-only for checkpoint diffs when a modified commit is specified

🤖 Generated with [Pochi](https://getpochi.com)