### PR TITLE
docs: add instruction for handling gh issue edit project failure

### DIFF
--- a/.pochi/workflows/create-issue.md
+++ b/.pochi/workflows/create-issue.md
@@ -13,5 +13,6 @@ model: google/gemini-3-pro
     ```bash
     gh issue edit <issue-number> --add-project "Pochi Tasks"
     ```
+7. If `gh issue edit` failed to add project, should ask user to refresh their gh token to authorize it with the project scope (`gh auth refresh -s project`).
 
 IMPORTANT: You only need to create the issue, DO NOT attempt to fix the issue or implement the feature.


### PR DESCRIPTION
## Summary
- Added an instruction to `.pochi/workflows/create-issue.md` to guide users when `gh issue edit` fails to add a project.
- Specified the command `gh auth refresh -s project` to resolve authorization issues.

## Test plan
- Verify the instruction is clear and correct in the markdown file.

🤖 Generated with [Pochi](https://getpochi.com)