### PR TITLE
fix: reuse container for workspace root

### DIFF
--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -1,5 +1,5 @@
 import { AuthEvents } from "@/lib/auth-events";
-import { workspaceScoped } from "@/lib/workspace-scoped";
+import { WorkspaceScope, workspaceScoped } from "@/lib/workspace-scoped";
 import { getLogger, toErrorMessage } from "@getpochi/common";
 import {
   type PochiTaskInfo,
@@ -276,7 +276,12 @@ export class PochiTaskEditorProvider
     info: PochiTaskInfo,
   ): Promise<PochiWebviewPanel> {
     const { cwd, uid } = info;
-    const workspaceContainer = workspaceScoped(cwd);
+    const mainWorkspaceScope = container.resolve(WorkspaceScope);
+    const isMainWorkspace = cwd === mainWorkspaceScope.cwd;
+    // reuse container for workspace root as siderbar has create VSCodeHostImpl for workspace root
+    const workspaceContainer = isMainWorkspace
+      ? container
+      : workspaceScoped(cwd);
 
     const events = workspaceContainer.resolve(AuthEvents);
     const pochiConfiguration = workspaceContainer.resolve(PochiConfiguration);


### PR DESCRIPTION
## Summary
- Import `WorkspaceScope` from `@/lib/workspace-scoped` to access the main workspace scope
- Check if the current working directory matches the main workspace directory
- Reuse the main container for workspace root instead of creating a new workspace-scoped container
- This prevents duplicate VSCodeHostImpl instances and ensures consistent state

## Test plan
- [ ] Verify that task editor opens correctly for workspace root directory
- [ ] Verify that task editor opens correctly for subdirectories
- [ ] Verify that no duplicate VSCodeHostImpl instances are created
- [ ] Verify that state remains consistent between sidebar and task editor

🤖 Generated with [Pochi](https://getpochi.com)