### PR TITLE
fix: improve Pochi layout detection

### DIFF
--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -39,7 +39,7 @@ import {
   applyPochiLayout,
   getSortedCurrentTabGroups,
   getViewColumnForTerminal,
-  isCurrentLayoutDerivedFromPochiLayout,
+  isPochiLayout,
   isPochiTaskTab,
 } from "./layout";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -657,7 +657,7 @@ export class CommandManager implements vscode.Disposable {
         async (...args) => {
           logger.debug("openPochiLayoutOrTerminal", { args });
           // Check if Pochi layout is already applied
-          if (isCurrentLayoutDerivedFromPochiLayout()) {
+          if (await isPochiLayout()) {
             vscode.commands.executeCommand("pochi.openTerminal", ...args);
           } else {
             vscode.commands.executeCommand("pochi.applyPochiLayout", ...args);


### PR DESCRIPTION
## Summary
- Refactored layout size constants in `packages/vscode/src/integrations/layout.ts` for better maintainability.
- Implemented a more robust `isPochiLayout` function that uses `vscode.getEditorLayout` to accurately verify the current editor group arrangement and proportions.
- Updated `CommandManager` to use the new asynchronous `isPochiLayout` check, ensuring more reliable behavior when opening Pochi-specific views.

## Test plan
- Verified changes by running the existing test suite (`bun run test`).
- Manually confirmed that the Pochi layout is correctly detected in the VS Code environment.

🤖 Generated with [Pochi](https://getpochi.com)