### PR TITLE
fix(vscode): auto-open task editor when applying layout if no tabs exist

### DIFF
--- a/packages/vscode/src/integrations/layout.ts
+++ b/packages/vscode/src/integrations/layout.ts
@@ -227,6 +227,14 @@ export async function applyPochiLayout(params: { cwd: string | undefined }) {
     vscode.window.showTextDocument(defaultTextDocument, vscode.ViewColumn.Two);
   }
 
+  // If no tabs in task group, open a new task
+  if (getSortedCurrentTabGroups()[0].tabs.length === 0 && params.cwd) {
+    await PochiTaskEditorProvider.openTaskEditor({
+      type: "new-task",
+      cwd: params.cwd,
+    });
+  }
+
   // Re-focus the user focus tab
   if (!userFocusTab) {
     await focusEditorGroup(0);


### PR DESCRIPTION
## Summary
- Automatically opens a new task editor when applying the Pochi layout if the task group is currently empty.
- Ensures a better user experience by providing an immediate starting point when no tasks are active.

## Test plan
- Manually verified that `applyPochiLayout` triggers `PochiTaskEditorProvider.openTaskEditor` when `getSortedCurrentTabGroups()[0].tabs.length === 0`.
- Existing tests passed during pre-push hook.

🤖 Generated with [Pochi](https://getpochi.com)