### PR TITLE
fix: hide edits made by Pochi in userEdits

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -360,6 +360,9 @@ export class LiveChatKit<
         duration: this.lastStepStartTimestamp
           ? Duration.millis(Date.now() - this.lastStepStartTimestamp)
           : undefined,
+        lastCheckpointHash: this.messages
+          .flatMap((m) => m.parts)
+          .findLast((p) => p.type === "data-checkpoint")?.data.commit,
       }),
     );
 


### PR DESCRIPTION
## Summary
- Clear `lastCheckpointHash` on stream start to hide changes made by Pochi.
- Update `UserEditState` to handle undefined `lastCheckpointHash` and add logging.

## Test plan
- Verify that edits made by Pochi are not shown in user edits during streaming.
- Verify that `UserEditState` correctly handles undefined `lastCheckpointHash`.

🤖 Generated with [Pochi](https://getpochi.com)