### PR TITLE
fix: fix extension error when there is no workspace folder open

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/user-edit-state.ts
+++ b/packages/vscode/src/integrations/checkpoint/user-edit-state.ts
@@ -32,13 +32,13 @@ export class UserEditState implements vscode.Disposable {
   }
 
   private get cwd() {
-    if (!this.workspaceScope.cwd) {
-      throw new Error("No workspace folder found. Please open a workspace.");
-    }
     return this.workspaceScope.cwd;
   }
 
   private setupEventListeners() {
+    if (!this.cwd) {
+      return;
+    }
     const watcher = vscode.workspace.createFileSystemWatcher(
       new vscode.RelativePattern(this.cwd, "**/*"),
     );


### PR DESCRIPTION
## Summary
Fixes an issue where the extension would throw an error if no workspace folder was open when setting up event listeners for checkpoints.

## Test plan
- Open VS Code without a workspace folder.
- Verify that the extension does not throw an error on startup.

🤖 Generated with [Pochi](https://getpochi.com)