### PR TITLE
fix: use Chat component in Storybook to avoid provider nesting issues

### DIFF
--- a/packages/vscode-webui/src/features/chat/__stories__/page.stories.tsx
+++ b/packages/vscode-webui/src/features/chat/__stories__/page.stories.tsx
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ChatPage } from "../page";
+import { Chat } from "../page";
 
 const meta = {
   title: "Chat/Page",
-  component: ChatPage,
+  component: Chat,
   parameters: {
     layout: "fullscreen",
   },
-} satisfies Meta<typeof ChatPage>;
+} satisfies Meta<typeof Chat>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -59,13 +59,13 @@ export function ChatPage(props: ChatProps) {
   );
 }
 
-interface ChatProps {
+export interface ChatProps {
   uid: string;
   user?: UserInfo;
   info: NonNullable<typeof window.POCHI_TASK_INFO>;
 }
 
-function Chat({ user, uid, info }: ChatProps) {
+export function Chat({ user, uid, info }: ChatProps) {
   const { t } = useTranslation();
   const { store } = useStore();
   const todosRef = useRef<Todo[] | undefined>(undefined);


### PR DESCRIPTION
## Summary
- Updates the Storybook configuration for the Chat page to use the `Chat` component directly instead of `ChatPage`.
- Exports `Chat` and `ChatProps` from `packages/vscode-webui/src/features/chat/page.tsx`.
- This prevents issues with nested `ChatContextProvider`s, as the Storybook decorators already provide the necessary context.

## Test plan
- Verified that the Storybook `Chat/Page` story renders correctly without provider errors.

🤖 Generated with [Pochi](https://getpochi.com)