### PR TITLE
fix: only cache JWKS in non-dev environment

### DIFF
--- a/packages/livekit-cf/src/lib/jwt.ts
+++ b/packages/livekit-cf/src/lib/jwt.ts
@@ -16,14 +16,21 @@ let JWKS: jose.JWTVerifyGetKey | null = null;
 export async function getJWKS() {
   const serverUrl = getServerBaseUrl(env.ENVIRONMENT);
   const key = `jwks:${serverUrl}`;
-  let jwks = await env.CACHE.get(key);
+  let jwks: string | null = null;
+  if (env.ENVIRONMENT !== "dev") {
+    jwks = await env.CACHE.get(key);
+  }
+
   if (!jwks) {
     const res = await fetch(new URL(`${serverUrl}/api/auth/jwks`));
     jwks = await res.text();
   }
-  await env.CACHE.put(key, jwks, {
-    expirationTtl: 60 * 60 * 24,
-  });
+
+  if (env.ENVIRONMENT !== "dev") {
+    await env.CACHE.put(key, jwks, {
+      expirationTtl: 60 * 60 * 24,
+    });
+  }
 
   return jose.createLocalJWKSet(JSON.parse(jwks));
 }


### PR DESCRIPTION
## Summary
- Modified `getJWKS` to skip caching JWKS when the environment is `dev`.
- This ensures that in development, we always fetch the latest JWKS, avoiding stale keys during local development or testing.

## Test plan
- Verify that in a dev environment, JWKS are fetched from the server every time.
- Verify that in a non-dev environment, JWKS are cached and retrieved from the cache.

🤖 Generated with [Pochi](https://getpochi.com)