### PR TITLE
refactor(chat): merge onStreamFailed into onStreamFinish for better error handling

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -44,13 +44,11 @@ export type LiveChatKitOptions<T> = {
   }) => void | Promise<void>;
   onStreamStart?: () => void;
   onStreamFinish?: (
-    data: Pick<Task, "id" | "cwd" | "status"> & { messages: Message[] },
+    data: Pick<Task, "id" | "cwd" | "status"> & {
+      messages: Message[];
+      error?: Error;
+    },
   ) => void;
-  onStreamFailed?: (data: {
-    error: Error;
-    messages: Message[];
-    cwd: string | null;
-  }) => void;
 
   customAgent?: CustomAgent;
   outputSchema?: z.ZodAny;
@@ -89,13 +87,9 @@ export class LiveChatKit<
   onStreamFinish?: (
     data: Pick<Task, "id" | "cwd" | "status"> & {
       messages: Message[];
+      error?: Error;
     },
   ) => void;
-  onStreamFailed?: (data: {
-    cwd: string | null;
-    error: Error;
-    messages: Message[];
-  }) => void;
   readonly compact: () => Promise<string>;
   private lastStepStartTimestamp: number | undefined;
 
@@ -112,14 +106,12 @@ export class LiveChatKit<
     outputSchema,
     onStreamStart,
     onStreamFinish,
-    onStreamFailed,
     ...chatInit
   }: LiveChatKitOptions<T>) {
     this.taskId = taskId;
     this.store = store;
     this.onStreamStart = onStreamStart;
     this.onStreamFinish = onStreamFinish;
-    this.onStreamFailed = onStreamFailed;
     this.transport = new FlexibleChatTransport({
       store,
       onStart: this.onStart,
@@ -398,10 +390,12 @@ export class LiveChatKit<
 
     this.clearLastStepTimestamp();
 
-    this.onStreamFailed?.({
+    this.onStreamFinish?.({
+      id: this.taskId,
       cwd: this.task?.cwd ?? null,
-      error,
+      status: "failed",
       messages: [...this.chat.messages],
+      error,
     });
   };
 }

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -130,12 +130,39 @@ export function Chat({ user, uid, info }: ChatProps) {
     (
       data: Pick<Task, "id" | "cwd" | "status"> & {
         messages: Message[];
+        error?: Error;
       },
     ) => {
-      const lastMessage = data.messages.at(-1);
       const topTaskUid = isSubTask ? task?.parentId : uid;
       const cwd = data.cwd;
-      if (!topTaskUid || !lastMessage || !cwd) return;
+      if (!topTaskUid || !cwd) return;
+
+      if (data.status === "failed" && data.error) {
+        let autoApprove = autoApproveGuard.current === "auto";
+        if (data.error && !isRetryableError(data.error)) {
+          autoApprove = false;
+        }
+
+        const retryLimit =
+          autoApproveActive && autoApproveSettings.retry && autoApprove
+            ? autoApproveSettings.maxRetryLimit
+            : 0;
+
+        if (
+          retryLimit === 0 ||
+          (retryCount?.count !== undefined && retryCount.count >= retryLimit)
+        ) {
+          sendNotification("failed", {
+            uid: topTaskUid,
+            displayId: topDisplayId,
+            isSubTask,
+          });
+        }
+        return;
+      }
+
+      const lastMessage = data.messages.at(-1);
+      if (!lastMessage) return;
 
       if (data.status === "pending-tool") {
         const pendingToolCallApproval = getPendingToolcallApproval(lastMessage);
@@ -188,34 +215,6 @@ export function Chat({ user, uid, info }: ChatProps) {
     },
   );
 
-  const onStreamFailed = useLatest(
-    ({ error, cwd }: { error: Error; cwd: string | null }) => {
-      const topTaskUid = isSubTask ? task?.parentId : uid;
-      if (!topTaskUid || !cwd) return;
-
-      let autoApprove = autoApproveGuard.current === "auto";
-      if (error && !isRetryableError(error)) {
-        autoApprove = false;
-      }
-
-      const retryLimit =
-        autoApproveActive && autoApproveSettings.retry && autoApprove
-          ? autoApproveSettings.maxRetryLimit
-          : 0;
-
-      if (
-        retryLimit === 0 ||
-        (retryCount?.count !== undefined && retryCount.count >= retryLimit)
-      ) {
-        sendNotification("failed", {
-          uid: topTaskUid,
-          displayId: topDisplayId,
-          isSubTask,
-        });
-      }
-    },
-  );
-
   const chatKit = useLiveChatKit({
     taskId: uid,
     getters,
@@ -244,9 +243,6 @@ export function Chat({ user, uid, info }: ChatProps) {
     },
     onStreamFinish(data) {
       onStreamFinish.current(data);
-    },
-    onStreamFailed(data) {
-      onStreamFailed.current(data);
     },
   });
 


### PR DESCRIPTION
## Summary
Refactor `LiveChatKit` and `Chat` component to handle stream failures within `onStreamFinish`.
- Remove `onStreamFailed` callback.
- Add `error` field to `onStreamFinish` data.
- Update `Chat` component to handle errors in `onStreamFinish`, including auto-approve logic and notifications.

## Test plan
- Verify that chat stream errors are correctly handled and displayed in the UI.
- Verify that auto-approve logic works as expected when errors occur.

🤖 Generated with Pochi