### PR TITLE
fix(vscode-webui): include file URL in attached file system reminder

### DIFF
--- a/packages/vscode-webui/src/lib/message-utils.ts
+++ b/packages/vscode-webui/src/lib/message-utils.ts
@@ -15,7 +15,9 @@ export function prepareMessageParts(
   for (const x of files) {
     parts.push({
       type: "text",
-      text: prompts.createSystemReminder(`Attached file: ${x.filename}`),
+      text: prompts.createSystemReminder(
+        `Attached file: ${x.filename} (${x.url})`,
+      ),
     });
     parts.push(x);
   }


### PR DESCRIPTION
## Summary
- Included the file URL in the system reminder string for attached files in `prepareMessageParts`.

## Test plan
- Verify that when a file is attached, the system reminder includes the file URL alongside the filename.

🤖 Generated with [Pochi](https://getpochi.com)