### PR TITLE
refactor(vscode): change latestCheckpoint to worktree scope

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/shadow-git-repo.ts
+++ b/packages/vscode/src/integrations/checkpoint/shadow-git-repo.ts
@@ -120,10 +120,16 @@ export class ShadowGitRepo implements vscode.Disposable {
   }
 
   // Get the latest commit hash in short form
-  async getLatestCommitHash(): Promise<string | null> {
+  async getLatestCommitHash(search: string): Promise<string | null> {
     try {
-      const hash = await this.git.raw(["log", "-1", "--format=%h"]);
-      const trimmedHash = hash.trim();
+      const result = await this.git.raw([
+        "log",
+        "-1",
+        "--oneline",
+        "--grep",
+        search,
+      ]);
+      const trimmedHash = result.split(/\s+/)[0].trim();
       logger.debug(`Latest commit hash: ${trimmedHash}`);
       return trimmedHash || null;
     } catch (error) {


### PR DESCRIPTION

<img width="2672" height="1756" alt="image" src="https://github.com/user-attachments/assets/238b23db-e07c-4e64-ae51-7d47726e93d1" />


## Summary
- Scope checkpoint commit messages with current working directory
- Update ShadowGitRepo to filter latest commit by grep pattern
- Remove unused getLatestCommitHash from CheckpointService

## Test plan
- Verify that checkpoints are correctly created and scoped to the current working directory.
- Verify that `latestCheckpoint` retrieval works as expected with the new filtering logic.

🤖 Generated with [Pochi](https://getpochi.com)