### PR TITLE
fix(vscode-webui): open user edits in diff editor

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -9,7 +9,7 @@ import type { UseChatHelpers } from "@ai-sdk/react";
 import type { Message } from "@getpochi/livekit";
 
 import { ReviewBadges } from "@/components/prompt-form/review-badges";
-import { UserEdits } from "@/components/prompt-form/user-edits";
+import { UserEditsBadge } from "@/components/prompt-form/user-edits";
 import type { Review } from "@getpochi/common/vscode-webui-bridge";
 import type { ReactNode } from "@tanstack/react-router";
 import { QueuedMessages } from "./queued-messages";
@@ -33,6 +33,7 @@ interface ChatInputFormProps {
   children?: ReactNode;
   reviews: Review[];
   taskId?: string;
+  lastCheckpointHash?: string;
 }
 
 export function ChatInputForm({
@@ -53,6 +54,7 @@ export function ChatInputForm({
   isSubTask,
   reviews,
   taskId,
+  lastCheckpointHash,
   children,
 }: ChatInputFormProps) {
   const editorRef = useRef<Editor | null>(null);
@@ -79,7 +81,9 @@ export function ChatInputForm({
             editorRef.current?.commands.insertContent(" @");
           }}
         />
-        {taskId && <UserEdits taskId={taskId} />}
+        {taskId && lastCheckpointHash && (
+          <UserEditsBadge taskId={taskId} lastCheckpoint={lastCheckpointHash} />
+        )}
         <ReviewBadges reviews={reviews} />
       </div>
       <DevRetryCountdown pendingApproval={pendingApproval} status={status} />

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -321,6 +321,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
         isSubTask={isSubTask}
         reviews={reviews}
         taskId={taskId}
+        lastCheckpointHash={task?.lastCheckpointHash ?? undefined}
       />
 
       {/* Hidden file input for image uploads */}


### PR DESCRIPTION
## Screen record

https://jam.dev/c/2697d8f1-d74b-41ce-b0bf-a5d4c021ab91

## Summary
- fix(vscode-webui): open user edits in diff editor
- refactor(vscode): change latestCheckpoint to worktree scope
- fix(vscode-webui): hide reviews from input form in sidebar (#966)
- fix: disable user edit

## Test plan
- Verify that user edits are opened in the diff editor.

🤖 Generated with [Pochi](https://getpochi.com)