### PR TITLE
fix: correct URI construction from file system paths

### DIFF
--- a/packages/vscode/src/integrations/editor/diff-changes-editor.ts
+++ b/packages/vscode/src/integrations/editor/diff-changes-editor.ts
@@ -21,7 +21,7 @@ export async function showDiffChanges(
   }
 
   const getFileUri = (filepath: string) =>
-    vscode.Uri.joinPath(vscode.Uri.parse(cwd ?? ""), filepath);
+    vscode.Uri.joinPath(vscode.Uri.file(cwd ?? ""), filepath);
 
   if (changedFiles.length === 1) {
     const changedFile = changedFiles[0];

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -507,7 +507,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     const fileUri = path.isAbsolute(resolvedPath)
       ? vscode.Uri.file(resolvedPath)
       : this.cwd
-        ? vscode.Uri.joinPath(vscode.Uri.parse(this.cwd), resolvedPath)
+        ? vscode.Uri.joinPath(vscode.Uri.file(this.cwd), resolvedPath)
         : vscode.Uri.file(resolvedPath);
 
     try {


### PR DESCRIPTION
## Summary
Fixes file opening failures for relative paths by correcting URI construction from file system paths. When `filePath` is a relative path that needs to be joined with `cwd`, the code previously used `vscode.Uri.parse()` which incorrectly interprets file system paths as URI strings, causing malformed URIs that prevent file system operations.

## Description
`workspaceScope.cwd` originates from `uri.fsPath` , which always returns a platform-specific file system path string, not a URI string.Multiple methods (`openFile`, `showCheckpointDiff`, `showChangedFiles`) were affected due to improper use of `vscode.Uri.parse()` with file system paths from `uri.fsPath`.

The issue was particularly evident on Windows due to drive letter notation:
- cwd from uri.fsPath: `"C:\\Users\\project"`
- vscode.Uri.parse("C:\\Users\\project") → scheme: "c", path: "/Users/project"
- vscode.Uri.file("C:\\Users\\project") → scheme: "file", path: "/c:/Users/project"

This caused file opening failures for relative paths in Windows workspaces.