### PR TITLE
fix(vscode): return 'workspace' when cwd matches workspace path (#989)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -256,7 +256,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.21.0-dev",
+      "version": "0.23.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/vscode/src/integrations/git/__tests__/issue-989.test.ts
+++ b/packages/vscode/src/integrations/git/__tests__/issue-989.test.ts
@@ -1,0 +1,60 @@
+import * as assert from "node:assert";
+import * as sinon from "sinon";
+import { describe, it, beforeEach, afterEach } from "mocha";
+import proxyquire from "proxyquire";
+import * as vscode from "vscode";
+
+const generateBranchNameStub = sinon.stub();
+const simpleGitStub = sinon.stub().returns({
+  revparse: sinon.stub().resolves("gitdir"),
+  checkIsRepo: sinon.stub().resolves(true),
+  raw: sinon.stub().resolves(""),
+});
+
+const { WorktreeManager } = proxyquire.noCallThru()("../worktree", {
+  "@/lib/generate-branch-name": { generateBranchName: generateBranchNameStub },
+  "simple-git": simpleGitStub,
+});
+
+describe("WorktreeManager Repro #989", () => {
+    let worktreeManager: any;
+    let gitStateStub: any;
+
+    beforeEach(() => {
+      gitStateStub = {
+        onDidRepositoryChange: sinon.stub().returns({ dispose: () => {} }),
+        onDidChangeGitState: sinon.stub().returns({ dispose: () => {} }),
+      };
+
+      const worktreeDataStoreStub = {
+        initialize: sinon.stub(),
+        get: sinon.stub().returns(undefined),
+        delete: sinon.stub(),
+      } as any;
+
+      const pochiConfigurationStub = {
+        detectWorktreesLimit: { value: 10 },
+      };
+
+      // Mock vscode.workspace.workspaceFolders
+      // Using sinon to stub the property getter
+      sinon.stub(vscode.workspace, "workspaceFolders").value([{ uri: { fsPath: "/path/to/repo" } }]);
+
+      worktreeManager = new WorktreeManager(
+        gitStateStub,
+        worktreeDataStoreStub,
+        pochiConfigurationStub,
+      );
+    });
+
+    afterEach(() => {
+      if (worktreeManager) worktreeManager.dispose();
+      sinon.restore();
+    });
+
+    it("should return 'workspace' when cwd matches workspace path even if worktree is not found", () => {
+      worktreeManager.worktrees.value = [];
+      const result = worktreeManager.getWorktreeDisplayName("/path/to/repo");
+      assert.strictEqual(result, "workspace");
+    });
+});

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -53,6 +53,9 @@ export class WorktreeManager implements vscode.Disposable {
   public getWorktreeDisplayName(cwd: string): string | undefined {
     const worktree = this.worktrees.value.find((wt) => wt.path === cwd);
     if (!worktree) {
+      if (this.workspacePath && cwd === this.workspacePath) {
+        return "workspace";
+      }
       return getWorktreeNameFromWorktreePath(cwd);
     }
     return worktree.isMain ? "workspace" : getWorktreeNameFromWorktreePath(cwd);


### PR DESCRIPTION
## Summary
- Fixes an issue where `getWorktreeDisplayName` returned `undefined` (or fell back to path name) instead of "workspace" when the current working directory matched the workspace path but was not found in the worktrees list.
- Adds a regression test case.

## Test plan
- Verified with new test case `packages/vscode/src/integrations/git/__tests__/issue-989.test.ts`.

🤖 Generated with [Pochi](https://getpochi.com)