### PR TITLE
fix: improve layout management and focus cycling

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -377,7 +377,7 @@
         "when": "editorTextFocus && pochiTabCompletionVisible"
       },
       {
-        "command": "pochi.openPochiLayoutOrTerminal",
+        "command": "pochi.applyPochiLayoutWithCycleFocus",
         "key": "ctrl+`",
         "when": "pochi.enablePochiLayoutKeybinding"
       }


### PR DESCRIPTION
## Summary
This PR improves the Pochi layout management and introduces focus cycling between major UI components.

### Fixes
- **Layout Stability**: Fixed an issue where the Pochi layout would fail or behave unexpectedly after moving an editor into a new window. The layout logic now correctly handles split windows and focuses on the main window before applying changes.
- **UI Performance**: Reduced flicker when applying the Pochi layout by checking if the layout is already in the desired state before performing destructive rearrangement steps.

### Enhancements
- **Focus Cycling**: Implemented a new mechanism to cycle focus between the editor, terminal, and task groups. This addresses feedback regarding the loss of hotkey focus switching after overriding default keybindings.
- **Robustness**: Added better logging and error handling within the layout management module.

## Test plan
1. Open multiple editors and move one to a new window.
2. Trigger the Pochi layout command and verify it correctly arranges the main window without errors.
3. Use the focus cycling hotkey to switch between editor, terminal, and task tabs.
4. Verify that applying the layout when already in Pochi layout results in minimal UI flicker.

🤖 Generated with [Pochi](https://getpochi.com)