### PR TITLE
fix(vscode): enable preview mode for task tab

### DIFF
--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -350,7 +350,7 @@ async function openTaskInColumn(uri: vscode.Uri) {
     "vscode.openWith",
     uri,
     PochiTaskEditorProvider.viewType,
-    { preview: false, viewColumn },
+    { preview: true, viewColumn },
   );
 }
 


### PR DESCRIPTION
## Summary
Enable preview mode when opening the task tab in VS Code. This ensures that the task tab opens as a preview tab, improving tab management for users.

## Test plan
1. Open a task in Pochi.
2. Verify that the task tab opens in preview mode (italicized title).
3. Click on another file or task; the preview tab should be replaced unless pinned or modified.

🤖 Generated with [Pochi](https://getpochi.com)