### PR TITLE
fix(cli): improve slash command detection by parsing markdown AST

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,10 +47,16 @@
         "cli-table3": "^0.6.5",
         "commander": "^14.0.0",
         "listr2": "^9.0.3",
+        "mdast": "^3.0.0",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-to-markdown": "^2.1.2",
         "ora": "^8.2.0",
+        "remark": "^15.0.1",
+        "remark-gfm": "^4.0.1",
         "remeda": "catalog:",
         "semver": "^7.6.3",
         "tabtab": "^3.0.2",
+        "unist-util-visit": "^5.0.0",
         "zod": "catalog:",
       },
     },
@@ -2820,6 +2826,8 @@
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast": ["mdast@3.0.0", "", {}, "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,10 +41,16 @@
     "cli-table3": "^0.6.5",
     "commander": "^14.0.0",
     "listr2": "^9.0.3",
+    "mdast": "^3.0.0",
+    "mdast-util-gfm": "^3.1.0",
+    "mdast-util-to-markdown": "^2.1.2",
     "ora": "^8.2.0",
+    "remark": "^15.0.1",
+    "remark-gfm": "^4.0.1",
     "remeda": "catalog:",
     "semver": "^7.6.3",
     "tabtab": "^3.0.2",
+    "unist-util-visit": "^5.0.0",
     "zod": "catalog:"
   }
 }

--- a/packages/cli/src/lib/__tests__/match-slash-command.test.ts
+++ b/packages/cli/src/lib/__tests__/match-slash-command.test.ts
@@ -25,6 +25,26 @@ describe("match-slash-command", () => {
       expect(containsSlashCommandReference("This is a prompt")).toBe(false);
       expect(containsSlashCommandReference("")).toBe(false);
     });
+
+    it("should not match markdown links and images", () => {
+      expect(containsSlashCommandReference("[link text](https://example.com/path)")).toBe(false);
+      expect(containsSlashCommandReference("![alt text](https://example.com/image.png)")).toBe(false);
+    });
+
+    it("should not match code blocks or inline code", () => {
+      expect(containsSlashCommandReference("`/some/path`")).toBe(false);
+      expect(containsSlashCommandReference("```\n/path/to/file\n```")).toBe(false);
+    });
+
+    it("should not match HTML closing tags", () => {
+      expect(containsSlashCommandReference("</div>")).toBe(false);
+      expect(containsSlashCommandReference("</workflow>")).toBe(false);
+    });
+
+    it("should match slash commands even with URLs present", () => {
+      expect(containsSlashCommandReference("Use /create-pr and visit https://workflow-a.com")).toBe(true);
+      expect(containsSlashCommandReference("/test-workflow check https://example.com/path")).toBe(true);
+    });
   });
 
   describe("extractSlashCommandNames", () => {
@@ -45,7 +65,11 @@ describe("match-slash-command", () => {
       expect(extractSlashCommandNames("Create a PR")).toEqual([]);
       expect(extractSlashCommandNames("")).toEqual([]);
     });
-  });
+
+    it("should not extract markdown links and images", () => {
+      expect(extractSlashCommandNames("[link](https://example.com/path)")).toEqual([]);
+      expect(extractSlashCommandNames("![image](https://example.com/image.png)")).toEqual([]);
+    });  });
 
   describe("getModelFromSlashCommand", () => {
     const workflows: Workflow[] = [

--- a/packages/cli/src/lib/match-slash-command.ts
+++ b/packages/cli/src/lib/match-slash-command.ts
@@ -1,19 +1,69 @@
 import { prompts } from "@getpochi/common";
 import type { CustomAgentFile } from "@getpochi/common/vscode-webui-bridge";
 import type { CustomAgent } from "@getpochi/tools";
+import type { Parent, Text } from "mdast";
+import { gfmToMarkdown } from "mdast-util-gfm";
+import { toMarkdown } from "mdast-util-to-markdown";
+import { remark } from "remark";
+import remarkGfm from "remark-gfm";
+import { SKIP, visit } from "unist-util-visit";
 import { getModelFromCustomAgent } from "./load-agents";
 import { type Workflow, getModelFromWorkflow } from "./workflow-loader";
 
+const IGNORED_NODE_TYPES = [
+  "code",
+  "inlineCode",
+  "link",
+  "image",
+  "html",
+  "linkReference",
+  "imageReference",
+];
+
+/**
+ * Extract slash command names from text, matching pattern /command-name
+ */
+function extractSlashCommandsFromText(text: string): string[] {
+  const slashCommandRegex = /\/\w+[\w-]*/g;
+  const matches = [...text.matchAll(slashCommandRegex)];
+  return matches.map((match) => match[0].substring(1)); // Remove the leading "/"
+}
+
 export function containsSlashCommandReference(prompt: string): boolean {
-  return /\/\w+[\w-]*/.test(prompt);
+  // Quick check before parsing - if no slash at all, return false
+  if (!/\//.test(prompt)) {
+    return false;
+  }
+
+  // Use the extraction function to properly detect slash commands
+  return extractSlashCommandNames(prompt).length > 0;
 }
 
 export function extractSlashCommandNames(prompt: string): string[] {
-  const slashCommandRegex = /(\/\w+[\w-]*)/g;
-  const matches = prompt.match(slashCommandRegex);
-  if (!matches) return [];
+  // Parse markdown to AST
+  const tree = remark().use(remarkGfm).parse(prompt);
 
-  return matches.map((match) => match.substring(1)); // Remove the leading "/"
+  const textNodes: string[] = [];
+
+  // Single pass: collect text nodes and skip unwanted node types
+  visit(tree, (node) => {
+    // Skip these node types and their children
+    if (IGNORED_NODE_TYPES.includes(node.type)) {
+      return SKIP; // Skip this node and all its children
+    }
+
+    if (node.type === "text") {
+      textNodes.push(String(node.value));
+    }
+  });
+
+  const allCommands: string[] = [];
+  for (const text of textNodes) {
+    const commands = extractSlashCommandsFromText(text);
+    allCommands.push(...commands);
+  }
+
+  return [...new Set(allCommands)];
 }
 
 export async function getModelFromSlashCommand(
@@ -61,30 +111,84 @@ export async function replaceSlashCommandReferences(
     customAgents: CustomAgentFile[];
   },
 ): Promise<{ prompt: string }> {
-  const commandNames = extractSlashCommandNames(prompt);
-
-  if (commandNames.length === 0) {
+  // Quick check - if no slash at all, return early
+  if (!/\//.test(prompt)) {
     return { prompt };
   }
-  let result = prompt;
-  // Process each workflow reference
-  for (const id of commandNames) {
-    const workflow = slashCommandContext.workflows.find((x) => x.id === id);
-    if (workflow?.content) {
-      result = result.replace(
-        `/${id}`,
-        prompts.workflow(id, workflow.pathName, workflow.content),
-      );
+
+  // Parse markdown to AST
+  const tree = remark().use(remarkGfm).parse(prompt);
+
+  // Visit and process nodes: replace slash commands
+  visit(tree, (node, index, parent) => {
+    // Skip these node types and their children
+    if (IGNORED_NODE_TYPES.includes(node.type)) {
+      return SKIP;
     }
 
-    const agent = slashCommandContext.customAgents.find((x) => x.name === id);
-    if (agent?.name) {
-      result = result.replace(
-        `/${id}`,
-        prompts.customAgent(id, agent.filePath),
-      );
-    }
-  }
+    // Replace slash commands in text nodes
+    if (node.type === "text" && parent) {
+      const textNode = node as Text;
+      const value = String(textNode.value);
+      const regex = /(\/\w+[\w-]*)/g;
 
-  return { prompt: result };
+      const parts = value.split(regex);
+      if (parts.length > 1) {
+        const newNodes: (Text | { type: "html"; value: string })[] = [];
+
+        for (const part of parts) {
+          if (!part) continue;
+
+          if (part.startsWith("/")) {
+            const commandName = part.substring(1);
+            const workflow = slashCommandContext.workflows.find(
+              (x) => x.id === commandName,
+            );
+            const agent = slashCommandContext.customAgents.find(
+              (x) => x.name === commandName,
+            );
+
+            if (workflow?.content) {
+              newNodes.push({
+                type: "html",
+                value: prompts.workflow(
+                  commandName,
+                  workflow.pathName,
+                  workflow.content,
+                ),
+              });
+              continue;
+            }
+            if (agent?.name) {
+              newNodes.push({
+                type: "html",
+                value: prompts.customAgent(commandName, agent.filePath),
+              });
+              continue;
+            }
+          }
+
+          newNodes.push({ type: "text", value: part });
+        }
+
+        // Replace the current node with the new nodes in parent
+        if (typeof index === "number" && parent) {
+          // biome-ignore lint/suspicious/noExplicitAny: need to splice multiple nodes of different types into mdast
+          (parent as Parent).children.splice(index, 1, ...(newNodes as any));
+        }
+      }
+    }
+  });
+
+  // Convert AST back to string
+  const result = toMarkdown(tree, {
+    extensions: [gfmToMarkdown()],
+    handlers: {
+      link(node) {
+        return node.url;
+      },
+    },
+  });
+
+  return { prompt: result.trimEnd() };
 }


### PR DESCRIPTION
## Summary
- Use `remark` and `unist-util-visit` to parse markdown and extract slash commands only from text nodes.
- Ignore slash-like patterns within code blocks, inline code, links, images, and HTML tags.
- Add comprehensive tests for markdown edge cases in slash command matching.
- Update dependencies to include markdown processing utilities.

## Screenshot
<img width="2660" height="418" alt="image" src="https://github.com/user-attachments/assets/62801242-8284-4266-af5a-716b9b5b2cd3" />


## Test plan
- Run `bun run test` in `packages/cli` to verify the new tests pass.
- Manually verify that slash commands are still detected correctly in normal text.
- Verify that URLs and code blocks no longer trigger slash command detection.

🤖 Generated with [Pochi](https://getpochi.com)