### PR TITLE
fix(vscode): improve tab input comparison to fix focus cycling

### DIFF
--- a/packages/vscode/src/integrations/layout.ts
+++ b/packages/vscode/src/integrations/layout.ts
@@ -567,7 +567,26 @@ async function focusEditorGroup(groupIndex: number) {
 function isSameTabInput(
   a: vscode.Tab["input"],
   b: vscode.Tab["input"],
+  fallback = false,
 ): boolean {
+  const isComparable = (input: unknown): boolean =>
+    input instanceof vscode.TabInputText ||
+    input instanceof vscode.TabInputTextDiff ||
+    input instanceof vscode.TabInputCustom ||
+    input instanceof vscode.TabInputWebview ||
+    input instanceof vscode.TabInputNotebook ||
+    input instanceof vscode.TabInputNotebookDiff;
+  const aComparable = isComparable(a);
+  const bComparable = isComparable(b);
+
+  if (!aComparable && !bComparable) {
+    return fallback;
+  }
+
+  if (!aComparable || !bComparable) {
+    return false;
+  }
+
   return (
     (a instanceof vscode.TabInputText &&
       b instanceof vscode.TabInputText &&
@@ -616,10 +635,7 @@ function isSameTabGroupsShape(a: TabGroupShape, b: TabGroupShape) {
       return false;
     }
     for (let j = 0; j < tabsA.length; j++) {
-      if (isTerminalTab(tabsA[j]) && isTerminalTab(tabsB[j])) {
-        continue;
-      }
-      if (!isSameTabInput(tabsA[j].input, tabsB[j].input)) {
+      if (!isSameTabInput(tabsA[j].input, tabsB[j].input, true)) {
         return false;
       }
     }


### PR DESCRIPTION
## Summary
- Improved `isSameTabInput` logic in `packages/vscode/src/integrations/layout.ts` to handle non-standard tab inputs (like User Settings or Terminals).
- Added a `fallback` parameter to `isSameTabInput` to allow flexible comparison when inputs are not directly comparable.
- Fixed a bug where cycling focus would fail when the User Settings tab was open.

## Test plan
1. Open VS Code with several tabs, including the User Settings tab.
2. Attempt to cycle focus between editor groups.
3. Verify that focus cycling works correctly regardless of whether the User Settings tab is active.

🤖 Generated with [Pochi](https://getpochi.com)