### PR TITLE
fix(vscode-webui): auto confirm recommend settings when all options are matched

### DIFF
--- a/packages/vscode-webui/src/components/recommend-settings.tsx
+++ b/packages/vscode-webui/src/components/recommend-settings.tsx
@@ -1,7 +1,7 @@
 import { useVSCodeSettings } from "@/lib/hooks/use-vscode-settings";
 import { vscodeHost } from "@/lib/vscode";
 import type { VSCodeSettings } from "@getpochi/common/vscode-webui-bridge";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
 import { Checkbox } from "./ui/checkbox";
@@ -60,6 +60,12 @@ export function RecommendSettings() {
     }
     return list;
   }, [vscodeSettings]);
+
+  useEffect(() => {
+    if (!vscodeSettings.recommendSettingsConfirmed && options.length === 0) {
+      vscodeHost.updateVSCodeSettings({ recommendSettingsConfirmed: true });
+    }
+  }, [vscodeSettings.recommendSettingsConfirmed, options]);
 
   const [selected, setSelected] = useState<Options[]>(options);
 


### PR DESCRIPTION
## Summary
- Automatically set `recommendSettingsConfirmed` to true when all recommended settings are already matched (i.e., manually changed by the user).
- Fixes the issue where `EmptyChat` placeholder remains empty because `recommendSettingsConfirmed` is false but there are no settings left to recommend.

## Test plan
1. Manually change all recommended settings to their target values in VSCode.
2. Open the Pochi chat webview.
3. Verify that the `EmptyChat` placeholder correctly shows `FunContent` instead of an empty space.

🤖 Generated with [Pochi](https://getpochi.com)