### PR TITLE
fix(vscode): update Pochi layout keybinding to Ctrl/Cmd+L

### DIFF
--- a/packages/vscode-webui/src/components/recommend-settings.tsx
+++ b/packages/vscode-webui/src/components/recommend-settings.tsx
@@ -29,7 +29,7 @@ function openSettingsLink(option: Options) {
   );
 }
 
-const OpenKeybindingLink = "(Ctrl/Cmd+`)";
+const OpenKeybindingLink = "(Ctrl/Cmd+L)";
 
 function openKeybindingLink() {
   const commandId = "pochi.applyPochiLayoutWithCycleFocus";

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -363,8 +363,8 @@
     "keybindings": [
       {
         "command": "pochi.toggleFocus",
-        "key": "ctrl+l",
-        "mac": "cmd+l"
+        "key": "ctrl+alt+l",
+        "mac": "cmd+alt+l"
       },
       {
         "command": "pochi.tabCompletion.accept",
@@ -378,7 +378,8 @@
       },
       {
         "command": "pochi.applyPochiLayoutWithCycleFocus",
-        "key": "ctrl+`",
+        "key": "ctrl+l",
+        "mac": "cmd+l",
         "when": "pochi.enablePochiLayoutKeybinding"
       }
     ],


### PR DESCRIPTION
## Summary
- Updated the keybinding for `pochi.applyPochiLayoutWithCycleFocus` from `Ctrl+`` to `Ctrl/Cmd+L`.
- Moved `pochi.toggleFocus` to `Ctrl+Alt+L` (`Cmd+Alt+L` on macOS) to avoid conflict.
- Updated the UI hint in `recommend-settings.tsx` to reflect the new keybinding.

## Test plan
- Verified the keybinding changes in `packages/vscode/package.json`.
- Verified the UI text update in `packages/vscode-webui/src/components/recommend-settings.tsx`.
- Ran `bun run test` to ensure no regressions (all 159 passing in VS Code package).

🤖 Generated with [Pochi](https://getpochi.com)