### PR TITLE
fix(vscode-webui): optimize worktree branch sorting and limit results

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -297,7 +297,7 @@ const VSCodeHostStub = {
 
   queryGithubIssues: async (): Promise<GithubIssue[]> => [],
 
-  readGitBranches: async (): Promise<string[]> => [],
+  readGitBranches: async (_limit?: number): Promise<string[]> => [],
 
   readReviews: (): Promise<ThreadSignalSerialization<Review[]>> => {
     return Promise.resolve({} as ThreadSignalSerialization<Review[]>);

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -339,7 +339,7 @@ export interface VSCodeHostApi {
 
   queryGithubIssues(query?: string): Promise<GithubIssue[]>;
 
-  readGitBranches(): Promise<string[]>;
+  readGitBranches(limit?: number): Promise<string[]>;
 
   readReviews(): Promise<ThreadSignalSerialization<Review[]>>;
 

--- a/packages/vscode-webui/src/components/worktree-select.tsx
+++ b/packages/vscode-webui/src/components/worktree-select.tsx
@@ -68,34 +68,19 @@ function BaseBranchSelector({
 }) {
   const { data: branches } = useQuery({
     queryKey: ["git-branches"],
-    queryFn: () => vscodeHost.readGitBranches(),
+    queryFn: () => vscodeHost.readGitBranches(50),
   });
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const { t } = useTranslation();
 
-  const filteredBranches = branches
-    ?.filter((branch) => {
-      const branchName = branch.replace(/^origin\//, "");
-      return (
-        branchName.toLowerCase().includes(search.toLowerCase()) ||
-        branch.toLowerCase().includes(search.toLowerCase())
-      );
-    })
-    .sort((a, b) => {
-      const isAMain = a === "main" || a === "master";
-      const isBMain = b === "main" || b === "master";
-      if (isAMain && !isBMain) return -1;
-      if (!isAMain && isBMain) return 1;
-
-      const isALocal = !a.startsWith("origin/");
-      const isBLocal = !b.startsWith("origin/");
-      if (isALocal && !isBLocal) return -1;
-      if (!isALocal && isBLocal) return 1;
-
-      return 0;
-    })
-    .slice(0, 50);
+  const filteredBranches = branches?.filter((branch) => {
+    const branchName = branch.replace(/^origin\//, "");
+    return (
+      branchName.toLowerCase().includes(search.toLowerCase()) ||
+      branch.toLowerCase().includes(search.toLowerCase())
+    );
+  });
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1014,11 +1014,11 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     return await this.githubIssueState.queryIssues(query);
   };
 
-  readGitBranches = async (): Promise<string[]> => {
+  readGitBranches = async (limit?: number): Promise<string[]> => {
     if (!this.cwd) {
       return [];
     }
-    return await this.gitState.getBranches(this.cwd);
+    return await this.gitState.getBranches(this.cwd, limit);
   };
 
   readReviews = async (): Promise<ThreadSignalSerialization<Review[]>> => {


### PR DESCRIPTION
## Summary
- Moved branch sorting and limiting logic from the frontend (`worktree-select.tsx`) to the backend (`GitState` class).
- Updated `readGitBranches` API to accept an optional `limit` parameter.
- This improves performance by reducing the amount of data sent to the frontend and processing it more efficiently in the extension host.

## Test plan
- Verify that the worktree selector still shows branches correctly.
- Verify that "main" and "master" branches appear at the top.
- Verify that local branches appear before remote branches.
- Verify that the list is limited to 50 items (as passed in the frontend call).

🤖 Generated with [Pochi](https://getpochi.com)