### PR TITLE
fix(vscode-webui): improve worktree select dropdown UI

### DIFF
--- a/packages/vscode-webui/src/components/worktree-select.tsx
+++ b/packages/vscode-webui/src/components/worktree-select.tsx
@@ -98,7 +98,10 @@ function BaseBranchSelector({
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="h-6 w-auto gap-0 px-0">
+              <Button
+                variant="ghost"
+                className="h-6 w-auto gap-0 px-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+              >
                 {value && (
                   <span className="ml-1 max-w-[8rem] truncate text-sm">
                     {value}
@@ -113,8 +116,9 @@ function BaseBranchSelector({
         </Tooltip>
       </TooltipProvider>
       <DropdownMenuContent
-        className="max-h-[300px] w-[200px] overflow-y-auto border bg-background p-0 text-popover-foreground shadow"
+        className="max-h-[300px] min-w-[160px] max-w-[80vw] overflow-y-auto border bg-background p-0 text-popover-foreground shadow sm:max-w-[600px]"
         align="start"
+        onCloseAutoFocus={(e) => e.preventDefault()}
       >
         <div className="sticky top-0 z-10 bg-background p-1">
           <Input
@@ -172,6 +176,7 @@ function BaseBranchSelector({
                   value === branch && "bg-accent text-accent-foreground",
                 )}
                 onMouseEnter={() => setSelectedIndex(index)}
+                title={branch}
               >
                 {isRemote ? (
                   <CloudIcon className={cn(" h-4 w-4 shrink-0")} />


### PR DESCRIPTION
## Summary
Improved the UI/UX of the worktree selector component in VS Code WebUI.

Changes:
- Improved styling of the selector button to remove focus rings.
- Adjusted dropdown menu width constraints for better responsiveness (min-width, max-width).
- Prevented auto-focus on close to improve user experience.
- Added `title` attribute to branch items for better accessibility and tooltip behavior.

## Screenshot
<img width="808" height="526" alt="image" src="https://github.com/user-attachments/assets/757a8574-622f-443e-9f0f-dc8320355a36" />


## Test plan
- Verify the worktree selector dropdown opens and closes correctly.
- Check that the button does not have a focus ring when clicked.
- Resize the window to ensure the dropdown width behaves correctly.
- Hover over branch items to see the full name in the native tooltip.

🤖 Generated with [Pochi](https://getpochi.com)