### PR TITLE
fix(vscode-webui): align custom model settings link

### DIFF
--- a/packages/vscode-webui/src/components/model-select.tsx
+++ b/packages/vscode-webui/src/components/model-select.tsx
@@ -200,7 +200,7 @@ export function ModelSelect({
                     href="command:pochi.openCustomModelSettings"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="group cursor-pointer px-3 py-2.5"
+                    className="group flex cursor-pointer items-center px-3 py-2.5"
                   >
                     <span className="text-[var(--vscode-textLink-foreground)] text-xs group-hover:underline ">
                       {t("modelSelect.manageCustomModels")}


### PR DESCRIPTION
## Summary
- Added `flex` and `items-center` classes to the custom model settings link in `ModelSelect` component to ensure proper alignment.

## Screenshot
<img width="502" height="494" alt="image" src="https://github.com/user-attachments/assets/9769546e-f880-414a-8b89-e44454254088" />


## Test plan
- Verify that the \"Manage Custom Models\" link in the model selector is vertically centered.

🤖 Generated with [Pochi](https://getpochi.com)