### PR TITLE
fix(vscode-webui): hide mermaid fix button when chart is empty

### DIFF
--- a/packages/vscode-webui/src/components/message/mermaid.tsx
+++ b/packages/vscode-webui/src/components/message/mermaid.tsx
@@ -99,7 +99,7 @@ export function Mermaid({ chart }: { chart: string }): ReactElement {
         <pre className="!p-2 max-h-32 w-full overflow-y-auto whitespace-pre-wrap rounded-md bg-[var(--vscode-textCodeBlock-background)] font-mono text-[var(--vscode-editor-foreground)]">
           {error}
         </pre>
-        {mermaidContext && chart.trim() !== "" && (
+        {mermaidContext && chart.trim() !== "" && chart !== "undefined" && (
           <Button
             variant="outline"
             size="sm"


### PR DESCRIPTION
## Summary
- Hide the "Fix" button in the Mermaid component when the chart content is empty or contains only whitespace.

## Test plan
- Verify that the "Fix" button does not appear for empty Mermaid blocks.
- Verify that the "Fix" button still appears for invalid non-empty Mermaid blocks.

🤖 Generated with [Pochi](https://getpochi.com)