### PR TITLE
fix: increase model select dropdown max height

### DIFF
--- a/packages/vscode-webui/src/components/model-select.tsx
+++ b/packages/vscode-webui/src/components/model-select.tsx
@@ -119,7 +119,7 @@ export function ModelSelect({
               side="bottom"
               align="start"
               alignOffset={6}
-              className="dropdown-menu max-h-[32vh] min-w-[18rem] animate-in overflow-y-auto overflow-x-hidden rounded-md border bg-background p-2 text-popover-foreground shadow"
+              className="dropdown-menu max-h-[90vh] min-w-[18rem] animate-in overflow-y-auto overflow-x-hidden rounded-md border bg-background p-2 text-popover-foreground shadow"
             >
               <DropdownMenuRadioGroup>
                 {hostedModels


### PR DESCRIPTION
## Summary
- Increased the max height of the model select dropdown from `32vh` to `90vh` in `ModelSelect` component.
- This improvement allows more models to be visible at once, reducing the need for excessive scrolling in environments with many available models.

## Screenshot
<img width="536" height="868" alt="image" src="https://github.com/user-attachments/assets/db7d189a-2bca-4de5-9524-6449beebe598" />


## Test plan
- Open the model selection dropdown in the webview.
- Verify that the dropdown can now expand up to 90% of the viewport height when many models are listed.
- Ensure scrolling still works correctly if the content exceeds this new limit.

🤖 Generated with [Pochi](https://getpochi.com)