### PR TITLE
fix(vscode): handle worktree init and checkpoint concurrency

### DIFF
--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -120,6 +120,7 @@ export class WorktreeManager implements vscode.Disposable {
 
   private async init() {
     if (!(await this.isGitRepository())) {
+      this.inited.resolve();
       return;
     }
     logger.info("init worktree manager");

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -700,12 +700,13 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     },
   );
 
-  readLatestCheckpoint = async (): Promise<
-    ThreadSignalSerialization<string | null>
-  > => {
-    await this.checkpointService.ensureInitialized();
-    return ThreadSignal.serialize(this.checkpointService.latestCheckpoint);
-  };
+  readLatestCheckpoint = runExclusive.build(
+    this.checkpointGroup,
+    async (): Promise<ThreadSignalSerialization<string | null>> => {
+      await this.checkpointService.ensureInitialized();
+      return ThreadSignal.serialize(this.checkpointService.latestCheckpoint);
+    },
+  );
 
   readCheckpointPath = async (): Promise<string | undefined> => {
     return this.checkpointService.getShadowGitPath();


### PR DESCRIPTION
## Summary
- Resolve `inited` promise when not a git repo in `WorktreeManager` to prevent hanging initialization.
- Use `runExclusive` for `readLatestCheckpoint` in `VSCodeHostImpl` to ensure proper serialization and avoid race conditions when reading checkpoints.

## Test plan
- Verify that opening a non-git folder does not cause the extension to hang on worktree initialization.
- Verify that reading checkpoints works correctly without race conditions.

🤖 Generated with [Pochi](https://getpochi.com)