### PR TITLE
fix(vscode-webui): handle deleted tasks in UI and update livestore name

### DIFF
--- a/packages/vscode-webui/src/components/task-row.tsx
+++ b/packages/vscode-webui/src/components/task-row.tsx
@@ -19,9 +19,11 @@ import { useTranslation } from "react-i18next";
 export function TaskRow({
   task,
   state,
+  isDeleted,
 }: {
   task: Task;
   state?: TaskState;
+  isDeleted?: boolean;
 }) {
   const { jwt } = usePochiCredentials();
 
@@ -32,9 +34,11 @@ export function TaskRow({
   const content = (
     <div
       className={cn(
-        "group cursor-pointer rounded-lg border border-border/50 bg-card/60 transition-all duration-200 hover:bg-card hover:shadow-md",
+        "group rounded-lg border border-border/50 bg-card/60 transition-all duration-200 hover:bg-card hover:shadow-md",
         {
           "border-primary/85": state?.focused,
+          "cursor-pointer": !isDeleted,
+          "opacity-60": isDeleted,
         },
       )}
     >
@@ -105,7 +109,9 @@ export function TaskRow({
     }
   }, [task.cwd, task.id, task.displayId, storeId, showFileChanges]);
 
-  return <div onClick={openTaskInPanel}>{content}</div>;
+  return (
+    <div onClick={!isDeleted ? openTaskInPanel : undefined}>{content}</div>
+  );
 }
 
 function GitBadge({

--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -492,7 +492,11 @@ function WorktreeSection({
               {tasks.map((task) => {
                 return (
                   <div key={task.id} className="py-0.5">
-                    <TaskRow task={task} state={pochiTasks[task.id]} />
+                    <TaskRow
+                      task={task}
+                      state={pochiTasks[task.id]}
+                      isDeleted={isDeleted}
+                    />
                   </div>
                 );
               })}

--- a/packages/vscode-webui/src/livestore-task-provider.tsx
+++ b/packages/vscode-webui/src/livestore-task-provider.tsx
@@ -20,9 +20,7 @@ export function LiveStoreTaskProvider({
   children,
 }: { children: React.ReactNode; cwd: string }) {
   const baseURI = document.baseURI;
-  const storeName = baseURI.startsWith("http://")
-    ? `${baseURI}-tasks`
-    : "tasks";
+  const storeName = baseURI.startsWith("http://") ? "local-tasks" : "tasks";
   logger.debug("Using LiveStore task store:", storeName);
   const storeId = sanitizeStoreId(isDev ? `dev-${storeName}` : storeName);
   return (


### PR DESCRIPTION
## Summary
- Improves the UI for deleted tasks in the worktree list by dimming them and disabling clicks.
- Adjusts the LiveStore name generation logic for HTTP environments.

## Test plan
- Verify deleted tasks appear dimmed and are not clickable.
- Verify LiveStore connection works as expected in web/dev environment.

🤖 Generated with [Pochi](https://getpochi.com)