### PR TITLE
fix(vscode): prevent opening new task when applying layout automatically

### DIFF
--- a/packages/vscode/src/integrations/layout.ts
+++ b/packages/vscode/src/integrations/layout.ts
@@ -96,6 +96,7 @@ export async function applyPochiLayout(params: {
   mergeSplitWindowEditors?: boolean;
   enabled?: boolean;
   cycleFocus?: boolean;
+  disableOpenTaskByDefault?: boolean;
   disableOpenTerminalByDefault?: boolean;
 }) {
   logger.trace("Begin applyPochiLayout.");
@@ -450,7 +451,11 @@ export async function applyPochiLayout(params: {
   }
 
   // If no tabs in task group, open a new task
-  if (getSortedCurrentTabGroups()[0].tabs.length === 0 && params.cwd) {
+  if (
+    !params.disableOpenTaskByDefault &&
+    getSortedCurrentTabGroups()[0].tabs.length === 0 &&
+    params.cwd
+  ) {
     logger.trace("Open new task tab.");
     await PochiTaskEditorProvider.openTaskEditor({
       type: "new-task",
@@ -557,7 +562,7 @@ export async function getViewColumnForTask(params: {
   }
 
   if (autoApplyPochiLayout) {
-    await applyPochiLayout({ cwd: params.cwd });
+    await applyPochiLayout({ cwd: params.cwd, disableOpenTaskByDefault: true });
     return vscode.ViewColumn.One;
   }
 


### PR DESCRIPTION
## Summary
- Add \`disableOpenTaskByDefault\` option to \`applyPochiLayout\`
- Use this option when auto-applying layout in \`getViewColumnForTask\` to avoid opening an unnecessary new task tab

## Test plan
- Verify that when opening a task that triggers auto-layout, a second empty 'new task' tab is not opened.

🤖 Generated with [Pochi](https://getpochi.com)