### PR TITLE
chore(ci): add patch release github workflow

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   patch-release:
-    if: github.event.issue.pull_request && github.event.issue.state == 'closed' && startsWith(github.event.comment.body, '/release ')
+    if: github.event.issue.pull_request && github.event.issue.state == 'closed' && startsWith(github.event.comment.body, '/release ') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## release directly

comment with `/release VERSION`

<img width="1896" height="2174" alt="CleanShot 2026-01-07 at 23 38 51@2x" src="https://github.com/user-attachments/assets/ef04b8cb-1b61-4bc8-9465-b7e666353e00" />

## pre-release with manual approval

comment with `/release VERSION pre`

<img width="1908" height="2292" alt="CleanShot 2026-01-07 at 23 43 23@2x" src="https://github.com/user-attachments/assets/28bf1b57-a965-42b4-911d-06b689eb75d8" />

approval issue:
<img width="2534" height="2568" alt="CleanShot 2026-01-07 at 23 46 30@2x" src="https://github.com/user-attachments/assets/843a27d4-9af6-4e1b-a399-9527c600b669" />

## error case

wrong usage:

<img width="1898" height="1002" alt="CleanShot 2026-01-07 at 23 50 08@2x" src="https://github.com/user-attachments/assets/93823a0e-b5d3-4545-9ca6-ef06f1fa38c9" />

released failed:

<img width="1876" height="794" alt="CleanShot 2026-01-07 at 23 50 45@2x" src="https://github.com/user-attachments/assets/871d1bf3-6eb7-499e-8185-94bb20aaee98" />
