### PR TITLE
chore: bump vscode package version to 0.25.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.23.0-dev",
+  "version": "0.25.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump `packages/vscode` version to `0.25.0-dev`.

## Test plan
- Verified `package.json` changes.
- Dependency check and linting passed via pre-commit hooks.

🤖 Generated with [Pochi](https://getpochi.com)