### PR TITLE
chore: update dev:vscode task with problemMatcher

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,24 @@
         "kind": "none",
         "isDefault": true
       },
-      "isBackground": true
+      "isBackground": true,
+      "problemMatcher": [
+        {
+          "pattern": [
+            {
+              "regexp": ".",
+              "file": 1,
+              "location": 2,
+              "message": 3
+            }
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "npm-run-all",
+            "endsPattern": "to show help"
+          }
+        }
+      ]
     },
     {
       "type": "shell",

--- a/bun.lock
+++ b/bun.lock
@@ -262,7 +262,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.23.0-dev",
+      "version": "0.25.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",


### PR DESCRIPTION
## Summary
- Added `problemMatcher` to `dev:vscode` task in `.vscode/tasks.json`.
- Updated `bun.lock` to reflect dependency changes.
- This improves VS Code integration by correctly identifying when the background task (running via `npm-run-all`) has started and finished its initial output.

## Test plan
- Open VS Code and run the `dev:vscode` task.
- Verify that the task status correctly transitions based on the output patterns.

🤖 Generated with [Pochi](https://getpochi.com)