### PR TITLE
fix(ci): use POCHI_HOMEBREW_GITHUB_TOKEN to do release

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.POCHI_HOMEBREW_GITHUB_TOKEN }}
 
       - name: Get PR Merged Commit
         if: steps.parse_version.outputs.parse_failed == 'false'
@@ -122,9 +122,6 @@ jobs:
           cd packages/vscode
           bun run release --release patch --quiet --yes
 
-          # Push changes back to the pre-branch
-          git push origin ${{ steps.parse_version.outputs.pre_branch }} --tags
-
       - name: Manual Approval
         if: steps.parse_version.outputs.parse_failed == 'false' && steps.parse_version.outputs.is_pre == 'true'
         uses: trstringer/manual-approval@v1
@@ -163,9 +160,6 @@ jobs:
           # Run release in packages/vscode
           cd packages/vscode
           bun run release --release patch --quiet --yes
-
-          # Push changes back to the main release branch
-          git push origin ${{ steps.parse_version.outputs.main_branch }} --tags
 
       - name: Report Failure
         if: failure() && steps.parse_version.outputs.parse_failed == 'false'


### PR DESCRIPTION
the action token provided by default will suppress the following workflows.
so used a PAT to do release

also drop the unnecessary push since bun release had push already