### PR TITLE
fix: remove useToolCallMiddleware from vendor options

### DIFF
--- a/packages/vendor-pochi/src/vendor.ts
+++ b/packages/vendor-pochi/src/vendor.ts
@@ -93,7 +93,6 @@ export class Pochi extends VendorBase {
           x.id,
           {
             contextWindow: x.contextWindow,
-            useToolCallMiddleware: x.id.includes("google"),
             label: x.costType === "basic" ? "swift" : "super",
             contentType: getContentTypesForModel(x.id),
           } satisfies ModelOptions,


### PR DESCRIPTION
## Summary
This PR removes the `useToolCallMiddleware` property from the model options in `packages/vendor-pochi/src/vendor.ts`. This property was conditionally set based on the model ID containing "google".

## Test plan
- Verify that the application builds and runs correctly.
- Ensure that models (especially those with "google" in the ID) still function as expected without this middleware option being explicitly set here.

🤖 Generated with [Pochi](https://getpochi.com)