### PR TITLE
fix: add check for tabGroups length to avoid undefined access

### DIFF
--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -379,6 +379,7 @@ function autoCleanTabGroupLock() {
 
     // if the tab group still have pochi tab, do nothing
     if (
+      vscode.window.tabGroups.all.length > 0 &&
       vscode.window.tabGroups.all[0].tabs.filter(
         (tab) =>
           tab.input instanceof vscode.TabInputCustom &&


### PR DESCRIPTION
## Summary
- Added a check for `vscode.window.tabGroups.all.length > 0` before accessing the first element to prevent potential runtime errors when no tab groups exist.

## Test plan
- Verify that the extension no longer throws an error when `tabGroups.all` is empty.

🤖 Generated with [Pochi](https://getpochi.com)