### PR TITLE
chore: run vscode e2e on release-vscode branches

### DIFF
--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -2,7 +2,7 @@ name: Pochi VSCode E2E test
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release-vscode*"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflow for VSCode E2E tests to trigger on push to branches prefixed with `release-vscode`.

## Test plan
- Verify that the workflow runs when pushing to a branch like `release-vscode-v1.0.0`.

🤖 Generated with [Pochi](https://getpochi.com)