### PR TITLE
feat(vscode-webui): implement infinite scroll for worktree list

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -53,9 +53,10 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as R from "remeda";
+
 import { usePaginatedTasks } from "#lib/hooks/use-paginated-tasks";
 import { TaskRow } from "./task-row";
 import { ScrollArea } from "./ui/scroll-area";
@@ -273,6 +274,25 @@ function WorktreeSection({
     cwd: group.path,
     pageSize: 15,
   });
+
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore) {
+          loadMore();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    if (loadMoreRef.current) {
+      observer.observe(loadMoreRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [hasMore, loadMore]);
 
   const pullRequest = group.data?.github?.pullRequest;
 
@@ -501,15 +521,8 @@ function WorktreeSection({
                 );
               })}
               {hasMore && (
-                <div className="py-1">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="w-full text-muted-foreground text-xs hover:text-foreground"
-                    onClick={loadMore}
-                  >
-                    {t("tasksPage.loadMore")}
-                  </Button>
+                <div ref={loadMoreRef} className="flex justify-center py-2">
+                  <Loader2 className="size-4 animate-spin text-muted-foreground" />
                 </div>
               )}{" "}
             </>


### PR DESCRIPTION
## Summary
- Replaced the manual "Load More" button in the worktree list with an infinite scroll mechanism.
- Used `IntersectionObserver` to detect when the user scrolls to the bottom of the list.
- Added a loading spinner to indicate when more tasks are being fetched.

## Test plan
- Open the worktree list in VS Code WebUI.
- Scroll down to the bottom of a list with many tasks.
- Verify that more tasks are automatically loaded without clicking a button.
- Verify that the loading spinner appears while fetching.

🤖 Generated with [Pochi](https://getpochi.com)