### PR TITLE
chore: update vscode settings to use biome for json and jsonc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,9 +16,11 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[json]": {
-    "editor.defaultFormatter": "vscode.json-language-features"
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "tailwindCSS.classFunctions": ["tw"],
-  "editor.formatOnSave": true,
-  "rust-analyzer.linkedProjects": []
+  "editor.formatOnSave": true
 }


### PR DESCRIPTION
## Summary
- Updated `.vscode/settings.json` to use `biomejs.biome` as the default formatter for `json` and `jsonc` files.
- Removed `rust-analyzer.linkedProjects` and cleaned up trailing comma.

## Test plan
1. Open a JSON or JSONC file in VS Code.
2. Verify that Biome is used for formatting.

🤖 Generated with [Pochi](https://getpochi.com)