### PR TITLE
chore: remove task displayId concept

### DIFF
--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -52,7 +52,6 @@ export type {
 } from "./types/review";
 export { isValidCustomAgentFile } from "./types/custom-agent";
 export {
-  prefixTaskDisplayId,
   prefixWorktreeName,
   getTaskDisplayTitle,
   WorktreePrefix,

--- a/packages/common/src/vscode-webui-bridge/task-utils.ts
+++ b/packages/common/src/vscode-webui-bridge/task-utils.ts
@@ -1,13 +1,10 @@
 export const WorktreePrefix = "⎇";
 export const prefixWorktreeName = (name: string) => `${WorktreePrefix} ${name}`;
-export const prefixTaskDisplayId = (displayId: number) =>
-  `${String(displayId).padStart(3, "0")}`;
 
 export const getTaskDisplayTitle = (params: {
   worktreeName: string;
   uid: string;
-  displayId: number | null;
 }) => {
-  const { worktreeName, uid, displayId } = params;
-  return `${prefixWorktreeName(worktreeName)}${displayId ? ` - ${prefixTaskDisplayId(displayId)}` : ` - ${uid.split("-")[0]} `}`;
+  const { worktreeName, uid } = params;
+  return `${prefixWorktreeName(worktreeName)} - ${uid.split("-")[0]}`;
 };

--- a/packages/common/src/vscode-webui-bridge/types/git.ts
+++ b/packages/common/src/vscode-webui-bridge/types/git.ts
@@ -9,7 +9,6 @@ export const GithubIssue = z.object({
 
 // Persisted in global storage by worktree.
 export const GitWorktreeInfo = z.object({
-  nextDisplayId: z.number().min(1),
   github: z.object({
     pullRequest: z
       .object({

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -35,14 +35,12 @@ export type PochiTaskParams = { cwd: string } & (
   | {
       type: "open-task";
       uid: string;
-      displayId: number | null;
       storeId?: string;
     }
 );
 
 export type PochiTaskInfo = PochiTaskParams & {
   uid: string;
-  displayId: number | null;
 };
 
 /**

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -321,7 +321,7 @@ export interface VSCodeHostApi {
 
   sendTaskNotification(
     kind: "failed" | "completed" | "pending-tool" | "pending-input",
-    params: { uid: string; displayId: number | null; isSubTask?: boolean },
+    params: { uid: string; isSubTask?: boolean },
   ): Promise<void>;
 
   onTaskUpdated(taskData: unknown): Promise<void>;

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -58,7 +58,6 @@ export type LiveChatKitOptions<T> = {
 
 type InitOptions = {
   initTitle?: string;
-  displayId?: number;
 } & (
   | {
       prompt?: string;
@@ -78,7 +77,6 @@ export class LiveChatKit<
   },
 > {
   protected readonly taskId: string;
-  protected readonly displayId?: number;
   protected readonly store: LiveKitStore;
   readonly chat: T;
   private readonly transport: FlexibleChatTransport;
@@ -238,7 +236,6 @@ export class LiveChatKit<
         cwd,
         createdAt: new Date(),
         initTitle: options?.initTitle,
-        displayId: options?.displayId,
         initMessages,
       }),
     );

--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -109,7 +109,11 @@ export const events = {
       ...taskInitFields,
       initMessages: Schema.optional(Schema.Array(DBMessage)),
       initTitle: Schema.optional(Schema.String),
-      displayId: Schema.optional(Schema.Number),
+      displayId: Schema.optional(Schema.Number).pipe(
+        deprecated("Concept of displayId is removed"),
+      ),
+      // @deprecated
+      // use initMessages instead
       initMessage: Schema.optional(
         Schema.Struct({
           id: Schema.String,
@@ -139,7 +143,7 @@ export const events = {
       updatedAt: Schema.Date,
       modelId: Schema.optional(Schema.String),
       displayId: Schema.optional(Schema.Number).pipe(
-        deprecated("use displayId in init instead"),
+        deprecated("Concept of displayId is removed"),
       ),
     }),
   }),

--- a/packages/livekit/src/livestore/types.ts
+++ b/packages/livekit/src/livestore/types.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@livestore/livestore";
+import { Schema, deprecated } from "@livestore/livestore";
 
 export const DBTextUIPart = Schema.Struct({
   type: Schema.Literal("text"),
@@ -98,5 +98,7 @@ export const taskFullFields = {
   lastCheckpointHash: Schema.optional(Schema.String),
   error: Schema.optional(TaskError),
   updatedAt: Schema.Date,
-  displayId: Schema.optional(Schema.Number),
+  displayId: Schema.optional(Schema.Number).pipe(
+    deprecated("Concept of displayId is removed"),
+  ),
 };

--- a/packages/vscode-webui/src/components/__stories__/worktree-list.stories.tsx
+++ b/packages/vscode-webui/src/components/__stories__/worktree-list.stories.tsx
@@ -18,7 +18,6 @@ const mockWorktrees = [
     isMain: true,
     branch: "main",
     data: {
-      nextDisplayId: 1,
       github: {
         pullRequest: {
           id: 122,
@@ -50,7 +49,6 @@ const mockWorktrees = [
     isMain: false,
     branch: "feature/auth",
     data: {
-      nextDisplayId: 2,
       github: {
         pullRequest: {
           id: 123,
@@ -96,7 +94,7 @@ const mockTasks = [
     createdAt: new Date("2025-12-15T10:00:00Z"),
     updatedAt: new Date("2025-12-15T10:00:00Z"),
     modelId: null,
-    displayId: 1,
+    displayId: null,
     lastCheckpointHash: null,
   },
   {
@@ -117,7 +115,7 @@ const mockTasks = [
     createdAt: new Date("2025-12-15T10:02:00Z"),
     updatedAt: new Date("2025-12-15T10:02:00Z"),
     modelId: null,
-    displayId: 2,
+    displayId: null,
     lastCheckpointHash: null,
   },
   {
@@ -138,7 +136,7 @@ const mockTasks = [
     createdAt: new Date("2025-12-15T10:05:00Z"),
     updatedAt: new Date("2025-12-15T10:05:00Z"),
     modelId: null,
-    displayId: 3,
+    displayId: null,
     lastCheckpointHash: null,
   },
 ] satisfies Task[];
@@ -363,9 +361,7 @@ export const WorktreeWithNoPR: Story = {
           path: "/Users/will/work/pochi-no-pr",
           isMain: false,
           branch: "feature/no-pr",
-          data: {
-            nextDisplayId: 5,
-          },
+          data: {},
         },
       ],
     },
@@ -387,7 +383,6 @@ export const WorktreeWithFailedChecks: Story = {
           isMain: false,
           branch: "fix/failed-checks",
           data: {
-            nextDisplayId: 6,
             github: {
               pullRequest: {
                 id: 127,

--- a/packages/vscode-webui/src/components/task-row.tsx
+++ b/packages/vscode-webui/src/components/task-row.tsx
@@ -6,10 +6,7 @@ import { cn } from "@/lib/utils";
 import { vscodeHost } from "@/lib/vscode";
 import { parseTitle } from "@getpochi/common/message-utils";
 import { encodeStoreId } from "@getpochi/common/store-id-utils";
-import {
-  type TaskState,
-  prefixTaskDisplayId,
-} from "@getpochi/common/vscode-webui-bridge";
+import type { TaskState } from "@getpochi/common/vscode-webui-bridge";
 import type { Task, UITools } from "@getpochi/livekit";
 import type { ToolUIPart } from "ai";
 import { GitBranch, Loader2 } from "lucide-react";
@@ -46,11 +43,6 @@ export function TaskRow({
         <div className="flex items-start gap-3">
           <div className="flex-1 space-y-1 overflow-hidden">
             <div className="flex items-center gap-1.5">
-              {task.displayId && (
-                <span className="flex shrink-0 items-center justify-center text-foreground/80">
-                  {prefixTaskDisplayId(task.displayId)}
-                </span>
-              )}
               <div className="line-clamp-2 flex flex-1 items-center font-medium text-foreground leading-relaxed">
                 <div
                   className={cn("truncate", {
@@ -101,13 +93,12 @@ export function TaskRow({
         type: "open-task",
         cwd: task.cwd,
         uid: task.id,
-        displayId: task.displayId,
         storeId,
       });
 
       showFileChanges();
     }
-  }, [task.cwd, task.id, task.displayId, storeId, showFileChanges]);
+  }, [task.cwd, task.id, storeId, showFileChanges]);
 
   return (
     <div onClick={!isDeleted ? openTaskInPanel : undefined}>{content}</div>

--- a/packages/vscode-webui/src/features/chat/__stories__/page.stories.tsx
+++ b/packages/vscode-webui/src/features/chat/__stories__/page.stories.tsx
@@ -39,7 +39,6 @@ export const Default: Story = {
     info: {
       uid: "default",
       cwd: "/foo/bar",
-      displayId: null,
       type: "open-task",
     },
   },

--- a/packages/vscode-webui/src/features/chat/hooks/use-keep-task-editor.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-keep-task-editor.ts
@@ -9,7 +9,6 @@ export const useKeepTaskEditor = (task?: Task) => {
   const status = useRef<string | null>(null);
   const taskStatus = task?.status;
   const taskCwd = task?.cwd;
-  const taskDisplayId = task?.displayId;
   useEffect(() => {
     if (taskCwd && taskStatus !== status.current && status.current !== null) {
       vscodeHost.openTaskInPanel(
@@ -17,11 +16,10 @@ export const useKeepTaskEditor = (task?: Task) => {
           type: "open-task",
           uid: task.id,
           cwd: taskCwd,
-          displayId: taskDisplayId ?? null,
         },
         { keepEditor: true },
       );
     }
     status.current = taskStatus ?? null;
-  }, [taskStatus, taskCwd, taskDisplayId, task?.id]);
+  }, [taskStatus, taskCwd, task?.id]);
 };

--- a/packages/vscode-webui/src/features/chat/lib/use-send-task-notification.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-send-task-notification.ts
@@ -9,7 +9,6 @@ export function useSendTaskNotification() {
       kind: "failed" | "completed" | "pending-tool" | "pending-input",
       openTaskParams: {
         uid: string;
-        displayId: number | null;
         isSubTask?: boolean;
       },
     ) => {

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -89,9 +89,6 @@ function Chat({ user, uid, info }: ChatProps) {
   const task = store.useQuery(catalog.queries.makeTaskQuery(uid));
   useKeepTaskEditor(task);
   const subtask = useSubtaskInfo(uid, task?.parentId);
-  const topDisplayId =
-    store.useQuery(catalog.queries.makeTaskQuery(task?.parentId ?? ""))
-      ?.displayId ?? info.displayId;
 
   const isSubTask = !!subtask;
 
@@ -166,7 +163,6 @@ function Chat({ user, uid, info }: ChatProps) {
         ) {
           sendNotification("failed", {
             uid: topTaskUid,
-            displayId: topDisplayId,
             isSubTask,
           });
         }
@@ -189,7 +185,6 @@ function Chat({ user, uid, info }: ChatProps) {
           if (!autoApproved) {
             sendNotification("pending-tool", {
               uid: topTaskUid,
-              displayId: topDisplayId,
               isSubTask,
             });
           }
@@ -211,7 +206,6 @@ function Chat({ user, uid, info }: ChatProps) {
         ) {
           sendNotification("pending-input", {
             uid: topTaskUid,
-            displayId: topDisplayId,
             isSubTask,
           });
         }
@@ -220,7 +214,6 @@ function Chat({ user, uid, info }: ChatProps) {
       if (data.status === "completed") {
         sendNotification("completed", {
           uid: topTaskUid,
-          displayId: topDisplayId,
           isSubTask,
         });
       }
@@ -310,7 +303,6 @@ function Chat({ user, uid, info }: ChatProps) {
   useEffect(() => {
     if (chatKit.inited || isMcpConfigLoading) return;
     const cwd = info.cwd;
-    const displayId = info.displayId ?? undefined;
     if (info.type === "new-task") {
       if (info.mcpConfigOverride && setMcpConfigOverride) {
         setMcpConfigOverride(info.mcpConfigOverride);
@@ -325,19 +317,16 @@ function Chat({ user, uid, info }: ChatProps) {
         }));
 
         chatKit.init(cwd, {
-          displayId,
           prompt: info.prompt,
           parts: prepareMessageParts(t, info.prompt || "", files || [], []),
         });
       } else {
         chatKit.init(cwd, {
-          displayId,
           prompt: info.prompt ?? undefined,
         });
       }
     } else if (info.type === "compact-task") {
       chatKit.init(cwd, {
-        displayId,
         messages: JSON.parse(info.messages),
       });
     } else if (info.type === "fork-task") {
@@ -348,7 +337,6 @@ function Chat({ user, uid, info }: ChatProps) {
 
       chatKit.init(cwd, {
         initTitle: info.title,
-        displayId,
         messages: JSON.parse(info.messages),
       });
     } else if (info.type === "open-task") {

--- a/packages/vscode-webui/src/routes/task.tsx
+++ b/packages/vscode-webui/src/routes/task.tsx
@@ -30,7 +30,6 @@ function RouteComponent() {
     } else {
       info = {
         uid: searchParams.uid,
-        displayId: null,
         cwd: window.POCHI_TASK_INFO.cwd,
         type: "open-task",
       };

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -280,7 +280,6 @@ export class CommandManager implements vscode.Disposable {
               type: "open-task",
               uid,
               cwd,
-              displayId: null,
             });
           },
         );

--- a/packages/vscode/src/integrations/git/git-worktree-info-provider.ts
+++ b/packages/vscode/src/integrations/git/git-worktree-info-provider.ts
@@ -16,9 +16,6 @@ export class GitWorktreeInfoProvider {
     @inject("vscode.ExtensionContext")
     private readonly context: vscode.ExtensionContext,
   ) {
-    this.getNextDisplayId = runExclusive
-      .buildMethod(this.getNextDisplayId)
-      .bind(this);
     this.updateGithubPullRequest = runExclusive
       .buildMethod(this.updateGithubPullRequest)
       .bind(this);
@@ -85,22 +82,10 @@ export class GitWorktreeInfoProvider {
     const existing = await this.get(worktreePath);
     if (!existing) {
       return await this.set(worktreePath, {
-        nextDisplayId: 1,
         github: {},
       });
     }
     return existing;
-  }
-
-  async getNextDisplayId(worktreePath: string): Promise<number> {
-    let data = await this.get(worktreePath);
-    if (!data) {
-      data = await this.initialize(worktreePath);
-    }
-    const id = data.nextDisplayId;
-    data.nextDisplayId += 1;
-    await this.set(worktreePath, data);
-    return id;
   }
 
   async updateGithubPullRequest(

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -902,7 +902,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
 
   sendTaskNotification = async (
     kind: "failed" | "completed" | "pending-tool" | "pending-input",
-    params: { uid: string; displayId: number | null; isSubTask?: boolean },
+    params: { uid: string; isSubTask?: boolean },
   ) => {
     if (!this.cwd) return;
 
@@ -932,14 +932,13 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       default:
         break;
     }
-    const { displayId, uid } = params;
+    const { uid } = params;
     const worktreeName = getWorktreeNameFromWorktreePath(this.cwd);
     const taskTitle = getTaskDisplayTitle({
       worktreeName:
         this.workspaceScope.isMainWorkspace || !worktreeName
           ? "workspace"
           : worktreeName,
-      displayId,
       uid,
     });
     const buttonText = "View Details";
@@ -955,7 +954,6 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
         type: "open-task",
         uid,
         cwd: this.cwd,
-        displayId,
       });
     }
   };

--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -12,7 +12,6 @@ import { container } from "tsyringe";
 import * as vscode from "vscode";
 import { z } from "zod/v4";
 import { PochiConfiguration } from "../configuration";
-import { GitWorktreeInfoProvider } from "../git/git-worktree-info-provider";
 import { WorktreeManager } from "../git/worktree";
 import { getViewColumnForTask } from "../layout";
 import { WebviewBase } from "./base";
@@ -138,7 +137,6 @@ export class PochiTaskEditorProvider
       .getWorktreeDisplayName(params.cwd);
     const displayName = getTaskDisplayTitle({
       worktreeName: worktreeName ?? "workspace",
-      displayId: params.displayId,
       uid: params.uid,
     });
     return vscode.Uri.from({
@@ -146,7 +144,6 @@ export class PochiTaskEditorProvider
       path: `/pochi/task/${displayName}`,
       query: JSON.stringify({
         uid: params.uid,
-        displayId: params.displayId,
         cwd: params.cwd,
       } satisfies TaskUri), // keep query string stable for identification
     });
@@ -170,14 +167,9 @@ export class PochiTaskEditorProvider
         ((params.type === "new-task" || params.type === "open-task") &&
           params.uid) ||
         crypto.randomUUID();
-      const displayId =
-        params.type === "open-task"
-          ? params.displayId
-          : await getNextDisplayId(params.cwd);
       const taskInfo: PochiTaskInfo = {
         ...params,
         uid,
-        displayId,
       };
       const uri = PochiTaskEditorProvider.createTaskUri(taskInfo);
       PochiTaskEditorProvider.taskInfo.set(uri.toString(), taskInfo);
@@ -317,15 +309,6 @@ export class PochiTaskEditorProvider
   }
 }
 
-async function getNextDisplayId(cwd: string) {
-  const worktreeManager = container.resolve(WorktreeManager);
-  const mainWorktreeCwd = worktreeManager.worktrees.value.find(
-    (wt) => wt.isMain,
-  )?.path;
-  const worktreeInfoProvider = container.resolve(GitWorktreeInfoProvider);
-  return await worktreeInfoProvider.getNextDisplayId(mainWorktreeCwd ?? cwd);
-}
-
 function setAutoLockGroupsConfig() {
   const autoLockGroupsConfig =
     vscode.workspace.getConfiguration("workbench.editor");
@@ -409,7 +392,6 @@ function autoCleanTabGroupLock() {
 const TaskUri = z.object({
   cwd: z.string(),
   uid: z.string(),
-  displayId: z.number().nullable(),
 });
 
 type TaskUri = z.infer<typeof TaskUri>;


### PR DESCRIPTION
## Summary
- Removed the `displayId` concept for tasks across the codebase.
- Updated task display titles to use the worktree name and the task UID.
- Deprecated `displayId` in the LiveStore schema and types to maintain backward compatibility while signaling removal.
- Cleaned up VSCode host and webview panel logic that handled `displayId` generation and propagation.

## Test plan
- Verified that tasks are still correctly displayed in the UI using their UID.
- Checked that clicking on tasks in the side panel still opens the correct task editor.
- Ensured that task notifications still work correctly without `displayId`.
- Ran existing tests to ensure no regressions in task management.

🤖 Generated with [Pochi](https://getpochi.com)