### PR TITLE
refactor: use executeCommandWithPty in VSCodeHostImpl

### DIFF
--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1,6 +1,6 @@
 import * as os from "node:os";
 import path from "node:path";
-import { executeCommandWithNode } from "@/integrations/terminal/execute-command-with-node";
+import { executeCommandWithPty } from "@/integrations/terminal/execute-command-with-pty";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { CustomAgentManager } from "@/lib/custom-agent";
 import {
@@ -963,7 +963,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
 
     let capturedOutput = "";
     try {
-      const { output } = await executeCommandWithNode({
+      const { output } = await executeCommandWithPty({
         command,
         cwd: this.cwd,
         abortSignal: signal as AbortSignal,


### PR DESCRIPTION
## Summary
- Replaced `executeCommandWithNode` with `executeCommandWithPty` in `VSCodeHostImpl`.
- This ensures that commands are executed within a PTY environment, which is more robust for terminal-related operations.

## Test plan
1. Verify that commands executed through the VSCode host still work as expected.
2. Check if any terminal-specific features (like ANSI escape codes) are better handled.

🤖 Generated with [Pochi](https://getpochi.com)