### PR TITLE
refactor(vscode): migrate worktree storage to disk files

### DIFF
--- a/packages/vscode/src/integrations/git/git-worktree-info-provider.ts
+++ b/packages/vscode/src/integrations/git/git-worktree-info-provider.ts
@@ -1,12 +1,17 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { toErrorMessage } from "@getpochi/common";
 import { GitWorktreeInfo } from "@getpochi/common/vscode-webui-bridge";
 import * as runExclusive from "run-exclusive";
 import { inject, injectable, singleton } from "tsyringe";
-import type * as vscode from "vscode";
+import * as vscode from "vscode";
 
 @injectable()
 @singleton()
 export class GitWorktreeInfoProvider {
+  private cache = new Map<string, GitWorktreeInfo>();
+
   constructor(
     @inject("vscode.ExtensionContext")
     private readonly context: vscode.ExtensionContext,
@@ -22,15 +27,52 @@ export class GitWorktreeInfoProvider {
       .bind(this);
   }
 
-  get(worktreePath: string): GitWorktreeInfo | undefined {
-    const raw = this.context.globalState.get<GitWorktreeInfo>(worktreePath);
-    return raw;
+  private getStorageUri(worktreePath: string): vscode.Uri {
+    // Create a safe filename from the worktree path using a hash
+    const hash = createHash("sha256").update(worktreePath).digest("hex");
+    return vscode.Uri.joinPath(
+      this.context.globalStorageUri,
+      `worktree-${hash}.json`,
+    );
   }
 
-  async set(worktreePath: string, data: GitWorktreeInfo) {
+  async get(worktreePath: string): Promise<GitWorktreeInfo | undefined> {
+    // Check cache first
+    if (this.cache.has(worktreePath)) {
+      return this.cache.get(worktreePath);
+    }
+
+    // Try to load from disk
+    try {
+      const uri = this.getStorageUri(worktreePath);
+      const data = await readFile(uri.fsPath, "utf8");
+      const parsed = GitWorktreeInfo.parse(JSON.parse(data));
+      this.cache.set(worktreePath, parsed);
+      return parsed;
+    } catch (error) {
+      // File doesn't exist or is invalid, return undefined
+      return undefined;
+    }
+  }
+
+  async set(
+    worktreePath: string,
+    data: GitWorktreeInfo,
+  ): Promise<GitWorktreeInfo> {
     try {
       const parsed = GitWorktreeInfo.parse(data);
-      await this.context.globalState.update(worktreePath, parsed);
+      const uri = this.getStorageUri(worktreePath);
+
+      // Ensure the storage directory exists
+      const dir = dirname(uri.fsPath);
+      await mkdir(dir, { recursive: true });
+
+      // Write to disk
+      await writeFile(uri.fsPath, JSON.stringify(parsed, null, 2), "utf8");
+
+      // Update cache
+      this.cache.set(worktreePath, parsed);
+
       return parsed;
     } catch (error) {
       throw new Error(
@@ -39,8 +81,8 @@ export class GitWorktreeInfoProvider {
     }
   }
 
-  private async initialize(worktreePath: string) {
-    const existing = this.get(worktreePath);
+  private async initialize(worktreePath: string): Promise<GitWorktreeInfo> {
+    const existing = await this.get(worktreePath);
     if (!existing) {
       return await this.set(worktreePath, {
         nextDisplayId: 1,
@@ -51,13 +93,13 @@ export class GitWorktreeInfoProvider {
   }
 
   async getNextDisplayId(worktreePath: string): Promise<number> {
-    let data = this.get(worktreePath);
+    let data = await this.get(worktreePath);
     if (!data) {
       data = await this.initialize(worktreePath);
     }
     const id = data.nextDisplayId;
     data.nextDisplayId += 1;
-    this.set(worktreePath, data);
+    await this.set(worktreePath, data);
     return id;
   }
 
@@ -65,19 +107,19 @@ export class GitWorktreeInfoProvider {
     worktreePath: string,
     pullRequest: GitWorktreeInfo["github"]["pullRequest"],
   ) {
-    let data = this.get(worktreePath);
+    let data = await this.get(worktreePath);
     if (!data) {
       data = await this.initialize(worktreePath);
     }
     data.github.pullRequest = pullRequest;
-    this.set(worktreePath, data);
+    await this.set(worktreePath, data);
     return pullRequest;
   }
 
-  getGithubIssues(
+  async getGithubIssues(
     worktreePath: string,
-  ): GitWorktreeInfo["github"]["issues"] | undefined {
-    const data = this.get(worktreePath);
+  ): Promise<GitWorktreeInfo["github"]["issues"] | undefined> {
+    const data = await this.get(worktreePath);
     return data?.github.issues;
   }
 
@@ -85,16 +127,26 @@ export class GitWorktreeInfoProvider {
     worktreePath: string,
     issues: GitWorktreeInfo["github"]["issues"],
   ) {
-    let data = this.get(worktreePath);
+    let data = await this.get(worktreePath);
     if (!data) {
       data = await this.initialize(worktreePath);
     }
     data.github.issues = issues;
-    this.set(worktreePath, data);
+    await this.set(worktreePath, data);
     return issues;
   }
 
-  delete(worktreePath: string) {
-    this.context.globalState.update(worktreePath, undefined);
+  async delete(worktreePath: string): Promise<void> {
+    try {
+      const uri = this.getStorageUri(worktreePath);
+      await unlink(uri.fsPath).catch(() => {
+        // Ignore error if file doesn't exist
+      });
+      this.cache.delete(worktreePath);
+    } catch (error) {
+      throw new Error(
+        `Failed to delete worktree data for path: ${worktreePath}. Error: ${toErrorMessage(error)}`,
+      );
+    }
   }
 }

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -306,13 +306,16 @@ export class WorktreeManager implements vscode.Disposable {
   private async getWorktrees(): Promise<GitWorktree[]> {
     try {
       const result = await this.git.raw(["worktree", "list", "--porcelain"]);
-      const worktrees = this.parseWorktreePorcelain(result)
+      const parsedWorktrees = this.parseWorktreePorcelain(result)
         .filter((wt) => wt.prunable === undefined)
-        .map<GitWorktree>((wt) => {
-          const storedData = this.worktreeInfoProvider.get(wt.path);
-          return { ...wt, data: storedData };
-        })
         .slice(0, this.maxWorktrees);
+
+      const worktrees = await Promise.all(
+        parsedWorktrees.map<Promise<GitWorktree>>(async (wt) => {
+          const storedData = await this.worktreeInfoProvider.get(wt.path);
+          return { ...wt, data: storedData };
+        }),
+      );
 
       const workspaceWorktree = worktrees.find(
         (x) => x.path === this.workspacePath,

--- a/packages/vscode/src/integrations/github/github-issue-state.ts
+++ b/packages/vscode/src/integrations/github/github-issue-state.ts
@@ -59,7 +59,7 @@ export class GithubIssueState implements vscode.Disposable {
 
       const mainWorktreePath = mainWorktree.path;
       const currentIssuesData =
-        this.worktreeInfoProvider.getGithubIssues(mainWorktreePath);
+        await this.worktreeInfoProvider.getGithubIssues(mainWorktreePath);
 
       const updatedAt = currentIssuesData?.updatedAt;
       const isInitialCheck = !updatedAt;
@@ -124,7 +124,7 @@ export class GithubIssueState implements vscode.Disposable {
         page++;
 
         const currentIssuesData =
-          this.worktreeInfoProvider.getGithubIssues(worktreePath);
+          await this.worktreeInfoProvider.getGithubIssues(worktreePath);
         // Process the updated issues: remove closed issues from current list and add new open issues
         const currentIssues = currentIssuesData?.data ?? [];
         const updatedIssues = this.processUpdatedIssues(
@@ -301,7 +301,7 @@ export class GithubIssueState implements vscode.Disposable {
         return [];
       }
 
-      const issuesData = this.worktreeInfoProvider.getGithubIssues(
+      const issuesData = await this.worktreeInfoProvider.getGithubIssues(
         mainWorktree.path,
       );
       if (!issuesData?.data) {

--- a/packages/vscode/src/integrations/github/github-pull-request-state.ts
+++ b/packages/vscode/src/integrations/github/github-pull-request-state.ts
@@ -130,7 +130,7 @@ export class GithubPullRequestState implements vscode.Disposable {
 
     await Promise.all(
       worktreesToCheck.map(async (worktree) => {
-        const currentInfo = this.worktreeInfoProvider.get(worktree.path);
+        const currentInfo = await this.worktreeInfoProvider.get(worktree.path);
         if (
           !currentInfo ||
           !currentInfo.github.pullRequest ||
@@ -138,21 +138,21 @@ export class GithubPullRequestState implements vscode.Disposable {
         ) {
           const updated = await this.fetchWorktreePrInfo(worktree);
           if (updated) {
-            this.updateWorktreeSignal(worktree.path);
+            await this.updateWorktreeSignal(worktree.path);
           }
         }
       }),
     );
   }
 
-  private updateWorktreeSignal(path: string) {
+  private async updateWorktreeSignal(path: string) {
     const currentWorktrees = this.worktreeManager.worktrees.value;
     const index = currentWorktrees.findIndex((w) => w.path === path);
     if (index !== -1) {
       const newWorktrees = [...currentWorktrees];
       newWorktrees[index] = {
         ...newWorktrees[index],
-        data: this.worktreeInfoProvider.get(path),
+        data: await this.worktreeInfoProvider.get(path),
       };
       this.worktreeManager.worktrees.value = newWorktrees;
     }
@@ -177,7 +177,7 @@ export class GithubPullRequestState implements vscode.Disposable {
       }`,
     );
 
-    const currentInfo = this.worktreeInfoProvider.get(worktree.path);
+    const currentInfo = await this.worktreeInfoProvider.get(worktree.path);
     const currentPrInfo = currentInfo?.github?.pullRequest;
     const newPrInfo = prInfo ?? undefined;
 


### PR DESCRIPTION
## Summary
- Migrated worktree storage from VSCode's global state (memento) to disk-based file storage
- Implemented file-based persistence using hashed filenames to avoid path-related issues
- Added in-memory cache layer for improved performance
- Converted all synchronous storage operations to async for consistency

## Why this change?
VSCode's global state has size limitations that can cause issues when storing large amounts of worktree metadata. By moving to disk-based storage:
- We avoid global state size limits
- Data is more easily inspectable and debuggable
- Storage is more reliable for large repositories with many worktrees

## Changes
- **GitWorktreeInfoProvider**: Refactored from sync to async operations, added file-based storage with SHA-256 hashed filenames
- **WorktreeManager**: Updated to handle async worktree info retrieval
- **GithubIssueState**: Updated all calls to async methods
- **GithubPullRequestState**: Updated all calls to async methods

## Test plan
- [ ] Verify existing worktrees continue to work (graceful migration)
- [ ] Test creating new worktrees and storing metadata
- [ ] Verify GitHub PR/issue integration still works correctly
- [ ] Check that storage files are created in the correct location

🤖 Generated with [Pochi](https://getpochi.com)