### PR TITLE
chore: add patch for @livestore/utils to remove unused ParcelWatcherLayer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ragdoll",
@@ -448,6 +447,7 @@
     "silver-fleece@1.2.1": "patches/silver-fleece@1.2.1.patch",
     "streamdown@1.6.10": "patches/streamdown@1.6.10.patch",
     "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch",
+    "@livestore/utils@0.4.0-dev.22": "patches/@livestore%2Futils@0.4.0-dev.22.patch",
     "tslog@4.9.3": "patches/tslog@4.9.3.patch",
   },
   "catalog": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "ai@5.0.59": "patches/ai@5.0.59.patch",
     "@ai-sdk/google-vertex@3.0.34": "patches/@ai-sdk%2Fgoogle-vertex@3.0.34.patch",
     "tslog@4.9.3": "patches/tslog@4.9.3.patch",
-    "streamdown@1.6.10": "patches/streamdown@1.6.10.patch"
+    "streamdown@1.6.10": "patches/streamdown@1.6.10.patch",
+    "@livestore/utils@0.4.0-dev.22": "patches/@livestore%2Futils@0.4.0-dev.22.patch"
   }
 }

--- a/patches/@livestore%2Futils@0.4.0-dev.22.patch
+++ b/patches/@livestore%2Futils@0.4.0-dev.22.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/node/mod.js b/dist/node/mod.js
+index 41ac137e58a31a6e72a29fa5e1b0c0f2df3ef02a..bcdc9568ae865f6553cbbc0f9746f22eb873cc0e 100644
+--- a/dist/node/mod.js
++++ b/dist/node/mod.js
+@@ -1,5 +1,4 @@
+ import * as http from 'node:http';
+-import { layer as ParcelWatcherLayer } from '@effect/platform-node/NodeFileSystem/ParcelWatcher';
+ import { Effect, Layer } from 'effect';
+ import { OtelTracer, UnknownError } from "../effect/mod.js";
+ import { makeNoopTracer } from "../NoopTracer.js";
+@@ -59,7 +58,6 @@ export const OtelLiveDummy = Layer.suspend(() => {
+  *
+  * @see https://github.com/Effect-TS/effect/issues/5913
+  */
+-export const NodeRecursiveWatchLayer = ParcelWatcherLayer;
+ /**
+  * Pre-composed layer providing FileSystem with recursive file watching via @parcel/watcher.
+  * This is the recommended way to get a FileSystem that supports recursive watching.
+@@ -70,5 +68,5 @@ export const NodeRecursiveWatchLayer = ParcelWatcherLayer;
+  */
+ export { NodeFileSystem } from '@effect/platform-node';
+ import { NodeFileSystem } from '@effect/platform-node';
+-export const NodeFileSystemWithWatch = NodeFileSystem.layer.pipe(Layer.provideMerge(ParcelWatcherLayer));
++export const NodeFileSystemWithWatch = NodeFileSystem.layer.pipe();
+ //# sourceMappingURL=mod.js.map
+\ No newline at end of file


### PR DESCRIPTION
Fix the issue that pochi cli would encounter the following error when running out side of project dir:

```
error: Cannot require module ./build/Release/watcher.node
      at <anonymous> (/$bunfs/root/pochi:117775:29)
      at <anonymous> (/$bunfs/root/pochi:117775:98)
      at <anonymous> (/$bunfs/root/pochi:63:48)
      at <anonymous> (/$bunfs/root/pochi:117837:15)
      at <anonymous> (/$bunfs/root/pochi:63:48)
      at <anonymous> (/$bunfs/root/pochi:117857:21)
      at <anonymous> (/$bunfs/root/pochi:63:48)
      at <anonymous> (/$bunfs/root/pochi:117864:21)
      at <anonymous> (/$bunfs/root/pochi:63:48)
      at <anonymous> (/$bunfs/root/pochi:137442:22)
      at <anonymous> (/$bunfs/root/pochi:63:48)
      at /$bunfs/root/pochi:485445:11
      at loadAndEvaluateModule (1:11)
```

## Summary
- Add patch for `@livestore/utils` to fix dependency issues
- Update `package.json` and `bun.lock`

## Test plan
- CI should pass

🤖 Generated with [Pochi](https://getpochi.com)