### PR TITLE
refactor: rename and reorganize task and tab state management

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/user-edit-state.ts
+++ b/packages/vscode/src/integrations/checkpoint/user-edit-state.ts
@@ -8,7 +8,7 @@ import * as runExclusive from "run-exclusive";
 import { Lifecycle, injectable, scoped } from "tsyringe";
 import * as vscode from "vscode";
 // biome-ignore lint/style/useImportType: needed for dependency injection
-import { PochiTaskTabState } from "../editor/pochi-task-state";
+import { TaskActivityTracker } from "../editor/task-activity-tracker";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { CheckpointService } from "./checkpoint-service";
 
@@ -26,7 +26,7 @@ export class UserEditState implements vscode.Disposable {
   constructor(
     private readonly workspaceScope: WorkspaceScope,
     private readonly checkpointService: CheckpointService,
-    private readonly pochiTaskState: PochiTaskTabState,
+    private readonly taskActivityTracker: TaskActivityTracker,
   ) {
     this.setupEventListeners();
   }
@@ -70,7 +70,7 @@ export class UserEditState implements vscode.Disposable {
 
     // Watch active pochi tasks to maintain tracking tasks state.
     this.disposables.push({
-      dispose: this.pochiTaskState.state.subscribe((tasks) => {
+      dispose: this.taskActivityTracker.state.subscribe((tasks) => {
         logger.trace("Received tasks update", {
           tasksCount: Object.keys(tasks).length,
           currentCwd: this.cwd,

--- a/packages/vscode/src/integrations/editor/editor-context-state.ts
+++ b/packages/vscode/src/integrations/editor/editor-context-state.ts
@@ -18,7 +18,7 @@ export type FileSelection = {
 
 @injectable()
 @singleton()
-export class TabState implements vscode.Disposable {
+export class EditorContextState implements vscode.Disposable {
   // Signal containing the current active tabs
   activeTabs = signal([] as { filepath: string; isDir: boolean }[]);
 

--- a/packages/vscode/src/integrations/editor/task-activity-tracker.ts
+++ b/packages/vscode/src/integrations/editor/task-activity-tracker.ts
@@ -7,11 +7,11 @@ import { injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
 import { PochiTaskEditorProvider } from "../webview/webview-panel";
 
-const logger = getLogger("PochiTaskState");
+const logger = getLogger("TaskActivityTracker");
 
 @injectable()
 @singleton()
-export class PochiTaskTabState implements vscode.Disposable {
+export class TaskActivityTracker implements vscode.Disposable {
   private disposables: vscode.Disposable[] = [];
   state = signal<TaskStates>({});
 

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -18,11 +18,11 @@ import { getLogger } from "@/lib/logger";
 import { ModelList } from "@/lib/model-list";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { PostHog } from "@/lib/posthog";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { TaskDataStore } from "@/lib/task-data-store";
 import { taskRunning, taskUpdated } from "@/lib/task-events";
 // biome-ignore lint/style/useImportType: needed for dependency injection
-import { TaskState } from "@/lib/task-state";
-// biome-ignore lint/style/useImportType: needed for dependency injection
-import { TaskStore } from "@/lib/task-store";
+import { TaskHistoryStore } from "@/lib/task-history-store";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { UserStorage } from "@/lib/user-storage";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -104,9 +104,12 @@ import { UserEditState } from "../checkpoint/user-edit-state";
 import { PochiConfiguration } from "../configuration";
 import { showDiffChanges } from "../editor/diff-changes-editor";
 // biome-ignore lint/style/useImportType: needed for dependency injection
-import { PochiTaskTabState } from "../editor/pochi-task-state";
+import {
+  EditorContextState,
+  type FileSelection,
+} from "../editor/editor-context-state";
 // biome-ignore lint/style/useImportType: needed for dependency injection
-import { type FileSelection, TabState } from "../editor/tab-state";
+import { TaskActivityTracker } from "../editor/task-activity-tracker";
 // biome-ignore lint/style/useImportType: needed for dependency injections
 import { GitState } from "../git/git-state";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -142,7 +145,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   constructor(
     @inject("vscode.ExtensionContext")
     private readonly context: vscode.ExtensionContext,
-    private readonly tabState: TabState,
+    private readonly editorContextState: EditorContextState,
     private readonly terminalState: TerminalState,
     private readonly posthog: PostHog,
     private readonly mcpHub: McpHub,
@@ -154,15 +157,15 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     private readonly checkpointService: CheckpointService,
     private readonly customAgentManager: CustomAgentManager,
     private readonly worktreeManager: WorktreeManager,
-    private readonly pochiTaskState: PochiTaskTabState,
+    private readonly taskActivityTracker: TaskActivityTracker,
     private readonly githubPullRequestState: GithubPullRequestState,
     private readonly githubIssueState: GithubIssueState,
     private readonly gitState: GitState,
     private readonly reviewController: ReviewController,
     private readonly userEditState: UserEditState,
     private readonly globalStateSignals: GlobalStateSignals,
-    private readonly taskStore: TaskStore,
-    private readonly taskStateStore: TaskState,
+    private readonly taskStore: TaskHistoryStore,
+    private readonly taskStateStore: TaskDataStore,
   ) {}
 
   private get cwd() {
@@ -275,10 +278,11 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
         files,
         isTruncated,
         gitStatus,
-        activeTabs: this.tabState.activeTabs.value.map((tab) => ({
+        activeTabs: this.editorContextState.activeTabs.value.map((tab) => ({
           filepath: asRelativePath(tab.filepath, this.cwd ?? ""),
           isActive:
-            tab.filepath === this.tabState.activeSelection.value?.filepath,
+            tab.filepath ===
+            this.editorContextState.activeSelection.value?.filepath,
         })),
         terminals: this.terminalState.visibleTerminals.value,
       },
@@ -296,7 +300,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   > => {
     return ThreadSignal.serialize(
       computed(() =>
-        this.tabState.activeTabs.value.map((tab) => ({
+        this.editorContextState.activeTabs.value.map((tab) => ({
           filepath: asRelativePath(tab.filepath, this.cwd ?? ""),
           isDir: tab.isDir,
         })),
@@ -305,13 +309,13 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   };
 
   readPochiTabs = async (): Promise<ThreadSignalSerialization<TaskStates>> => {
-    return ThreadSignal.serialize(this.pochiTaskState.state);
+    return ThreadSignal.serialize(this.taskActivityTracker.state);
   };
 
   readActiveSelection = async (): Promise<
     ThreadSignalSerialization<FileSelection | undefined>
   > => {
-    return ThreadSignal.serialize(this.tabState.activeSelection);
+    return ThreadSignal.serialize(this.editorContextState.activeSelection);
   };
 
   readVisibleTerminals = async () => {
@@ -902,7 +906,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   ) => {
     if (!this.cwd) return;
 
-    const taskStates = this.pochiTaskState.state.value;
+    const taskStates = this.taskActivityTracker.state.value;
     const targetTaskState = taskStates[params.uid];
     if (targetTaskState?.active) {
       return;

--- a/packages/vscode/src/lib/__test__/task-history-store.test.ts
+++ b/packages/vscode/src/lib/__test__/task-history-store.test.ts
@@ -1,14 +1,14 @@
 import assert from "assert";
-import { TaskStore } from "../task-store";
+import { TaskHistoryStore } from "../task-history-store";
 import * as vscode from "vscode";
 import sinon from "sinon";
 import "reflect-metadata";
 import { TextEncoder } from "util";
 
-describe("TaskStore", () => {
+describe("TaskHistoryStore", () => {
   let context: vscode.ExtensionContext;
   let globalState: any;
-  let taskStore: TaskStore;
+  let taskStore: TaskHistoryStore;
   let clock: sinon.SinonFakeTimers;
   let tempStorageUri: vscode.Uri;
 
@@ -58,7 +58,7 @@ describe("TaskStore", () => {
   });
 
   it("should start with empty tasks if file does not exist", async () => {
-    taskStore = new TaskStore(context);
+    taskStore = new TaskHistoryStore(context);
     await taskStore.ready;
 
     const currentTasks = taskStore.tasks.value;
@@ -80,7 +80,7 @@ describe("TaskStore", () => {
         new TextEncoder().encode(JSON.stringify(tasks))
     );
 
-    taskStore = new TaskStore(context);
+    taskStore = new TaskHistoryStore(context);
     await taskStore.ready;
 
     const currentTasks = taskStore.tasks.value;
@@ -106,7 +106,7 @@ describe("TaskStore", () => {
         new TextEncoder().encode(JSON.stringify(tasks))
     );
 
-    taskStore = new TaskStore(context);
+    taskStore = new TaskHistoryStore(context);
     await taskStore.ready;
 
     // Verify only recent task remains

--- a/packages/vscode/src/lib/task-data-store.ts
+++ b/packages/vscode/src/lib/task-data-store.ts
@@ -8,11 +8,11 @@ type TaskStateData = {
   mcpConfigOverride?: McpConfigOverride;
 };
 
-const logger = getLogger("TaskState");
+const logger = getLogger("TaskDataStore");
 
 @injectable()
 @singleton()
-export class TaskState {
+export class TaskDataStore {
   private readonly storageKeyPrefix = "taskState.";
 
   state = signal<Record<string, TaskStateData>>({});

--- a/packages/vscode/src/lib/task-history-store.ts
+++ b/packages/vscode/src/lib/task-history-store.ts
@@ -12,11 +12,11 @@ type EncodedTask = {
   updatedAt: number;
 };
 
-const logger = getLogger("TaskStore");
+const logger = getLogger("TaskHistoryStore");
 
 @injectable()
 @singleton()
-export class TaskStore implements vscode.Disposable {
+export class TaskHistoryStore implements vscode.Disposable {
   private disposables: vscode.Disposable[] = [];
   private storageKey: string;
   tasks = signal<Record<string, EncodedTask>>({});


### PR DESCRIPTION
## Summary
This PR refactors the task and tab state management in the VS Code extension for better clarity and organization:
- `TabState` is renamed to `EditorContextState` to better reflect its purpose of tracking the current editor context (active tabs and selection).
- `PochiTaskTabState` is renamed to `TaskActivityTracker` to distinguish it from other task-related states.
- `TaskStore` is renamed to `TaskHistoryStore` as it specifically handles the persistence of task history.
- `TaskState` is renamed to `TaskDataStore` as it manages the data/configuration for specific tasks.

## Test plan
1. Verify that the VS Code extension still correctly tracks active tabs and selections.
2. Verify that task history is still correctly saved and loaded.
3. Verify that task-specific configurations (like MCP overrides) are still correctly managed.
4. Run existing tests: `bun run test` in `packages/vscode`.

🤖 Generated with [Pochi](https://getpochi.com)