### PR TITLE
chore(vscode): reduce logout latency

### DIFF
--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -115,7 +115,8 @@ export class CommandManager implements vscode.Disposable {
           "Logout",
         );
         if (selection === "Logout") {
-          await this.authClient.signOut();
+          this.authClient.signOut();
+
           await getVendor("pochi").logout();
           this.authEvents.logoutEvent.fire();
         }


### PR DESCRIPTION
## Summary
- Remove `await` when calling `authClient.signOut()` to improve logout responsiveness.

## Test plan
- Verify logout functionality works as expected.

🤖 Generated with [Pochi](https://getpochi.com)