### PR TITLE
feat: improve worktree display name

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -57,6 +57,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as R from "remeda";
 
+import { getBaseName } from "@/lib/utils/file";
 import { usePaginatedTasks } from "#lib/hooks/use-paginated-tasks";
 import { TaskRow } from "./task-row";
 import { ScrollArea } from "./ui/scroll-area";
@@ -131,7 +132,7 @@ export function WorktreeList({
         const isMain = wt.isMain;
 
         if (wt.isMain) {
-          name = "workspace";
+          name = getBaseName(wt.path);
         } else {
           name = getWorktreeNameFromWorktreePath(wt.path) || "unknown";
         }

--- a/packages/vscode-webui/src/components/worktree-select.tsx
+++ b/packages/vscode-webui/src/components/worktree-select.tsx
@@ -18,6 +18,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { getBaseName } from "@/lib/utils/file";
 import { vscodeHost } from "@/lib/vscode";
 import { getWorktreeNameFromWorktreePath } from "@getpochi/common/git-utils";
 import {
@@ -54,7 +55,7 @@ const getWorktreeName = (worktree: GitWorktree | undefined) => {
     return;
   }
   if (worktree.isMain) {
-    return "workspace";
+    return getBaseName(worktree.path);
   }
   return getWorktreeNameFromWorktreePath(worktree.path);
 };

--- a/packages/vscode-webui/src/features/settings/components/sections/mcp-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/mcp-section.tsx
@@ -14,7 +14,7 @@ import {
   useThirdPartyMcp,
 } from "@/lib/hooks/use-third-party-mcp";
 import { cn } from "@/lib/utils";
-import { getFileName } from "@/lib/utils/file";
+import { getBaseName } from "@/lib/utils/file";
 import type { McpServerConnection } from "@getpochi/common/mcp-utils";
 import {
   ChevronsUpDown,
@@ -106,7 +106,7 @@ const McpConfigList: React.FC<{
   return (
     <div className="flex max-h-[100px] flex-col gap-1 overflow-y-auto rounded border p-1">
       {configs.map((config, index) => {
-        const fileName = getFileName(config.path);
+        const fileName = getBaseName(config.path);
         return (
           <div
             key={config.path + index}

--- a/packages/vscode-webui/src/features/tools/components/file-list.tsx
+++ b/packages/vscode-webui/src/features/tools/components/file-list.tsx
@@ -1,6 +1,6 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import { getFileName, isFolder } from "@/lib/utils/file";
+import { getBaseName, isFolder } from "@/lib/utils/file";
 import { vscodeHost } from "@/lib/vscode";
 import { useState } from "react";
 import { FileIcon } from "./file-icon";
@@ -51,7 +51,7 @@ export const FileList: React.FC<{
             />
             {showBaseName && (
               <>
-                {getFileName(match.file)}
+                {getBaseName(match.file)}
                 {match.line && (
                   <span
                     className={`truncate ${activeIndex === index ? "text-secondary-foreground/70" : "text-foreground/70"}`}

--- a/packages/vscode-webui/src/lib/utils/__tests__/file.test.ts
+++ b/packages/vscode-webui/src/lib/utils/__tests__/file.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isFolder, getFileName, addLineBreak } from "../file";
+import { isFolder, getBaseName, addLineBreak } from "../file";
 
 describe("isFolder", () => {
   describe("should return true for folders", () => {
@@ -139,16 +139,16 @@ describe("isFolder", () => {
   });
 });
 
-describe("getFileName", () => {
+describe("getBaseName", () => {
   it("should extract filename from path", () => {
-    expect(getFileName("path/to/file.txt")).toBe("file.txt");
-    expect(getFileName("file.txt")).toBe("file.txt");
-    expect(getFileName("folder/")).toBe("");
-    expect(getFileName("")).toBe("");
+    expect(getBaseName("path/to/file.txt")).toBe("file.txt");
+    expect(getBaseName("file.txt")).toBe("file.txt");
+    expect(getBaseName("folder/")).toBe("");
+    expect(getBaseName("")).toBe("");
   });
 
   it("should handle Windows paths", () => {
-    expect(getFileName("C:\\path\\to\\file.txt")).toBe("file.txt");
+    expect(getBaseName("C:\\path\\to\\file.txt")).toBe("file.txt");
   });
 });
 

--- a/packages/vscode-webui/src/lib/utils/active-selection.ts
+++ b/packages/vscode-webui/src/lib/utils/active-selection.ts
@@ -1,6 +1,6 @@
 import type { ActiveSelection } from "@getpochi/common/vscode-webui-bridge";
 import type { TFunction } from "i18next";
-import { getFileName } from "./file";
+import { getBaseName } from "./file";
 
 export const getActiveSelectionLabel = (
   activeSelection: ActiveSelection,
@@ -8,7 +8,7 @@ export const getActiveSelectionLabel = (
 ) => {
   if (!activeSelection) return "";
 
-  const filename = getFileName(activeSelection.filepath);
+  const filename = getBaseName(activeSelection.filepath);
 
   if (activeSelection.notebookCell) {
     const cellIndex = activeSelection.notebookCell.cellIndex + 1;

--- a/packages/vscode-webui/src/lib/utils/file.ts
+++ b/packages/vscode-webui/src/lib/utils/file.ts
@@ -1,4 +1,4 @@
-export const getFileName = (filePath: string) => {
+export const getBaseName = (filePath: string) => {
   // Normalize path separators (handle both / and \)
   const normalizedPath = filePath.replace(/\\/g, "/");
   const parts = normalizedPath.split("/");

--- a/packages/vscode/src/integrations/git/__tests__/issue-989.test.ts
+++ b/packages/vscode/src/integrations/git/__tests__/issue-989.test.ts
@@ -63,6 +63,6 @@ describe("WorktreeManager Repro #989", () => {
     it("should return 'workspace' when cwd matches workspace path even if worktree is not found", () => {
       worktreeManager.worktrees.value = [];
       const result = worktreeManager.getWorktreeDisplayName("/path/to/repo");
-      assert.strictEqual(result, "workspace");
+      assert.strictEqual(result, "repo");
     });
 });

--- a/packages/vscode/src/integrations/git/__tests__/worktree.test.ts
+++ b/packages/vscode/src/integrations/git/__tests__/worktree.test.ts
@@ -74,7 +74,7 @@ describe("WorktreeManager", () => {
       worktreeManager.worktrees.value = [mainWorktree];
 
       const result = worktreeManager.getWorktreeDisplayName("/path/to/repo");
-      assert.strictEqual(result, "workspace");
+      assert.strictEqual(result, "repo");
     });
 
     it("should return worktree name from path for non-main worktree", () => {
@@ -113,7 +113,7 @@ describe("WorktreeManager", () => {
       worktreeManager.worktrees.value = [mainWorktree];
 
       const result = worktreeManager.getWorktreeDisplayName("/path/to/repo");
-      assert.strictEqual(result, "workspace");
+      assert.strictEqual(result, "repo");
     });
 
     it("should handle multiple worktrees correctly", () => {
@@ -146,7 +146,7 @@ describe("WorktreeManager", () => {
 
       assert.strictEqual(
         worktreeManager.getWorktreeDisplayName("/path/to/repo"),
-        "workspace",
+        "repo",
       );
       assert.strictEqual(
         worktreeManager.getWorktreeDisplayName("/path/to/worktrees/feature-1"),

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -59,11 +59,13 @@ export class WorktreeManager implements vscode.Disposable {
     const worktree = this.worktrees.value.find((wt) => wt.path === cwd);
     if (!worktree) {
       if (this.workspacePath && cwd === this.workspacePath) {
-        return "workspace";
+        return path.basename(cwd);
       }
       return getWorktreeNameFromWorktreePath(cwd);
     }
-    return worktree.isMain ? "workspace" : getWorktreeNameFromWorktreePath(cwd);
+    return worktree.isMain
+      ? path.basename(cwd)
+      : getWorktreeNameFromWorktreePath(cwd);
   }
 
   private async setupWatcher() {

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -937,7 +937,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     const taskTitle = getTaskDisplayTitle({
       worktreeName:
         this.workspaceScope.isMainWorkspace || !worktreeName
-          ? "workspace"
+          ? path.basename(this.cwd)
           : worktreeName,
       uid,
     });

--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { AuthEvents } from "@/lib/auth-events";
 import { WorkspaceScope, workspaceScoped } from "@/lib/workspace-scoped";
 import { getLogger, toErrorMessage } from "@getpochi/common";
@@ -136,7 +137,7 @@ export class PochiTaskEditorProvider
       .resolve(WorktreeManager)
       .getWorktreeDisplayName(params.cwd);
     const displayName = getTaskDisplayTitle({
-      worktreeName: worktreeName ?? "workspace",
+      worktreeName: worktreeName ?? path.basename(params.cwd),
       uid: params.uid,
     });
     return vscode.Uri.from({


### PR DESCRIPTION
## Summary
- Replaced the hardcoded "workspace" string with the actual directory basename for the main worktree.
- Renamed `getFileName` to `getBaseName` in `vscode-webui` utilities for better clarity.
- Updated tests to reflect the change from "workspace" to the directory name.

## Test plan
- Verified that the display name correctly shows the directory name instead of "workspace".
- Ran existing tests in `packages/vscode` and `packages/vscode-webui` to ensure no regressions.
- `bun run test` in `packages/vscode` passed.

🤖 Generated with [Pochi](https://getpochi.com)