### PR TITLE
feat: allow comments on plan.md in ReviewController

### DIFF
--- a/packages/vscode/src/integrations/review-controller.ts
+++ b/packages/vscode/src/integrations/review-controller.ts
@@ -56,6 +56,13 @@ export class ReviewController implements vscode.Disposable {
           return [];
         }
 
+        if (
+          document.uri.scheme === "pochi" &&
+          ["/plan.md"].includes(document.uri.path)
+        ) {
+          return [new vscode.Range(0, 0, document.lineCount, 0)];
+        }
+
         // Otherwise, allow comments if it's there exists original changes from content provider.
         const hasMatchingDiffDoc = vscode.workspace.textDocuments.some(
           (doc) => {


### PR DESCRIPTION
## Summary
- Enable commenting on `pochi:/plan.md` files within the `ReviewController`.
- Adds a check for `pochi` scheme and `/plan.md` path to allow comments.

## Test plan
- Verify that comments can be added to `plan.md` files in the Pochi virtual file system.

🤖 Generated with [Pochi](https://getpochi.com)