### PR TITLE
fix(vscode-webui): simplify task filtering in usePaginatedTasks

### DIFF
--- a/packages/vscode-webui/src/lib/hooks/use-paginated-tasks.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-paginated-tasks.ts
@@ -34,12 +34,7 @@ export function usePaginatedTasks({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   const tasks = useTasks()
-    .filter(
-      (t) =>
-        t.parentId === null &&
-        (t.cwd === cwd ||
-          t.git?.worktree?.gitdir.startsWith(`${cwd}/.git/worktrees`)),
-    )
+    .filter((t) => t.parentId === null && t.cwd === cwd)
     .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 
   const paginatedTasks = tasks.slice(0, limit);


### PR DESCRIPTION
## Summary
- Simplified the task filtering logic in `usePaginatedTasks` hook.
- Removed the check for worktree gitdir, ensuring tasks are strictly filtered by exact `cwd` match.

## Test plan
- Verify that tasks list only shows tasks from the current working directory.
- Verify that tasks from other worktrees do not appear in the current window's task list.

🤖 Generated with [Pochi](https://getpochi.com)