### PR TITLE
fix(vscode-webui): prioritize submit reviews button over complete subtask button

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -253,20 +253,18 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     isExecuting,
   );
 
-  const showCompleteSubtaskButton = useShowCompleteSubtaskButton(
-    subtask,
-    messages,
-  );
-
   const showSubmitReviewButton =
     !isSubmitDisabled &&
     !!reviews.length &&
     !!messages.length &&
     !isLoading &&
-    (!isSubTask || !showCompleteSubtaskButton) &&
     (!pendingApproval ||
       (pendingApproval.name === "retry" &&
         !isRetryApprovalCountingDown(pendingApproval)));
+
+  // If there are pending reviews, we prioritize submitting them over completing the subtask.
+  const showCompleteSubtaskButton =
+    useShowCompleteSubtaskButton(subtask, messages) && !showSubmitReviewButton;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Prioritize showing the 'Submit reviews' button over the 'Complete subtask' button when there are pending reviews in a subtask.
- This ensures users address feedback before completing the subtask.

## Test plan
- Verify that the 'Submit reviews' button appears and the 'Complete subtask' button is hidden when there are pending reviews.
- Verify that the 'Complete subtask' button appears after reviews are submitted.

🤖 Generated with [Pochi](https://getpochi.com)