### PR TITLE
fix(vscode-webui): simplify MCP servers submenu label

### DIFF
--- a/packages/vscode-webui/src/components/submit-dropdown-button.tsx
+++ b/packages/vscode-webui/src/components/submit-dropdown-button.tsx
@@ -206,11 +206,7 @@ function McpSubMenu({ mcpConfigOverride, onToggleServer }: McpSubMenuProps) {
               !hasServers && "text-muted-foreground",
             )}
           />
-          <span>
-            {hasServers
-              ? t("mcpSelect.servers")
-              : t("mcpSelect.noServersConfigured")}
-          </span>
+          <span>{t("mcpSelect.servers")}</span>
         </DropdownMenuSubTrigger>
         <DropdownMenuPortal>
           <DropdownMenuSubContent


### PR DESCRIPTION
## Summary
- Simplified the MCP servers submenu label in the submit dropdown button
- Removed conditional logic that would display "No servers configured" text
- Now always shows "Servers" as the label regardless of server availability
- Visual feedback (muted foreground color) still indicates when no servers are configured

## Test plan
- [ ] Verify submenu displays "Servers" when MCP servers are configured
- [ ] Verify submenu displays "Servers" with muted styling when no MCP servers are configured
- [ ] Verify submenu interaction works correctly in both scenarios

🤖 Generated with [Pochi](https://getpochi.com)