### PR TITLE
fix: update recommend settings title translations

### DIFF
--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -448,7 +448,7 @@
     "forkedTaskTitle": "フォーク 元: {{taskTitle}}"
   },
   "recommendSettings": {
-    "title": "Pochi は以下の設定を変更します",
+    "title": "Pochiは以下の設定を推奨します",
     "hide": "非表示",
     "options": {
       "enablePochiLayout": "Pochi レイアウトを有効にする",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -443,7 +443,7 @@
     "forkedTaskTitle": "포크됨 원본: {{taskTitle}}"
   },
   "recommendSettings": {
-    "title": "Pochi가 다음 설정을 수정합니다",
+    "title": "Pochi는 다음 설정을 권장합니다",
     "hide": "숨기기",
     "options": {
       "enablePochiLayout": "Pochi 레이아웃 활성화",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -447,7 +447,7 @@
     "forkedTaskTitle": "任务分支自：{{taskTitle}}"
   },
   "recommendSettings": {
-    "title": "Pochi 将修改以下设置",
+    "title": "Pochi 推荐以下设置",
     "hide": "隐藏",
     "options": {
       "enablePochiLayout": "启用 Pochi 布局",


### PR DESCRIPTION
## Summary
Updated the translation for `recommendSettings.title` in Japanese, Korean, and Chinese locales to more accurately reflect that Pochi is recommending settings rather than just modifying them.

## Test plan
- Verified the changes in the translation files.
- The changes are limited to translation strings and do not affect application logic.

🤖 Generated with [Pochi](https://getpochi.com)