### PR TITLE
fix(vscode): fix pochi layout explicit specify viewColumn one for default open task

### DIFF
--- a/packages/vscode/src/integrations/layout.ts
+++ b/packages/vscode/src/integrations/layout.ts
@@ -567,10 +567,15 @@ async function applyPochiLayoutImpl(params: {
     params.cwd
   ) {
     logger.trace("Open new task tab.");
-    await PochiTaskEditorProvider.openTaskEditor({
-      type: "new-task",
-      cwd: params.cwd,
-    });
+    await PochiTaskEditorProvider.openTaskEditor(
+      {
+        type: "new-task",
+        cwd: params.cwd,
+      },
+      {
+        viewColumn: vscode.ViewColumn.One,
+      },
+    );
   }
 
   // If no editors in editor group, open a default text file


### PR DESCRIPTION
## Summary
- Explicitly specify `viewColumn: vscode.ViewColumn.One` when opening the task editor in `applyPochiLayoutImpl`.
- This ensures the new task editor always opens in the first column, following the fix in #1097.

## Test plan
- Manually verified that the task editor opens in the expected column.
- Ran existing tests to ensure no regressions.

🤖 Generated with [Pochi](https://getpochi.com)