### PR TITLE
fix(cli): add mimetype for video formats

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -515,6 +515,14 @@ function getMimeType(filePath: string): string {
       return "image/webp";
     case ".svg":
       return "image/svg+xml";
+    case ".mp4":
+      return "video/mp4";
+    case ".webm":
+      return "video/webm";
+    case ".mov":
+      return "video/quicktime";
+    case ".avi":
+      return "video/x-msvideo";
     default:
       return "application/octet-stream";
   }


### PR DESCRIPTION
### What does this PR do
- This PR adds video format mimetypes (.mp4, .mov, etc) into `packages/cli.ts`'s `getMimeType` function. This prevents Pochi from confusing video input as octet streams, which might timeout the response as a large amount of octets is streamed when streaming video.

Here is a sample error log that happens before the fix was implemented:
```
POCHI_LOG=debug ./pochi -a video_log_1.mp4 -p "Generate a json list of all the actions that took place this game"
2026-01-19 21:48:09.842	DEBUG	native:1	Pochi	pochi v0.5.100
2026-01-19 21:48:10.349	DEBUG	/$bunfs/root/pochi:495965	loadAgents	Loaded 0 custom agents (0 valid, 0 invalid)
2026-01-19 21:48:12.431	DEBUG	/$bunfs/root/pochi:476787	MCPConnection(context7)	State changed: stopped
2026-01-19 21:48:12.432	DEBUG	/$bunfs/root/pochi:476908	MCPHub	Connection status changed.
2026-01-19 21:48:12.432	DEBUG	/$bunfs/root/pochi:477364	MCPConnection(context7)	Starting MCP connection...
2026-01-19 21:48:12.432	DEBUG	/$bunfs/root/pochi:477079	MCPConnection(context7)	Connecting using Stdio transport.
2026-01-19 21:48:12.434	DEBUG	native:1	MCPConnection(context7)	State changed: starting
2026-01-19 21:48:12.434	DEBUG	/$bunfs/root/pochi:476908	MCPHub	Connection status changed.
2026-01-19 21:48:12.434	DEBUG	/$bunfs/root/pochi:477317	MCPHub	Connection context7 created.
2026-01-19 21:48:12.434	DEBUG	/$bunfs/root/pochi:412685	MCPHub	MCP servers configuration changed via signal:
2026-01-19 21:48:12.434	DEBUG	/$bunfs/root/pochi:477271	MCPHub	Updating context7 with new config.
2026-01-19 21:48:12.489	DEBUG	/$bunfs/root/pochi:412797	MCPHub	Build MCPHub Status
⠦ Initializing MCP connections...2026-01-19 21:48:13.907	DEBUG	native:1	MCPConnection(context7)	State changed: ready
2026-01-19 21:48:13.907	DEBUG	/$bunfs/root/pochi:476908	MCPHub	Connection status changed.
⠧ Initializing MCP connections...2026-01-19 21:48:13.998	DEBUG	/$bunfs/root/pochi:412797	MCPHub	Build MCPHub Status
You
⠋ 2026-01-19 21:48:15.071	DEBUG	/$bunfs/root/pochi:495541	TaskRunner	Starting TaskRunner...
2026-01-19 21:48:15.079	DEBUG	/$bunfs/root/pochi:449010	listFiles	Listing workspace files from /Users/warrenlow/Documents/projects/video-analysis with maxItems 500
2026-01-19 21:48:15.144	DEBUG	/$bunfs/root/pochi:490821	generateTaskTitle	Generating task title, old: null, new: Generate a json list of all the actions that took place this game
Generate a json list of all the actions that took place this game ⠙ 2026-01-19 21:53:09.873	ERROR	/$bunfs/root/pochi:428975	LiveChatKit	onError

 Error  The operation timed out., 425263, 49, 425263, 49, /$bunfs/root/pochi
error stack:
  • pochi	<anonymous>
	/$bunfs/root/pochi:425263
  • pochi	<anonymous>
	/$bunfs/root/pochi:424900
  • pochi	<anonymous>
	/$bunfs/root/pochi:427912
  • pochi	<anonymous>
	/$bunfs/root/pochi:427910
  • pochi	processQueue
	/$bunfs/root/pochi:427903
  • pochi	processQueue
	/$bunfs/root/pochi:427897
  • pochi	<anonymous>
	/$bunfs/root/pochi:427918
  • native	new Promise
	native:1
  • pochi	run
	/$bunfs/root/pochi:427909
  • pochi	run
	/$bunfs/root/pochi:427908
  • pochi	transform
	/$bunfs/root/pochi:424900
  • pochi	transform
	/$bunfs/root/pochi:424899
  • native	<anonymous>
	native:1
  • native	<anonymous>
	native:1
  • native	<anonymous>
	native:1
  • native	<anonymous>
	native:1
  • native	<anonymous>
	native:1
  • native	<anonymous>
	native:1
  • native	<anonymous>
	native:1
  • native	<anonymous>
	native:7
  • native	processTicksAndRejections
	native:7
Generate a json list of all the actions that took place this game ⠴ 2026-01-19 21:53:15.908	ERROR	/$bunfs/root/pochi:495590	TaskRunner	Task is failed, trying to resend last message to resume it. {
  kind: 'InternalError',
  message: 'The operation timed out.'
}
2026-01-19 21:53:15.912	DEBUG	/$bunfs/root/pochi:449010	listFiles	Listing workspace files from /Users/warrenlow/Documents/projects/video-analysis with maxItems 500
Generate a json list of all the actions that took place this game ⠹
```

The below screenshot shows the result once the fix is implemented:
<img width="749" height="795" alt="Screenshot 2026-01-19 at 2 20 25 PM" src="https://github.com/user-attachments/assets/44860fbb-048c-4bcd-9f50-1f8c90955c5f" />
