### PR TITLE
fix(vscode-webui): hide empty tasks in worktree list

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -311,6 +311,10 @@ function WorktreeSection({
     return `${info.webUrl}/pull/${pullRequest.id}`;
   }, [gitOriginUrl, pullRequest?.id]);
 
+  const visibleTasks = useMemo(() => {
+    return tasks.filter((task) => !!task.title?.trim());
+  }, [tasks]);
+
   return (
     <Collapsible
       open={isExpanded}
@@ -508,9 +512,9 @@ function WorktreeSection({
             // When there is only one workspace group, we let it grow naturally without max-height constraint
           })}
         >
-          {tasks.length > 0 ? (
+          {visibleTasks.length > 0 || hasMore ? (
             <>
-              {tasks.map((task) => {
+              {visibleTasks.map((task) => {
                 return (
                   <div key={task.id} className="py-0.5">
                     <TaskRow


### PR DESCRIPTION
## Summary
- Filter out tasks with empty titles in `WorktreeSection` component.
- Update list rendering condition to use `visibleTasks` length or `hasMore` flag.

## Test plan
- Verify that tasks with empty or whitespace-only titles do not appear in the worktree list.
- Verify that the list still renders if there are visible tasks or more tasks to load.

🤖 Generated with [Pochi](https://getpochi.com)