### PR TITLE
chore: add merge_group trigger to integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: ["main"]
   workflow_dispatch:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
This PR adds the `merge_group` trigger to the integration tests workflow. This ensures that integration tests are run when a pull request is added to a merge queue.

## Test plan
- Verify that the workflow runs correctly when triggered by a merge group event.

🤖 Generated with [Pochi](https://getpochi.com)