### PR TITLE
fix: auto apply pochi layout when opening the first text editor

### DIFF
--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -36,9 +36,8 @@ import { WorktreeManager } from "./git/worktree";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import {
   LayoutManager,
-  getSortedCurrentTabGroups,
+  findActivePochiTaskTab,
   getViewColumnForTerminal,
-  isPochiTaskTab,
 } from "./layout";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import {
@@ -772,33 +771,4 @@ export class CommandManager implements vscode.Disposable {
     }
     this.disposables = [];
   }
-}
-
-function findActivePochiTaskTab():
-  | (vscode.Tab & {
-      input: vscode.TabInputCustom & {
-        viewType: typeof PochiTaskEditorProvider.viewType;
-      };
-    })
-  | undefined {
-  // Try find active tab in active group
-  const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
-  if (activeTab && isPochiTaskTab(activeTab)) {
-    return activeTab;
-  }
-  // Otherwise find active tab in other groups
-  const group = getSortedCurrentTabGroups().find(
-    (group) => group.activeTab && isPochiTaskTab(group.activeTab),
-  );
-  if (group?.activeTab && isPochiTaskTab(group.activeTab)) {
-    return group.activeTab;
-  }
-  // Otherwise find first task tab
-  const tab = getSortedCurrentTabGroups()
-    .flatMap((group) => group.tabs)
-    .find((tab) => isPochiTaskTab(tab));
-  if (tab) {
-    return tab;
-  }
-  return undefined;
 }


### PR DESCRIPTION
## Summary
- Automatically applies the Pochi layout when the first text editor tab (non-pochi-task and non-terminal) is opened.
- Moves `findActivePochiTaskTab` from `command.ts` to `layout.ts` and exports it for shared use.
- Adds `countOtherTabs` helper to monitor the number of active editor tabs.
- Refactors several functions in `layout.ts` to be internal where appropriate.

## Test plan
1. Open Pochi with no editor tabs open.
2. Open a text file.
3. Verify that the Pochi layout is automatically applied (e.g., side panel opens, terminal is configured).

🤖 Generated with [Pochi](https://getpochi.com)