### PR TITLE
refactor: deprecate and remove blobs from livestore

### DIFF
--- a/packages/livekit-cf/src/do/livestore-client/app.ts
+++ b/packages/livekit-cf/src/do/livestore-client/app.ts
@@ -90,19 +90,6 @@ store
   })
   .get("/tasks/:taskId/html", async (c) => {
     return c.env.ASSETS.fetch(c.req.raw);
-  })
-  .get("/blobs/:blobId", async (c) => {
-    const store = await c.env.getStore();
-    const blob = store.query(
-      catalog.queries.makeBlobQuery(c.req.param("blobId")),
-    );
-    if (!blob) {
-      throw new HTTPException(404, { message: "Blob not found" });
-    }
-    return c.body(blob.data, 200, {
-      "content-type": blob.mimeType,
-      "cache-control": "public, max-age=31536000, immutable",
-    });
   });
 
 export const app = new Hono<{ Bindings: Env }>();

--- a/packages/livekit/src/livestore/default-queries.ts
+++ b/packages/livekit/src/livestore/default-queries.ts
@@ -30,15 +30,6 @@ export const makeSubTaskQuery = (taskId: string) =>
     deps: [taskId],
   });
 
-export const makeBlobQuery = (checksum: string) =>
-  queryDb(
-    () => tables.blobs.where("checksum", "=", checksum).first(undefined),
-    {
-      label: "blobs",
-      deps: [checksum],
-    },
-  );
-
 export const makeFileQuery = (taskId: string, filePath: string) =>
   queryDb(
     () =>


### PR DESCRIPTION
## Summary
- Removed `blobs` table from `default-schema.ts`.
- Removed `makeBlobQuery` from `default-queries.ts`.
- Deprecated `v1.BlobInserted` event and updated materializer to be a no-op.
- Removed `/blobs/:blobId` endpoint from `livestore-client/app.ts`.

## Test plan
- Verify that the application still builds and runs correctly without the `blobs` table in livestore.
- Ensure that the deprecated event doesn't cause any runtime issues.

🤖 Generated with [Pochi](https://getpochi.com)