### PR TITLE
fix(vscode): ensure git state initialization resolves and refine checkpoint clearing

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/user-edit-state.ts
+++ b/packages/vscode/src/integrations/checkpoint/user-edit-state.ts
@@ -135,9 +135,9 @@ export class UserEditState implements vscode.Disposable {
         logger.trace(
           `Updating edits for task ${uid} with hash ${hash}, latest ${latestCheckpoint}`,
         );
-        // If the checkpoint hash is not the latest, we cannot guarantee
-        // the diffs are accurate, so we clear them.
-        if (hash !== latestCheckpoint) {
+        // If the checkpoint hash is not the latest, or if there's no checkpoint yet,
+        // we cannot guarantee the diffs are accurate, so we clear them.
+        if (!hash || hash !== latestCheckpoint) {
           nextEdits[uid] = [];
         } else {
           const diffs = await this.checkpointService.getCheckpointFileEdits(

--- a/packages/vscode/src/integrations/git/git-state.ts
+++ b/packages/vscode/src/integrations/git/git-state.ts
@@ -100,6 +100,7 @@ export class GitState implements vscode.Disposable {
 
       if (!git) {
         logger.debug("VS Code Git extension not found");
+        this.inited.resolve();
         return;
       }
 
@@ -111,6 +112,7 @@ export class GitState implements vscode.Disposable {
 
       if (!this.gitExtension) {
         logger.debug("Failed to get Git extension exports");
+        this.inited.resolve();
         return;
       }
 
@@ -119,6 +121,7 @@ export class GitState implements vscode.Disposable {
 
       if (!this.git) {
         logger.debug("Failed to get Git API");
+        this.inited.resolve();
         return;
       }
       await this.gitApiReady();
@@ -149,6 +152,7 @@ export class GitState implements vscode.Disposable {
       logger.debug("Git state monitor initialized successfully");
     } catch (error) {
       logger.debug("Failed to initialize Git state monitor:", error);
+      this.inited.resolve();
     }
   }
 

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -122,28 +122,35 @@ export class WorktreeManager implements vscode.Disposable {
   }
 
   private async init() {
-    if (!(await this.isGitRepository())) {
-      this.inited.resolve();
-      return;
-    }
-    logger.info("init worktree manager");
-    await this.updateWorktrees();
-    await this.setupWatcher();
-    await this.gitState.inited.promise;
+    try {
+      if (!(await this.isGitRepository())) {
+        this.inited.resolve();
+        return;
+      }
+      logger.info("init worktree manager");
+      await this.updateWorktrees();
+      await this.setupWatcher();
+      await this.gitState.inited.promise;
 
-    this.disposables.push(
-      this.gitState.onDidChangeBranch((e) => {
-        if (e.type === "branch-changed") {
-          this.worktrees.value = this.worktrees.value.map((wt) => {
-            if (wt.path === e.repository) {
-              return { ...wt, branch: e.currentBranch };
-            }
-            return wt;
-          });
-        }
-      }),
-    );
-    this.inited.resolve();
+      this.disposables.push(
+        this.gitState.onDidChangeBranch((e) => {
+          if (e.type === "branch-changed") {
+            this.worktrees.value = this.worktrees.value.map((wt) => {
+              if (wt.path === e.repository) {
+                return { ...wt, branch: e.currentBranch };
+              }
+              return wt;
+            });
+          }
+        }),
+      );
+      this.inited.resolve();
+    } catch (error) {
+      logger.error(
+        `Failed to initialize worktree manager: ${toErrorMessage(error)}`,
+      );
+      this.inited.resolve();
+    }
   }
 
   getMainWorktree() {


### PR DESCRIPTION
## Summary
- Resolves `GitState.inited` and `WorktreeManager.inited` promises in error paths to prevent initialization hangs.
- Updates `UserEditState` to handle missing checkpoint hashes when clearing edits.

## Test plan
- Verify VS Code extension initializes correctly even without Git extension or in non-git workspaces.
- Verify checkpoint edits are handled correctly.

🤖 Generated with [Pochi](https://getpochi.com)