### PR TITLE
feat(vscode): support Pochi-provided sweep-next-edit model

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -569,6 +569,11 @@
                             "type": {
                               "type": "string",
                               "const": "NES:pochi"
+                            },
+                            "model": {
+                              "type": "string",
+                              "enum": ["default", "sweep-next-edit"],
+                              "default": "sweep-next-edit"
                             }
                           },
                           "required": ["type"]

--- a/packages/vscode/src/integrations/configuration.ts
+++ b/packages/vscode/src/integrations/configuration.ts
@@ -180,6 +180,7 @@ const TabCompletionFIMProviderSettings = z.discriminatedUnion("type", [
 const TabCompletionNESProviderSettings = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("NES:pochi"),
+    model: z.enum(["sweep-next-edit", "default"]).optional(),
   }),
   z.object({
     type: z.literal("NES:openai"),

--- a/packages/vscode/src/tab-completion/providers/nes-clients/index.ts
+++ b/packages/vscode/src/tab-completion/providers/nes-clients/index.ts
@@ -1,4 +1,6 @@
 import type { TabCompletionNESProviderSettings } from "@/integrations/configuration";
+import { getVendor } from "@getpochi/common/vendor";
+import type { PochiCredentials } from "@getpochi/common/vscode-webui-bridge";
 import { OpenAIFetcher } from "../fetchers";
 import type { TabCompletionProviderClient } from "../types";
 import { NESChatModelClient } from "./chat-model-client";
@@ -12,7 +14,11 @@ export function createNESProviderClient(
 ): TabCompletionProviderClient<object, object> | undefined {
   if (config.type === "NES:openai") {
     if (config.model.startsWith("sweep-next-edit")) {
-      const fetcher = new OpenAIFetcher(config);
+      const fetcher = new OpenAIFetcher({
+        baseURL: config.baseURL,
+        authToken: config.apiKey,
+        model: config.model,
+      });
       return new NESSweepModelClient(id, fetcher);
     }
   }
@@ -26,9 +32,25 @@ export function createNESProviderClient(
   }
 
   if (config.type === "NES:pochi") {
+    if (config.model === "sweep-next-edit") {
+      const fetcher = new OpenAIFetcher({
+        baseURL:
+          "https://api-gateway.getpochi.com/https/tabbyml--vllm-gguf-ngram-server-serve.modal.run/v1",
+        authToken: getPochiJwt,
+        model: "sweep-next-edit-1.5b",
+      });
+      return new NESSweepModelClient(id, fetcher);
+    }
+
     const model = createPochiModel();
     return new NESChatModelClient(id, model);
   }
 
   return undefined;
+}
+
+async function getPochiJwt() {
+  const pochiVendor = getVendor("pochi");
+  const { jwt } = (await pochiVendor.getCredentials()) as PochiCredentials;
+  return jwt || undefined;
 }


### PR DESCRIPTION
## Summary
This PR adds support for the `sweep-next-edit` model when using the Pochi Next Edit Suggestion (NES) provider in VS Code.

Key changes:
- Added `sweep-next-edit` as an optional model for the `NES:pochi` provider in `package.json` and configuration schema.
- Refactored `OpenAIFetcher` to handle `authToken` as either a string or a function returning a string (to support dynamic JWT fetching).
- Implemented `getPochiJwt` to retrieve credentials from the Pochi vendor.
- Configured the NES client to use `NESSweepModelClient` with the Pochi gateway URL when the `sweep-next-edit` model is selected.

## Test plan
1. Go to VS Code settings and search for Pochi NES configuration.
2. Select `NES:pochi` as the provider.
3. Set the model to `sweep-next-edit`.
4. Verify that tab completions are now powered by the sweep model (check logs or network activity to `api-gateway.getpochi.com`).
5. Ensure that the default Pochi chat model still works when the model is set to `default` or not specified.

🤖 Generated with [Pochi](https://getpochi.com)