### PR TITLE
fix(vscode): Increase subtask max step limit from 24 to 100

### DIFF
--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -355,7 +355,7 @@ export function useLiveSubTask(
   };
 }
 
-const SubtaskMaxStep = 24;
+const SubtaskMaxStep = 100;
 const SubtaskMaxRetry = 2;
 
 const useInitAutoStart = ({


### PR DESCRIPTION
## Summary
- Increased `SubtaskMaxStep` constant from 24 to 100 in the live subtask hook

This change allows for more complex multi-step tasks by increasing the maximum number of steps a subtask can have, providing better support for longer workflows.

## Test plan
- [ ] Verify that subtasks can now handle up to 100 steps
- [ ] Test existing functionality with subtasks having fewer than 24 steps to ensure backward compatibility
- [ ] Monitor performance with larger subtask counts

🤖 Generated with [Pochi](https://getpochi.com)