### PR TITLE
fix(vscode-webui): include active selection in siderbar input

### DIFF
--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -1,3 +1,5 @@
+import type { ActiveSelection } from "./message";
+
 export type FileUIPart = {
   name: string;
   contentType: string;
@@ -20,6 +22,7 @@ export type PochiTaskParams = { cwd: string } & (
       uid?: string;
       prompt?: string;
       files?: FileUIPart[];
+      activeSelection?: ActiveSelection;
       mcpConfigOverride?: McpConfigOverride;
     }
   | {

--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -13,6 +13,7 @@ import {
   WorktreeSelect,
 } from "@/components/worktree-select";
 import { useSelectedModels, useSettingsStore } from "@/features/settings";
+import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import type { useAttachmentUpload } from "@/lib/hooks/use-attachment-upload";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { useMcpConfigOverride } from "@/lib/hooks/use-mcp-config-override";
@@ -48,6 +49,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
   deletingWorktreePaths,
 }) => {
   const { t } = useTranslation();
+  const activeSelection = useActiveSelection();
   const { draft: input, setDraft: setInput, clearDraft } = useTaskInputDraft();
   const {
     globalMcpConfig,
@@ -168,6 +170,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
         cwd: worktree && typeof worktree === "object" ? worktree.path : cwd,
         prompt: content,
         files: uploadedFiles,
+        activeSelection: activeSelection ?? undefined,
         mcpConfigOverride:
           Object.keys(mcpConfigOverride).length > 0
             ? mcpConfigOverride
@@ -194,6 +197,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       mcpConfigOverride,
       resetMcpTools,
       globalMcpConfig,
+      activeSelection,
     ],
   );
 

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -317,17 +317,26 @@ function Chat({ user, uid, info }: ChatProps) {
         setMcpConfigOverride(info.mcpConfigOverride);
       }
 
-      if (info.files?.length) {
-        const files = info.files?.map((file) => ({
-          type: "file" as const,
-          filename: file.name,
-          mediaType: file.contentType,
-          url: file.url,
-        }));
+      const activeSelection = info.activeSelection;
+      const files = info.files?.map((file) => ({
+        type: "file" as const,
+        filename: file.name,
+        mediaType: file.contentType,
+        url: file.url,
+      }));
+      const shouldUseParts = (files?.length ?? 0) > 0 || !!activeSelection;
 
+      if (shouldUseParts) {
         chatKit.init(cwd, {
           prompt: info.prompt,
-          parts: prepareMessageParts(t, info.prompt || "", files || [], []),
+          parts: prepareMessageParts(
+            t,
+            info.prompt || "",
+            files || [],
+            [],
+            undefined,
+            activeSelection,
+          ),
         });
       } else {
         chatKit.init(cwd, {


### PR DESCRIPTION
## Summary
- pass active selection through task params when creating tasks
- initialize chat message parts when active selection exists even without file uploads

## Test plan
- Not run (pre-push hook ran; reported Vite server not exiting after tests).

🤖 Generated with [Pochi](https://getpochi.com)