### PR TITLE
feat: add async sub agents support

### DIFF
--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -10,6 +10,7 @@ export type { McpStatus } from "../mcp-utils";
 export type {
   FileDiff,
   ExecuteCommandResult,
+  TaskOutputResult,
   SaveCheckpointOptions,
 } from "./types/execution";
 export type { ResourceURI } from "./types/common";

--- a/packages/common/src/vscode-webui-bridge/types/execution.ts
+++ b/packages/common/src/vscode-webui-bridge/types/execution.ts
@@ -15,6 +15,13 @@ export type ExecuteCommandResult = {
   error?: string; // Optional error message if the execution aborted / failed
 };
 
+export type TaskOutputResult = {
+  output: string;
+  status: ExecuteCommandResult["status"];
+  isTruncated?: boolean;
+  error?: string;
+};
+
 export type SaveCheckpointOptions = {
   /**
    * By default, will only save checkpoint if there are changes, but if you want to force a save, set this to true

--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -266,7 +266,10 @@ const VSCodeHostStub = {
 
   openTaskInPanel: async (
     _params: PochiTaskParams,
-    _options?: { keepEditor?: boolean },
+    _options?: {
+      keepEditor?: boolean;
+      preserveFocus?: boolean;
+    },
   ): Promise<void> => {},
 
   sendTaskNotification: async (): Promise<void> => {},

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -18,6 +18,7 @@ import type {
   SessionState,
   TaskArchivedParams,
   TaskChangedFile,
+  TaskOutputResult,
   TaskStates,
   WorkspaceState,
 } from "./index";
@@ -317,7 +318,10 @@ export interface VSCodeHostApi {
    */
   openTaskInPanel(
     params: PochiTaskParams,
-    options?: { keepEditor?: boolean },
+    options?: {
+      keepEditor?: boolean;
+      preserveFocus?: boolean;
+    },
   ): Promise<void>;
 
   sendTaskNotification(
@@ -398,4 +402,6 @@ export interface WebviewHostApi {
   ): Promise<void>;
 
   readTaskFile(taskId: string, filePath: string): Promise<string | null>;
+
+  queryTaskOutput(taskId: string): Promise<TaskOutputResult>;
 }

--- a/packages/livekit-cf/src/do/livestore-client/app.ts
+++ b/packages/livekit-cf/src/do/livestore-client/app.ts
@@ -121,6 +121,9 @@ function inlineSubTasks(
     const partsWithSubtasks = uiMessage.parts.map((part) => {
       if (part.type === "tool-newTask" && part.state !== "input-streaming") {
         const input = part.input as InferToolInput<ClientTools["newTask"]>;
+        if (input.runAsync) {
+          return part;
+        }
         const subtask = subtasks.find(
           (t) => t.clientTaskId === input._meta?.uid,
         );

--- a/packages/livekit/src/chat/middlewares/new-task-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/new-task-middleware.ts
@@ -100,6 +100,7 @@ export function createNewTaskMiddleware(
                   id: uid,
                   cwd,
                   parentId: parentTaskId,
+                  runAsync: args.runAsync ?? false,
                   createdAt: new Date(),
                   initMessages: [
                     {

--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -27,6 +27,7 @@ export const tables = {
       isPublicShared: State.SQLite.boolean({ default: false }),
       title: State.SQLite.text({ nullable: true }),
       parentId: State.SQLite.text({ nullable: true }),
+      runAsync: State.SQLite.boolean({ nullable: true }),
       status: State.SQLite.text({
         default: "pending-input",
         schema: TaskStatus,
@@ -238,6 +239,7 @@ const materializers = State.SQLite.materializers(events, {
   "v1.TaskInited": ({
     id,
     parentId,
+    runAsync,
     createdAt,
     cwd,
     initMessage,
@@ -255,6 +257,7 @@ const materializers = State.SQLite.materializers(events, {
           ? "pending-model"
           : "pending-input",
       parentId,
+      runAsync: runAsync ?? false,
       createdAt,
       cwd,
       title: initTitle,

--- a/packages/livekit/src/livestore/types.ts
+++ b/packages/livekit/src/livestore/types.ts
@@ -78,6 +78,7 @@ export const Git = Schema.Struct({
 export const taskInitFields = {
   id: Schema.String,
   parentId: Schema.optional(Schema.String),
+  runAsync: Schema.optional(Schema.Boolean),
   cwd: Schema.optional(Schema.String),
   createdAt: Schema.Date,
   modelId: Schema.optional(Schema.String),
@@ -85,6 +86,7 @@ export const taskInitFields = {
 
 export const taskFullFields = {
   ...taskInitFields,
+  runAsync: Schema.optional(Schema.Boolean),
   git: Schema.optional(Git),
   shareId: Schema.optional(Schema.String),
   isPublicShared: Schema.Boolean,

--- a/packages/tools/src/new-task.ts
+++ b/packages/tools/src/new-task.ts
@@ -64,6 +64,10 @@ export const inputSchema = z.object({
     .string()
     .optional()
     .describe("The type of the specialized agent to use for the task."),
+  runAsync: z
+    .boolean()
+    .optional()
+    .describe("Set to true to run this agent in the background."),
   _meta: z
     .object({
       uid: z.string().describe("A unique identifier for the task."),
@@ -85,6 +89,8 @@ ${makeCustomAgentToolDescription(customAgents)}
 Always include a reminder in your prompt to ensure the result will be submitted through the \`attemptCompletion\` tool.
 If the task stops without submitting the result, it will return an error message.
 
+You can optionally run agents in the background using the runAsync parameter. You can continue working while background agents run.
+
 When NOT to use the newTask tool:
 - If you want to read a specific file path, use the readFile or globFiles tool instead of the newTask tool, to find the match more quickly
 - If you are searching for a specific class definition like "class Foo", use the globFiles tool instead, to find the match more quickly
@@ -105,7 +111,7 @@ Usage notes:
       result: z
         .string()
         .describe(
-          "The result of the task, submitted through the `attemptCompletion` tool.",
+          "The task result. For async tasks, this contains the spawned task uid; otherwise it is the completion result.",
         ),
     }),
   });

--- a/packages/tools/src/read-background-job-output.ts
+++ b/packages/tools/src/read-background-job-output.ts
@@ -2,9 +2,11 @@ import z from "zod";
 import { defineClientTool } from "./types";
 
 const toolDef = {
-  description: `- Retrieves output from a running or completed background job
-- Takes a backgroundJobId parameter identifying the job
-- Always returns only new output since the last check
+  description:
+    `- Retrieves output from a running or completed background job or async task
+- Takes a backgroundJobId parameter identifying the job or task
+- For terminal jobs, returns only new output since the last check
+- For task IDs, returns the latest attemptCompletion result once completed
 - Returns stdout and stderr output along with job status
 - Supports optional regex filtering to show only lines matching a pattern
 - Use this tool when you need to monitor or check the output of a long-running background job`.trim(),

--- a/packages/vscode-webui/src/components/__stories__/worktree-list.stories.tsx
+++ b/packages/vscode-webui/src/components/__stories__/worktree-list.stories.tsx
@@ -95,6 +95,7 @@ const mockTasks = [
     updatedAt: new Date("2025-12-15T10:00:00Z"),
     modelId: null,
     displayId: null,
+    runAsync: null,
     lastCheckpointHash: null,
   },
   {
@@ -116,6 +117,7 @@ const mockTasks = [
     updatedAt: new Date("2025-12-15T10:02:00Z"),
     modelId: null,
     displayId: null,
+    runAsync: null,
     lastCheckpointHash: null,
   },
   {
@@ -137,6 +139,7 @@ const mockTasks = [
     updatedAt: new Date("2025-12-15T10:05:00Z"),
     modelId: null,
     displayId: null,
+    runAsync: null,
     lastCheckpointHash: null,
   },
 ] satisfies Task[];

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -303,6 +303,7 @@ function Chat({ user, uid, info }: ChatProps) {
       vscodeHost.onTaskUpdated(
         Schema.encodeSync(catalog.tables.tasks.rowSchema)({
           ...task,
+          runAsync: task.runAsync ?? false,
           pendingToolCalls,
         }),
       );

--- a/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
@@ -1,5 +1,6 @@
 import { TaskThread, type TaskThreadSource } from "@/components/task-thread";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   FixedStateChatContextProvider,
   ToolCallStatusRegistry,
@@ -7,9 +8,10 @@ import {
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { cn } from "@/lib/utils";
-import { isVSCodeEnvironment } from "@/lib/vscode";
+import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
 import { Link } from "@tanstack/react-router";
 import { type RefObject, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { useInlinedSubTask } from "../../hooks/use-inlined-sub-task";
 import { useLiveSubTask } from "../../hooks/use-live-sub-task";
 import { StatusIcon } from "../status-icon";
@@ -25,11 +27,16 @@ interface NewTaskToolProps extends ToolProps<"newTask"> {
 export const newTaskTool: React.FC<NewTaskToolProps> = (props) => {
   const { tool, taskThreadSource } = props;
   const uid = tool.input?._meta?.uid;
+  const isRunAsync = tool.input?.runAsync;
 
   let taskSource: (TaskThreadSource & { parentId?: string }) | undefined =
     taskThreadSource;
 
   const inlinedTaskSource = useInlinedSubTask(tool);
+
+  if (isRunAsync) {
+    return <BackgroundTaskToolView {...props} uid={uid} />;
+  }
 
   if (inlinedTaskSource) {
     taskSource = inlinedTaskSource;
@@ -41,6 +48,60 @@ export const newTaskTool: React.FC<NewTaskToolProps> = (props) => {
 
   return <NewTaskToolView {...props} taskSource={taskSource} uid={uid} />;
 };
+
+function BackgroundTaskToolView(
+  props: NewTaskToolProps & { uid: string | undefined },
+) {
+  const { tool, isExecuting, uid } = props;
+  const { t } = useTranslation();
+  const store = useDefaultStore();
+  const agentType = tool.input?.agentType;
+  const toolTitle = agentType ?? "Subtask";
+  const description = tool.input?.description ?? "";
+  const cwd = window.POCHI_TASK_INFO?.cwd;
+  const storeId = store.storeId;
+
+  const canOpen = isVSCodeEnvironment() && !!uid && !!cwd;
+  const openInTab = () => {
+    if (!uid || !cwd) return;
+    vscodeHost.openTaskInPanel({
+      type: "open-task",
+      uid,
+      cwd,
+      storeId,
+    });
+  };
+
+  return (
+    <div>
+      <ToolTitle className="justify-between">
+        <span className={cn("flex items-center gap-2")}>
+          <StatusIcon tool={tool} isExecuting={isExecuting} />
+          <Badge variant="secondary" className={cn("my-0.5 mr-1 ml-2 py-0")}>
+            {toolTitle}
+          </Badge>
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          onClick={openInTab}
+          disabled={!canOpen}
+        >
+          {t("toolInvocation.openTask")}
+        </Button>
+      </ToolTitle>
+      <div className="mt-1 ml-7 flex flex-col gap-1">
+        <div className="rounded border border-border/60 bg-muted/40 px-2 py-1 text-muted-foreground text-xs">
+          {t("toolInvocation.backgroundTaskStarted")}
+        </div>
+        {description && (
+          <div className="text-muted-foreground text-xs">{description}</div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 function LiveSubTaskToolView(props: NewTaskToolProps & { uid: string }) {
   const { tool, isExecuting, uid } = props;

--- a/packages/vscode-webui/src/features/tools/hooks/use-inlined-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-inlined-sub-task.tsx
@@ -9,7 +9,6 @@ export function useInlinedSubTask(
   tool: ToolProps<"newTask">["tool"],
 ): TaskThreadSource | undefined {
   const todosRef = useRef<Todo[] | undefined>(undefined);
-
   const subtask = tool.input?._transient?.task;
 
   const { todos } = useTodos({
@@ -17,6 +16,10 @@ export function useInlinedSubTask(
     messages: (subtask?.messages ?? []) as Message[],
     todosRef,
   });
+
+  if (tool.input?.runAsync) {
+    return undefined;
+  }
 
   if (tool.state === "input-streaming") {
     return undefined;

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -255,6 +255,8 @@
   "toolInvocation": {
     "requiresApproval": "Requires approval",
     "taskCompleted": "Task Completed",
+    "backgroundTaskStarted": "Background task started",
+    "openTask": "Open",
     "reading": "Reading ",
     "writing": "Writing ",
     "continue": "Continue",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -253,6 +253,8 @@
   "toolInvocation": {
     "requiresApproval": "承認待ち",
     "taskCompleted": "タスク完了",
+    "backgroundTaskStarted": "バックグラウンドタスクを開始しました",
+    "openTask": "開く",
     "reading": "読み込み中 ",
     "writing": "書き込み中 ",
     "continue": "続行",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -253,6 +253,8 @@
   "toolInvocation": {
     "requiresApproval": "승인 대기 중",
     "taskCompleted": "작업 완료",
+    "backgroundTaskStarted": "백그라운드 작업 시작됨",
+    "openTask": "열기",
     "reading": "읽는 중 ",
     "writing": "쓰는 중 ",
     "continue": "계속",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -252,6 +252,8 @@
   "toolInvocation": {
     "requiresApproval": "需要批准",
     "taskCompleted": "任务完成",
+    "backgroundTaskStarted": "后台任务已开始",
+    "openTask": "打开",
     "reading": "正在读取 ",
     "writing": "正在写入 ",
     "continue": "继续",

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@getpochi/common";
 import type {
+  TaskOutputResult,
   VSCodeHostApi,
   WebviewHostApi,
 } from "@getpochi/common/vscode-webui-bridge";
@@ -7,6 +8,7 @@ import { catalog } from "@getpochi/livekit";
 import { ThreadNestedWindow } from "@quilted/threads";
 import Emittery from "emittery";
 import type { WebviewApi } from "vscode-webview";
+import { extractTaskResult } from "../features/chat/lib/tool-call-life-cycle";
 import { queryClient } from "./query-client";
 import type { useDefaultStore } from "./use-default-store";
 
@@ -157,6 +159,61 @@ function createVSCodeHost(): VSCodeHostApi {
           );
         },
 
+        async queryTaskOutput(taskId: string): Promise<TaskOutputResult> {
+          if (!globalStore) {
+            logger.warn("Global store not set, cannot query task output");
+            return {
+              output: "",
+              status: "idle",
+              isTruncated: false,
+              error: "Webview store not ready",
+            };
+          }
+
+          const task = globalStore.query(catalog.queries.makeTaskQuery(taskId));
+          if (!task) {
+            return {
+              output: "",
+              status: "idle",
+              isTruncated: false,
+              error: `Task with ID "${taskId}" not found.`,
+            };
+          }
+
+          const status = mapTaskStatus(task.status);
+          if (status !== "completed") {
+            return {
+              output:
+                "Task still running, you can continue working while async tasks run",
+              status,
+              isTruncated: false,
+            };
+          }
+
+          let output: string | undefined;
+          let outputError: string | undefined;
+          try {
+            output = extractTaskResult(globalStore, taskId);
+          } catch (error) {
+            logger.warn("Failed to extract task result", error);
+            outputError = "Task completed but output is not available yet.";
+          }
+          const error =
+            task.status === "failed"
+              ? (getTaskErrorMessage(task.error) ?? "Task failed.")
+              : output
+                ? undefined
+                : (outputError ??
+                  "Task completed but no attemptCompletion output found.");
+
+          return {
+            output: output ?? "",
+            status,
+            isTruncated: false,
+            error,
+          };
+        },
+
         async readTaskFile(taskId: string, filePath: string) {
           if (!globalStore) {
             logger.warn("Global store not set, cannot read file");
@@ -180,3 +237,29 @@ export const vscodeHost = createVSCodeHost();
 export const fileChangeEvent = new Emittery<{
   fileChanged: { filepath: string; content: string };
 }>();
+
+function mapTaskStatus(
+  status:
+    | "completed"
+    | "pending-input"
+    | "failed"
+    | "pending-tool"
+    | "pending-model",
+): TaskOutputResult["status"] {
+  switch (status) {
+    case "pending-input":
+      return "idle";
+    case "pending-tool":
+    case "pending-model":
+      return "running";
+    case "completed":
+    case "failed":
+      return "completed";
+  }
+}
+
+function getTaskErrorMessage(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const record = error as { message?: unknown };
+  return typeof record.message === "string" ? record.message : undefined;
+}

--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -330,6 +330,7 @@ export abstract class WebviewBase implements vscode.Disposable {
           "onFileChanged",
           "writeTaskFile",
           "readTaskFile",
+          "queryTaskOutput",
         ],
       },
     );

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -934,8 +934,19 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
 
   openTaskInPanel = async (
     params: PochiTaskParams,
-    options?: { keepEditor?: boolean },
+    options?: {
+      keepEditor?: boolean;
+      preserveFocus?: boolean;
+    },
   ): Promise<void> => {
+    if (
+      options?.preserveFocus &&
+      (params.type === "open-task" || params.type === "new-task") &&
+      params.uid &&
+      this.taskActivityTracker.state.value[params.uid]
+    ) {
+      return;
+    }
     await PochiTaskEditorProvider.openTaskEditor(params, options);
   };
 

--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -100,6 +100,12 @@ export class PochiWebviewPanel
       ?.webviewHost?.writeTaskFile(taskId, filePath, content);
   }
 
+  static queryTaskOutput(taskId: string) {
+    return PochiWebviewPanel.panels
+      .get(taskId)
+      ?.webviewHost?.queryTaskOutput(taskId);
+  }
+
   dispose(): void {
     super.dispose();
     this.panel.dispose();

--- a/packages/vscode/src/tools/read-background-job-output.ts
+++ b/packages/vscode/src/tools/read-background-job-output.ts
@@ -1,22 +1,49 @@
 import { OutputManager } from "@/integrations/terminal/output";
+import { PochiWebviewPanel } from "@/integrations/webview/webview-panel";
+import type { TaskOutputResult } from "@getpochi/common/vscode-webui-bridge";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 
 export const readBackgroundJobOutput: ToolFunctionType<
   ClientTools["readBackgroundJobOutput"]
 > = async ({ backgroundJobId, regex }) => {
   const outputManager = OutputManager.get(backgroundJobId);
-  if (!outputManager) {
+  if (outputManager) {
+    const output = outputManager.readOutput(
+      regex ? new RegExp(regex) : undefined,
+    );
+
+    return {
+      output: output.output,
+      isTruncated: output.isTruncated,
+      status: output.status,
+      error: output.error,
+    };
+  }
+
+  if (backgroundJobId.startsWith("bgjob-")) {
     throw new Error(`Background job with ID "${backgroundJobId}" not found.`);
   }
 
-  const output = outputManager.readOutput(
-    regex ? new RegExp(regex) : undefined,
-  );
+  const taskOutput = await queryTaskOutput(backgroundJobId);
 
   return {
-    output: output.output,
-    isTruncated: output.isTruncated,
-    status: output.status,
-    error: output.error,
+    output: taskOutput.output,
+    isTruncated: taskOutput.isTruncated,
+    status: taskOutput.status,
+    error: taskOutput.error,
   };
 };
+
+async function queryTaskOutput(taskId: string): Promise<TaskOutputResult> {
+  const panelOutput = await PochiWebviewPanel.queryTaskOutput(taskId);
+  if (panelOutput) {
+    return panelOutput;
+  }
+
+  return {
+    output: "",
+    status: "idle",
+    isTruncated: false,
+    error: "Webview not ready. Open the task panel to load task data.",
+  };
+}


### PR DESCRIPTION
  add  async sub  agent support end‑to‑end (newTask + background output reading) and tighten VS Code webview behavior.

  What’s implemented

  - newTask supports background execution via runAsync and flows through CLI/tools/livekit/webui.
  - Background output retrieval tool added (readBackgroundJobOutput) and wired into VS Code.
  - VS Code webview bridge/types/stubs updated, with stricter env handling and panel options.
  - UI/UX updates for background tasks and subtask lifecycle (back button + async subtask fixes).
  - i18n strings updated for new task/background UI.
  
todo: cli support:
see: https://github.com/TabbyML/pochi/pull/1140

screenshot:
<img width="1736" height="1164" alt="wechat_2026-01-22_175255_592" src="https://github.com/user-attachments/assets/576eda86-bbca-448a-92be-f804b06bbc5a" />
<img width="1784" height="1374" alt="wechat_2026-01-22_175308_787" src="https://github.com/user-attachments/assets/ce8d76e1-61fe-4776-831c-5bc538063781" />

copied from 
https://github.com/TabbyML/pochi/pull/1085