### PR TITLE
fix: hide user edits actions in share page

### DIFF
--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -53,6 +53,7 @@ export const MessageList: React.FC<{
   showLoader?: boolean;
   forkTask?: (commitId: string, messageId?: string) => Promise<void>;
   hideCheckPoint?: boolean;
+  hideUserEditsActions?: boolean;
   repairMermaid?: MermaidContext["repairMermaid"];
   repairingChart?: string | null;
 }> = ({
@@ -66,6 +67,7 @@ export const MessageList: React.FC<{
   showLoader = true,
   forkTask,
   hideCheckPoint,
+  hideUserEditsActions,
   repairMermaid,
   repairingChart,
 }) => {
@@ -160,6 +162,7 @@ export const MessageList: React.FC<{
                       messages={renderMessages}
                       forkTask={forkTask}
                       hideCheckPoint={hideCheckPoint}
+                      hideUserEditsActions={hideUserEditsActions}
                       latestCheckpoint={latestCheckpoint}
                       lastCheckpointInMessage={lastCheckpointInMessage}
                       userEditsCheckpoint={getUserEditsCheckpoint(
@@ -251,6 +254,7 @@ function Part({
   hideCheckPoint,
   latestCheckpoint,
   lastCheckpointInMessage,
+  hideUserEditsActions,
   userEditsCheckpoint,
 }: {
   role: Message["role"];
@@ -262,6 +266,7 @@ function Part({
   messages: Message[];
   forkTask?: (commitId: string) => Promise<void>;
   hideCheckPoint?: boolean;
+  hideUserEditsActions?: boolean;
   latestCheckpoint: string | null;
   lastCheckpointInMessage: string | undefined;
   userEditsCheckpoint?: {
@@ -314,6 +319,7 @@ function Part({
       <UserEditsPart
         userEdits={part.data.userEdits}
         checkpoints={userEditsCheckpoint}
+        hideActions={hideUserEditsActions}
       />
     );
   }

--- a/packages/vscode-webui/src/components/message/user-edits.tsx
+++ b/packages/vscode-webui/src/components/message/user-edits.tsx
@@ -22,9 +22,14 @@ interface Props {
     origin: string | undefined;
     modified: string | undefined;
   };
+  hideActions?: boolean;
 }
 
-export const UserEditsPart: React.FC<Props> = ({ userEdits, checkpoints }) => {
+export const UserEditsPart: React.FC<Props> = ({
+  userEdits,
+  checkpoints,
+  hideActions,
+}) => {
   const { t } = useTranslation();
 
   if (!userEdits || userEdits.length === 0) return null;
@@ -69,7 +74,7 @@ export const UserEditsPart: React.FC<Props> = ({ userEdits, checkpoints }) => {
             editSummary={{ added: totalAdded, removed: totalRemoved }}
             className="text-xs"
           />
-          {checkpoints?.origin && (
+          {!hideActions && checkpoints?.origin && (
             <div
               className="hidden items-center group-hover:flex"
               onClick={(e) => e.stopPropagation()}
@@ -100,6 +105,7 @@ export const UserEditsPart: React.FC<Props> = ({ userEdits, checkpoints }) => {
           key={edit.filepath}
           edit={edit}
           checkpoints={checkpoints}
+          hideActions={hideActions}
         />
       ))}
     </CollapsibleSection>
@@ -112,9 +118,10 @@ interface UserEditItemProps {
     origin: string | undefined;
     modified: string | undefined;
   };
+  hideActions?: boolean;
 }
 
-function UserEditItem({ edit, checkpoints }: UserEditItemProps) {
+function UserEditItem({ edit, checkpoints, hideActions }: UserEditItemProps) {
   const [isOpen, setIsOpen] = useState(false);
   const { t } = useTranslation();
 
@@ -158,38 +165,40 @@ function UserEditItem({ edit, checkpoints }: UserEditItemProps) {
         </div>
         <div className="flex items-center gap-2 px-3 text-xs">
           <EditSummary editSummary={{ added, removed }} className="text-xs" />
-          <div className="hidden items-center gap-1 group-hover:flex">
-            {checkpoints?.origin && (
+          {!hideActions && (
+            <div className="hidden items-center gap-1 group-hover:flex">
+              {checkpoints?.origin && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={onShowDiff}
+                      className="h-5 w-5"
+                    >
+                      <FileDiff className="size-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t("userEdits.showDiff", { defaultValue: "Show Diff" })}
+                  </TooltipContent>
+                </Tooltip>
+              )}
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
                     size="icon"
-                    onClick={onShowDiff}
+                    onClick={onOpenFile}
                     className="h-5 w-5"
                   >
-                    <FileDiff className="size-3.5" />
+                    <VscGoToFile className="size-3.5" />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>
-                  {t("userEdits.showDiff", { defaultValue: "Show Diff" })}
-                </TooltipContent>
+                <TooltipContent>{t("diffSummary.openFile")}</TooltipContent>
               </Tooltip>
-            )}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onOpenFile}
-                  className="h-5 w-5"
-                >
-                  <VscGoToFile className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{t("diffSummary.openFile")}</TooltipContent>
-            </Tooltip>
-          </div>
+            </div>
+          )}
         </div>
       </div>
       <CollapsibleContent>

--- a/packages/vscode-webui/src/features/share/page.tsx
+++ b/packages/vscode-webui/src/features/share/page.tsx
@@ -106,6 +106,7 @@ export function SharePage() {
                   assistant={assistant}
                   messages={renderMessages}
                   isLoading={isLoading}
+                  hideUserEditsActions
                 />
                 <ErrorMessageView error={error ?? undefined} />
               </div>


### PR DESCRIPTION
## Summary
- Introduces `hideUserEditsActions` prop to `MessageList` and `UserEditsPart` components.
- Hides actions (Show Diff, Open File) in the `UserEditsPart` when `hideUserEditsActions` is true.
- Enables `hideUserEditsActions` in the `SharePage` to prevent unauthorized or broken file operations in shared views.

## Test plan
1. Open a shared page.
2. Verify that the user edits section does not show "Show Diff" or "Open File" buttons.

## Screenshot
<img width="2062" height="514" alt="image" src="https://github.com/user-attachments/assets/6b39de67-8aee-4fb7-a6a7-0b69afee3fec" />


🤖 Generated with [Pochi](https://getpochi.com)