### PR TITLE
fix(common): drop OpenAI itemId from provider options

### DIFF
--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -243,6 +243,24 @@ function removeEmptyTextParts(messages: UIMessage[]) {
   });
 }
 
+function removeOpenAIItemId(messages: UIMessage[]) {
+  return messages.map((message) => {
+    message.parts = message.parts.map((part) => {
+      if ("providerOptions" in part && part.providerOptions) {
+        for (const options of Object.values(part.providerOptions)) {
+          if (options && typeof options === "object" && "itemId" in options) {
+            // biome-ignore lint/performance/noDelete: need delete to make zod happy
+            delete (options as { itemId?: unknown }).itemId;
+          }
+        }
+      }
+      return part;
+    });
+
+    return message;
+  });
+}
+
 function refineDetectedNewPromblems(messages: UIMessage[]) {
   const isWriteFileResultToolPart = (
     part: UIMessage["parts"][number],
@@ -348,6 +366,7 @@ type FormatOp = (messages: UIMessage[]) => UIMessage[];
 const LLMFormatOps: FormatOp[] = [
   removeEmptyTextParts,
   removeEmptyMessages,
+  removeOpenAIItemId,
   refineDetectedNewPromblems,
   extractCompactMessages,
   removeMessagesWithoutTextOrToolCall,
@@ -361,6 +380,7 @@ const LLMFormatOps: FormatOp[] = [
 const UIFormatOps = [
   removeEmptyTextParts,
   removeEmptyMessages,
+  removeOpenAIItemId,
   refineDetectedNewPromblems,
   resolvePendingToolCalls,
   removeSystemReminder,
@@ -370,6 +390,7 @@ const ShareUIFormatOps = [...UIFormatOps, resolvePendingToolCallsForShareUI];
 const StorageFormatOps = [
   removeEmptyTextParts,
   removeEmptyMessages,
+  removeOpenAIItemId,
   refineDetectedNewPromblems,
   removeInvalidCharForStorage,
   removeToolCallArgumentTransientData,


### PR DESCRIPTION
## Notes for reviewer

Fixing error: 
<img width="1326" height="388" alt="image" src="https://github.com/user-attachments/assets/d291b3cf-6fbf-4c0e-b4cf-97b69aa750e9" />
<img width="1324" height="378" alt="image" src="https://github.com/user-attachments/assets/683074dd-e54d-4c8a-943b-29ff55cab23c" />


Chat and stream with openai gpt codex works:
<img width="1679" height="513" alt="image" src="https://github.com/user-attachments/assets/64ec9205-4916-49ff-a5ab-ecb1b1635393" />

Learn from: 
- discuss: https://github.com/anomalyco/opencode/issues/2941
- commit: https://github.com/anomalyco/opencode/commit/40836e96835862e98e042d3fc0869970eaaaedfb

in the commit comment, it also says codex also did this patch.

related discuss:
- https://github.com/vercel/ai/issues/7099


## Summary
- strip OpenAI itemId fields from providerOptions on message parts
- keep formatted/stored messages aligned with schema validation

## Test plan
- Not run (not requested)

🤖 Generated with [Pochi](https://getpochi.com)