### PR TITLE
feat(vscode-webui): add file mention preview and refactor configuration

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/context-mention/mention-config.ts
+++ b/packages/vscode-webui/src/components/prompt-form/context-mention/mention-config.ts
@@ -1,0 +1,213 @@
+import { getLogger } from "@getpochi/common";
+import { type Editor, type Range, ReactRenderer } from "@tiptap/react";
+import type {
+  SuggestionMatch,
+  SuggestionOptions,
+  Trigger,
+} from "@tiptap/suggestion";
+import { findSuggestionMatch } from "@tiptap/suggestion";
+import tippy from "tippy.js";
+import type { MentionListActions } from "../shared";
+import { fileMentionPluginKey, fileMentionPreviewPluginKey } from "./extension";
+import { MentionList, type MentionListProps } from "./mention-list";
+
+const logger = getLogger("mention-config");
+
+interface CreateFileMentionConfigOptions<T extends { filepath: string }> {
+  fetchItems: (query?: string) => Promise<T[]>;
+  checkHasIssues: () => Promise<boolean>;
+}
+
+export function createFileMentionConfig<T extends { filepath: string }>({
+  fetchItems,
+  checkHasIssues,
+}: CreateFileMentionConfigOptions<T>) {
+  let isFileMentionComposing = false;
+
+  const render: SuggestionOptions["render"] = () => {
+    let component: ReactRenderer<MentionListActions, MentionListProps> | null =
+      null;
+    let popup: Array<{ destroy: () => void; hide: () => void }>;
+    let currentRange: Range | null = null;
+    let currentEditor: Editor | null = null;
+    let isActive = false;
+
+    const updateIsComposingRef = (v: boolean) => {
+      isFileMentionComposing = v;
+    };
+
+    const destroyMention = () => {
+      if (popup?.[0]) {
+        popup[0].destroy();
+      }
+      if (component) {
+        component.destroy();
+      }
+
+      clearPreview(currentEditor);
+
+      updateIsComposingRef(false);
+      isActive = false;
+    };
+
+    const updatePreview = (editor: Editor, range: Range) => {
+      // Only update preview when mention dropdown is active
+      if (!isActive || !component || !component.ref || !editor || !range)
+        return;
+
+      const selectedIndex = component.ref.selectedIndex ?? 0;
+      const items = (component.ref.items as T[]) ?? [];
+      const selectedItem = items[selectedIndex];
+
+      // Only show preview if there are items and a selected item exists
+      if (items.length > 0 && selectedItem && selectedItem.filepath) {
+        // Update decoration to show preview
+        const tr = editor.state.tr;
+        tr.setMeta(fileMentionPreviewPluginKey, {
+          filepath: selectedItem.filepath,
+          pos: range.to,
+        });
+        editor.view.dispatch(tr);
+      } else {
+        // Clear preview if no items
+        clearPreview(editor);
+      }
+    };
+
+    const clearPreview = (editor: Editor | null) => {
+      if (!editor) {
+        return;
+      }
+      try {
+        // Clear preview decoration
+        const tr = editor.state.tr;
+        tr.setMeta(fileMentionPreviewPluginKey, "clear");
+        editor.view.dispatch(tr);
+      } catch (error) {
+        logger.error("Error clearing preview:", error);
+      }
+    };
+
+    const onSelectedIndexChange = () => {
+      if (isActive && currentEditor && currentRange && component) {
+        updatePreview(currentEditor, currentRange);
+      }
+    };
+
+    return {
+      onStart: (props) => {
+        updateIsComposingRef(props.editor.view.composing);
+        currentEditor = props.editor;
+        currentRange = props.range;
+        isActive = true;
+
+        component = new ReactRenderer(MentionList, {
+          props: {
+            ...props,
+            fetchItems,
+            checkHasIssues,
+            onSelectedIndexChange,
+          },
+          editor: props.editor,
+        });
+
+        if (!props.clientRect) {
+          return;
+        }
+
+        popup = tippy("body", {
+          getReferenceClientRect: props.clientRect as () => DOMRect,
+          appendTo: () => document.body,
+          content: component.element,
+          showOnCreate: true,
+          interactive: true,
+          trigger: "manual",
+          placement: "top-start",
+          offset: [0, 6],
+          maxWidth: "none",
+          onHide() {
+            clearPreview(currentEditor);
+          },
+          onDestroy: () => {
+            clearPreview(currentEditor);
+          },
+        });
+
+        // Initial preview update - delayed to ensure component is ready
+        setTimeout(() => {
+          if (isActive && component) {
+            updatePreview(props.editor, props.range);
+          }
+        }, 50);
+      },
+      onUpdate: (props) => {
+        updateIsComposingRef(props.editor.view.composing);
+        currentEditor = props.editor;
+        currentRange = props.range;
+
+        if (component) {
+          component.updateProps({
+            ...props,
+            onSelectedIndexChange,
+          });
+
+          // Update preview with the currently selected item
+          setTimeout(() => {
+            if (isActive && component) {
+              updatePreview(props.editor, props.range);
+            }
+          }, 0);
+        }
+      },
+      onExit: () => {
+        isActive = false;
+        destroyMention();
+        currentEditor = null;
+        currentRange = null;
+        component = null;
+      },
+      onKeyDown: (props) => {
+        props.event.isComposing;
+        if (props.event.key === "Escape") {
+          isActive = false;
+          destroyMention();
+          currentEditor = null;
+          currentRange = null;
+          component = null;
+          return true;
+        }
+
+        const result = component?.ref?.onKeyDown(props) ?? false;
+
+        // Preview will be updated automatically via onSelectedIndexChange callback
+
+        return result;
+      },
+    };
+  };
+
+  const findSuggestionMatchFn = (config: Trigger): SuggestionMatch => {
+    const match = findSuggestionMatch({
+      ...config,
+      allowSpaces: isFileMentionComposing,
+    });
+    if (match?.query.startsWith("#")) {
+      return null;
+    }
+    return match;
+  };
+
+  const items = async ({ query }: { query?: string }) => {
+    return fetchItems(query ?? "");
+  };
+
+  return {
+    suggestion: {
+      char: "@",
+      pluginKey: fileMentionPluginKey,
+      items,
+      render,
+      findSuggestionMatch: findSuggestionMatchFn,
+    },
+  };
+}

--- a/packages/vscode-webui/src/components/prompt-form/context-mention/mention-list.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/context-mention/mention-list.tsx
@@ -32,6 +32,7 @@ export interface MentionListProps {
   query?: string;
   fetchItems?: (query?: string) => Promise<MentionItem[]>;
   checkHasIssues?: () => Promise<boolean>;
+  onSelectedIndexChange?: (index: number) => void;
 }
 
 /**
@@ -40,7 +41,14 @@ export interface MentionListProps {
  */
 export const MentionList = forwardRef<MentionListActions, MentionListProps>(
   (
-    { items: initialItems, command, query, fetchItems, checkHasIssues },
+    {
+      items: initialItems,
+      command,
+      query,
+      fetchItems,
+      checkHasIssues,
+      onSelectedIndexChange,
+    },
     ref,
   ) => {
     const { t } = useTranslation();
@@ -61,6 +69,11 @@ export const MentionList = forwardRef<MentionListActions, MentionListProps>(
       }
     }, [items.length, selectedIndex]);
 
+    // Notify parent when selected index changes
+    useEffect(() => {
+      onSelectedIndexChange?.(selectedIndex);
+    }, [selectedIndex, onSelectedIndexChange]);
+
     const handleSelect = useCallback(
       (item: MentionItem) => {
         command({ id: item.filepath, filepath: item.filepath });
@@ -75,7 +88,11 @@ export const MentionList = forwardRef<MentionListActions, MentionListProps>(
       handleSelect,
     );
 
-    useImperativeHandle(ref, () => keyboardNavigation);
+    useImperativeHandle(ref, () => ({
+      ...keyboardNavigation,
+      selectedIndex,
+      items,
+    }));
 
     return (
       <div className="relative flex w-[80vw] flex-col overflow-hidden py-1 sm:w-[600px]">
@@ -136,6 +153,7 @@ const MentionItemView = memo(function MentionItemView({
       className={`flex cursor-pointer flex-nowrap items-center gap-1 overflow-hidden rounded-md px-2 py-1.5 text-sm ${
         isSelected ? "bg-accent text-accent-foreground" : "hover:bg-muted/50"
       }`}
+      title={data.filepath}
       {...rest}
       ref={ref}
     >

--- a/packages/vscode-webui/src/components/prompt-form/context-mention/mention-preview.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/context-mention/mention-preview.tsx
@@ -1,0 +1,28 @@
+import { FileIcon } from "@/features/tools";
+import { memo } from "react";
+import type { MentionItem } from "./mention-list";
+
+interface MentionPreviewProps {
+  item: MentionItem;
+}
+
+/**
+ * Preview component that shows detailed information about the selected mention item
+ */
+export const MentionPreview = memo(function MentionPreview({
+  item,
+}: MentionPreviewProps) {
+  return (
+    <div className="max-w-md rounded-md border bg-popover p-3 shadow-lg">
+      <div className="flex items-center gap-2">
+        <FileIcon isDirectory={item.isDir} path={item.filepath} />
+        <div className="flex-1 overflow-hidden">
+          <div className="truncate font-medium text-sm">{item.filepath}</div>
+          <div className="mt-1 text-muted-foreground text-xs">
+            {item.isDir ? "Directory" : "File"}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/packages/vscode-webui/src/components/prompt-form/shared.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/shared.tsx
@@ -3,6 +3,8 @@ import { useLayoutEffect, useRef, useState } from "react";
 
 export interface MentionListActions {
   onKeyDown: (props: SuggestionKeyDownProps) => boolean;
+  selectedIndex?: number;
+  items?: unknown[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Refactor file mention configuration from `FormEditor` to `mention-config.ts` for better separation of concerns.
- Add `MentionPreview` component (currently unused but prepared).
- Implement `fileMentionPreviewPluginKey` in `extension.tsx` to show a preview decoration (filepath) next to the cursor when navigating the mention list.
- Update `MentionList` to expose `selectedIndex` and notify on change to support the preview feature.

## Test plan
- Open the prompt form in VSCode WebUI.
- Type `@` to trigger file mentions.
- Navigate through the list using arrow keys.
- Verify that the filepath of the selected item is shown as a preview decoration in the editor.
- Verify that selecting an item inserts the mention correctly.

## Recording
https://jam.dev/c/32c6d9b6-7ebf-4b5d-86f5-36c7047e0aef


## Screenshot
### Hover title
<img width="860" height="524" alt="image" src="https://github.com/user-attachments/assets/a61f02ea-d6fc-48dd-a29e-029542bed2ed" />


### Mention preview
<img width="474" height="440" alt="image" src="https://github.com/user-attachments/assets/35eb26c6-70fd-4e77-97b0-9a1d18a3492c" />



🤖 Generated with [Pochi](https://getpochi.com)