### PR TITLE
refactor: centralize terminal environment variables

### DIFF
--- a/packages/cli/src/lib/background-job-manager.ts
+++ b/packages/cli/src/lib/background-job-manager.ts
@@ -1,7 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import * as crypto from "node:crypto";
+import { getTerminalEnv } from "@getpochi/common/env-utils";
 import { getShellPath } from "@getpochi/common/tool-utils";
-import { getCommonProcessEnv } from "./process-env";
 
 export interface BackgroundJob {
   id: string;
@@ -23,7 +23,7 @@ export class BackgroundJobManager {
     const child = spawn(command, {
       shell,
       cwd,
-      env: getCommonProcessEnv(),
+      env: { ...process.env, ...getTerminalEnv() },
       stdio: ["ignore", "pipe", "pipe"],
     });
 

--- a/packages/cli/src/lib/process-env.ts
+++ b/packages/cli/src/lib/process-env.ts
@@ -1,6 +1,6 @@
+import { getTerminalEnv } from "@getpochi/common/env-utils";
+
 export const getCommonProcessEnv = () => ({
   ...process.env,
-  PAGER: "cat",
-  GIT_COMMITTER_NAME: "Pochi",
-  GIT_COMMITTER_EMAIL: "noreply@getpochi.com",
+  ...getTerminalEnv(),
 });

--- a/packages/cli/src/tools/execute-command.ts
+++ b/packages/cli/src/tools/execute-command.ts
@@ -5,13 +5,13 @@ import {
 } from "node:child_process";
 import * as path from "node:path";
 import { promisify } from "node:util";
+import { getTerminalEnv } from "@getpochi/common/env-utils";
 import {
   MaxTerminalOutputSize,
   fixExecuteCommandOutput,
   getShellPath,
 } from "@getpochi/common/tool-utils";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
-import { getCommonProcessEnv } from "../lib/process-env";
 
 export const executeCommand =
   (): ToolFunctionType<ClientTools["executeCommand"]> =>
@@ -40,7 +40,7 @@ export const executeCommand =
         timeout: timeout * 1000, // Convert to milliseconds
         cwd: resolvedCwd,
         signal: abortSignal,
-        env: getCommonProcessEnv(),
+        env: { ...process.env, ...getTerminalEnv() },
       });
 
       const { output, isTruncated } = processCommandOutput(

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,6 +13,7 @@
     "./message-utils": "./src/message-utils/index.ts",
     "./git-utils": "./src/git-utils.ts",
     "./diff-utils": "./src/diff-utils.ts",
+    "./env-utils": "./src/env-utils.ts",
     "./tool-utils": "./src/tool-utils/index.ts",
     "./mcp-utils": "./src/mcp-utils/index.ts",
     "./vscode-webui-bridge": "./src/vscode-webui-bridge/index.ts",

--- a/packages/common/src/env-utils.ts
+++ b/packages/common/src/env-utils.ts
@@ -1,3 +1,10 @@
+export const getTerminalEnv = () => ({
+  PAGER: "cat",
+  GIT_COMMITTER_NAME: "Pochi",
+  GIT_COMMITTER_EMAIL: "noreply@getpochi.com",
+  GIT_EDITOR: "true",
+});
+
 export const isVSCodeEnvironment = () => {
   if (typeof process !== "undefined") {
     if (process.env.VSCODE_PID) {

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { getLogger } from "@/lib/logger";
+import { getTerminalEnv } from "@getpochi/common/env-utils";
 import { getShellPath } from "@getpochi/common/tool-utils";
 import * as vscode from "vscode";
 import { OutputManager } from "./output";
@@ -63,11 +64,7 @@ export class TerminalJob implements vscode.Disposable {
       cwd: config.cwd,
       location: config.location,
       shellPath: getShellPath(),
-      env: {
-        PAGER: "cat",
-        GIT_COMMITTER_NAME: "Pochi",
-        GIT_COMMITTER_EMAIL: "noreply@getpochi.com",
-      },
+      env: getTerminalEnv(),
       iconPath: new vscode.ThemeIcon("piano"),
       hideFromUser: false,
       isTransient: false,


### PR DESCRIPTION
## Summary
- Extracted terminal environment variables to `packages/common/src/env-utils.ts`.
- Updated `BackgroundJobManager`, `executeCommand`, and `TerminalJob` to use the centralized `getTerminalEnv` function.
- Added `GIT_EDITOR: "true"` to the default environment variables to ensure git commands that require an editor (like `git commit` without `-m`) exit immediately instead of hanging.

## Test plan
- Verify that terminal jobs and executed commands still have access to necessary environment variables like `PAGER`.
- Verify that `git` commands run correctly within the terminal/background jobs.

🤖 Generated with [Pochi](https://getpochi.com)