### PR TITLE
fix(vscode-webui): fix worktree list layout when deleted groups are hidden

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -195,7 +195,7 @@ export function WorktreeList({
   const containsOnlyWorkspaceGroup =
     optimisticGroups.length === 1 &&
     optimisticGroups[0].path === (workspacePath || cwd) &&
-    !deletedGroups.length;
+    (!deletedGroups.length || !showAnyTasks);
 
   // Archive all tasks older than 7 days across all worktrees (no cwd = all worktrees)
   const handleArchiveAllOldTasks = () => {


### PR DESCRIPTION
## Summary
- Fix `containsOnlyWorkspaceGroup` calculation to consider `showAnyTasks` state
- When deleted groups exist but are hidden (showAnyTasks=false), the main workspace group should behave as if it's the only group (no max-height constraint)

## Test plan
1. Open a workspace with deleted worktrees
2. Ensure "Show Any Tasks" (eye icon) is toggled OFF
3. Verify the main workspace group expands to full height (not constrained)
4. Toggle "Show Any Tasks" ON
5. Verify the main workspace group gets constrained height if deleted groups appear

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-59727c06cfc046e4894d34643ec1b471)