### PR TITLE
refactor(vscode): Move archive task eligibility logic to VSCode host

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -343,10 +343,12 @@ const VSCodeHostStub = {
   },
   readTaskArchived(): Promise<{
     value: ThreadSignalSerialization<Record<string, boolean>>;
+    hasArchivableTasks: ThreadSignalSerialization<boolean>;
     setTaskArchived: (params: TaskArchivedParams) => Promise<void>;
   }> {
     return Promise.resolve({
       value: {} as ThreadSignalSerialization<Record<string, boolean>>,
+      hasArchivableTasks: {} as ThreadSignalSerialization<boolean>,
       setTaskArchived: (_params: TaskArchivedParams) => Promise.resolve(),
     });
   },

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -370,6 +370,7 @@ export interface VSCodeHostApi {
    */
   readTaskArchived(): Promise<{
     value: ThreadSignalSerialization<Record<string, boolean>>;
+    hasArchivableTasks: ThreadSignalSerialization<boolean>;
     setTaskArchived: (params: TaskArchivedParams) => Promise<void>;
   }>;
 

--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -90,7 +90,7 @@ export function WorktreeList({
 }) {
   const { t } = useTranslation();
   const [showAnyTasks, setShowAnyTasks] = useState(false);
-  const { setTaskArchived } = useTaskArchived();
+  const { setTaskArchived, hasArchivableTasks } = useTaskArchived();
 
   const { data: currentWorkspace, isLoading: isLoadingCurrentWorkspace } =
     useCurrentWorkspace();
@@ -243,21 +243,23 @@ export function WorktreeList({
           </Tooltip>
 
           {/* Archive Old Tasks Button */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-6 w-6 p-0"
-                aria-label="archive-old-tasks-button"
-                onClick={handleArchiveAllOldTasks}
-                data-testid="global-archive-old-tasks"
-              >
-                <Archive className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t("tasksPage.archiveOldTasks")}</TooltipContent>
-          </Tooltip>
+          {hasArchivableTasks && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  aria-label="archive-old-tasks-button"
+                  onClick={handleArchiveAllOldTasks}
+                  data-testid="global-archive-old-tasks"
+                >
+                  <Archive className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t("tasksPage.archiveOldTasks")}</TooltipContent>
+            </Tooltip>
+          )}
         </div>
       </div>
 

--- a/packages/vscode-webui/src/lib/hooks/use-task-archived.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-task-archived.ts
@@ -25,6 +25,7 @@ export const useTaskArchived = () => {
 
   return {
     tasksArchived: data?.tasksArchived.value,
+    hasArchivableTasks: data?.hasArchivableTasks.value,
     setTaskArchived: data?.setTaskArchived,
     isLoading: isLoading,
     isTaskArchived,
@@ -35,6 +36,7 @@ async function fetchTaskArchived() {
   const result = await vscodeHost.readTaskArchived();
   return {
     tasksArchived: threadSignal(result.value),
+    hasArchivableTasks: threadSignal(result.hasArchivableTasks),
     setTaskArchived: result.setTaskArchived,
   };
 }


### PR DESCRIPTION
## Summary
This PR refactors the "Archive tasks older than one week" feature to move the eligibility check from the webview client to the VSCode extension host. This improves performance by avoiding unnecessary data processing in the UI thread and centralizes the logic.

**Changes:**
- **Common:** Updated `VSCodeHostApi` in `vscode-webui-bridge` to include `hasArchivableTasks` in the `readTaskArchived` return type.
- **VSCode:** Updated `VSCodeHostImpl` to compute `hasArchivableTasks`. The logic checks for tasks that are:
  1. Root tasks (not subtasks)
  2. Not already archived
  3. Older than 7 days
- **Webview:**
  - Updated `useTaskArchived` hook to expose the `hasArchivableTasks` signal.
  - Simplified `WorktreeList` component to use this signal directly, removing the need to fetch all tasks and compute filtering client-side.

## Test plan
- Verify that the "Archive tasks older than one week" button only appears when there are eligible tasks.
- Verify that clicking the button archives the tasks correctly.
- Verify that the button disappears after archiving.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fa565cea062c4c19917567fc9583b1f2)