### PR TITLE
fix(vscode): show error message when worktree creation fails

### DIFF
--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -225,6 +225,8 @@ export class WorktreeManager implements vscode.Disposable {
       setupWorktree(newWorktree.path);
       return newWorktree;
     }
+
+    vscode.window.showErrorMessage("Failed to create worktree.");
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Added `vscode.window.showErrorMessage` when worktree creation fails to provide feedback to the user.

## Test plan
- Verify that an error message is shown if worktree creation fails (e.g. by forcing a failure or invalid state).

## Recording
https://jam.dev/c/bca671c4-157f-4f42-90ae-f303d04709e6

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4a12b5883d5e4a05ab32a481d5a34028)