### PR TITLE
refactor: update prompts for custom agents and skills to use natural language

### DIFF
--- a/packages/cli/src/lib/__tests__/match-slash-command.test.ts
+++ b/packages/cli/src/lib/__tests__/match-slash-command.test.ts
@@ -132,7 +132,7 @@ describe("match-slash-command", () => {
         skills,
       });
       expect(result).toBe(
-        'Please use <custom-agent id="test-agent" path=".pochi/agents/test-agent.md">newTask:test-agent</custom-agent> for this task'
+        'Please use <custom-agent id="test-agent" path=".pochi/agents/test-agent.md">Please use the newTask tool to run test-agent to complete the following request:\n</custom-agent> for this task'
       );
     });
 
@@ -143,7 +143,7 @@ describe("match-slash-command", () => {
         skills,
       });
       expect(result).toBe(
-        'Please use <skill id="test-skill" path=".pochi/skills/test-skill/SKILL.md">useSkill:test-skill</skill> for this task',
+        'Please use <skill id="test-skill" path=".pochi/skills/test-skill/SKILL.md">Please use the useSkill tool to run test-skill to complete the following request:\n</skill> for this task',
       );
     });
 
@@ -154,7 +154,7 @@ describe("match-slash-command", () => {
         skills,
       });
       expect(result).toBe(
-        'Use <custom-agent id="test-agent" path=".pochi/agents/test-agent.md">newTask:test-agent</custom-agent> and then <skill id="test-skill" path=".pochi/skills/test-skill/SKILL.md">useSkill:test-skill</skill>',
+        'Use <custom-agent id="test-agent" path=".pochi/agents/test-agent.md">Please use the newTask tool to run test-agent to complete the following request:\n</custom-agent> and then <skill id="test-skill" path=".pochi/skills/test-skill/SKILL.md">Please use the useSkill tool to run test-skill to complete the following request:\n</skill>',
       );
     });
   });

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -85,5 +85,5 @@ function createCustomAgentPrompt(id: string, path?: string) {
       return match.replace("<", "&lt;");
     },
   );
-  return `<custom-agent id="${id}" path="${path || BuiltInAgentPath}">newTask:${processedAgentName}</custom-agent>`;
+  return `<custom-agent id="${id}" path="${path || BuiltInAgentPath}">Please use the newTask tool to run ${processedAgentName} to complete the following request:\n</custom-agent>`;
 }

--- a/packages/common/src/base/prompts/skill.ts
+++ b/packages/common/src/base/prompts/skill.ts
@@ -8,7 +8,7 @@ export function createSkillPrompt(id: string, path: string) {
   processedSkillName = processedSkillName.replace(skillTagRegex, (match) => {
     return match.replace("<", "&lt;");
   });
-  return `<skill id="${id}" path="${path}">useSkill:${processedSkillName}</skill>`;
+  return `<skill id="${id}" path="${path}">Please use the useSkill tool to run ${processedSkillName} to complete the following request:\n</skill>`;
 }
 
 /**

--- a/packages/tools/src/new-task.ts
+++ b/packages/tools/src/new-task.ts
@@ -104,7 +104,6 @@ Usage notes:
 4. The agent's outputs should generally be trusted
 5. Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent
 6. If the agent description mentions that it should be used proactively, then you should try your best to use it without the user having to ask for it first. Use your judgement.
-7. If the user's message contains "newTask:<agentType>", you must use the this tool with the specified agentType.
       `.trim(),
     inputSchema,
     outputSchema: z.object({

--- a/packages/tools/src/use-skill.ts
+++ b/packages/tools/src/use-skill.ts
@@ -81,7 +81,6 @@ Important:
   * references/ - on-demand documentation (REFERENCE.md, FORMS.md, domain-specific files)
   * assets/ - static resources (templates, images, data files, schemas)
   Use these resources when they exist and are relevant to the current task
-- If the user's message contains "useSkill:<skill>", you must use the this tool with the specified skill.
 
 ${makeSkillToolDescription(skills)}
 `.trim(),


### PR DESCRIPTION
## Summary
- Updated `createCustomAgentPrompt` and `createSkillPrompt` to use natural language instructions for `newTask` and `useSkill` tools instead of the special syntax `newTask:<agent>` and `useSkill:<skill>`.
- Removed outdated instructions from `newTask` and `useSkill` tool descriptions.
- Updated tests in `packages/cli` to reflect these changes.

## Test plan
- Verified that `packages/cli` tests pass with `bun run test`.
- Verified that `packages/common` and `packages/vscode-webui` tests pass.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e0caccb4858a40a3ba0cceeb921e8fc6)