### PR TITLE
fix(vscode-webui): use cwd instead of workspacePath for matching worktree

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
+++ b/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
@@ -21,7 +21,7 @@ export const AttemptCompletionTool: React.FC<
 
   const currentWorktree = useMemo(() => {
     if (!worktrees || !currentWorkspace) return null;
-    return worktrees.find((wt) => wt.path === currentWorkspace.workspacePath);
+    return worktrees.find((wt) => wt.path === currentWorkspace.cwd);
   }, [worktrees, currentWorkspace]);
 
   const hasPR = !!currentWorktree?.data?.github?.pullRequest;


### PR DESCRIPTION
## Summary
- Updated `AttemptCompletionTool` to use `cwd` instead of `workspacePath` when finding the current worktree.

## Test plan
- Verify that the attempt completion tool correctly identifies the current worktree and associated PR status.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-70288cc1dda7473cb1751800567d6d5d)