### PR TITLE
fix(vscode-webui): fix editor placeholder not applying i18n settings promptly

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -192,7 +192,7 @@ export function FormEditor({
         Paragraph,
         Text,
         Placeholder.configure({
-          placeholder: t("formEditor.placeholder"),
+          placeholder: () => t("formEditor.placeholder"),
         }),
         CustomEnterKeyHandler(formRef),
         PromptFormMentionExtension.configure(


### PR DESCRIPTION
## Summary
This PR fixes a bug where the editor placeholder did not apply i18n settings promptly. By updating the placeholder configuration in `FormEditor` to use a function, we ensure that the placeholder text is correctly resolved and reactive to language changes.

## Test plan
- Verify that the placeholder text in the prompt form editor is displayed correctly.
- Switch languages and verify that the placeholder updates immediately.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fdeac5977b3d4065b5c2b38aeb2890b9)