### PR TITLE
feat: enhance Planner UI and update plan path mapping

### DIFF
--- a/packages/common/src/base/agents/planner.ts
+++ b/packages/common/src/base/agents/planner.ts
@@ -31,11 +31,7 @@ Follow this strict sequence of operations:
 
 ### Phase 3: Plan Serialization
 1.  **Construct**: Create the plan content using the "Professional Plan Template" below.
-2.  **Save**: Write the plan to \`pochi://parent/plan.md\`.
-    > **CRITICAL**: You are a **sub-agent**.
-    > - You MUST write to \`pochi://parent/plan.md\`.
-    > - You MUST NOT write to \`pochi://self/plan.md\`.
-    > - You MUST NOT write to \`plan.md\` (relative path).
+2.  **Save**: Write the plan to \`pochi://-/plan.md\`.
 
 ### Phase 4: Completion
 1.  **Verify**: Ensure the file was written successfully.
@@ -93,9 +89,7 @@ The plan file MUST be a high-quality Markdown document adhering to this structur
 
 Upon successfully writing the plan, call \`attemptCompletion\` with this EXACT message:
 
-"Technical plan architected and saved to \`pochi://self/plan.md\`. Please implement according to the plan."
-
-> **Note**: In the completion message, you must tell the **main agent** to read from \`pochi://self/plan.md\`. Although you wrote to \`pochi://parent/plan.md\`, the main agent access this file at \`pochi://self/plan.md\`.
+"Technical plan architected and saved to \`pochi://-/plan.md\`. Please start implementation using the plan"
 
 `.trim(),
 };

--- a/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
@@ -35,7 +35,7 @@ export function PlannerView(props: NewTaskToolViewProps) {
         storeId: store.storeId,
       },
     });
-    vscodeHost.openFile("pochi://self/plan.md");
+    vscodeHost.openFile("pochi://-/plan.md");
   };
 
   const handleExecutePlan = () => {

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -442,7 +442,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       const abortSignal = new ThreadAbortSignal(options.abortSignal);
       const toolCallStart = Date.now();
       const result = await safeCall(
-        tool(resolveToolCallArgs(args, this.task), {
+        tool(resolveToolCallArgs(args, this.task.id), {
           abortSignal,
           messages: [],
           toolCallId: options.toolCallId,
@@ -511,11 +511,14 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
         : undefined;
 
       return await safeCall<PreviewReturnType>(
-        tool(resolveToolCallArgs(args, this.task) as Partial<unknown> | null, {
-          ...options,
-          abortSignal,
-          cwd: this.cwd,
-        }),
+        tool(
+          resolveToolCallArgs(args, this.task.id) as Partial<unknown> | null,
+          {
+            ...options,
+            abortSignal,
+            cwd: this.cwd,
+          },
+        ),
       );
     },
   );
@@ -536,7 +539,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
 
     // Open file directly if it's a pochi scheme
     if (fileUri.scheme === "pochi" && this.task) {
-      resolvedPath = resolvePochiUri(filePath, this.task);
+      resolvedPath = resolvePochiUri(filePath, this.task.id);
       vscode.commands.executeCommand(
         "vscode.open",
         vscode.Uri.parse(resolvedPath),
@@ -1213,27 +1216,18 @@ function safeCall<T>(x: Promise<T>) {
   });
 }
 
-const resolvePochiUri = (
-  path: string,
-  task: { id: string; parentId: string | null },
-) => {
+const resolvePochiUri = (path: string, taskId: string) => {
   const uri = vscode.Uri.parse(path);
   if (uri.scheme !== "pochi") {
     return path;
   }
-  if (uri.authority === "self") {
-    return path.replace("self", task.id);
-  }
-  if (uri.authority === "parent") {
-    return path.replace("parent", task.parentId || task.id);
+  if (uri.authority === "-") {
+    return path.replace("-", taskId);
   }
   return path;
 };
 
-const resolveToolCallArgs = (
-  args: unknown,
-  task: { id: string; parentId: string | null },
-) => {
+const resolveToolCallArgs = (args: unknown, taskId: string) => {
   if (!R.isObjectType(args)) {
     return args;
   }
@@ -1241,7 +1235,7 @@ const resolveToolCallArgs = (
   return R.mapValues(args, (v) => {
     if (typeof v === "string") {
       try {
-        return resolvePochiUri(v, task);
+        return resolvePochiUri(v, taskId);
       } catch (err) {
         return v;
       }


### PR DESCRIPTION
## Summary
- Updated the technical plan storage path from `pochi://task/plan.md` to `pochi://-/plan.md` for consistent URI handling.
- Enhanced the `PlannerView` UI with collapsible task details, improved layout, and better localization support.
- Refactored `PlannerView` stories to use `queryClient` for more reliable data seeding.
- Improved VSCode host implementation to correctly resolve `pochi://-` URIs to the current task ID.

## Test plan
- Verified that the planner correctly saves the plan to the new path.
- Checked that clicking "Open Plan" in the UI opens the correct file.
- Confirmed that the UI improvements (collapsible sections, alignment) are working as expected in the webview.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-255f0b3a0e884317a984bce6b2f49d50)