### PR TITLE
fix(vscode): fix checkpoint service delay by avoiding worktree manager dependency

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
+++ b/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
@@ -15,8 +15,7 @@ import { signal } from "@preact/signals-core";
 import { Lifecycle, inject, injectable, scoped } from "tsyringe";
 import type * as vscode from "vscode";
 import type { FileChange } from "../editor/diff-changes-editor";
-// biome-ignore lint/style/useImportType: needed for dependency injection
-import { WorktreeManager } from "../git/worktree";
+import { getMainWorktreePath } from "../git/util";
 import { ShadowGitRepo } from "./shadow-git-repo";
 import {
   filterGitChanges,
@@ -26,6 +25,26 @@ import {
 
 const logger = getLogger("CheckpointService");
 const checkpointCommitPrefix = (cwd: string) => `checkpoint-${cwd}-msg-`;
+
+/** Timeout for saveCheckpoint operation in milliseconds */
+const SaveCheckpointTimeoutMs = 10_000;
+
+/**
+ * Wraps a promise with a timeout. Returns null if the timeout is reached.
+ */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operationName: string,
+): Promise<T | null> {
+  const timeoutPromise = new Promise<null>((resolve) => {
+    setTimeout(() => {
+      logger.warn(`${operationName} timed out after ${timeoutMs}ms`);
+      resolve(null);
+    }, timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]);
+}
 
 @scoped(Lifecycle.ContainerScoped)
 @injectable()
@@ -40,7 +59,6 @@ export class CheckpointService implements vscode.Disposable {
     private readonly workspaceScope: WorkspaceScope,
     @inject("vscode.ExtensionContext")
     private readonly context: vscode.ExtensionContext,
-    private readonly worktreeManager: WorktreeManager,
   ) {}
 
   private get cwd() {
@@ -83,9 +101,20 @@ export class CheckpointService implements vscode.Disposable {
   /**
    * Saves a checkpoint for the current workspace.
    * @param message A message to associate with the checkpoint.
-   * @returns The commit hash of the created checkpoint. If the repository is clean, returns undefined.
+   * @returns The commit hash of the created checkpoint. If the repository is clean or timeout, returns null.
    */
   saveCheckpoint = async (
+    message: string,
+    options: SaveCheckpointOptions = {},
+  ): Promise<string | null> => {
+    return withTimeout(
+      this.saveCheckpointImpl(message, options),
+      SaveCheckpointTimeoutMs,
+      "saveCheckpoint",
+    );
+  };
+
+  private saveCheckpointImpl = async (
     message: string,
     options: SaveCheckpointOptions = {},
   ): Promise<string | null> => {
@@ -185,12 +214,7 @@ export class CheckpointService implements vscode.Disposable {
     if (!this.context.globalStorageUri) {
       throw new Error("Extension global storage URI is not available");
     }
-    await this.worktreeManager.inited.promise;
-    const workspacePath =
-      this.worktreeManager.getMainWorktree()?.path ?? this.workspaceScope.cwd;
-    if (!workspacePath) {
-      throw new Error("Cannot get workspace path");
-    }
+    const workspacePath = (await getMainWorktreePath(this.cwd)) ?? this.cwd;
     const storagePath = await this.getWorkspaceStoragePath(workspacePath);
     const checkpointDir = path.join(storagePath, "checkpoint");
     logger.info(

--- a/packages/vscode/src/integrations/git/util.ts
+++ b/packages/vscode/src/integrations/git/util.ts
@@ -1,0 +1,42 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+/**
+ * Gets the main worktree path for the given directory.
+ *
+ * In git:
+ * - Main worktree has a `.git` directory
+ * - Non-main worktrees have a `.git` file containing `gitdir: <path>` pointing to
+ *   the main repo's `.git/worktrees/<name>` directory
+ *
+ * @param cwd - The directory to check
+ * @returns The main worktree path, or undefined if not a git repository
+ */
+export async function getMainWorktreePath(
+  cwd: string,
+): Promise<string | undefined> {
+  const gitPath = path.join(cwd, ".git");
+  try {
+    const stat = await fs.stat(gitPath);
+    if (stat.isDirectory()) {
+      // This is the main worktree
+      return cwd;
+    }
+    if (stat.isFile()) {
+      // This is a non-main worktree, read the .git file to find the main worktree
+      const content = await fs.readFile(gitPath, "utf8");
+      const match = content.match(/^gitdir:\s*(.+)$/m);
+      if (match) {
+        // gitdir points to: /main/repo/.git/worktrees/<name>
+        // Go up 3 levels to get: /main/repo
+        const gitdir = match[1].trim();
+        const mainGitDir = path.resolve(gitdir, "..", ".."); // .git directory
+        const mainWorktreePath = path.dirname(mainGitDir); // main worktree
+        return mainWorktreePath;
+      }
+    }
+  } catch {
+    // .git doesn't exist or can't be accessed
+  }
+  return undefined;
+}

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -153,10 +153,6 @@ export class WorktreeManager implements vscode.Disposable {
     }
   }
 
-  getMainWorktree() {
-    return this.worktrees.value.find((wt) => wt.isMain);
-  }
-
   async isGitRepository(): Promise<boolean> {
     try {
       const isRepo = await this.git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);


### PR DESCRIPTION
## Summary
- Introduces `getMainWorktreePath` utility to resolve the main worktree path directly from the filesystem.
- Updates `CheckpointService`, `CommandManager`, and `GithubIssueState` to use this utility instead of depending on `WorktreeManager`.
- Adds a timeout to `saveCheckpoint` to prevent indefinite hanging.

## Test plan
- Verify that checkpoint service works correctly without errors.
- Verify that GitHub issues are loaded correctly.
- Verify that clearing GitHub info works.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b1dc525ca96a4001b9285588c7ec3079)