### PR TITLE
fix(vscode-webui): fix fork task stuck after closing a recent task tab

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -362,6 +362,18 @@ const VSCodeHostStub = {
       updateLang: (_lang: string) => Promise.resolve(),
     };
   },
+
+  readForkTaskStatus: async (): Promise<{
+    status: ThreadSignalSerialization<Record<string, "inProgress" | "ready">>;
+    setForkTaskStatus: () => Promise<void>;
+  }> => {
+    return {
+      status: {} as ThreadSignalSerialization<
+        Record<string, "inProgress" | "ready">
+      >,
+      setForkTaskStatus: () => Promise.resolve(),
+    };
+  },
 } satisfies VSCodeHostApi;
 
 export function createVscodeHostStub(overrides?: Partial<VSCodeHostApi>) {

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -378,6 +378,14 @@ export interface VSCodeHostApi {
     value: ThreadSignalSerialization<string>;
     updateLang: (lang: string) => Promise<void>;
   }>;
+
+  readForkTaskStatus(): Promise<{
+    status: ThreadSignalSerialization<Record<string, "inProgress" | "ready">>;
+    setForkTaskStatus: (
+      uid: string,
+      status: "inProgress" | "ready",
+    ) => Promise<void>;
+  }>;
 }
 
 export interface WebviewHostApi {

--- a/packages/vscode-webui/src/lib/hooks/use-fork-task-status.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-fork-task-status.ts
@@ -1,0 +1,19 @@
+import { threadSignal } from "@quilted/threads/signals";
+import { useQuery } from "@tanstack/react-query";
+import { vscodeHost } from "../vscode";
+
+/** @useSignals this comment is needed to enable signals in this hook */
+export const useForkTaskStatus = (): Record<string, "inProgress" | "ready"> => {
+  const { data: forkTaskStatus } = useQuery({
+    queryKey: ["forkTaskStatus"],
+    queryFn: fetchForkTaskStatus,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  return forkTaskStatus?.value || {};
+};
+
+async function fetchForkTaskStatus() {
+  const signal = threadSignal((await vscodeHost.readForkTaskStatus()).status);
+  return signal;
+}

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -117,6 +117,7 @@ function createVSCodeHost(): VSCodeHostApi {
         "readMcpConfigOverride",
         "readTaskArchived",
         "readLang",
+        "readForkTaskStatus",
       ],
       exports: {
         openTaskList() {

--- a/packages/vscode-webui/src/routes/task.tsx
+++ b/packages/vscode-webui/src/routes/task.tsx
@@ -3,6 +3,7 @@ import "@/components/prompt-form/prompt-form.css";
 import { GlobalStoreInitializer } from "@/components/global-store-initializer";
 import { WelcomeScreen } from "@/components/welcome-screen";
 import { ChatPage, ChatSkeleton } from "@/features/chat";
+import { useForkTaskStatus } from "@/lib/hooks/use-fork-task-status";
 import { useModelList } from "@/lib/hooks/use-model-list";
 import { usePochiCredentials } from "@/lib/hooks/use-pochi-credentials";
 import { useUserStorage } from "@/lib/hooks/use-user-storage";
@@ -64,12 +65,34 @@ function RouteComponent() {
 
   if (isPending) return null;
 
+  const chatPage = (
+    <>
+      <GlobalStoreInitializer />
+      <ChatPage key={key} user={users?.pochi} uid={uid} info={info} />
+    </>
+  );
+
   return (
     <Suspense fallback={<ChatSkeleton />}>
       <DefaultStoreOptionsProvider storeId={storeId} jwt={jwt}>
-        <GlobalStoreInitializer />
-        <ChatPage key={key} user={users?.pochi} uid={uid} info={info} />
+        {info?.type === "fork-task" ? (
+          <ForkTaskQueryWrapper uid={uid}>{chatPage}</ForkTaskQueryWrapper>
+        ) : (
+          chatPage
+        )}
       </DefaultStoreOptionsProvider>
     </Suspense>
   );
+}
+
+function ForkTaskQueryWrapper({
+  uid,
+  children,
+}: {
+  uid: string;
+  children: React.ReactNode;
+}) {
+  // All useStore and queries must run after forkTask status is ready
+  const forkTaskStatus = useForkTaskStatus();
+  return forkTaskStatus[uid] === "ready" ? children : <ChatSkeleton />;
 }

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -11,6 +11,8 @@ import {
   getSystemInfo,
   getWorkspaceRulesFileUri,
 } from "@/lib/env";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { ForkTaskStatus } from "@/lib/fork-task-status";
 import { asRelativePath, isFileExists } from "@/lib/fs";
 import { getLogger } from "@/lib/logger";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -180,6 +182,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     private readonly taskHistoryStore: TaskHistoryStore,
     private readonly taskStateStore: TaskDataStore,
     private readonly lang: PochiLanguage,
+    private readonly forkTaskStatus: ForkTaskStatus,
   ) {}
 
   private get cwd() {
@@ -1198,6 +1201,13 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   readLang = async () => ({
     value: ThreadSignal.serialize(this.lang.currentLang),
     updateLang: this.lang.updateLang,
+  });
+
+  readForkTaskStatus = async () => ({
+    status: ThreadSignal.serialize(this.forkTaskStatus.status),
+    setForkTaskStatus: async (uid: string, status: "inProgress" | "ready") => {
+      this.forkTaskStatus.setStatus(uid, status);
+    },
   });
 
   dispose() {

--- a/packages/vscode/src/lib/fork-task-status.ts
+++ b/packages/vscode/src/lib/fork-task-status.ts
@@ -1,0 +1,15 @@
+import { signal } from "@preact/signals-core";
+import { injectable, singleton } from "tsyringe";
+
+@injectable()
+@singleton()
+export class ForkTaskStatus {
+  readonly status = signal<Record<string, "inProgress" | "ready">>({});
+
+  setStatus(uid: string, status: "inProgress" | "ready") {
+    this.status.value = {
+      ...this.status.value,
+      [uid]: status,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Coordinate fork status between tabs using a signal to ensure the new tab only loads after the fork is prepared.
- Open the new task tab early to prevent service worker 408 errors caused by closing a recent webview.

## Test plan
1. Open a task.
2. Fork the task.
3. Verify that the fork process completes successfully and the new tab loads correctly without getting stuck.
4. Verify that the original tab remains open if requested.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-163b0c94f58b4dbb8b7c2fb4461766e8)