### PR TITLE
fix(vscode-webui): replace Link with Button for better navigation control

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/subtask.tsx
+++ b/packages/vscode-webui/src/features/chat/components/subtask.tsx
@@ -1,9 +1,9 @@
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { cn } from "@/lib/utils";
 import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
 import { catalog } from "@getpochi/livekit";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { ChevronLeft } from "lucide-react";
 import { type MouseEvent, useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -23,7 +23,9 @@ export const SubtaskHeader: React.FC<{
   );
   const runAsync = subtaskTask?.runAsync;
   const parentCwd = parentTask?.cwd;
-  const handleBack = useCallback(
+  const navigate = useNavigate();
+
+  const handleBackClick = useCallback(
     (event: MouseEvent) => {
       // Async tasks (runAsync=true) need VS Code API to switch panes, sync tasks use React Router
       if (runAsync && parentCwd && isVSCodeEnvironment()) {
@@ -34,23 +36,24 @@ export const SubtaskHeader: React.FC<{
           cwd: parentCwd,
           storeId: store.storeId,
         });
+      } else {
+        // Use navigate for sync tasks
+        navigate({
+          to: "/task",
+          search: { uid: subtask.parentUid },
+          replace: true,
+          viewTransition: true,
+        });
       }
-      // Sync tasks (runAsync=false/undefined) or missing parentCwd use React Router navigation
     },
-    [parentCwd, store.storeId, subtask.parentUid, runAsync],
+    [parentCwd, store.storeId, subtask.parentUid, runAsync, navigate],
   );
 
   return (
     <div className={cn("px-2 pb-0", className)}>
-      <Link
-        to="/task"
-        search={{ uid: subtask.parentUid }}
-        replace={true}
-        className={cn(buttonVariants({ variant: "ghost" }), "gap-1")}
-        onClick={handleBack}
-      >
+      <Button variant="ghost" className="gap-1" onClick={handleBackClick}>
         <ChevronLeft className="mr-1.5 size-4" /> {t("subtask.back")}
-      </Link>
+      </Button>
     </div>
   );
 };

--- a/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
@@ -9,7 +9,7 @@ import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { cn } from "@/lib/utils";
 import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
-import { Link } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { type RefObject, useEffect, useRef } from "react";
 import { useInlinedSubTask } from "../../hooks/use-inlined-sub-task";
 
@@ -120,6 +120,7 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
   const { tool, isExecuting, taskSource, uid, toolCallStatusRegistryRef } =
     props;
   const store = useDefaultStore();
+  const navigate = useNavigate();
   const agent = tool.input?.agentType;
   const description = tool.input?.description ?? "";
   const agentType = tool.input?.agentType;
@@ -151,17 +152,23 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
           <StatusIcon tool={tool} isExecuting={isExecuting} />
           <Badge variant="secondary" className={cn("my-0.5 py-0")}>
             {uid && taskSource?.parentId && isVSCodeEnvironment() ? (
-              <Link
-                to="/task"
-                search={{
-                  uid,
-                  storeId: store.storeId,
+              <Button
+                variant="link"
+                className="h-auto p-0 font-inherit text-inherit underline-offset-2"
+                onClick={() => {
+                  navigate({
+                    to: "/task",
+                    search: {
+                      uid,
+                      storeId: store.storeId,
+                    },
+                    replace: true,
+                    viewTransition: true,
+                  });
                 }}
-                replace={true}
-                viewTransition
               >
                 {toolTitle}
-              </Link>
+              </Button>
             ) : (
               <>{toolTitle}</>
             )}


### PR DESCRIPTION
## Summary
- Fixes an issue in dev mode where clicking on the back icon in subtask opens a new browser window.
- Replaced `Link` components with `Button` components in `SubtaskHeader` and `NewTaskToolView`.
- Implemented `handleBackClick` using `useNavigate` to handle navigation logic explicitly.
- Ensures consistent navigation behavior, especially in VSCode environment where `Link` behavior might be intercepted or inconsistent.

## Test plan
- Verify that clicking the "Back" button in a subtask navigates back to the parent task correctly.
- Verify that clicking the task title in `NewTaskToolView` navigates to the task details.
- Check behavior in both browser and VSCode webview environments.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-629936a56ada420c972bcb17e67f1b49)