### PR TITLE
chore(vscode): clean up related data when removing stale tasks

### DIFF
--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -25,6 +25,7 @@ export type {
   McpConfigOverride,
   TaskArchivedParams,
 } from "./types/task";
+export { getChangedFileStoreKey } from "./types/task";
 export type {
   VSCodeLmModel,
   VSCodeLmRequestCallback,

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -93,3 +93,11 @@ export type TaskStates = Record<string, TaskState>;
 export type TaskArchivedParams =
   | { type: "single"; taskId: string; archived: boolean }
   | { type: "batch"; cwd?: string };
+
+/**
+ * Get the global state key for the changed file store of a task.
+ * This is used by both the webview (zustand persist) and vscode extension (cleanup).
+ */
+export function getChangedFileStoreKey(taskId: string): string {
+  return `changed-file-store-${taskId}`;
+}

--- a/packages/vscode-webui/src/lib/hooks/use-task-changed-files.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-task-changed-files.ts
@@ -1,6 +1,9 @@
 import { fileChangeEvent, vscodeHost } from "@/lib/vscode";
 import { getLogger } from "@getpochi/common";
-import type { TaskChangedFile } from "@getpochi/common/vscode-webui-bridge";
+import {
+  type TaskChangedFile,
+  getChangedFileStoreKey,
+} from "@getpochi/common/vscode-webui-bridge";
 import type { Message } from "@getpochi/livekit";
 import { useCallback, useEffect, useMemo } from "react";
 import { create, useStore } from "zustand";
@@ -47,51 +50,6 @@ const vscodeStorage: StateStorage = {
   },
 };
 
-/**
- * Migrates data from localStorage to VS Code global state.
- * This is needed when switching from the default localStorage storage
- * to the custom VS Code global state storage.
- */
-async function migrateFromLocalStorage(storeName: string): Promise<void> {
-  try {
-    // Check if we're in a browser environment with localStorage
-    if (typeof window === "undefined" || !window.localStorage) {
-      return;
-    }
-
-    // Check if data exists in localStorage
-    const localStorageData = window.localStorage.getItem(storeName);
-    if (!localStorageData) {
-      logger.trace(
-        `No migration needed for ${storeName} - no localStorage data`,
-      );
-      return;
-    }
-
-    // Check if data already exists in global state
-    const globalStateData = await vscodeHost.getGlobalState(storeName);
-    if (globalStateData) {
-      logger.trace(
-        `No migration needed for ${storeName} - global state already has data`,
-      );
-      // Clean up localStorage since global state is the source of truth now
-      window.localStorage.removeItem(storeName);
-      return;
-    }
-
-    // Migrate data from localStorage to global state
-    logger.info(`Migrating ${storeName} from localStorage to global state`);
-    const parsedData = JSON.parse(localStorageData);
-    await vscodeHost.setGlobalState(storeName, parsedData);
-
-    // Clean up localStorage after successful migration
-    window.localStorage.removeItem(storeName);
-    logger.info(`Successfully migrated ${storeName}`);
-  } catch (error) {
-    logger.error(`Failed to migrate ${storeName}:`, error);
-    // Don't throw - migration failure shouldn't break the app
-  }
-}
 export type ChangedFileContent =
   | {
       type: "text";
@@ -206,49 +164,23 @@ const createChangedFileStore = (taskId: string) =>
         };
       },
       {
-        name: `changed-file-store-${taskId}`,
+        name: getChangedFileStoreKey(taskId),
         storage: createJSONStorage(() => vscodeStorage),
       },
     ),
   );
 
 const taskStores = new Map<string, ReturnType<typeof createChangedFileStore>>();
-const migrationPromises = new Map<string, Promise<void>>();
 
 export const getTaskChangedFileStore = (taskId: string) => {
   if (taskStores.has(taskId)) {
     return taskStores.get(taskId) as ReturnType<typeof createChangedFileStore>;
   }
 
-  const storeName = `changed-file-store-${taskId}`;
   const storeHook = createChangedFileStore(taskId);
   taskStores.set(taskId, storeHook);
 
-  // Trigger migration from localStorage if needed (async, don't block)
-  if (!migrationPromises.has(taskId)) {
-    const migrationPromise = migrateFromLocalStorage(storeName).then(() => {
-      // After migration, trigger rehydration to load the migrated data
-      return storeHook.persist.rehydrate();
-    });
-    migrationPromises.set(taskId, migrationPromise);
-  }
-
   return storeHook;
-};
-
-/**
- * Wait for the store to complete migration and hydration.
- * Should be called before reading changed files from the store.
- */
-export const waitForTaskStoreReady = async (taskId: string): Promise<void> => {
-  // Ensure store is created (triggers migration if needed)
-  getTaskChangedFileStore(taskId);
-
-  // Wait for migration to complete
-  const migrationPromise = migrationPromises.get(taskId);
-  if (migrationPromise) {
-    await migrationPromise;
-  }
 };
 
 export const useTaskChangedFiles = (
@@ -297,7 +229,6 @@ export const useTaskChangedFiles = (
       if (visibleChangedFiles.length === 0) {
         return;
       }
-      await waitForTaskStoreReady(taskId);
       await vscodeHost.showChangedFiles(
         filePath
           ? visibleChangedFiles.filter((f) => f.filepath === filePath)
@@ -305,15 +236,14 @@ export const useTaskChangedFiles = (
         filePath ? `Changes in ${filePath}` : "Changed Files",
       );
     },
-    [visibleChangedFiles, taskId],
+    [visibleChangedFiles],
   );
 
   const revertFileChanges = useCallback(
     async (file?: string) => {
-      await waitForTaskStoreReady(taskId);
       await revertChangedFile(file);
     },
-    [taskId, revertChangedFile],
+    [revertChangedFile],
   );
 
   const acceptChangedFile = useCallback(

--- a/packages/vscode/src/lib/task-data-store.ts
+++ b/packages/vscode/src/lib/task-data-store.ts
@@ -91,4 +91,30 @@ export class TaskDataStore {
       return result;
     });
   }
+
+  /**
+   * Remove task data for the given task IDs.
+   * Used for cleaning up stale tasks.
+   */
+  async removeTaskData(taskIds: string[]): Promise<void> {
+    if (taskIds.length === 0) {
+      return;
+    }
+
+    const newState = { ...this.state.value };
+    let hasChanges = false;
+
+    for (const taskId of taskIds) {
+      if (taskId in newState) {
+        delete newState[taskId];
+        hasChanges = true;
+        logger.debug(`Removed task data for stale task: ${taskId}`);
+      }
+    }
+
+    if (hasChanges) {
+      await this.context.globalState.update(this.storageKey, newState);
+      this.state.value = newState;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- When TaskHistoryStore cleans up stale tasks (older than 90 days), now also clean up related data:
  - TaskDataStore: mcpConfigOverride and archived state
  - Changed file store: zustand persist data in globalState
- Extract `getChangedFileStoreKey()` to common package for consistency between webview and vscode extension
- Remove unused localStorage migration code from use-task-changed-files.ts

## Test plan
- [x] Unit tests updated and passing for TaskHistoryStore
- [x] Type check passes
- [x] Linting passes

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ad4aec95a62244dc850c07b1b6f43479)