### PR TITLE
chore(ci): sync main branch to pochi branch on tabby

### DIFF
--- a/.github/workflows/sync-tabby.yml
+++ b/.github/workflows/sync-tabby.yml
@@ -1,0 +1,28 @@
+name: Sync to Tabby
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync to Tabby
+        env:
+          GH_TOKEN: ${{ secrets.POCHI_HOMEBREW_GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+          git remote add target https://github.com/${{ github.repository_owner }}/tabby.git
+          git push target HEAD:pochi --no-verify


### PR DESCRIPTION
We can sync main to pochi branch in tabby repository silently and see how it works.

and change to default branch when it's ready and when we need to.

- Test CI: https://github.com/zwpaper/pochi/actions/runs/21484893968/job/61891249735
- Pushed branch: https://github.com/zwpaper/tabby/tree/pochi

## Token update

Please note that i reused the POCHI_HOMEBREW_GITHUB_TOKEN secret, which we used to push codes to homebrew-pochi, to push code to tabby.

so should add:
1. a target repository TabbyML/tabby to the token
2. workflow scope to the token

for example:
<img width="1241" height="1234" alt="image" src="https://github.com/user-attachments/assets/925dd7dd-0da9-405a-8492-c2da5e642bea" />
