### PR TITLE
feat(cli): Support attaching URLs in Pochi CLI

### DIFF
--- a/packages/cli/src/attachment-utils.ts
+++ b/packages/cli/src/attachment-utils.ts
@@ -1,92 +1,90 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { type BlobStore, fileToUri } from "@getpochi/livekit";
-import { prompts } from "@getpochi/common";
-import type { FileUIPart, TextUIPart } from "ai";
 import type { Command } from "@commander-js/extra-typings";
+import { prompts } from "@getpochi/common";
+import { type BlobStore, fileToUri } from "@getpochi/livekit";
+import type { FileUIPart, TextUIPart } from "ai";
 
 export async function processAttachments(
   attachments: string[],
   blobStore: BlobStore,
-  program: Command
+  program: Command,
 ): Promise<(TextUIPart | FileUIPart)[]> {
   const parts: (TextUIPart | FileUIPart)[] = [];
 
   if (attachments && attachments.length > 0) {
-        for (const attachmentPath of attachments) {
-          try {
-            const isRemoteUrl = isUrl(attachmentPath);
-            let dataUrl: string;
-            let mimeType: string;
-            let filename: string;
+    for (const attachmentPath of attachments) {
+      try {
+        const isRemoteUrl = isUrl(attachmentPath);
+        let dataUrl: string;
+        let mimeType: string;
+        let filename: string;
 
-            if (isRemoteUrl) {
-              //TODO: Large video URLs now do not cause OOM, but will still not be completed by the assistant
-              //TODO: Follow up fix is needed to fix this issue.
-              dataUrl = attachmentPath;
-              filename = path.basename(new URL(attachmentPath).pathname);
-  
-              // Special handling for YouTube URLs
-              if (
-                attachmentPath.match(
-                  /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+$/,
-                )
-              ) {
-                mimeType = "video/mp4"; // Treat YouTube as video
+        if (isRemoteUrl) {
+          //TODO: Large video URLs now do not cause OOM, but will still not be completed by the assistant
+          //TODO: Follow up fix is needed to fix this issue.
+          dataUrl = attachmentPath;
+          filename = path.basename(new URL(attachmentPath).pathname);
+
+          // Special handling for YouTube URLs
+          if (
+            attachmentPath.match(
+              /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+$/,
+            )
+          ) {
+            mimeType = "video/mp4"; // Treat YouTube as video
+          } else {
+            // Try to get mime type from HEAD request
+            try {
+              const response = await fetch(attachmentPath, {
+                method: "HEAD",
+              });
+              const contentType = response.headers.get("content-type");
+              if (contentType) {
+                mimeType = contentType.split(";")[0].trim();
               } else {
-                // Try to get mime type from HEAD request
-                try {
-                  const response = await fetch(attachmentPath, {
-                    method: "HEAD",
-                  });
-                  const contentType = response.headers.get("content-type");
-                  if (contentType) {
-                    mimeType = contentType.split(";")[0].trim();
-                  } else {
-                    // Fallback to extension if no content-type header
-                    mimeType = getMimeType(new URL(attachmentPath).pathname);
-                  }
-                } catch (e) {
-                  // Fallback to extension if fetch fails
-                  mimeType = getMimeType(new URL(attachmentPath).pathname);
-                }
+                // Fallback to extension if no content-type header
+                mimeType = getMimeType(new URL(attachmentPath).pathname);
               }
-            } else {
-              const absolutePath = path.resolve(process.cwd(), attachmentPath);
-              const buffer = await fs.readFile(absolutePath);
-              mimeType = getMimeType(attachmentPath);
-              filename = path.basename(absolutePath);
-              dataUrl = await fileToUri(
-                blobStore,
-                new File([buffer], attachmentPath, {
-                  type: mimeType,
-                }),
-              );
+            } catch (e) {
+              // Fallback to extension if fetch fails
+              mimeType = getMimeType(new URL(attachmentPath).pathname);
             }
-  
-            parts.push({
-              type: "text",
-              text: prompts.createSystemReminder(
-                `Attached file: ${
-                  isRemoteUrl
-                    ? attachmentPath
-                    : path.relative(process.cwd(), attachmentPath)
-                }`,
-              ),
-            });
-            parts.push({
-              type: "file",
-              mediaType: mimeType,
-              filename,
-              url: dataUrl,
-            } satisfies FileUIPart);
-          } catch (error) {
-            program.error(
-              `Failed to read attachment: ${attachmentPath}\n${error}`,
-            );
           }
+        } else {
+          const absolutePath = path.resolve(process.cwd(), attachmentPath);
+          const buffer = await fs.readFile(absolutePath);
+          mimeType = getMimeType(attachmentPath);
+          filename = path.basename(absolutePath);
+          dataUrl = await fileToUri(
+            blobStore,
+            new File([buffer], attachmentPath, {
+              type: mimeType,
+            }),
+          );
         }
+
+        parts.push({
+          type: "text",
+          text: prompts.createSystemReminder(
+            `Attached file: ${
+              isRemoteUrl
+                ? attachmentPath
+                : path.relative(process.cwd(), attachmentPath)
+            }`,
+          ),
+        });
+        parts.push({
+          type: "file",
+          mediaType: mimeType,
+          filename,
+          url: dataUrl,
+        } satisfies FileUIPart);
+      } catch (error) {
+        program.error(`Failed to read attachment: ${attachmentPath}\n${error}`);
       }
+    }
+  }
 
   return parts;
 }
@@ -123,7 +121,7 @@ function isUrl(str: string): boolean {
     const url = new URL(str);
     // Allow http, https, gs, and other remote protocols
     // Exclude file:// protocol as those are local paths
-    return url.protocol !== 'file:';
+    return url.protocol !== "file:";
   } catch {
     return false;
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,10 +24,7 @@ import {
 } from "@getpochi/common/configuration";
 import { getVendor, getVendors } from "@getpochi/common/vendor";
 import { createModel } from "@getpochi/common/vendor/edge";
-import {
-  type LLMRequestData,
-  type Message,
-} from "@getpochi/livekit";
+import type { LLMRequestData, Message } from "@getpochi/livekit";
 import chalk from "chalk";
 import * as commander from "commander";
 import z from "zod/v4";
@@ -51,6 +48,7 @@ import type {
   SkillFile,
   ValidCustomAgentFile,
 } from "@getpochi/common/vscode-webui-bridge";
+import { processAttachments } from "./attachment-utils";
 import { JsonRenderer } from "./json-renderer";
 import {
   containsSlashCommandReference,
@@ -68,7 +66,6 @@ import { blobStore } from "./node-blob-store";
 import { OutputRenderer } from "./output-renderer";
 import { TaskRunner } from "./task-runner";
 import { checkForUpdates, registerUpgradeCommand } from "./upgrade";
-import { processAttachments } from "./attachment-utils";
 
 const logger = getLogger("Pochi");
 globalThis.POCHI_CLIENT = `PochiCli/${packageJson.version}`;
@@ -169,7 +166,11 @@ const program = new Command()
     );
 
     const store = await createStore(uid);
-    const parts: Message["parts"] = await processAttachments(attachments, blobStore, program);
+    const parts: Message["parts"] = await processAttachments(
+      attachments,
+      blobStore,
+      program,
+    );
 
     if (prompt) {
       parts.push({ type: "text", text: prompt });


### PR DESCRIPTION
### Summary
- This provides a partial reference for how to handle URLs in Pochi
- Added partial handling for URLs in `cli.ts`. This allows us to now be able to attach urls and fetch the information from URLs in CLI.
- With current implementation, it will also not OOM on large video files


### Unsolved Bugs/Blockers:
- When videos and text based URL are attached, Pochi currently hang on user prompt, and Pochi times out.
- I have tested that at least for text based URL, this is due to enabling all URLs in `vendor-pochi/model.ts`, under the variable `supportedURLs` under the function `createPochiModel`
- This variable changes the behaviour of Pochi, which forces it to attach the URL as a message, rather than download the file and sending the data of the file inline, which is the main cause of OOM for large video files.