### PR TITLE
feat(vendor-pochi): add supported URLs for Google models

### DIFF
--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -24,8 +24,16 @@ export function createPochiModel({
     specificationVersion: "v2",
     provider: "pochi",
     modelId: modelId || "<default>",
-    // FIXME(meng): fill supported urls based on modelId.
-    supportedUrls: {},
+    supportedUrls: modelId.includes("google")
+      ? {
+          "*": [
+            // HTTP URLs:
+            /^https?:\/\/.*$/,
+            // Google Cloud Storage URLs:
+            /^gs:\/\/.*$/,
+          ],
+        }
+      : {},
     doGenerate: async ({
       abortSignal,
       prompt,


### PR DESCRIPTION
## Summary
This PR adds `supportedUrls` configuration for Google-based models in the Pochi vendor. It specifically enables support for:
- HTTP/HTTPS URLs (`http://`, `https://`)
- Google Cloud Storage URLs (`gs://`)

This allows these models to process content from these external sources.

## Test plan
1. Use a Google-based model through Pochi.
2. Verify that `supportedUrls` is correctly populated when the model ID contains "google".
3. Test with an external URL to ensure it's accepted by the model interface.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f9b1306d0a244ddab7ddb4631bee5f65)