### PR TITLE
refactor(skills): move filePath to _meta in useSkill tool output

### DIFF
--- a/packages/cli/src/tools/use-skill.ts
+++ b/packages/cli/src/tools/use-skill.ts
@@ -42,6 +42,8 @@ export const useSkill =
     // Return the skill instructions
     return {
       result: prompts.createUseSkillResult(skill),
-      filePath: resolvedFilePath,
+      _meta: {
+        filePath: resolvedFilePath,
+      },
     };
   };

--- a/packages/tools/src/use-skill.ts
+++ b/packages/tools/src/use-skill.ts
@@ -89,7 +89,13 @@ ${makeSkillToolDescription(skills)}
       result: z
         .string()
         .describe("The result of getting the skill instructions."),
-      filePath: z.string().describe("The file path of the resolved SKILL.md"),
+      _meta: z
+        .object({
+          filePath: z
+            .string()
+            .describe("The file path of the resolved SKILL.md"),
+        })
+        .optional(),
     }),
   });
 };

--- a/packages/vscode-webui/src/features/tools/__stories__/use-skill.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/use-skill.stories.tsx
@@ -62,7 +62,9 @@ export const WithoutFilePath: Story = {
     tool: {
       ...toolCall,
       output: {
-        filePath: "foo.md",
+        _meta: {
+          filePath: "foo.md",
+        },
         result: "Operation completed successfully without file path.",
       },
     },

--- a/packages/vscode-webui/src/features/tools/components/use-skill.tsx
+++ b/packages/vscode-webui/src/features/tools/components/use-skill.tsx
@@ -13,13 +13,13 @@ export const UseSkillTool: React.FC<ToolProps<"useSkill">> = ({
 }) => {
   const { t } = useTranslation();
   const { skill } = tool.input || {};
-  const { result, filePath } = tool.output || {};
+  const { result, _meta } = tool.output || {};
 
   const onClick = useCallback(() => {
-    if (filePath) {
-      vscodeHost.openFile(filePath);
+    if (_meta?.filePath) {
+      vscodeHost.openFile(_meta.filePath);
     }
-  }, [filePath]);
+  }, [_meta?.filePath]);
 
   return (
     <ExpandableToolContainer

--- a/packages/vscode/src/tools/use-skill.ts
+++ b/packages/vscode/src/tools/use-skill.ts
@@ -30,6 +30,8 @@ export const useSkill: ToolFunctionType<ClientTools["useSkill"]> = async (
 
   return {
     result: prompts.createUseSkillResult(skill),
-    filePath: skill.filePath,
+    _meta: {
+      filePath: skill.filePath,
+    },
   };
 };


### PR DESCRIPTION
## Summary
- Refactored `useSkill` tool to move `filePath` into a `_meta` object in its output.
- Updated the Zod schema in `packages/tools` to reflect this change.
- Updated CLI, VSCode extension, and WebUI components to handle the new output structure.
- Updated Storybook stories to match the new schema.

## Test plan
- Verified that the `useSkill` tool still works as expected in both CLI and VSCode.
- Verified that clicking on the skill file path in the WebUI still opens the file correctly.
- Ran existing tests to ensure no regressions.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fe3db3cfa043480ca0bb2ed26340826f)