### PR TITLE
fix(livekit): remove protocol check when URL is supported by model

### DIFF
--- a/packages/livekit/src/store-blob.ts
+++ b/packages/livekit/src/store-blob.ts
@@ -143,7 +143,7 @@ export function makeDownloadFunction(blobStore: BlobStore) {
         data: Uint8Array;
         mediaType: string | undefined;
       } | null> => {
-        if (isUrlSupportedByModel && url.protocol.startsWith("http")) {
+        if (isUrlSupportedByModel) {
           return null;
         }
         if (url.protocol === blobStore.protocol) {


### PR DESCRIPTION
## Summary
- Removed the protocol check `url.protocol.startsWith("http")` in `makeDownloadFunction` when `isUrlSupportedByModel` is true.
- This ensures that if a model explicitly supports a URL (e.g., `gs://` or `http://` for Google models), the `store-blob` download function correctly returns `null` to let the model handle the URL directly.

## Test plan
- Verified that the change correctly allows models to handle supported URLs regardless of their protocol.
- Ran existing tests in `packages/livekit` and `packages/cli` to ensure no regressions.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-259f914e792e432ab6e9a31c18a9eeb1)