### PR TITLE
fix(vscode-webui): hide create pr button on shared pages

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
+++ b/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
@@ -57,7 +57,7 @@ export const AttemptCompletionTool: React.FC<
           <Check className="size-4" />
           {t("toolInvocation.taskCompleted")}
         </span>
-        {isLastPart && !hasPR && !isSubTask && (
+        {!!currentWorkspace && isLastPart && !hasPR && !isSubTask && (
           <Button
             variant="ghost"
             size="sm"


### PR DESCRIPTION
## Summary
- Hide the "Create PR" button in the `AttemptCompletionTool` component when `currentWorkspace` is not present.
- This ensures the button doesn't appear on shared pages or contexts where PR creation is not applicable.

## Test plan
- Verify that the "Create PR" button is hidden when viewing a shared conversation/page.
- Verify that the "Create PR" button still appears in a valid workspace context when a task is completed.

## Screenshot
<img width="1272" height="188" alt="image" src="https://github.com/user-attachments/assets/fcc6e19e-51d5-4ef6-8eaf-bf708eb1a4ee" />


🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3473478d185f47508e00956b2679311b)