### PR TITLE
fix(vscode): ensure proper cleanup of browser sessions

### DIFF
--- a/packages/vscode/src/lib/browser-session-store.ts
+++ b/packages/vscode/src/lib/browser-session-store.ts
@@ -2,12 +2,19 @@ import { spawn } from "node:child_process";
 import type { BrowserSession } from "@getpochi/common/vscode-webui-bridge";
 import { signal } from "@preact/signals-core";
 import { injectable, singleton } from "tsyringe";
+import type * as vscode from "vscode";
 import { getAvailablePort } from "./get-available-port";
 
 @injectable()
 @singleton()
-export class BrowserSessionStore {
+export class BrowserSessionStore implements vscode.Disposable {
   browserSessions = signal<Record<string, BrowserSession>>({});
+
+  dispose() {
+    for (const taskId of Object.keys(this.browserSessions.value)) {
+      void this.unregisterBrowserSession(taskId);
+    }
+  }
 
   async registerBrowserSession(taskId: string) {
     const port = await getAvailablePort();
@@ -21,20 +28,22 @@ export class BrowserSessionStore {
   }
 
   async unregisterBrowserSession(taskId: string) {
-    const { [taskId]: _, ...rest } = this.browserSessions.value;
-    this.browserSessions.value = rest;
-
     // Cleanup agent-browser process
     const envs = this.getAgentBrowserEnvs(taskId);
-    const child = spawn("agent-browser", ["close"], {
-      env: {
-        ...process.env,
-        ...envs,
-      },
-      detached: true,
-      stdio: "ignore",
-    });
-    child.unref();
+    if (envs) {
+      const child = spawn("agent-browser", ["close"], {
+        env: {
+          ...process.env,
+          ...envs,
+        },
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+    }
+
+    const { [taskId]: _, ...rest } = this.browserSessions.value;
+    this.browserSessions.value = rest;
   }
 
   getAgentBrowserEnvs(taskId: string): Record<string, string> | undefined {


### PR DESCRIPTION
## Summary
This PR addresses issues with browser session cleanup in `BrowserSessionStore`.

- Implemented the `dispose` method to iterate through and unregister all active browser sessions when the store is disposed.
- Fixed a bug in `unregisterBrowserSession` where the session data was removed from the state *before* retrieving the environment variables needed to kill the `agent-browser` process. This ensured the process is correctly terminated.

## Test plan
- Verified that `dispose` correctly calls `unregisterBrowserSession` for all sessions.
- Verified that `unregisterBrowserSession` correctly spawns the process to close the `agent-browser` session.
- Ran existing tests for `packages/vscode` and they passed.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-446b61b471c14d00a9e9c1e6491ea02f)