### PR TITLE
fix(cli): attempt-completion hook does not work during streaming completions

### DIFF
--- a/packages/cli/src/json-renderer.ts
+++ b/packages/cli/src/json-renderer.ts
@@ -57,13 +57,10 @@ export class JsonRenderer {
         if (isToolUIPart(part) && part.type === "tool-attemptCompletion") {
           if (part.input) {
             const input = part.input as Record<string, unknown>;
-            if (
-              this.attemptCompletionSchemaOverride 
-            ) {
+            if (this.attemptCompletionSchemaOverride) {
               console.log(JSON.stringify(input.result, null, 2));
             } else {
               console.log(input.result);
-
             }
           }
           return;

--- a/packages/cli/src/output-renderer.ts
+++ b/packages/cli/src/output-renderer.ts
@@ -263,12 +263,12 @@ function renderToolPart(
     const input = part.input || {};
 
     let content = "";
-    if (part.state === "input-streaming"){
+    if (part.state === "input-streaming") {
       return {
         text: "",
         stop: "stopAndPersist",
         error: errorText,
-      }
+      };
     }
     if (attemptCompletionSchemaOverride) {
       content = JSON.stringify(input.result, null, 2);

--- a/packages/tools/src/attempt-completion.ts
+++ b/packages/tools/src/attempt-completion.ts
@@ -8,7 +8,7 @@ export const attemptCompletionSchema = z.object({
     .describe(
       "The result of the task. Formulate this result in a way that is final and does not require further input from the user.",
     ),
-  });
+});
 
 const toolDef = {
   description:


### PR DESCRIPTION
### Summary
- Add fix for completion hook, and improve streaming UI
- Instead of streaming multiple incomplete JSONs, we just display that the answer is still streaming. A sample is attached below.
- Moreover, there was a previous issue with completion hook, where it would just give an error. The main cause is due to `output-renderer.ts` not catching all possible states, and sending some valid requests to the error branch of the if conditional (line 90 of `output-renderer.ts`)
  - This has been fixed by updating the if condition to also accept "call" in the state.
<img width="290" height="54" alt="Screenshot 2026-02-02 at 9 15 14 PM" src="https://github.com/user-attachments/assets/9864a00d-22a4-4184-8879-c62899bf6c72" />

