### PR TITLE
fix(vscode-webui): correct task info initialization logic in task route

### DIFF
--- a/packages/vscode-webui/src/routes/task.tsx
+++ b/packages/vscode-webui/src/routes/task.tsx
@@ -27,7 +27,7 @@ function RouteComponent() {
   const searchParams = Route.useSearch();
   let info: typeof window.POCHI_TASK_INFO;
   if (window.POCHI_WEBVIEW_KIND === "pane" && window.POCHI_TASK_INFO) {
-    if (info?.uid !== searchParams.uid) {
+    if (searchParams.uid === window.POCHI_TASK_INFO.uid) {
       info = window.POCHI_TASK_INFO;
     } else {
       info = {


### PR DESCRIPTION
## Summary
- Corrected the logic for initializing the `info` object in the task route.
- Replaced an incorrect check on an uninitialized variable `info?.uid` with a direct comparison between `searchParams.uid` and `window.POCHI_TASK_INFO.uid`.

## Test plan
1. Open a task in the VS Code pane.
2. Verify that the task information is correctly loaded and displayed.
3. Switch between different tasks and ensure the UI updates correctly with the new task information.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4b1db3bd37a4469ea074fbb7e3f3c46c)