### PR TITLE
docs(livekit): refine comments in filterCompletionTools

### DIFF
--- a/packages/livekit/src/chat/filter-completion-tools.ts
+++ b/packages/livekit/src/chat/filter-completion-tools.ts
@@ -1,11 +1,10 @@
 import type { Message } from "../types";
 
-// type A: attemptCompletion/askFollowupQuestion
-// type B: toolcalls exclude todoWrite and attemptCompletion/askFollowupQuestion
-
-// Rules:
-// If there are both type A and B tool calls in the last step, remove all type A tool calls
-
+// Condition A: The last step contains completion tools (attemptCompletion or askFollowupQuestion).
+// Condition B: The last step contains other functional tools (excluding todoWrite).
+// Rule:
+// If both conditions are met, remove the completion tools. This prevents the agent from
+// attempting to complete the task or ask a question while simultaneously performing other actions.
 export function filterCompletionTools(message: Message): Message {
   const lastStepStartIndex = message.parts.findLastIndex(
     (part) => part.type === "step-start",


### PR DESCRIPTION
## Summary
Refines the comments in `filterCompletionTools` to clearer explain the logic for filtering completion tools when other functional tools are present.

## Test plan
- Verify the code logic remains unchanged, only comments are updated.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-68760f80f929417799b9c1995ea8359f)