### PR TITLE
fix(vscode): update task archiving test for new filter dropdown UI

### DIFF
--- a/packages/vscode/tests/pageobjects/pochi-sidebar.ts
+++ b/packages/vscode/tests/pageobjects/pochi-sidebar.ts
@@ -157,14 +157,22 @@ export class PochiSidebar {
   }
 
   async toggleArchivedTasksVisibility() {
-    // Find the Tasks header and hover to reveal the toggle button
+    // Find the Tasks header and hover to reveal the filter button
     const tasksHeader = $('[data-testid="tasks-header"]');
     await tasksHeader.moveTo();
 
-    // Click the toggle all/active tasks button
-    const toggleButton = $('[data-testid="toggle-all-tasks"]');
-    await toggleButton.waitForClickable();
-    await toggleButton.click();
+    // Click the filter dropdown button
+    const filterButton = $('[data-testid="filter-tasks-dropdown"]');
+    await filterButton.waitForClickable();
+    await filterButton.click();
+
+    // Wait for dropdown to open
+    await browser.pause(300);
+
+    // Click the archived tasks checkbox
+    const archivedCheckbox = $('[data-testid="filter-archived-tasks"]');
+    await archivedCheckbox.waitForClickable();
+    await archivedCheckbox.click();
 
     // Wait for UI to update
     await browser.pause(500);


### PR DESCRIPTION
## Summary
- Updated `toggleArchivedTasksVisibility()` in the test page object to work with the new filter dropdown UI
- The UI changed from a simple toggle button (`data-testid="toggle-all-tasks"`) to a filter dropdown menu with checkboxes (`data-testid="filter-tasks-dropdown"` and `data-testid="filter-archived-tasks"`)

## Test plan
- [ ] Run the task archiving integration test: `bun turbo test:integration --filter=pochi -- --spec tests/specs/git-workspace/task-archiving.test.ts`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-89b0120a10d846b4b267a1744a2de3e3)