### PR TITLE
fix: refactor and improve post processing for tab completion NES models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -253,7 +253,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.27.0-dev",
+      "version": "0.29.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/vscode/src/tab-completion/providers/nes-clients/post-process.ts
+++ b/packages/vscode/src/tab-completion/providers/nes-clients/post-process.ts
@@ -1,0 +1,57 @@
+import { linesDiffComputers } from "vscode-diff";
+import type { TabCompletionContext } from "../../context";
+import {
+  LinesDiffOptions,
+  type RangeMapping,
+  type TextChange,
+  type TextDocumentSnapshot,
+  type TextEdit,
+  createTextDocumentSnapshotWithApplyEdit,
+  getLines,
+  toCodeDiff,
+  toOffsetRange,
+} from "../../utils";
+
+export function postprocess(
+  edit: TextEdit,
+  context: TabCompletionContext,
+  filterFn: (
+    change: RangeMapping,
+    originalDocument: TextDocumentSnapshot,
+    modifiedDocument: TextDocumentSnapshot,
+  ) => boolean,
+): TextEdit | undefined {
+  const document = context.documentSnapshot;
+  const editedDocument = createTextDocumentSnapshotWithApplyEdit(
+    document,
+    edit,
+  );
+  const diffResult = linesDiffComputers
+    .getDefault()
+    .computeDiff(
+      getLines(document),
+      getLines(editedDocument),
+      LinesDiffOptions,
+    );
+  const diff = toCodeDiff(diffResult);
+
+  const changes: TextChange[] = [];
+  for (const change of diff.changes) {
+    for (const innerChange of change.innerChanges) {
+      if (filterFn(innerChange, document, editedDocument)) {
+        changes.push({
+          range: toOffsetRange(innerChange.original, document),
+          text: editedDocument.getText(innerChange.modified),
+        });
+      }
+    }
+  }
+
+  if (changes.length < 1) {
+    return undefined;
+  }
+
+  return {
+    changes,
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted NES post-processing logic into a shared `postprocess` utility to ensure consistency between `NESChatModelClient` and `NESSweepModelClient`.
- Improved blank line detection and filtering during the post-processing phase.
- Refactored `TabCompletionSolutionItem` to use the shared `LinesDiffOptions` and simplified its diffing logic.
- Moved common diffing utilities and constants to `packages/vscode/src/tab-completion/utils/code-diff.ts`.

## Test plan
1. Trigger tab completion using NES models (Chat and Sweep).
2. Verify that completions are still correctly suggested and applied.
3. Verify that unwanted blank line additions/removals are correctly filtered out as before, but now through the shared logic.
4. Run existing tests to ensure no regressions in tab completion logic.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-54d7e4cd7ab24520ac631454dc58b093)