### PR TITLE
feat(vscode): support opening log file in developer mode for Pochi layout

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -726,6 +726,10 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Enable Pochi Layout."
+                  },
+                  "developerMode": {
+                    "type": "boolean",
+                    "default": false
                   }
                 }
               },

--- a/packages/vscode/src/integrations/configuration.ts
+++ b/packages/vscode/src/integrations/configuration.ts
@@ -214,6 +214,7 @@ const PochiAdvanceSettings = z.object({
   pochiLayout: z
     .object({
       enabled: z.boolean().optional(),
+      developerMode: z.boolean().optional(),
     })
     .optional(),
   logToFile: z

--- a/packages/vscode/src/integrations/layout/layout-manager.ts
+++ b/packages/vscode/src/integrations/layout/layout-manager.ts
@@ -16,6 +16,7 @@ import {
   findActivePochiTaskTab,
   getTabGroupType,
   getTabGroupsShape,
+  isPochiOutputTab,
   isPochiTaskTab,
   isSameTabGroupsShape,
   isSameTabInput,
@@ -641,6 +642,19 @@ export class LayoutManager implements vscode.Disposable {
     }
     logger.trace("End merge tabs in split window.");
 
+    // Open Pochi output log in dev mode
+    if (
+      this.configuration.advancedSettings.value.pochiLayout?.developerMode &&
+      !this.allTabGroups[2].tabs.some((tab) => isPochiOutputTab(tab))
+    ) {
+      await focusEditorGroup(2);
+      await executeVSCodeCommand("workbench.action.unlockEditorGroup");
+      await executeVSCodeCommand("pochi.outputPanel.focus");
+      await executeVSCodeCommand("workbench.action.openActiveLogOutputFile");
+      await executeVSCodeCommand("workbench.action.lockEditorGroup");
+      await executeVSCodeCommand("workbench.action.closeAuxiliaryBar");
+    }
+
     // Move all terminals from panel into terminal groups, then lock
     await this.moveTerminalsImpl();
 
@@ -819,7 +833,9 @@ export class LayoutManager implements vscode.Disposable {
   private async moveTerminalsImpl() {
     for (
       let i = 0;
-      i < vscode.window.terminals.length - countTerminalTabs(this.allTabGroups);
+      i <
+      vscode.window.terminals.length -
+        countTerminalTabs(this.allTabGroups, true);
       i++
     ) {
       await focusEditorGroup(2);

--- a/packages/vscode/src/integrations/layout/tab-utils.ts
+++ b/packages/vscode/src/integrations/layout/tab-utils.ts
@@ -12,10 +12,26 @@ export function isPochiTaskTab(tab: vscode.Tab): tab is vscode.Tab & {
   );
 }
 
-export function isTerminalTab(tab: vscode.Tab): tab is vscode.Tab & {
+export function isTerminalTab(
+  tab: vscode.Tab,
+  excludeOutput = false,
+): tab is vscode.Tab & {
   input: vscode.TabInputTerminal;
 } {
-  return tab.input instanceof vscode.TabInputTerminal;
+  return (
+    tab.input instanceof vscode.TabInputTerminal ||
+    (!excludeOutput &&
+      tab.input instanceof vscode.TabInputText &&
+      tab.input.uri.scheme === "output")
+  );
+}
+
+export function isPochiOutputTab(tab: vscode.Tab) {
+  return (
+    tab.input instanceof vscode.TabInputText &&
+    tab.input.uri.scheme === "output" &&
+    tab.input.uri.path === "TabbyML.pochi.Pochi.log"
+  );
 }
 
 export function getTabGroupType(tabs: readonly vscode.Tab[]) {
@@ -151,9 +167,14 @@ export function countPochiTaskTabs(tabGroups: TabGroupShape) {
   );
 }
 
-export function countTerminalTabs(tabGroups: TabGroupShape) {
+export function countTerminalTabs(
+  tabGroups: TabGroupShape,
+  excludeOutput = false,
+) {
   return tabGroups.reduce(
-    (acc, group) => acc + group.tabs.filter((tab) => isTerminalTab(tab)).length,
+    (acc, group) =>
+      acc +
+      group.tabs.filter((tab) => isTerminalTab(tab, excludeOutput)).length,
     0,
   );
 }


### PR DESCRIPTION
## Summary
- Added `developerMode` setting to `pochiLayout` configuration.
- Automatically open Pochi output log in the right bottom group when `developerMode` is enabled and Pochi layout is active.
- Improved terminal tab detection and counting logic in layout manager.

## Test plan
- Enable Pochi layout and `developerMode` in settings.
- Verify that Pochi output log is opened in the right bottom group.
- Verify that terminals are still correctly moved to the right bottom group.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-410bd64c0a414ea19d471cedacf6d180)