### PR TITLE
fix(common): add Flatpak support for shell command execution

### DIFF
--- a/packages/common/src/tool-utils/__tests__/shell.test.ts
+++ b/packages/common/src/tool-utils/__tests__/shell.test.ts
@@ -60,6 +60,18 @@ describe("buildShellCommand", () => {
       args: ["-c", "echo 'hello'"],
     });
   });
+
+  it("should use flatpak-spawn on Linux when running inside Flatpak", () => {
+    vi.stubGlobal("process", {
+      platform: "linux",
+      env: { SHELL: "/bin/bash", FLATPAK_ID: "com.visualstudio.code" },
+    });
+    const command = buildShellCommand("echo 'hello'");
+    expect(command).toEqual({
+      command: "/usr/bin/flatpak-spawn",
+      args: ["--host", "/bin/bash", "-lc", "echo 'hello'"],
+    });
+  });
 });
 
 describe("fixExecuteCommandOutput", () => {
@@ -73,4 +85,3 @@ describe("fixExecuteCommandOutput", () => {
     expect(fixExecuteCommandOutput(output)).toBe("line 1\r\nline 2");
   });
 });
-


### PR DESCRIPTION
## Summary
- Detect Flatpak environment via `FLATPAK_ID` or `FLATPAK_SANDBOX_DIR` environment variables
- Use `flatpak-spawn --host` to execute shell commands on the host system when running inside Flatpak
- Use login shell flag (`-lc`) instead of (`-c`) for proper environment initialization in Flatpak

## Test plan
- [x] Added unit test for Flatpak shell command execution
- [x] Manual test on Flatpak VS Code installation

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f3d69aa5da95477cac1e2a32cd0d2840)