### PR TITLE
fix(vscode-webui): simplify completion check in browser view

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
@@ -15,10 +15,7 @@ export function BrowserView(props: NewTaskToolViewProps) {
     props;
   const { t } = useTranslation();
   const description = tool.input?.description;
-  const completed =
-    tool.state === "output-available" &&
-    "result" in tool.output &&
-    tool.output.result.trim().length > 0;
+  const completed = tool.state === "output-available";
   const browserSession = useBrowserSession(uid || "");
   const streamUrl = browserSession?.streamUrl;
   const frame = useBrowserFrame({


### PR DESCRIPTION
## Summary
- Simplify the completion check in `BrowserView` component by removing the check for result content length.

## Test plan
- Verify that the browser view correctly indicates completion when the tool state is "output-available".

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c2076075850346a18d26ada2200b507e)