### PR TITLE
fix(vscode-webui): align worktree list title and improve filter icon

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -49,9 +49,10 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
-  Filter,
   GitCompare,
   GitPullRequest,
+  ListFilterIcon,
+  ListFilterPlusIcon,
   Loader2,
   Plus,
   Terminal,
@@ -209,10 +210,10 @@ export function WorktreeList({
     <div className="flex flex-col gap-1">
       {/* Tasks Header */}
       <div
-        className="group flex items-center gap-2 px-1 pt-2 pb-1"
+        className="group flex items-center gap-2 px-1 pb-1"
         data-testid="tasks-header"
       >
-        <span className="font-bold font-sans text-sm uppercase">
+        <span className="font-bold font-sans text-sm uppercase leading-6">
           {t("tasksPage.tasks")}
         </span>
         <div
@@ -228,15 +229,15 @@ export function WorktreeList({
                   <Button
                     variant="ghost"
                     size="sm"
-                    className={cn(
-                      "h-6 w-6 p-0",
-                      hasActiveFilters &&
-                        "text-primary hover:bg-primary/10 hover:text-primary",
-                    )}
+                    className="h-6 w-6 p-0"
                     aria-label="filter-tasks-button"
                     data-testid="filter-tasks-dropdown"
                   >
-                    <Filter className="size-4" />
+                    {hasActiveFilters ? (
+                      <ListFilterPlusIcon className="size-4" />
+                    ) : (
+                      <ListFilterIcon className="size-4" />
+                    )}
                   </Button>
                 </DropdownMenuTrigger>
               </TooltipTrigger>


### PR DESCRIPTION

<img width="642" height="334" alt="image" src="https://github.com/user-attachments/assets/f69a8a2a-366f-462b-b94a-fda12a5d28cc" />

<img width="652" height="508" alt="image" src="https://github.com/user-attachments/assets/fa0fce60-8064-40a8-8b8d-db74b14e06db" />


## Summary
- Remove top padding from tasks header and add `leading-6` to title for consistent vertical alignment
- Replace `Filter` icon with `ListFilterIcon` and `ListFilterPlusIcon` from lucide-react
- Show `ListFilterPlusIcon` when filters are active to provide visual feedback of filter state

## Test plan
- [ ] Verify the tasks header alignment is consistent
- [ ] Verify the filter icon changes when filters are active vs inactive

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e449c79a2ab341c0989fff9f68b377a5)