### PR TITLE
fix(vscode): improve handling of 402/429 errors in status bar

### DIFF
--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -291,6 +291,13 @@ export class CommandManager implements vscode.Disposable {
       }),
 
       vscode.commands.registerCommand(
+        "pochi.showWarningMessage",
+        async (message: string) => {
+          vscode.window.showWarningMessage(message);
+        },
+      ),
+
+      vscode.commands.registerCommand(
         "pochi.webui.navigate.taskList",
         async () => {
           await vscode.commands.executeCommand("pochiSidebar.focus");

--- a/packages/vscode/src/integrations/status-bar-item.ts
+++ b/packages/vscode/src/integrations/status-bar-item.ts
@@ -185,7 +185,11 @@ export class StatusBarItem implements vscode.Disposable {
         this.statusBarItem.text = "$(warning) Pochi";
         this.statusBarItem.tooltip = this.tabCompletionManager.error.value;
         this.statusBarItem.backgroundColor = undefined;
-        this.statusBarItem.command = undefined;
+        this.statusBarItem.command = {
+          command: "pochi.showWarningMessage",
+          title: "",
+          arguments: [this.tabCompletionManager.error.value],
+        };
         break;
 
       case "ready":

--- a/packages/vscode/src/tab-completion/utils/errors.ts
+++ b/packages/vscode/src/tab-completion/utils/errors.ts
@@ -49,15 +49,3 @@ export function isCanceledError(error: unknown) {
     (error instanceof HttpError && error.status === 499)
   );
 }
-
-export function isUnauthorizedError(error: unknown) {
-  return error instanceof HttpError && [401, 403].includes(error.status);
-}
-
-export function isRateLimitExceededError(error: unknown) {
-  return error instanceof HttpError && error.status === 429;
-}
-
-export function isPaymentRequiredError(error: unknown) {
-  return error instanceof HttpError && error.status === 402;
-}


### PR DESCRIPTION
## Summary
- Detect 402 (Payment Required) and 429 (Rate Limit Exceeded) errors in completion manager.
- Expose error state in completion manager.
- Update status bar to show warning icon and error message tooltip when these errors occur.

## Test plan
- Manually verified that 402/429 errors trigger the warning icon in the status bar.
- Verified that other errors do not trigger the warning icon.
- Verified that the error clears when the condition is resolved.

## Screenshot
<img width="780" height="240" alt="image" src="https://github.com/user-attachments/assets/758478af-d318-46f2-bdf1-931d8a1b5aa3" />


🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-76d49ac7dacc4df9bd60a6658432cb2f)