### PR TITLE
fix(common): deduplicate matches from fallback search strategies in diff-utils

### DIFF
--- a/packages/common/src/__tests__/diff-utils.test.ts
+++ b/packages/common/src/__tests__/diff-utils.test.ts
@@ -404,6 +404,45 @@ const x = 1;`;
         ).rejects.toThrow(DiffError);
       });
 
+      it("should reject duplicate matches produced by fallback search strategies", async () => {
+        const fileContent = `interface VSCodeHostApi {
+  previewToolCall(
+    toolName: string,
+    args: unknown,
+    options: {
+      toolCallId: string;
+      state: "partial-call" | "call" | "result";
+      abortSignal?: ThreadAbortSignalSerialization;
+    },
+  ): Promise<PreviewReturnType>;
+}`;
+
+        const searchContent = `  previewToolCall(
+    toolName: string,
+    args: unknown,
+    options: {
+      toolCallId: string;
+      state: "partial-call" | "call" | "result";
+      abortSignal?: ThreadAbortSignalSerialization;
+    },
+  ): Promise<PreviewReturnType>;`;
+
+        const replaceContent = `  previewToolCall(
+    toolName: string,
+    args: unknown,
+    options: {
+      toolCallId: string;
+      state: "partial-call" | "call" | "result";
+      abortSignal?: ThreadAbortSignalSerialization;
+      taskId?: string;
+    },
+  ): Promise<PreviewReturnType>;`;
+
+        await expect(
+          parseDiffAndApply(fileContent, searchContent, replaceContent, 2),
+        ).rejects.toThrow(DiffError);
+      });
+
       it("should handle content with only whitespace", async () => {
         const fileContent = "   \n  \n   ";
         const searchContent = "   ";
@@ -496,7 +535,7 @@ function test() {
           fileContent,
           searchContent,
           replaceContent,
-          3, // All matches: exact, trimmed, and potentially block anchor
+          2, // Two unique matches in file content
         );
 
         expect(result).toContain("return 2;");


### PR DESCRIPTION
## Summary
- Add unique match tracking using `start:end` position keys to prevent duplicate matches when multiple search strategies (exact, line-trimmed, block anchor) find the same location
- Sort matches by position before applying replacements for consistent ordering
- Add test case that verifies duplicate matches from fallback strategies are properly rejected

## Test plan
- [x] Existing diff-utils tests pass
- [x] New test case for duplicate match detection
- [x] Manual testing with the interface case that could produce duplicate matches

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-296f925223ca4c9a88c048b139f5db05)