### PR TITLE
fix(vscode): handle disposed status in completion request

### DIFF
--- a/packages/vscode/src/tab-completion/providers/provider.ts
+++ b/packages/vscode/src/tab-completion/providers/provider.ts
@@ -40,6 +40,9 @@ export class TabCompletionProvider implements vscode.Disposable {
           this.error.value = status.error.message;
         } else if (status.type === "finished") {
           this.error.value = undefined;
+        } else if (status.type === "disposed") {
+          this.disposables = this.disposables.filter((d) => d !== disposable);
+          disposable.dispose();
         }
       }),
     };

--- a/packages/vscode/src/tab-completion/providers/request.ts
+++ b/packages/vscode/src/tab-completion/providers/request.ts
@@ -15,7 +15,8 @@ export type TabCompletionProviderRequestStatus =
   | TabCompletionProviderRequestStatusInit
   | TabCompletionProviderRequestStatusProcessing
   | TabCompletionProviderRequestStatusFinished
-  | TabCompletionProviderRequestStatusError;
+  | TabCompletionProviderRequestStatusError
+  | TabCompletionProviderRequestStatusDisposed;
 
 export interface TabCompletionProviderRequestStatusInit {
   readonly type: "init";
@@ -34,6 +35,10 @@ export interface TabCompletionProviderRequestStatusFinished {
 export interface TabCompletionProviderRequestStatusError {
   readonly type: "error";
   readonly error: Error;
+}
+
+export interface TabCompletionProviderRequestStatusDisposed {
+  readonly type: "disposed";
 }
 
 export class TabCompletionProviderRequest implements vscode.Disposable {
@@ -181,5 +186,9 @@ export class TabCompletionProviderRequest implements vscode.Disposable {
       this.fetchingCancellationTokenSource.cancel();
       this.fetchingCancellationTokenSource = undefined;
     }
+
+    this.updateStatus({
+      type: "disposed",
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Added `disposed` status to `TabCompletionProviderRequestStatus`.
- Updated `TabCompletionProviderRequest.dispose` to emit `disposed` status.
- Implemented cleanup logic in `TabCompletionProvider` to remove and dispose requests when they are marked as disposed.

## Test plan
- Verify that completion requests are properly cleaned up when cancelled or finished.
- Check that no memory leaks occur with rapid completion requests.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-73092e8e10044df0bebe7cea03af9c78)