### PR TITLE
fix(vscode-webui): increase subtask max steps and retries

### DIFF
--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -377,8 +377,8 @@ export function useLiveSubTask(
   };
 }
 
-const SubtaskMaxStep = 100;
-const SubtaskMaxRetry = 2;
+const SubtaskMaxStep = 65535;
+const SubtaskMaxRetry = 8;
 
 const useInitAutoStart = ({
   start,


### PR DESCRIPTION
## Summary
- Increase `SubtaskMaxStep` from 100 to 65535.
- Increase `SubtaskMaxRetry` from 2 to 8.

These changes allow for longer running subtasks and make them more resilient by increasing the retry limit.

## Test plan
1. Verified that subtasks can now exceed 100 steps if needed.
2. Verified that subtasks retry up to 8 times on failure.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0a4d5aa513c0449b9ebcd13d79238cc6)