### PR TITLE
feat(vscode): include recent edit history from other files in completion context

### DIFF
--- a/packages/vscode/src/tab-completion/utils/text-document-edit-step.ts
+++ b/packages/vscode/src/tab-completion/utils/text-document-edit-step.ts
@@ -13,6 +13,7 @@ export class TextDocumentEditStep {
 
   private after: TextDocumentSnapshot;
   private lastEditedRanges: OffsetRange[] | undefined = undefined;
+  private lastEditedTimestamp: number | undefined = undefined;
 
   constructor(base: TextDocumentSnapshot, initialEdit: TextEdit) {
     this.before = base;
@@ -48,6 +49,10 @@ export class TextDocumentEditStep {
     return result;
   }
 
+  getTimestamp() {
+    return this.lastEditedTimestamp;
+  }
+
   // return true if appended as continuing edit.
   // return false if the edit is not continuing edit, in which case it is not appended.
   appendEdit(newEdit: TextEdit): boolean {
@@ -62,6 +67,7 @@ export class TextDocumentEditStep {
     this.offsetMaps.push(offsetMap);
     this.after = createTextDocumentSnapshotWithNewText(this.after, text);
     this.lastEditedRanges = editedRanges;
+    this.lastEditedTimestamp = Date.now();
     return true;
   }
 


### PR DESCRIPTION
## Summary
This PR enhances the context provided to the completion model by including recent edit steps from other tracked files.

Key changes:
- `EditHistoryTracker`: Added `getOtherFilesEditSteps` to retrieve edit steps from other files, sorted by recency.
- `NESSweepModelClient`: Updated to fetch and include these edit steps as diffs in the prompt, sorted by timestamp.
- `TextDocumentEditStep`: Added timestamp tracking for edits.

This allows the model to be aware of recent changes across the project, potentially improving the relevance of completions.

## Test plan
1. Open multiple files in VS Code.
2. Make edits in file A and file B.
3. Switch to file C and trigger completion.
4. Verify that the completion model context includes the recent edits from file A and file B.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-cc87a1743b4546baaa39e5c4afa6a08e)