### PR TITLE
fix(vscode-webui): prevent down arrow from clearing input when at latest history

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/submit-history-extension.ts
+++ b/packages/vscode-webui/src/components/prompt-form/submit-history-extension.ts
@@ -129,6 +129,13 @@ export const SubmitHistoryExtension = Extension.create<
             if (storage.currentIndex > 0) {
               storage.currentIndex--;
             } else if (storage.currentIndex === 0) {
+              // Check if current content is already the latest history content
+              // If so, don't clear input - just return false to allow default cursor behavior
+              const latestHistoryContent = storage.history[historyLength - 1];
+              if (currentContent === latestHistoryContent) {
+                return false;
+              }
+
               // Go back to current draft
               storage.currentIndex = -1;
               storage.isNavigating = false;


### PR DESCRIPTION
## Summary
- Fixes a bug where pressing the down arrow would clear the input if the content matches the latest history item.
- Ensures that if the current content is already the latest history content, the down arrow allows default cursor behavior instead of resetting to the draft.

## Test plan
1. Type something and submit it to add to history.
2. Press Up arrow to recall the latest history item.
3. Press Down arrow.
4. Verify that the input is not cleared (it should remain as the latest history item or allow cursor movement).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d0aeb7812f2f4d1cb20ab5083b10b6d7)