### PR TITLE
fix(settings): subtask offhand defaults

### DIFF
--- a/packages/vscode-webui/src/features/settings/store.ts
+++ b/packages/vscode-webui/src/features/settings/store.ts
@@ -105,7 +105,7 @@ export const useSettingsStore = create<SettingsState>()(
     (set) => ({
       selectedModel: undefined,
       subtaskSelectedModel: undefined,
-      subtaskOffhand: false,
+      subtaskOffhand: true,
 
       autoApproveActive: true,
       autoApproveSettings: {
@@ -115,7 +115,6 @@ export const useSettingsStore = create<SettingsState>()(
         retry: true,
         maxRetryLimit: 3,
         mcp: false,
-        autoRunSubtask: true,
       },
 
       // subtask manual run specific auto-approve settings
@@ -127,7 +126,6 @@ export const useSettingsStore = create<SettingsState>()(
         retry: true,
         maxRetryLimit: 3,
         mcp: false,
-        autoRunSubtask: false,
       },
 
       isDevMode: false,


### PR DESCRIPTION
## Summary
- default subtask offhand to true to align with manual run behaviour
- drop the stale autoRunSubtask flag from persisted auto-approve settings

## Test plan
- bun run test (via pre-push hook)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e3140b15f5d04acdbdb80a6276770a9a)