### PR TITLE
fix(ci): skip git hooks during patch release to avoid EPIPE errors

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -173,7 +173,8 @@ jobs:
           git checkout .
           git checkout ${{ steps.parse_version.outputs.pre_branch }}
           cd packages/vscode
-          bun run release --release patch --quiet --yes
+          # Use --no-git-hooks to skip pre-push hook in CI (already validated by CI workflows)
+          bun run release --release patch --quiet --yes --no-git-hooks
 
       - name: Manual Approval
         if: steps.parse_version.outputs.parse_failed == 'false' && steps.parse_version.outputs.is_pre == 'true'
@@ -265,7 +266,8 @@ jobs:
           git checkout .
           git checkout ${{ steps.parse_version.outputs.main_branch }}
           cd packages/vscode
-          bun run release --release patch --quiet --yes
+          # Use --no-git-hooks to skip pre-push hook in CI (already validated by CI workflows)
+          bun run release --release patch --quiet --yes --no-git-hooks
 
       - name: Report Failure
         if: failure() && steps.parse_version.outputs.parse_failed == 'false'


### PR DESCRIPTION
## Summary
- Add `--no-git-hooks` flag to bumpp release commands in the patch-release workflow
- This prevents EPIPE errors that occur with Node.js v24+ when biome output pipe is closed prematurely during the pre-push hook
- The CI workflows already validate the code before release, so skipping the pre-push hook is safe in this context

## Test plan
- [ ] Verify patch release workflow runs successfully without EPIPE errors

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a58b6e98547e4c2a96bba4c370e156c3)