### PR TITLE
feat(vscode-webui): add enhanced diff viewer with validation and fallback

### DIFF
--- a/.pochi/skills/validator/SKILL.md
+++ b/.pochi/skills/validator/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: validator
+description: Validates code changes by writing/updating integration tests, running them, and fixing failures. Use after making UI or extension modifications.
+---
+
+# Integration Test Validator
+
+You validate code changes by writing tests, running them, and fixing any failures. Should follow E2E Testing Guidelines.
+
+## Trigger
+
+Invoke after making code changes to:
+- UI components in `packages/vscode-webui/`
+- Extension code in `packages/vscode/src/`
+- Core logic in `packages/common/`
+
+## Workflow
+
+### Step 1: Analyze Changes
+
+1. Identify what functionality was added/modified
+2. Check existing test coverage in `packages/vscode/tests/specs/`
+3. Determine if new tests needed or existing tests need updates
+
+### Step 2: Write/Update Tests
+
+Tests are organized by workspace type:
+- `git-workspace/` - Tests requiring a git repository
+- `plain-workspace/` - Tests for non-git directories
+- `git-worktrees-workspace/` - Tests for git worktrees
+- `no-workspace/` - Tests without any workspace
+
+Follow existing patterns:
+
+```typescript
+import { browser, expect } from "@wdio/globals";
+import type { Workbench } from "wdio-vscode-service";
+import { PochiSidebar } from "../../pageobjects/pochi-sidebar";
+
+describe("Feature Name", () => {
+  let workbench: Workbench;
+
+  beforeEach(async () => {
+    workbench = await browser.getWorkbench();
+  });
+
+  it("should [expected behavior]", async () => {
+    const pochi = new PochiSidebar();
+    await pochi.open();
+
+    // Test actions...
+
+    await pochi.close();
+    expect(result).toBeDefined();
+  });
+});
+```
+
+### Step 3: Run Tests
+
+From the repository root:
+
+```bash
+# Run specific test
+bun turbo test:integration --filter=pochi -- --spec "./tests/specs/git-workspace/create-task.test.ts"
+
+# Run all tests for a workspace type
+bun turbo test:integration --filter=pochi -- --spec "./tests/specs/git-workspace/**/*.ts"
+
+# Run all integration tests
+bun turbo test:integration --filter=pochi
+```
+
+### Step 4: Fix Failures (if any)
+
+**Error Classification:**
+
+| Error Type | Likely Cause | Fix |
+|------------|--------------|-----|
+| Element not found | Selector changed | Update selector in test |
+| Timeout | Async issue | Add waits or increase timeout |
+| Assertion failed | Logic mismatch | Fix code or update expectation |
+| Runtime error | Code bug | Check stack trace, fix source |
+
+**Common Fixes:**
+
+```typescript
+// Element not found → Add wait
+const element = await $('.my-element');
+await element.waitForDisplayed({ timeout: 10000 });
+
+// Timeout → Use waitUntil
+await browser.waitUntil(
+  async () => await $('.response').isExisting(),
+  { timeout: 30000 }
+);
+```
+
+### Step 5: Iterate
+
+1. Re-run only the failing test
+2. Maximum 3 fix attempts per failure
+3. If still failing after 3 attempts, escalate to user
+
+## Safety Rules
+
+- Max 3 fix attempts per test
+- Never skip tests to make suite pass
+- Always explain what was fixed and why
+- Verify no regressions by running related tests

--- a/bun.lock
+++ b/bun.lock
@@ -344,6 +344,7 @@
         "@livestore/sync-cf": "catalog:",
         "@livestore/utils": "catalog:",
         "@livestore/wa-sqlite": "catalog:",
+        "@pierre/diffs": "^1.1.0-beta.13",
         "@preact/signals-core": "catalog:",
         "@quilted/threads": "catalog:",
         "@radix-ui/react-avatar": "^1.1.7",
@@ -1166,6 +1167,8 @@
     "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.3.15", "", { "dependencies": { "asn1js": "^3.0.5", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w=="],
 
     "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "asn1js": "^3.0.5", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg=="],
+
+    "@pierre/diffs": ["@pierre/diffs@1.1.0-beta.13", "", { "dependencies": { "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-D35rxDu5V7XHX5aVGU6PF12GhscL+I+9QYgxK/i3h0d2XSirAxDdVNm49aYwlOhgmdvL0NbS1IHxPswVB5yJvw=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "https://registry.npmmirror.com/@pinojs/redact/-/redact-0.4.0.tgz", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
@@ -3197,6 +3200,8 @@
 
     "lru-cache": ["lru-cache@11.1.0", "", {}, "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="],
 
+    "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
+
     "lucide-react": ["lucide-react@0.542.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
@@ -4658,6 +4663,8 @@
     "@parcel/watcher/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
     "@parcel/watcher/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "@pierre/diffs/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
     "@poppinss/dumper/@sindresorhus/is": ["@sindresorhus/is@7.0.2", "", {}, "sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw=="],
 

--- a/packages/vscode-webui/package.json
+++ b/packages/vscode-webui/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@ai-sdk/react": "catalog:",
     "@getpochi/common": "workspace:*",
+    "@pierre/diffs": "^1.1.0-beta.13",
     "@getpochi/livekit": "workspace:*",
     "@getpochi/vendor-codex": "workspace:*",
     "@getpochi/vendor-gemini-cli": "workspace:*",

--- a/packages/vscode-webui/src/components/message/diff-viewer.tsx
+++ b/packages/vscode-webui/src/components/message/diff-viewer.tsx
@@ -1,0 +1,184 @@
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { parsePatchFiles, resolveThemes } from "@pierre/diffs";
+import { PatchDiff } from "@pierre/diffs/react";
+import { Columns2, Rows2, WrapText } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../theme-provider";
+import { CodeBlock } from "./code-block";
+
+export interface DiffViewerProps {
+  /** The diff patch content to display */
+  patch: string;
+  /** The file path to display in the header */
+  filePath?: string;
+}
+
+// Pre-resolve themes to avoid async loading on each render
+let themesResolved = false;
+const resolveThemesOnce = async () => {
+  if (themesResolved) return;
+  try {
+    await resolveThemes(["dark-plus", "light-plus"]);
+    themesResolved = true;
+  } catch (err) {
+    console.error("Failed to resolve themes for diff viewer:", err);
+  }
+};
+
+export const DiffViewer: React.FC<DiffViewerProps> = ({ patch, filePath }) => {
+  const { theme } = useTheme();
+  const { t } = useTranslation();
+  const [isReady, setIsReady] = useState(themesResolved);
+  const [diffStyle, setDiffStyle] = useState<"unified" | "split">("unified");
+  const [lineWrap, setLineWrap] = useState(false);
+
+  // Validate the patch using parsePatchFiles
+  const isValidPatch = useMemo(() => {
+    try {
+      const parsed = parsePatchFiles(patch, undefined, true);
+      // Check if we got at least one valid patch with files
+      return parsed.length > 0 && parsed.some((p) => p.files.length > 0);
+    } catch {
+      return false;
+    }
+  }, [patch]);
+
+  // Resolve themes on first render
+  useEffect(() => {
+    if (!themesResolved) {
+      resolveThemesOnce().then(() => setIsReady(true));
+    }
+  }, []);
+
+  const options = useMemo(
+    () => ({
+      theme: theme === "dark" ? "dark-plus" : "light-plus",
+      diffStyle,
+      overflow: lineWrap ? ("wrap" as const) : ("scroll" as const),
+      disableFileHeader: true,
+      diffIndicators: "bars" as const,
+    }),
+    [theme, diffStyle, lineWrap],
+  );
+
+  const toggleDiffStyle = () => {
+    setDiffStyle((prev) => (prev === "unified" ? "split" : "unified"));
+  };
+
+  const toggleLineWrap = () => {
+    setLineWrap((prev) => !prev);
+  };
+
+  // If patch is invalid, fall back to CodeBlock render
+  if (!isValidPatch) {
+    return <CodeBlock language="diff" value={patch} />;
+  }
+
+  // Don't render until themes are ready
+  if (!isReady) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center p-4 text-muted-foreground text-sm",
+        )}
+      >
+        {t("diffViewer.loading")}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "diff-viewer-container overflow-hidden rounded-sm border bg-[var(--vscode-editor-background)]",
+      )}
+    >
+      {filePath && (
+        <div className="flex items-center justify-between border-b px-2 py-1">
+          {filePath && (
+            <span className="truncate font-mono text-muted-foreground text-xs">
+              {filePath}
+            </span>
+          )}
+          <div className="ml-auto flex gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className={cn(
+                    "size-6 p-0 text-xs opacity-70 hover:opacity-100",
+                    lineWrap && "bg-accent opacity-100",
+                  )}
+                  onClick={toggleLineWrap}
+                  aria-label={t("diffViewer.toggleLineWrap")}
+                >
+                  <WrapText className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="m-0">
+                  {lineWrap
+                    ? t("diffViewer.disableLineWrap")
+                    : t("diffViewer.enableLineWrap")}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-6 p-0 text-xs opacity-70 hover:opacity-100"
+                  onClick={toggleDiffStyle}
+                  aria-label={t("diffViewer.toggleView")}
+                >
+                  {diffStyle === "unified" ? (
+                    <Columns2 className="size-4" />
+                  ) : (
+                    <Rows2 className="size-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="m-0">
+                  {diffStyle === "unified"
+                    ? t("diffViewer.splitView")
+                    : t("diffViewer.unifiedView")}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+      )}
+      <div className="max-h-60 overflow-auto">
+        <PatchDiff
+          patch={patch}
+          options={{
+            ...options,
+            unsafeCSS: `
+            [data-separator="line-info"] {
+              height: 24px;
+            }`,
+          }}
+          style={
+            {
+              "--diffs-font-family": "JetBrains Mono, monospace",
+              "--diffs-font-size": "11px",
+              "--diffs-line-height": 1.5,
+            } as React.CSSProperties
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
+DiffViewer.displayName = "DiffViewer";

--- a/packages/vscode-webui/src/components/message/user-edits.tsx
+++ b/packages/vscode-webui/src/components/message/user-edits.tsx
@@ -1,4 +1,4 @@
-import { CodeBlock } from "@/components/message";
+import { DiffViewer } from "@/components/message/diff-viewer";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
@@ -203,12 +203,7 @@ function UserEditItem({ edit, checkpoints, hideActions }: UserEditItemProps) {
       </div>
       <CollapsibleContent>
         <div className="pr-3 pb-2 pl-9">
-          <CodeBlock
-            className=""
-            language="diff"
-            value={edit.diff}
-            isMinimalView={true}
-          />
+          <DiffViewer patch={edit.diff} filePath={edit.filepath} />
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/packages/vscode-webui/src/features/tools/components/apply-diff.tsx
+++ b/packages/vscode-webui/src/features/tools/components/apply-diff.tsx
@@ -49,7 +49,13 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
   const details = [];
 
   if (result?._meta?.edit) {
-    details.push(<ModelEdits key="model-edits" edit={result?._meta?.edit} />);
+    details.push(
+      <ModelEdits
+        key="model-edits"
+        edit={result?._meta?.edit}
+        filePath={path}
+      />,
+    );
   }
 
   if (result?.newProblems) {
@@ -61,7 +67,7 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
   const expandableDetail = details.length > 0 ? <>{details}</> : undefined;
 
   const detail = previewInfo?.edit ? (
-    <ModelEdits edit={previewInfo.edit} />
+    <ModelEdits edit={previewInfo.edit} filePath={path} />
   ) : null;
 
   return (

--- a/packages/vscode-webui/src/features/tools/components/code-edits.tsx
+++ b/packages/vscode-webui/src/features/tools/components/code-edits.tsx
@@ -1,11 +1,12 @@
-import { CodeBlock } from "@/components/message";
+import { DiffViewer } from "@/components/message/diff-viewer";
 
 export const ModelEdits: React.FC<{
   edit: string;
-}> = ({ edit }) => {
+  filePath?: string;
+}> = ({ edit, filePath }) => {
   return (
     <div className="my-2 ml-1 flex flex-col">
-      <CodeBlock className="" language="diff" value={edit} />
+      <DiffViewer patch={edit} filePath={filePath} />
     </div>
   );
 };

--- a/packages/vscode-webui/src/features/tools/components/multi-apply-diff.tsx
+++ b/packages/vscode-webui/src/features/tools/components/multi-apply-diff.tsx
@@ -52,7 +52,13 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
   const details = [];
 
   if (result?._meta?.edit) {
-    details.push(<ModelEdits key="model-edits" edit={result?._meta?.edit} />);
+    details.push(
+      <ModelEdits
+        key="model-edits"
+        edit={result?._meta?.edit}
+        filePath={path}
+      />,
+    );
   }
 
   if (result?.newProblems) {
@@ -64,7 +70,7 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
   const expandableDetail = details.length > 0 ? <>{details}</> : undefined;
 
   const detail = previewInfo?.edit ? (
-    <ModelEdits edit={previewInfo.edit} />
+    <ModelEdits edit={previewInfo.edit} filePath={path} />
   ) : null;
 
   return (

--- a/packages/vscode-webui/src/features/tools/components/write-to-file.tsx
+++ b/packages/vscode-webui/src/features/tools/components/write-to-file.tsx
@@ -50,7 +50,13 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
   const details = [];
 
   if (result?._meta?.edit) {
-    details.push(<ModelEdits key="model-edits" edit={result?._meta?.edit} />);
+    details.push(
+      <ModelEdits
+        key="model-edits"
+        edit={result?._meta?.edit}
+        filePath={path}
+      />,
+    );
   }
 
   if (result?.newProblems) {
@@ -62,7 +68,7 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
   const expandableDetail = details.length > 0 ? <>{details}</> : undefined;
 
   const detail = previewInfo?.edit ? (
-    <ModelEdits edit={previewInfo.edit} />
+    <ModelEdits edit={previewInfo.edit} filePath={path} />
   ) : null;
 
   return (

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -354,6 +354,15 @@
     "copy": "Copy",
     "toggleLineWrap": "Toggle line wrap"
   },
+  "diffViewer": {
+    "loading": "Loading diff viewer...",
+    "toggleView": "Toggle diff view",
+    "splitView": "Switch to split view",
+    "unifiedView": "Switch to unified view",
+    "toggleLineWrap": "Toggle line wrap",
+    "enableLineWrap": "Enable line wrap",
+    "disableLineWrap": "Disable line wrap"
+  },
   "messageList": {
     "compactedConversationTooltip": "Conversation has been compacted from this point onward to reduce token usage"
   },

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -352,6 +352,15 @@
     "copy": "コピー",
     "toggleLineWrap": "行の折り返しを切り替える"
   },
+  "diffViewer": {
+    "loading": "差分ビューアを読み込み中...",
+    "toggleView": "差分表示を切り替え",
+    "splitView": "分割表示に切り替え",
+    "unifiedView": "統合表示に切り替え",
+    "toggleLineWrap": "折り返しを切り替え",
+    "enableLineWrap": "折り返しを有効にする",
+    "disableLineWrap": "折り返しを無効にする"
+  },
   "messageList": {
     "compactedConversationTooltip": "トークン使用量を削減するため、この時点から会話が圧縮されています"
   },

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -351,6 +351,15 @@
     "copy": "복사",
     "toggleLineWrap": "줄 바꿈 전환"
   },
+  "diffViewer": {
+    "loading": "차이점 뷰어 로딩 중...",
+    "toggleView": "차이점 보기 전환",
+    "splitView": "분할 보기로 전환",
+    "unifiedView": "통합 보기로 전환",
+    "toggleLineWrap": "줄 바꿈 전환",
+    "enableLineWrap": "줄 바꿈 활성화",
+    "disableLineWrap": "줄 바꿈 비활성화"
+  },
   "messageList": {
     "compactedConversationTooltip": "토큰 사용량을 줄이기 위해 이 지점부터 대화가 압축되었습니다"
   },

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -350,6 +350,15 @@
     "copy": "复制",
     "toggleLineWrap": "切换换行"
   },
+  "diffViewer": {
+    "loading": "加载差异查看器...",
+    "toggleView": "切换差异视图",
+    "splitView": "切换到分栏视图",
+    "unifiedView": "切换到统一视图",
+    "toggleLineWrap": "切换自动换行",
+    "enableLineWrap": "启用自动换行",
+    "disableLineWrap": "禁用自动换行"
+  },
   "messageList": {
     "compactedConversationTooltip": "从此处开始，对话已被压缩以减少令牌使用量"
   },

--- a/packages/vscode/src/lib/__test__/create-pretty-patch.test.ts
+++ b/packages/vscode/src/lib/__test__/create-pretty-patch.test.ts
@@ -59,17 +59,24 @@ suite("diff-utils", () => {
 
     test("should handle both strings empty or undefined", () => {
       let result = createPrettyPatch("file", "", "");
-      assert.strictEqual(
-        result,
-        "",
-        "With empty strings, no diff content should remain after header removal",
+      // With empty strings, we get only the header lines (no hunks)
+      assert.ok(
+        result.includes("Index: file"),
+        "With empty strings, should include Index header",
+      );
+      assert.ok(
+        !result.includes("@@"),
+        "With empty strings, should not include hunk header",
       );
 
       result = createPrettyPatch("file", undefined, undefined);
-      assert.strictEqual(
-        result,
-        "",
-        "With undefined strings, no diff content should remain after header removal",
+      assert.ok(
+        result.includes("Index: file"),
+        "With undefined strings, should include Index header",
+      );
+      assert.ok(
+        !result.includes("@@"),
+        "With undefined strings, should not include hunk header",
       );
     });
 
@@ -87,19 +94,20 @@ suite("diff-utils", () => {
       assert.ok(result.includes("+line5"), "Should include added line");
     });
 
-    test("should skip the first 4 lines of the diff output", () => {
+    test("should include full patch format for proper parsing", () => {
       const oldStr = "line1";
       const newStr = "modified line1";
 
       const result = createPrettyPatch("file", oldStr, newStr);
 
+      // Now returns full patch including headers for parsePatchFiles validation
       assert.ok(
-        !result.includes("diff --git"),
-        "Should not include diff --git line",
+        result.includes("Index: file"),
+        "Should include Index header",
       );
-      assert.ok(!result.includes("index"), "Should not include index line");
-      assert.ok(!result.includes("---"), "Should not include --- line");
-      assert.ok(!result.includes("+++"), "Should not include +++ line");
+      assert.ok(result.includes("--- file"), "Should include --- line");
+      assert.ok(result.includes("+++ file"), "Should include +++ line");
+      assert.ok(result.includes("@@"), "Should include hunk header");
     });
   });
 });

--- a/packages/vscode/src/lib/fs.ts
+++ b/packages/vscode/src/lib/fs.ts
@@ -27,9 +27,7 @@ export function createPrettyPatch(
   newStr?: string,
 ) {
   const patch = diff.createPatch(filename, oldStr || "", newStr || "");
-  const lines = patch.split("\n");
-  const prettyPatchLines = lines.slice(4);
-  return prettyPatchLines.join("\n");
+  return patch;
 }
 
 /**


### PR DESCRIPTION
## Screenshot

<img width="1914" height="560" alt="image" src="https://github.com/user-attachments/assets/05df2622-3d1a-43b4-b46d-759c33ba70cd" />

<img width="1974" height="556" alt="image" src="https://github.com/user-attachments/assets/5b2e4ac7-94fc-4eb0-9bea-bfc590d058cd" />


## Summary
- Add a new `DiffViewer` component using `@pierre/diffs` for rich diff visualization with unified/split view toggle and line wrap options
- Validate patches with `parsePatchFiles` before rendering; falls back to `CodeBlock` when patch is invalid (e.g., trimmed data)
- Replace `CodeBlock` with `DiffViewer` in user edits display and tool invocation results (applyDiff, writeToFile, multiApplyDiff)
- Return full patch from `createPrettyPatch` instead of trimming header lines, enabling proper patch parsing

## Test plan
- [x] Verify diff viewer renders valid patches correctly
- [x] Verify fallback to CodeBlock when patch is invalid/trimmed
- [x] Verify user edits section displays diffs with new viewer
- [x] Verify tool results (applyDiff, writeToFile, multiApplyDiff) display diffs correctly
- [x] All unit tests pass

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d58a2fc63306431f9215aa0b18bb633e)