### PR TITLE
fix(vscode-webui): remove unnecessary wrapper div for video in BrowserView

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
@@ -36,15 +36,13 @@ export function BrowserView(props: NewTaskToolViewProps) {
       expandable={!!videoUrl || !!frame}
     >
       {videoUrl ? (
-        <div className="relative aspect-video h-[200px]">
-          {/* biome-ignore lint/a11y/useMediaCaption: No audio track available */}
-          <video
-            src={videoUrl}
-            controls
-            playsInline
-            className="h-full w-full object-contain"
-          />
-        </div>
+        // biome-ignore lint/a11y/useMediaCaption: No audio track available
+        <video
+          src={videoUrl}
+          controls
+          playsInline
+          className="aspect-video h-full w-full object-contain"
+        />
       ) : frame ? (
         <img
           src={`data:image/jpeg;base64,${frame}`}


### PR DESCRIPTION
## Summary
- Removed the wrapper `div` around the `video` element in `BrowserView`.
- Applied `aspect-video` directly to the `video` element to simplify the layout and ensure correct aspect ratio handling.

## Test plan
- Verify that the video in the browser view tool still displays correctly with the correct aspect ratio.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c722b17308eb4ae484640eaaf031c078)