### PR TITLE
feat(vscode-webui): show last tool call in sub-agent view

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
@@ -113,7 +113,7 @@ export function SubAgentView({
           {showExpandIcon && (
             <div className="flex items-center">
               <ExpandIcon
-                className="mt-1 rotate-270 cursor-pointer text-muted-foreground"
+                className="rotate-270 cursor-pointer text-muted-foreground"
                 isExpanded={!isCollapsed}
                 onClick={() => setIsCollapsed(!isCollapsed)}
               />
@@ -121,8 +121,8 @@ export function SubAgentView({
                 <div className="truncate text-muted-foreground text-xs">
                   <ToolCallLite
                     tools={[lastToolCall.current]}
-                    textOnly
-                    showDetails
+                    showApprove={false}
+                    showCommandDetails
                   />
                 </div>
               )}

--- a/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
@@ -9,15 +9,15 @@ import { useTranslation } from "react-i18next";
 interface Props {
   tools: Array<ToolUIPart<UITools>> | undefined;
   requiresApproval?: boolean;
-  textOnly?: boolean;
-  showDetails?: boolean;
+  showApprove?: boolean;
+  showCommandDetails?: boolean;
 }
 
 export function ToolCallLite({
   tools,
   requiresApproval,
-  textOnly,
-  showDetails,
+  showApprove = true,
+  showCommandDetails,
 }: Props) {
   const { t } = useTranslation();
 
@@ -40,7 +40,12 @@ export function ToolCallLite({
       );
       break;
     case "tool-executeCommand":
-      detail = <ExecuteCommandTool tool={tool} showDetails={showDetails} />;
+      detail = (
+        <ExecuteCommandTool
+          tool={tool}
+          showCommandDetails={showCommandDetails}
+        />
+      );
       break;
     case "tool-startBackgroundJob":
       detail = <StartBackgroundJobTool tool={tool} />;
@@ -86,7 +91,7 @@ export function ToolCallLite({
 
   return detail ? (
     <div className="flex flex-nowrap items-center overflow-x-hidden whitespace-nowrap">
-      {!textOnly &&
+      {showApprove &&
         (requiresApproval ? (
           <Pause className="size-3.5 shrink-0" />
         ) : (
@@ -129,7 +134,7 @@ interface LabelAndFilePathViewProps<T extends ToolName> {
 
 interface ToolCallLiteViewProps<T extends ToolName> {
   tool: Extract<ToolUIPart<UITools>, { type: `tool-${T}` }>;
-  showDetails?: boolean;
+  showCommandDetails?: boolean;
 }
 
 const LabelAndFilePathView = ({
@@ -151,7 +156,7 @@ const LabelAndFilePathView = ({
 
 const ExecuteCommandTool = ({
   tool,
-  showDetails,
+  showCommandDetails,
 }: ToolCallLiteViewProps<"executeCommand">) => {
   const { t } = useTranslation();
 
@@ -169,7 +174,7 @@ const ExecuteCommandTool = ({
       <span className="ml-2">
         {text}
         {cwdNode}
-        {showDetails ? ` ${command}` : ""}
+        {showCommandDetails ? ` ${command}` : ""}
       </span>
     </>
   );


### PR DESCRIPTION
## Summary
- Show the last tool call in the sub-agent view header when collapsed or running.
- Update `ToolCallLite` to support text-only mode and showing details.
- Show command details in `ExecuteCommandTool` when `showDetails` is enabled.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/7db64ad8-8f7f-4213-937f-c34de21ab3d0" />

## Test plan
- Verify that the last tool call is displayed in the sub-agent view header when the agent is running or the view is collapsed.
- Verify that the tool call is displayed in text-only mode.
- Verify that the command is shown for `executeCommand` tool calls.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-303d10965d0248268f9d5034053401fe)