### PR TITLE
feat(planner): restrict file access for planner agent

### DIFF
--- a/packages/common/src/tool-utils/__tests__/resolve-tool-call-args.test.ts
+++ b/packages/common/src/tool-utils/__tests__/resolve-tool-call-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolvePochiUri, resolveToolCallArgs } from "../resolve-tool-call-args";
+import { PlannerPermissionError, resolvePochiUri, resolveToolCallArgs } from "../resolve-tool-call-args";
 
 describe("resolvePochiUri", () => {
   const taskId = "task-123";
@@ -75,5 +75,17 @@ describe("resolveToolCallArgs", () => {
     expect(resolveToolCallArgs(123, taskId)).toBe(123);
     expect(resolveToolCallArgs(null, taskId)).toBe(null);
     expect(resolveToolCallArgs(true, taskId)).toBe(true);
+  });
+
+  it("should resolve plan.md for planner", () => {
+    expect(
+      resolveToolCallArgs("pochi://-/plan.md", taskId, { type: "planner" }),
+    ).toBe("pochi://task-123/plan.md");
+  });
+
+  it("should throw error for planner writing to non-plan files", () => {
+    expect(() =>
+      resolveToolCallArgs("pochi://-/file.txt", taskId, { type: "planner" }),
+    ).toThrowError(PlannerPermissionError);
   });
 });

--- a/packages/common/src/tool-utils/resolve-tool-call-args.ts
+++ b/packages/common/src/tool-utils/resolve-tool-call-args.ts
@@ -1,28 +1,54 @@
 import * as R from "remeda";
+import type { BuiltinSubAgentInfo } from "../vscode-webui-bridge";
 
-export const resolvePochiUri = (path: string, taskId: string) => {
+export class PlannerPermissionError extends Error {
+  constructor() {
+    super("Planner only able to write pochi://-/plan.md");
+  }
+}
+
+export const resolvePochiUri = (
+  path: string,
+  taskId: string,
+  builtinSubAgentInfo?: BuiltinSubAgentInfo,
+): string => {
   if (!path.startsWith("pochi:")) {
     return path;
+  }
+
+  if (builtinSubAgentInfo?.type === "planner" && path !== "pochi://-/plan.md") {
+    throw new PlannerPermissionError();
   }
 
   return path.replace("/-/", `/${taskId}/`);
 };
 
-export const resolveToolCallArgs = (args: unknown, taskId: string): unknown => {
+export const resolveToolCallArgs = (
+  args: unknown,
+  taskId: string,
+  builtinSubAgentInfo?: BuiltinSubAgentInfo,
+): unknown => {
   if (typeof args === "string") {
     try {
-      return resolvePochiUri(args, taskId);
+      return resolvePochiUri(args, taskId, builtinSubAgentInfo);
     } catch (err) {
+      if (err instanceof PlannerPermissionError) {
+        throw err;
+      }
       return args;
     }
   }
 
   if (Array.isArray(args)) {
-    return args.map((item) => resolveToolCallArgs(item, taskId));
+    return args.map((item) =>
+      resolveToolCallArgs(item, taskId, builtinSubAgentInfo),
+    );
   }
 
   if (R.isObjectType(args)) {
-    return R.mapValues(args, (v) => resolveToolCallArgs(v, taskId));
+    return R.mapValues(args, (v) =>
+      resolveToolCallArgs(v, taskId, builtinSubAgentInfo),
+    );
   }
 
   return args;

--- a/packages/common/src/vscode-webui-bridge/types/sub-agent.ts
+++ b/packages/common/src/vscode-webui-bridge/types/sub-agent.ts
@@ -1,4 +1,8 @@
-export interface BuiltinSubAgentInfo {
-  type: "browser";
-  sessionId: string;
-}
+export type BuiltinSubAgentInfo =
+  | {
+      type: "browser";
+      sessionId: string;
+    }
+  | {
+      type: "planner";
+    };

--- a/packages/vscode-webui/src/features/approval/components/tool-call-approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/tool-call-approval-button.tsx
@@ -90,7 +90,9 @@ export const ToolCallApprovalButton: React.FC<ToolCallApprovalButtonProps> = ({
   const builtinSubAgentInfo: BuiltinSubAgentInfo | undefined =
     isSubTask && subtask?.agent === "browser" && taskId
       ? { type: subtask.agent, sessionId: taskId }
-      : undefined;
+      : isSubTask && subtask?.agent === "planner"
+        ? { type: subtask.agent }
+        : undefined;
 
   const manualRunSubtask = useCallback(
     (subtaskUid: string) => {

--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -132,7 +132,11 @@ export function useLiveSubTask(
               type: tool.input.agentType,
               sessionId: uid,
             }
-          : undefined;
+          : tool.input?.agentType === "planner"
+            ? {
+                type: "planner",
+              }
+            : undefined;
 
       const result = await vscodeHost.executeToolCall(
         toolCall.toolName,

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -494,7 +494,11 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
         options.builtinSubAgentInfo,
       );
       const toolCallStart = Date.now();
-      const resolvedArgs = resolveToolCallArgs(args, options.taskId);
+      const resolvedArgs = resolveToolCallArgs(
+        args,
+        options.taskId,
+        options.builtinSubAgentInfo,
+      );
       const result = await safeCall(
         tool(resolvedArgs, {
           abortSignal,
@@ -569,6 +573,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
         args,
         options.taskId,
       ) as Partial<unknown> | null;
+
       return await safeCall<PreviewReturnType>(
         tool(resolvedArgs, {
           ...options,


### PR DESCRIPTION
## Summary
- Restrict planner agent to only write to `pochi://-/plan.md`.
- Update `resolveToolCallArgs` to enforce this restriction.
- Pass `builtinSubAgentInfo` correctly in `vscode-webui` and `vscode` host.
- Add tests for the restriction.

## Test plan
- Verify that planner agent can only write to `pochi://-/plan.md`.
- Verify that other agents are not affected.
- Run tests: `bun run test`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-845b5dfeb47a43529adc57cfe209a01f)