### PR TITLE
refactor(vscode): remove changed files migration logic

### DIFF
--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1250,9 +1250,6 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
   });
 
   readTaskChangedFiles = async (taskId: string) => {
-    // Migrate from global state if needed (async, handles its own errors)
-    await this.taskChangedFilesManager.migrateFromGlobalState(taskId);
-
     return {
       changedFiles: ThreadSignal.serialize(
         this.taskChangedFilesManager.getChangedFilesSignal(taskId),

--- a/packages/vscode/src/lib/task-changed-files-manager.ts
+++ b/packages/vscode/src/lib/task-changed-files-manager.ts
@@ -226,13 +226,6 @@ export class TaskChangedFilesManager {
   }
 
   /**
-   * Migrate changed files from global state (old storage) to task data store.
-   */
-  async migrateFromGlobalState(taskId: string): Promise<boolean> {
-    return this.taskDataStore.migrateFromGlobalState(taskId);
-  }
-
-  /**
    * Show changed files in a diff view.
    * @param taskId The task ID
    * @param cwd The current working directory


### PR DESCRIPTION
## Summary
- Removes the `migrateFromGlobalState` method from `TaskDataStore` that was used to migrate changed files from the old global state storage format
- Removes the wrapper method in `TaskChangedFilesManager`
- Removes the migration call in `VSCodeHostImpl.readTaskChangedFiles`

The migration logic is no longer needed as users have had sufficient time to migrate from the old storage format.

## Test plan
- [x] TypeScript compilation passes
- [ ] Verify existing changed files functionality works correctly

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-bf61ebbcc1c343e49c86c2dc4086d89c)