### PR TITLE
fix(fim): fim openai config and fetcher mismatch

### DIFF
--- a/packages/vscode/src/tab-completion/providers/fim-clients/models/openai.ts
+++ b/packages/vscode/src/tab-completion/providers/fim-clients/models/openai.ts
@@ -20,7 +20,11 @@ export class FIMOpenAIModel implements FIMCompletionModel {
   private readonly promptTemplate: string;
 
   constructor(config: OpenAIProviderConfig) {
-    this.fetcher = new OpenAIFetcher(config);
+    this.fetcher = new OpenAIFetcher({
+      baseURL: config.baseURL,
+      authToken: config.apiKey,
+      model: config.model,
+    });
     this.model = config.model?.trim();
     this.promptTemplate =
       config.promptTemplate?.trim() || getDefaultPromptTemplate(this.model);


### PR DESCRIPTION
The config is using apiKey, but OpenAI fetcher is using authToken.

this pr fix the issue to let OpenAI FIM pass the auth token correctly

before:

<img width="729" height="96" alt="image" src="https://github.com/user-attachments/assets/6f3923fe-ef46-436f-8aae-f6f1602ef370" />

after:

<img width="1073" height="236" alt="image" src="https://github.com/user-attachments/assets/53c0c312-910e-4876-8d06-97ff60816764" />
