### PR TITLE
fix(vscode-webui): only show planner footer actions for the last message

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
@@ -23,8 +23,14 @@ const reviewTutorialImage =
   "https://app.getpochi.com/images/review-plan-tutorial.gif";
 
 export function PlannerView(props: NewTaskToolViewProps) {
-  const { tool, isExecuting, taskSource, uid, toolCallStatusRegistryRef } =
-    props;
+  const {
+    tool,
+    isExecuting,
+    taskSource,
+    uid,
+    toolCallStatusRegistryRef,
+    isLastPart,
+  } = props;
 
   const { t } = useTranslation();
   const store = useDefaultStore();
@@ -69,7 +75,8 @@ export function PlannerView(props: NewTaskToolViewProps) {
       taskSource={taskSource}
       toolCallStatusRegistryRef={toolCallStatusRegistryRef}
       footerActions={
-        isVSCodeEnvironment() && (
+        isVSCodeEnvironment() &&
+        isLastPart && (
           <>
             <HoverCard
               openDelay={0}


### PR DESCRIPTION
## Summary
- Ensure "Review Plan" and "Execute Plan" buttons are only visible for the most recent planner message.
- Prevents confusion with older plans in the chat history.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e2c73975-5fce-48c6-9798-1ec3a0ae2f2c" />

## Test plan
- Verify that only the latest planner message shows the "Review Plan" and "Execute Plan" buttons.
- Verify that older planner messages do not show these buttons.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0560ef460f194702b6be3b994c0414cc)