### PR TITLE
fix(vscode-webui): ensure browser agent shows latest streaming frame after resuming recording

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
@@ -35,7 +35,7 @@ export function BrowserView(props: NewTaskToolViewProps) {
       toolCallStatusRegistryRef={toolCallStatusRegistryRef}
       expandable={!!videoUrl || !!frame}
     >
-      {videoUrl ? (
+      {!isExecuting && videoUrl ? (
         // biome-ignore lint/a11y/useMediaCaption: No audio track available
         <video
           src={videoUrl}

--- a/packages/vscode-webui/src/lib/browser-session-manager.ts
+++ b/packages/vscode-webui/src/lib/browser-session-manager.ts
@@ -84,7 +84,10 @@ export class BrowserRecordingSession {
             if (data.type === "frame") {
               const frame = data.data;
               this.addFrame(frame);
-              this.notifyFrame(frame);
+              // Only notify subscribers after recording has started (passed white screen check)
+              if (this.muxer) {
+                this.notifyFrame(frame);
+              }
             } else if (data.type === "error") {
               logger.error("Browser message error", event);
               this.ws?.close();


### PR DESCRIPTION
## Summary
- Fixes an issue where the browser agent would not show the latest streaming frame after resuming recording.
- Ensures `notifyFrame` is only called when `this.muxer` is available.
- Updates `BrowserView` to only show the video element when execution is complete.

## Test plan
- Verify that the browser agent correctly displays the streaming frame when running.
- Verify that the video player is shown after the task completes.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1f878b93ba2a41ddb6a4e6245c6e4fbb)