### PR TITLE
fix(vscode): fix notebook context for FIM client

### DIFF
--- a/packages/vscode/src/tab-completion/completion-manager.ts
+++ b/packages/vscode/src/tab-completion/completion-manager.ts
@@ -373,7 +373,7 @@ export class TabCompletionManager implements vscode.Disposable {
     const editHistory = editHistoryTracker.getEditSteps(event.document);
 
     const notebook = vscode.workspace.notebookDocuments.find((notebook) => {
-      notebook.getCells().some((cell) => {
+      return notebook.getCells().some((cell) => {
         return cell.document.uri.toString() === event.document.uri.toString();
       });
     });

--- a/packages/vscode/src/tab-completion/providers/fim-clients/client.ts
+++ b/packages/vscode/src/tab-completion/providers/fim-clients/client.ts
@@ -75,12 +75,9 @@ export class FIMClient
     let notebookCellsPrefix = "";
     let notebookCellsSuffix = "";
     if (notebookCells) {
-      const currentCellIndex = notebookCells.indexOf(document);
-      if (
-        currentCellIndex >= 0 &&
-        currentCellIndex < notebookCells.length - 1
-      ) {
-        const currentLanguageId = document.languageId;
+      const currentCellIndex = notebookCells.indexOf(context.document);
+      if (currentCellIndex >= 0 && currentCellIndex < notebookCells.length) {
+        const currentLanguageId = context.document.languageId;
         const formatContext = (cells: vscode.TextDocument[]): string => {
           const notebookLanguageComments: {
             [languageId: string]: (code: string) => string;
@@ -104,7 +101,7 @@ export class FIMClient
                 )
               ) {
                 return (
-                  notebookLanguageComments[currentLanguageId]?.(
+                  notebookLanguageComments[textDocument.languageId]?.(
                     textDocument.getText(),
                   ) ?? ""
                 );
@@ -132,8 +129,10 @@ export class FIMClient
       return undefined;
     }
 
-    const documentCurrentLineSuffixRange = document.validateRange(
-      new vscode.Range(position.line, position.character, position.line + 1, 0),
+    const currentLine = document.lineAt(position.line);
+    const documentCurrentLineSuffixRange = new vscode.Range(
+      position,
+      currentLine.range.end,
     );
     const documentCurrentLineSuffix = documentCurrentLineSuffixRange.isEmpty
       ? ""
@@ -143,14 +142,12 @@ export class FIMClient
       ? documentCurrentLineSuffix.replace(/\r?\n$/, "").length
       : 0;
 
-    const suffixRange = document.validateRange(
-      new vscode.Range(
-        new vscode.Position(
-          position.line,
-          position.character + lineEndReplaceLength,
-        ),
-        fullDocumentRange.end,
+    const suffixRange = new vscode.Range(
+      new vscode.Position(
+        position.line,
+        position.character + lineEndReplaceLength,
       ),
+      fullDocumentRange.end,
     );
     const documentSuffix = suffixRange.isEmpty
       ? ""


### PR DESCRIPTION
## Summary
- Fixed a bug in `completion-manager.ts` where the notebook document search was missing a `return` statement in the predicate.
- Improved notebook cell context handling in `FIMClient` by correctly identifying the current cell using `context.document` and ensuring appropriate comment formatting for different cell languages.
- Simplified range calculations for prefix and suffix in `FIMClient`.

## Test plan
1. Open a notebook in VS Code.
2. Trigger tab completion in a cell.
3. Verify that the context from other cells is correctly included in the FIM request.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d15685e0a31446e789993a08685ef2a1)