### PR TITLE
fix: disable async new-task by default and defer panel open

### DIFF
--- a/packages/cli/src/tools/new-task.ts
+++ b/packages/cli/src/tools/new-task.ts
@@ -1,3 +1,4 @@
+import { constants } from "@getpochi/common";
 import type {
   ClientTools,
   CustomAgent,
@@ -37,7 +38,7 @@ export const newTask =
       await options.browserSessionStore?.registerBrowserSession(taskId);
     }
 
-    const isAsync = !!runAsync;
+    const isAsync = !!runAsync && constants.enableAsyncNewTask;
     const subTaskRunner = options.createSubTaskRunner(
       taskId,
       isAsync,

--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -14,3 +14,5 @@ export const DefaultMaxOutputTokens = 4096;
 export const PochiTaskIdHeader = "x-pochi-task-id";
 export const PochiClientHeader = "x-pochi-client";
 export const PochiRequestUseCaseHeader = "x-pochi-request-use-case";
+
+export const enableAsyncNewTask = false;

--- a/packages/livekit/src/chat/middlewares/new-task-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/new-task-middleware.ts
@@ -3,6 +3,7 @@ import type {
   LanguageModelV2StreamPart,
 } from "@ai-sdk/provider";
 import { safeParseJSON } from "@ai-sdk/provider-utils";
+import { constants } from "@getpochi/common";
 import { type CustomAgent, newTaskInputSchema } from "@getpochi/tools";
 import { InvalidToolInputError } from "ai";
 import { events } from "../../livestore/default-schema";
@@ -92,6 +93,9 @@ export function createNewTaskMiddleware(
               }
 
               const uid = crypto.randomUUID();
+              const runAsync =
+                (args.runAsync ?? false) && constants.enableAsyncNewTask;
+              args.runAsync = runAsync;
               args._meta = {
                 uid,
               };
@@ -100,7 +104,7 @@ export function createNewTaskMiddleware(
                   id: uid,
                   cwd,
                   parentId: parentTaskId,
-                  runAsync: args.runAsync ?? false,
+                  runAsync,
                   createdAt: new Date(),
                   initMessages: [
                     {

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -379,15 +379,17 @@ export class ManagedToolCallLifeCycle
     if (runAsync && isVSCodeEnvironment()) {
       const cwd = window.POCHI_TASK_INFO?.cwd;
       if (cwd) {
-        void vscodeHost.openTaskInPanel(
-          {
-            type: "open-task",
-            uid,
-            cwd,
-            storeId: this.store.storeId,
-          },
-          { preserveFocus: true, preview: false },
-        );
+        setTimeout(() => {
+          void vscodeHost.openTaskInPanel(
+            {
+              type: "open-task",
+              uid,
+              cwd,
+              storeId: this.store.storeId,
+            },
+            { preserveFocus: true, preview: false },
+          );
+        }, 0);
       }
     }
 


### PR DESCRIPTION
## Screen record

https://jam.dev/c/e8f67556-d9fd-48a6-91b7-31765a747baf

## Summary

- Add `enableAsyncNewTask` constant (default `false`) to gate async sub-task execution behind a feature flag, preventing unintended async task spawning
- Apply the flag consistently in both `packages/cli` (`new-task.ts`) and `packages/livekit` (`new-task-middleware.ts`) so the behaviour is uniform across all transports
- Wrap `openTaskInPanel` in `setTimeout(..., 0)` in `tool-call-life-cycle.ts` to defer panel opening until after the current call stack settles, preventing race conditions when the panel is opened too early

## Test plan

- [ ] Verify that sub-tasks with `runAsync: true` now run synchronously by default (panel not opened prematurely)
- [ ] Confirm async behaviour can be re-enabled by setting `enableAsyncNewTask = true` in constants
- [ ] Check that the deferred `openTaskInPanel` call still opens the panel correctly after the timeout

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-c0aee02292f445939a24e2151a123c7f) | [Task](https://app.getpochi.com/share/p-c0aee02292f445939a24e2151a123c7f)