### PR TITLE
chore(vscode): bump version to 0.33.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.31.0-dev",
+  "version": "0.33.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump VSCode extension version from `0.31.0-dev` to `0.33.0-dev`

## Test plan
- [ ] Verify the version number is correct in `packages/vscode/package.json`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-da014527c64644409a97dc845213d59b)