### PR TITLE
feat(vscode): adjust tab completion scroll indicator UI

### DIFF
--- a/packages/vscode/src/tab-completion/decoration-manager.ts
+++ b/packages/vscode/src/tab-completion/decoration-manager.ts
@@ -110,16 +110,13 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
     this.scrollIndicatorDecorationOptions = {
       before: {
         contentText: "⇥ Tab to scroll",
-        color: new vscode.ThemeColor(
-          "pochi.tabCompletion.scrollIndicator.foreground",
-        ),
-        backgroundColor: new vscode.ThemeColor(
-          "pochi.tabCompletion.scrollIndicator.background",
-        ),
-        margin:
-          "-4px 0 0 55.5ch; padding: 4px; position: absolute; z-index: 10000;",
-        border:
-          "0; border-radius: 4px; box-shadow: 0 0 4px 4px rgba(0,108,198,0.2);",
+        color: new vscode.ThemeColor("editorWidget.foreground"),
+        backgroundColor: new vscode.ThemeColor("editorWidget.background"),
+        border: "1px solid",
+        borderColor: new vscode.ThemeColor("editorWidget.border"),
+        margin: "-4px 0 0 55.5ch; position: absolute; z-index: 10000;",
+        textDecoration:
+          "none; padding: 4px 11px; border-radius: 4px; box-shadow: 0 2px 6px rgba(0, 0, 0, 0.16); opacity: 0.97; font-size: 12px; font-weight: 400; letter-spacing: 0.15px;",
       },
     };
 


### PR DESCRIPTION
## Summary
- Update tab completion scroll indicator to use `editorWidget` theme colors.
- Improve the border, padding, and box-shadow styling for better visibility.

## Screenshot
<img width="668" height="196" alt="image" src="https://github.com/user-attachments/assets/0452fa17-fcb0-4661-aa2f-580baaad0a19" />


🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-be0fb0f635104f9a9462f319c3deff3e)