### PR TITLE
refactor: centralize GitOperationTimeoutMs and add readGitStatus timeout guard

### DIFF
--- a/packages/cli/src/tools/new-task.ts
+++ b/packages/cli/src/tools/new-task.ts
@@ -38,7 +38,7 @@ export const newTask =
       await options.browserSessionStore?.registerBrowserSession(taskId);
     }
 
-    const isAsync = !!runAsync && constants.enableAsyncNewTask;
+    const isAsync = !!runAsync && constants.EnableAsyncNewTask;
     const subTaskRunner = options.createSubTaskRunner(
       taskId,
       isAsync,

--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -15,4 +15,11 @@ export const PochiTaskIdHeader = "x-pochi-task-id";
 export const PochiClientHeader = "x-pochi-client";
 export const PochiRequestUseCaseHeader = "x-pochi-request-use-case";
 
-export const enableAsyncNewTask = false;
+export const EnableAsyncNewTask = false;
+
+/**
+ * Timeout (ms) for any single git operation.
+ * Used across all git invocations (simple-git block timeout, exec timeout)
+ * to prevent hangs when git itself is broken or unresponsive.
+ */
+export const GitOperationTimeoutMs = 10_000;

--- a/packages/common/src/tool-utils/git-status.ts
+++ b/packages/common/src/tool-utils/git-status.ts
@@ -1,6 +1,6 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { type GitStatus, getLogger } from "../base";
+import { constants, type GitStatus, getLogger } from "../base";
 import { parseGitOriginUrl } from "../git-utils";
 
 export interface GitStatusReaderOptions {
@@ -12,9 +12,12 @@ const logger = getLogger("GitStatus");
 
 const execPromise = promisify(exec);
 
+/** Overall timeout (ms) for the entire readGitStatus operation. */
+const ReadGitStatusTimeoutMs = 12_000;
+
 /**
  * Execute a git command and return the output
- * Returns empty string if command fails or repository not found
+ * Returns empty string if command fails, times out, or repository not found
  */
 const execGit = async (cwd: string, command: string): Promise<string> => {
   if (!cwd) {
@@ -24,6 +27,7 @@ const execGit = async (cwd: string, command: string): Promise<string> => {
   try {
     const { stdout } = await execPromise(`git ${command}`, {
       cwd,
+      timeout: constants.GitOperationTimeoutMs,
     });
     return stdout.trim();
   } catch {
@@ -191,7 +195,16 @@ export class GitStatusReader {
         path: this.cwd,
       });
 
-      return await this.readGitStatusImpl();
+      const timeoutPromise = new Promise<undefined>((resolve) => {
+        setTimeout(() => {
+          logger.warn(
+            `readGitStatus timed out after ${ReadGitStatusTimeoutMs}ms, returning undefined`,
+          );
+          resolve(undefined);
+        }, ReadGitStatusTimeoutMs);
+      });
+
+      return await Promise.race([this.readGitStatusImpl(), timeoutPromise]);
     } catch (error) {
       logger.error("Error reading Git status", error);
       return undefined;

--- a/packages/livekit/src/chat/middlewares/new-task-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/new-task-middleware.ts
@@ -94,7 +94,7 @@ export function createNewTaskMiddleware(
 
               const uid = crypto.randomUUID();
               const runAsync =
-                (args.runAsync ?? false) && constants.enableAsyncNewTask;
+                (args.runAsync ?? false) && constants.EnableAsyncNewTask;
               args.runAsync = runAsync;
               args._meta = {
                 uid,

--- a/packages/vscode/src/integrations/checkpoint/shadow-git-repo.ts
+++ b/packages/vscode/src/integrations/checkpoint/shadow-git-repo.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getLogger, toErrorMessage } from "@getpochi/common";
+import { constants, getLogger, toErrorMessage } from "@getpochi/common";
 import { isFileExists } from "@getpochi/common/tool-utils";
 import simpleGit, { type SimpleGit } from "simple-git";
 import type * as vscode from "vscode";
@@ -8,9 +8,6 @@ import type { FileChange } from "../editor/diff-changes-editor";
 import { writeExcludesFile } from "./shadow-git-excludes";
 
 const logger = getLogger("ShadowGitRepo");
-
-/** Timeout (ms) for any single git operation; kills the process if git produces no output. */
-const GitOperationTimeoutMs = 10_000;
 
 export class ShadowGitRepo implements vscode.Disposable {
   private git: SimpleGit;
@@ -20,7 +17,9 @@ export class ShadowGitRepo implements vscode.Disposable {
     workspaceDir: string,
   ): Promise<ShadowGitRepo> {
     try {
-      await simpleGit({ timeout: { block: GitOperationTimeoutMs } }).version();
+      await simpleGit({
+        timeout: { block: constants.GitOperationTimeoutMs },
+      }).version();
     } catch (error) {
       const errorMessage = toErrorMessage(error);
       throw new Error(
@@ -48,7 +47,7 @@ export class ShadowGitRepo implements vscode.Disposable {
     private workspaceDir: string,
   ) {
     this.git = simpleGit(this.gitPath, {
-      timeout: { block: GitOperationTimeoutMs },
+      timeout: { block: constants.GitOperationTimeoutMs },
     }).env("GIT_DIR", this.gitPath);
   }
 

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -7,7 +7,7 @@ import { generateBranchName } from "@/lib/generate-branch-name";
 import { getLogger } from "@/lib/logger";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { WorkspaceScope } from "@/lib/workspace-scoped";
-import { toErrorMessage } from "@getpochi/common";
+import { constants, toErrorMessage } from "@getpochi/common";
 import { getWorktreeNameFromWorktreePath } from "@getpochi/common/git-utils";
 import { isPlainText } from "@getpochi/common/tool-utils";
 import type {
@@ -51,7 +51,9 @@ export class WorktreeManager implements vscode.Disposable {
     private readonly pochiConfiguration: PochiConfiguration,
   ) {
     this.workspacePath = this.workspaceScope.workspacePath;
-    this.git = simpleGit(this.workspacePath);
+    this.git = simpleGit(this.workspacePath, {
+      timeout: { block: constants.GitOperationTimeoutMs },
+    });
     this.init();
   }
 
@@ -583,7 +585,9 @@ async function showWorktreeDiff(
     return false;
   }
 
-  const git = simpleGit(cwd);
+  const git = simpleGit(cwd, {
+    timeout: { block: constants.GitOperationTimeoutMs },
+  });
   const result: FileChange[] = [];
   try {
     const output = await git.raw(["diff", "--name-status", base]);


### PR DESCRIPTION
## Summary

- Moves `GitOperationTimeoutMs` (10 s) from `shadow-git-repo.ts` into `packages/common/src/base/constants.ts` so all git invocations share one authoritative value
- Applies the shared timeout to `WorktreeManager` and `showWorktreeDiff` in `worktree.ts` (previously they had no block timeout)
- Adds a `ReadGitStatusTimeoutMs` (12 s) race in `GitStatusReader.readGitStatus` so a hung `git` process can no longer block the system-info step indefinitely
- Renames `enableAsyncNewTask` → `EnableAsyncNewTask` to match the PascalCase convention for global constants (rule 6 of README.pochi.md)

## Test plan

- [ ] All existing unit/integration tests pass (`bun run test` in cli, common, vscode)
- [ ] Verify shadow-git-repo still initialises correctly when `git` is available
- [ ] Verify worktree operations (create, delete, list) still work end-to-end
- [ ] Simulate a slow/hung `git` process and confirm `readGitStatus` returns `undefined` after ~12 s instead of hanging

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-cac6e28d67b2481c89b5a6cd47e9772f)