### PR TITLE
feat(vscode-webui): update toolcall expand toggle to display on hover

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/tool-container.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-container.tsx
@@ -16,7 +16,10 @@ export const ToolTitle: React.FC<{
   return (
     <div
       onClick={onClick}
-      className={`flex items-center gap-2 break-words rounded text-sm ${className}`}
+      className={cn(
+        "group flex items-center gap-2 break-words rounded text-sm",
+        className,
+      )}
     >
       {children}
     </div>
@@ -31,7 +34,8 @@ export const ExpandIcon: React.FC<{
   return (
     <span
       className={cn(
-        "mt-0.5 self-start rounded bg-muted p-1 hover:bg-secondary",
+        "mt-0.5 self-start rounded bg-muted p-1 transition-opacity hover:bg-secondary",
+        !isExpanded && "opacity-0 group-hover:opacity-100",
         className,
       )}
       onClick={onClick}


### PR DESCRIPTION
## Summary
- Update `ToolTitle` to use `group` class for hover state triggering.
- Update `ExpandIcon` to be hidden by default and fade in on hover when collapsed.
- Ensure `ExpandIcon` is always visible when the toolcall is expanded.

Screen record: https://jam.dev/c/cc98fb4d-1d73-49e5-a2bd-19b5439bea64

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-bcd3f442211d4a1294e1ca2afb0d420b)