### PR TITLE
fix(vscode-webui): handle all parallel browser agent sessions in useManageBrowserSession

### DIFF
--- a/packages/vscode-webui/src/lib/use-browser-session.ts
+++ b/packages/vscode-webui/src/lib/use-browser-session.ts
@@ -23,48 +23,49 @@ export const useBrowserSession = (taskId: string) => {
 export const useManageBrowserSession = ({
   messages,
 }: { messages: Message[] }) => {
-  const lastToolPart = messages.at(-1)?.parts.at(-1);
   const store = useDefaultStore();
+  const lastMessage = messages.at(-1);
 
   useEffect(() => {
     const manageBrowserSession = async () => {
-      if (!lastToolPart) {
+      if (!lastMessage) {
         return;
       }
 
-      // Register browser related sessions
-      if (
-        lastToolPart.type === "tool-newTask" &&
-        lastToolPart.input?.agentType === "browser" &&
-        lastToolPart.state === "input-available"
-      ) {
-        const taskId = lastToolPart.input?._meta?.uid || "";
-        const { taskId: parentId } = decodeStoreId(store.storeId);
-        if (browserSessionManager.isRegistered(taskId)) {
-          return;
+      for (const part of lastMessage.parts) {
+        if (part.type !== "tool-newTask") {
+          continue;
         }
-        await browserSessionManager.registerSession(taskId, parentId);
-      }
+        if (part.input?.agentType !== "browser") {
+          continue;
+        }
 
-      // Unregister browser related sessions
-      if (
-        lastToolPart.type === "tool-newTask" &&
-        lastToolPart.input?.agentType === "browser" &&
-        (lastToolPart.state === "output-available" ||
-          lastToolPart.state === "output-error")
-      ) {
-        const taskId = lastToolPart.input?._meta?.uid || "";
-        if (!browserSessionManager.isRegistered(taskId)) {
-          return;
+        // Register browser related sessions
+        if (part.state === "input-available") {
+          const taskId = part.input?._meta?.uid || "";
+          const { taskId: parentId } = decodeStoreId(store.storeId);
+          if (!browserSessionManager.isRegistered(taskId)) {
+            await browserSessionManager.registerSession(taskId, parentId);
+          }
         }
-        await browserSessionManager.unregisterSession(
-          taskId,
-          lastToolPart.toolCallId,
-          store,
-        );
+
+        // Unregister browser related sessions
+        if (
+          part.state === "output-available" ||
+          part.state === "output-error"
+        ) {
+          const taskId = part.input?._meta?.uid || "";
+          if (browserSessionManager.isRegistered(taskId)) {
+            await browserSessionManager.unregisterSession(
+              taskId,
+              part.toolCallId,
+              store,
+            );
+          }
+        }
       }
     };
 
     manageBrowserSession();
-  }, [lastToolPart, store]);
+  }, [lastMessage, store]);
 };


### PR DESCRIPTION
## Summary

- `useManageBrowserSession` previously only watched `messages.at(-1)?.parts.at(-1)` — the single last part of the last message
- When two browser agents are spawned in parallel, both `newTask` tool calls land in the **same** assistant message as adjacent parts; only the last one's state change was ever observed
- The first agent's `stopRecording` was never called, so its video was never finalized or saved
- Fix: iterate over **all parts** of the last message (scoped to the last message only to avoid reprocessing history), so every parallel browser session is individually registered and unregistered

## Test plan

- [ ] Prompt with two parallel browser agents (e.g. "start two browser agents and get top 5 posts from HackerNews and TechCrunch")
- [ ] Verify both browser agent cards show a video after completion
- [ ] Verify single browser agent still works as before

## Verification

https://app.getpochi.com/share/p-0815208fb21a46b1a996aef80b134c30

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7907b15b0ed04d6596b066b543606340)