### PR TITLE
feat(vscode-webui): show tool call action buttons on hover

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -142,7 +142,7 @@ export const CommandPanelContainer: FC<{
   return (
     <div
       className={cn(
-        "code-block relative w-full overflow-hidden rounded-sm border bg-[var(--vscode-editor-background)] font-sans",
+        "group code-block relative w-full overflow-hidden rounded-sm border bg-[var(--vscode-editor-background)] font-sans",
         className,
       )}
     >
@@ -162,7 +162,14 @@ export const CommandPanelContainer: FC<{
             </span>
           </ScrollArea>
         </div>
-        <div className="ml-2 flex space-x-3 self-start">{actions}</div>
+        <div
+          className={cn(
+            "ml-2 flex space-x-3 self-start transition-opacity",
+            expanded ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+          )}
+        >
+          {actions}
+        </div>
       </div>
       {expanded && output && (
         <div


### PR DESCRIPTION
## Summary

- Action buttons in `CommandPanelContainer` (used by `execute-command`, background job panels, etc.) are now hidden by default and revealed on hover via Tailwind `group`/`group-hover` classes
- When the panel is **expanded**, actions remain always visible (`opacity-100`)
- When the panel is **collapsed**, actions fade in on hover (`opacity-0 group-hover:opacity-100`) with a smooth transition

## Demo

https://jam.dev/c/0ce3145e-64b1-49da-b178-66f4afcdd98b

## Test plan

- [ ] Hover over a collapsed execute-command panel — action buttons should appear
- [ ] Expand the panel — action buttons should always be visible
- [ ] Move cursor away — action buttons should hide again when collapsed

Closes #1325

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-feeb91d3b7e24b56aaa487350473f012)