### PR TITLE
feat(vscode-webui): add Mod+Shift+Enter shortcut for plan mode submission

### DIFF
--- a/packages/vscode-webui/src/__stories__/submit-dropdown-button.stories.tsx
+++ b/packages/vscode-webui/src/__stories__/submit-dropdown-button.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   tags: ["autodocs"],
   args: {
     onSubmit: fn(),
-    onSubmitPlan: fn(),
+    onModShiftSubmit: fn(),
     onToggleServer: fn(),
     resetMcpTools: fn(),
     mcpConfigOverride: {},

--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -81,6 +81,13 @@ function CustomEnterKeyHandler(
             () => commands.splitBlock(),
           ]);
         },
+        "Mod-Shift-Enter": () => {
+          if (formRef.current) {
+            formRef.current.setAttribute("submitAction", "modShiftEnter");
+            formRef.current.requestSubmit();
+          }
+          return true;
+        },
         "Mod-Enter": () => {
           if (formRef.current) {
             formRef.current.setAttribute("submitAction", "ctrlEnter");
@@ -105,6 +112,7 @@ interface FormEditorProps {
   setInput: (input: ChatInput) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   onCtrlSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onModShiftSubmit?: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
   isLoading: boolean;
   editable?: boolean;
   formRef?: React.RefObject<HTMLFormElement>;
@@ -125,6 +133,7 @@ export function FormEditor({
   setInput,
   onSubmit,
   onCtrlSubmit,
+  onModShiftSubmit,
   isLoading,
   editable,
   children,
@@ -622,13 +631,16 @@ export function FormEditor({
         editor.commands.addToSubmitHistory(JSON.stringify(editor.getJSON()));
       }
       const submitAction = e.currentTarget.getAttribute("submitAction");
-      if (submitAction === "ctrlEnter") {
+      e.currentTarget.removeAttribute("submitAction");
+      if (submitAction === "modShiftEnter" && onModShiftSubmit) {
+        onModShiftSubmit(e);
+      } else if (submitAction === "ctrlEnter") {
         onCtrlSubmit(e);
       } else {
         onSubmit(e);
       }
     },
-    [enableSubmitHistory, editor, onSubmit, onCtrlSubmit],
+    [enableSubmitHistory, editor, onSubmit, onCtrlSubmit, onModShiftSubmit],
   );
 
   return (

--- a/packages/vscode-webui/src/components/submit-dropdown-button.tsx
+++ b/packages/vscode-webui/src/components/submit-dropdown-button.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { KbdShortcut } from "@/components/ui/kbd-shortcut";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
@@ -38,7 +39,7 @@ interface SubmitDropdownButtonProps {
   isLoading?: boolean;
   disabled?: boolean;
   onSubmit: () => void;
-  onSubmitPlan: () => void;
+  onModShiftSubmit: () => void;
   mcpConfigOverride: McpConfigOverride;
   onToggleServer: (serverName: string) => void;
   resetMcpTools: () => void;
@@ -48,7 +49,7 @@ export function SubmitDropdownButton({
   isLoading = false,
   disabled = false,
   onSubmit,
-  onSubmitPlan,
+  onModShiftSubmit,
   mcpConfigOverride,
   onToggleServer,
   resetMcpTools,
@@ -148,10 +149,11 @@ export function SubmitDropdownButton({
             <div className="p-1">
               <DropdownMenuItem
                 className="flex cursor-pointer items-center gap-2 px-2 py-1"
-                onClick={onSubmitPlan}
+                onClick={onModShiftSubmit}
               >
                 <ClipboardList className="size-3.5 transition-colors duration-200" />
                 <span>{t("chat.createPlan")}</span>
+                <KbdShortcut keys={["Mod", "Shift", "Enter"]} />
               </DropdownMenuItem>
 
               <DropdownMenuSeparator />

--- a/packages/vscode-webui/src/components/ui/kbd-shortcut.tsx
+++ b/packages/vscode-webui/src/components/ui/kbd-shortcut.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+import { isMac } from "@/lib/utils/platform";
+
+interface KbdShortcutProps {
+  /**
+   * Keys to display. Use "Mod" for Cmd/Ctrl, "Shift" for shift, "Enter" for enter.
+   * Each key is rendered as a separate <kbd> badge.
+   */
+  keys: string[];
+  className?: string;
+}
+
+const KeyLabel: Record<string, { mac: string; other: string }> = {
+  Mod: { mac: "⌘", other: "Ctrl" },
+  Shift: { mac: "⇧", other: "⇧" },
+  Alt: { mac: "⌥", other: "Alt" },
+  Enter: { mac: "↵", other: "↵" },
+};
+
+function resolveKey(key: string): string {
+  const entry = KeyLabel[key];
+  if (entry) {
+    return isMac ? entry.mac : entry.other;
+  }
+  return key;
+}
+
+export function KbdShortcut({ keys, className }: KbdShortcutProps) {
+  return (
+    <span className={cn("ml-auto flex items-center gap-0.5", className)}>
+      {keys.map((key) => (
+        <kbd
+          key={key}
+          className="px-0.5 font-sans text-[8px] text-muted-foreground"
+        >
+          {resolveKey(key)}
+        </kbd>
+      ))}
+    </span>
+  );
+}

--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -20,6 +20,7 @@ interface ChatInputFormProps {
   setInput: (input: ChatInput) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
   onCtrlSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+  onModShiftSubmit?: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
   isLoading: boolean;
   editable?: boolean;
   onPaste: (event: ClipboardEvent) => void;
@@ -50,6 +51,7 @@ export const ChatInputForm = forwardRef<
     setInput,
     onSubmit,
     onCtrlSubmit,
+    onModShiftSubmit,
     isLoading,
     editable,
     onPaste,
@@ -85,6 +87,7 @@ export const ChatInputForm = forwardRef<
       setInput={setInput}
       onSubmit={onSubmit}
       onCtrlSubmit={onCtrlSubmit}
+      onModShiftSubmit={onModShiftSubmit}
       isLoading={isLoading}
       editable={editable}
       editorRef={editorRef}

--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -294,6 +294,14 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
     [handleSubmitImpl],
   );
 
+  const handleModShiftSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      handleSubmitImpl({ shouldCreatePlan: true });
+    },
+    [handleSubmitImpl],
+  );
+
   const handleClickSubmit = useCallback(
     async (shouldCreatePlan?: boolean) => {
       chatInputFormRef.current?.addToSubmitHistory();
@@ -312,6 +320,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
         setInput={setInput}
         onSubmit={handleSubmit}
         onCtrlSubmit={handleCtrlSubmit}
+        onModShiftSubmit={handleModShiftSubmit}
         isLoading={isCreatingTask}
         editable={!isCreatingTask}
         onPaste={handlePasteAttachment}
@@ -400,7 +409,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
             isLoading={debouncedIsCreatingTask}
             disabled={!selectedModel || isUploadingAttachments}
             onSubmit={() => handleClickSubmit()}
-            onSubmitPlan={() => handleClickSubmit(true)}
+            onModShiftSubmit={() => handleClickSubmit(true)}
             mcpConfigOverride={mcpConfigOverride}
             onToggleServer={toggleServer}
             resetMcpTools={resetMcpTools}

--- a/packages/vscode-webui/src/lib/utils/platform.ts
+++ b/packages/vscode-webui/src/lib/utils/platform.ts
@@ -1,0 +1,3 @@
+export const isMac =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform);


### PR DESCRIPTION
## Summary

- Add `Mod+Shift+Enter` keyboard shortcut (`⌘⇧↵` on macOS, `Ctrl⇧↵` on Windows/Linux) to submit in plan mode directly from the editor
- Show a platform-aware keyboard hint next to the "Plan" dropdown item via a new `KbdShortcut` component
- Clear `submitAction` attribute after each submission to prevent stale values carrying over

## Changes

- **`form-editor.tsx`** — Add `Mod-Shift-Enter` to `CustomEnterKeyHandler` (sets `submitAction="modShiftEnter"`); handle `modShiftEnter` in `handleSubmit`, dispatching to optional `onModShiftSubmit`; clear attribute after reading
- **`chat-input-form.tsx`** — Thread `onModShiftSubmit` prop through to `FormEditor`
- **`create-task-input.tsx`** — Add `handleModShiftSubmit` callback (calls `handleSubmitImpl({ shouldCreatePlan: true })`); pass to both `ChatInputForm` and `SubmitDropdownButton`
- **`submit-dropdown-button.tsx`** — Rename `onSubmitPlan` → `onModShiftSubmit`; add `<KbdShortcut>` hint next to "Plan" item
- **`kbd-shortcut.tsx`** *(new)* — Platform-aware `<kbd>` badge component; `Mod`→`⌘`/`Ctrl`, `Shift`→`⇧`, `Enter`→`↵`
- **`platform.ts`** *(new)* — `isMac` utility via `navigator.platform`

## Test plan

- [ ] Press `Mod+Shift+Enter` in the chat input → task opens in plan mode (planner agent prompt prepended)
- [ ] Click the "Plan" dropdown item → same behaviour
- [ ] Verify keyboard hint shows `⌘⇧↵` on macOS and `Ctrl⇧↵` on Windows/Linux
- [ ] Press `Enter` after a `Mod+Shift+Enter` submission → normal submit (no stale `submitAction`)

Closes #1322

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f3b039fa4e92402abff4fee2e52d5215)