### PR TITLE
fix(install): improve version fetching and download progress

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -13,7 +13,11 @@ download_release_from_repo() {
   local download_file="$tmpdir/$filename"
   local archive_url="$(release_url)/download/$version/$filename"
 
-  curl --progress-bar --show-error --location --fail "$archive_url" --output "$download_file" --write-out "$download_file"
+  if [ -t 2 ]; then
+    curl --progress-bar --show-error --location --fail "$archive_url" --output "$download_file" --write-out "$download_file"
+  else
+    curl -s --show-error --location --fail "$archive_url" --output "$download_file" --write-out "$download_file"
+  fi
 }
 
 usage() {
@@ -285,7 +289,16 @@ if [ $# -gt 0 ]; then
 fi
 
 get_latest_version() {
-  curl -s https://api.github.com/repos/TabbyML/pochi/releases | grep 'tag_name' | grep 'cli@' | head -1 | cut -d '"' -f 4
+  local version
+  version=$(curl -s https://api.github.com/repos/TabbyML/pochi/releases | grep 'tag_name' | grep 'cli@' | head -1 | cut -d '"' -f 4)
+  if [ -z "$version" ]; then
+    version=$(git ls-remote --tags --refs https://github.com/TabbyML/pochi.git "cli@*" |
+      awk '{print $2}' |
+      sed 's|refs/tags/||' |
+      sort -V |
+      tail -n1)
+  fi
+  echo "$version"
 }
 
 if [ -z "$version_to_install" ]; then


### PR DESCRIPTION
## Notes

GitHub limited unauthed api requests at 60 rph per ip, when install multiple times in a short time will easily hit the limit.

this add a fallback to use git to fetch the latest cli tags.

## Summary
- Fallback to `git ls-remote` when `curl` fails to fetch the latest version in `get_latest_version`
- Only show curl progress bar when running in a TTY to prevent log spam

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5f4b8f06ae6a4002b632887261e58dd0)