### PR TITLE
feat(.pochi): add builtin skills for skill management

### DIFF
--- a/.pochi/skills/create-skill/SKILL.md
+++ b/.pochi/skills/create-skill/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: create-skill
+description: Helps users create new custom agent skills. Use when the user wants to create a new skill, automate a workflow, or package specialized knowledge for reuse.
+---
+
+# Create Skill
+
+This skill guides you through creating a new custom agent skill stored in `.pochi/skills/`.
+
+## What is a Skill?
+
+A skill is a SKILL.md file placed in `.pochi/skills/<skill-name>/SKILL.md`. It contains:
+- A YAML frontmatter block with `name` and `description`
+- Markdown instructions that guide the agent when the skill is invoked
+
+Skills can be:
+- **Project-level**: `.pochi/skills/<skill-name>/SKILL.md` — available only in this project
+- **User-level**: `~/.pochi/skills/<skill-name>/SKILL.md` — available globally across all projects
+
+## Workflow
+
+### Step 1: Understand the Skill's Purpose
+
+Ask the user (or infer from context):
+1. What task should this skill automate or assist with?
+2. What domain does it cover? (e.g., testing, documentation, deployment)
+3. Should it be project-level or user-level?
+4. What steps should the agent follow when executing this skill?
+
+### Step 2: Choose a Skill Name
+
+- Use kebab-case (e.g., `create-changelog`, `review-pr`, `deploy-staging`)
+- Should be short, descriptive, and unique
+- Avoid generic names like `helper` or `utils`
+
+### Step 3: Create the Skill File
+
+Create the skill file at the appropriate location:
+
+**Project-level skill:**
+```bash
+mkdir -p .pochi/skills/<skill-name>
+```
+
+**User-level skill:**
+```bash
+mkdir -p ~/.pochi/skills/<skill-name>
+```
+
+### Step 4: Write the SKILL.md
+
+Use this template as a starting point:
+
+```markdown
+---
+name: <skill-name>
+description: <One sentence description of what this skill does and when to use it>
+---
+
+# <Skill Title>
+
+<Brief overview of what this skill does>
+
+## When to Use This Skill
+
+Use this skill when:
+- <trigger condition 1>
+- <trigger condition 2>
+
+## Workflow
+
+### Step 1: <First step>
+
+<Instructions for the agent>
+
+### Step 2: <Second step>
+
+<Instructions for the agent>
+
+## Notes
+
+- <Any important caveats or tips>
+```
+
+### Step 5: Verify the Skill
+
+After creating the skill, confirm:
+1. The file is at the correct path
+2. The YAML frontmatter is valid (name and description fields present)
+3. The instructions are clear and actionable for an agent
+
+```bash
+# Verify the file exists and is readable
+cat .pochi/skills/<skill-name>/SKILL.md
+```
+
+## Example Skills
+
+### Example: `create-changelog` skill
+
+```markdown
+---
+name: create-changelog
+description: Generates a CHANGELOG.md entry from recent git commits. Use when releasing a new version.
+---
+
+# Create Changelog
+
+Generates a formatted CHANGELOG.md entry from recent git commits.
+
+## Workflow
+
+### Step 1: Get recent commits
+
+Run:
+\`\`\`bash
+git log --oneline --since="last week"
+\`\`\`
+
+### Step 2: Group by type
+
+Categorize commits into: Features, Bug Fixes, Breaking Changes.
+
+### Step 3: Write the entry
+
+Append to CHANGELOG.md with the version and date header.
+```
+
+## Tips for Writing Good Skills
+
+1. **Be specific**: Vague instructions lead to inconsistent behavior
+2. **Include examples**: Show the agent what good output looks like
+3. **Add error handling**: Document what to do when steps fail
+4. **Keep it focused**: One skill, one purpose — avoid Swiss Army knife skills
+5. **Use code blocks**: Format commands and file content in fenced code blocks
+6. **Reference tools**: Mention specific tools (git, gh, curl, etc.) the agent should use

--- a/.pochi/skills/find-skills/SKILL.md
+++ b/.pochi/skills/find-skills/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What are Skills?
+
+Skills are modular instruction files (SKILL.md) stored in `.pochi/skills/<skill-name>/SKILL.md` that extend agent capabilities with specialized knowledge, workflows, and tools. They are plain Markdown files with YAML frontmatter.
+
+**Skills are stored in:**
+- Project-level: `.pochi/skills/<skill-name>/SKILL.md` (current working directory)
+- User-level: `~/.pochi/skills/<skill-name>/SKILL.md` (global, available in all projects)
+
+**Browse community skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Search for Skills
+
+Search for community skills using the GitHub API or by browsing https://skills.sh/. You can use `curl` to query the GitHub API:
+
+```bash
+# Search for skills repositories
+curl -s "https://api.github.com/search/repositories?q=agent-skills+topic:pochi-skill&sort=stars" | jq '.items[] | {name: .full_name, description: .description, stars: .stargazers_count}'
+
+# Or browse known community skill repositories
+curl -s "https://api.github.com/repos/vercel-labs/agent-skills/contents/" | jq '.[].name'
+```
+
+Alternatively, guide the user to browse https://skills.sh/ for available skills.
+
+### Step 3: Install Skills
+
+To install a skill from a GitHub repository, use the `install-skill` skill or follow these steps manually:
+
+1. Find the raw SKILL.md URL from the repository (e.g., `https://raw.githubusercontent.com/<owner>/<repo>/main/<path>/SKILL.md`)
+2. Download and save it to the appropriate skills directory:
+
+```bash
+# Install to project-level (current project only)
+mkdir -p .pochi/skills/<skill-name>
+curl -s "<raw-skill-url>" -o .pochi/skills/<skill-name>/SKILL.md
+
+# Install to user-level (available globally)
+mkdir -p ~/.pochi/skills/<skill-name>
+curl -s "<raw-skill-url>" -o ~/.pochi/skills/<skill-name>/SKILL.md
+```
+
+### Step 4: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install command (using `curl` or the `install-skill` skill)
+3. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "vercel-react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+
+To install it at the project level:
+mkdir -p .pochi/skills/vercel-react-best-practices
+curl -s "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/vercel-react-best-practices/SKILL.md" \
+  -o .pochi/skills/vercel-react-best-practices/SKILL.md
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices
+```
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill using the `create-skill` built-in skill
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own custom skill.
+Ask me to use the "create-skill" skill to help you build one.
+```

--- a/.pochi/skills/install-skill/SKILL.md
+++ b/.pochi/skills/install-skill/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: install-skill
+description: Installs an agent skill from a GitHub repository or URL into the project or user-level skills directory. Use when the user wants to add a community skill or a skill from an external source.
+---
+
+# Install Skill
+
+This skill installs a community or external skill into the `.pochi/skills/` directory without requiring any external CLI tools.
+
+## What is a Skill?
+
+A skill is a SKILL.md file in `.pochi/skills/<skill-name>/SKILL.md` that guides agent behavior for a specific domain or task. Community skills are hosted on GitHub and browsable at https://skills.sh/.
+
+## Workflow
+
+### Step 1: Identify the Skill to Install
+
+Gather from the user:
+1. The skill name or GitHub repo reference (e.g., `vercel-labs/agent-skills@vercel-react-best-practices`)
+2. A direct URL to the SKILL.md file (if known)
+3. Whether to install project-level (`.pochi/skills/`) or user-level (`~/.pochi/skills/`)
+
+If no URL is provided, search for the skill on GitHub:
+
+```bash
+# Search for skills matching a query
+curl -s "https://api.github.com/search/code?q=<query>+filename:SKILL.md" \
+  -H "Accept: application/vnd.github.v3+json" | jq '.items[] | {path: .path, repo: .repository.full_name, url: .html_url}'
+```
+
+### Step 2: Resolve the Raw URL
+
+Convert the GitHub URL to a raw content URL:
+
+- GitHub URL: `https://github.com/<owner>/<repo>/blob/<branch>/<path>/SKILL.md`
+- Raw URL: `https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>/SKILL.md`
+
+For `@`-style references (e.g., `owner/repo@skill-name`):
+```
+https://raw.githubusercontent.com/<owner>/<repo>/main/<skill-name>/SKILL.md
+```
+
+### Step 3: Download and Install
+
+**Project-level installation** (recommended — scoped to this project):
+
+```bash
+SKILL_NAME="<skill-name>"
+RAW_URL="<raw-github-url>"
+
+mkdir -p ".pochi/skills/${SKILL_NAME}"
+curl -fsSL "${RAW_URL}" -o ".pochi/skills/${SKILL_NAME}/SKILL.md"
+echo "Installed skill '${SKILL_NAME}' to .pochi/skills/${SKILL_NAME}/SKILL.md"
+```
+
+**User-level installation** (available across all projects):
+
+```bash
+SKILL_NAME="<skill-name>"
+RAW_URL="<raw-github-url>"
+
+mkdir -p "${HOME}/.pochi/skills/${SKILL_NAME}"
+curl -fsSL "${RAW_URL}" -o "${HOME}/.pochi/skills/${SKILL_NAME}/SKILL.md"
+echo "Installed skill '${SKILL_NAME}' to ~/.pochi/skills/${SKILL_NAME}/SKILL.md"
+```
+
+### Step 4: Install Supporting Files (if any)
+
+Some skills include additional assets (scripts, references, templates). Check if the skill has a directory structure:
+
+```bash
+# List files in the skill's GitHub directory
+curl -s "https://api.github.com/repos/<owner>/<repo>/contents/<path>" \
+  -H "Accept: application/vnd.github.v3+json" | jq '.[].name'
+```
+
+Download additional files as needed into the skill directory.
+
+### Step 5: Verify Installation
+
+```bash
+# Confirm the skill is installed and readable
+cat ".pochi/skills/${SKILL_NAME}/SKILL.md"
+```
+
+Check:
+- The file has valid YAML frontmatter (`name` and `description` fields)
+- The instructions are complete and not truncated
+
+## Example: Installing a Community Skill
+
+To install `vercel-labs/agent-skills@vercel-react-best-practices`:
+
+```bash
+mkdir -p .pochi/skills/vercel-react-best-practices
+curl -fsSL "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/vercel-react-best-practices/SKILL.md" \
+  -o .pochi/skills/vercel-react-best-practices/SKILL.md
+```
+
+## Skill Directory Layout
+
+```
+.pochi/
+  skills/
+    <skill-name>/
+      SKILL.md          # Required: main skill instructions
+      scripts/          # Optional: executable scripts
+      references/       # Optional: reference documentation
+      assets/           # Optional: templates, schemas, data files
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `curl` returns 404 | Check the raw URL path and branch name (try `main` vs `master`) |
+| Frontmatter missing | Edit the SKILL.md to add `name` and `description` fields |
+| Skill not discovered | Ensure the file is at `.pochi/skills/<name>/SKILL.md` exactly |
+| Permission denied | Check directory permissions with `ls -la .pochi/skills/` |


### PR DESCRIPTION
## Summary

- Add `find-skills` built-in skill: discovers community skills via GitHub API and skills.sh without requiring any external CLI (`npx skills`)
- Add `create-skill` built-in skill: guides agents to author new custom `SKILL.md` files in `.pochi/skills/`
- Add `install-skill` built-in skill: installs skills from GitHub repos using `curl`, supporting both project-level and user-level installation

Replaces the previous approach of depending on the external `npx skills` CLI. All skill management is now handled natively through built-in skills using standard tools (`curl`, GitHub API).

## Test plan

- [ ] Invoke `find-skills` and verify it searches GitHub/skills.sh without calling `npx skills`
- [ ] Invoke `create-skill` to author a new skill and confirm it creates a valid `SKILL.md` with frontmatter
- [ ] Invoke `install-skill` with a known GitHub skill URL and confirm it downloads to `.pochi/skills/<name>/SKILL.md`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-23bdca7f12ba4f5bbebece35cf8d2c29)