### PR TITLE
fix(ui): prevent click propagation on status icon tooltip

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/status-icon.tsx
+++ b/packages/vscode-webui/src/features/tools/components/status-icon.tsx
@@ -114,7 +114,10 @@ export function StatusIcon({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>{statusIcon}</TooltipTrigger>
-          <TooltipContent className="max-w-[calc(100vw-30px)]">
+          <TooltipContent
+            className="max-w-[calc(100vw-30px)]"
+            onClick={(e) => e.stopPropagation()}
+          >
             {tooltipContent.map((item, index) => (
               <div className="text-wrap break-words" key={index}>
                 {item}


### PR DESCRIPTION
## Summary
- Added `onClick={(e) => e.stopPropagation()}` to `TooltipContent` in `status-icon.tsx` to prevent click events from bubbling up and triggering unintended actions.

## Test plan
- Verify that clicking inside the status icon tooltip does not trigger parent click handlers.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-769b8b5426f14a158c0c51f99b035bc6)