### PR TITLE
feat: add builtin skills (find-skills, create-skill)

### DIFF
--- a/packages/cli/src/lib/load-skills.ts
+++ b/packages/cli/src/lib/load-skills.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getLogger } from "@getpochi/common";
+import { BuiltInSkillPath, builtInSkills, getLogger } from "@getpochi/common";
 import { isFileExists, parseSkillFile } from "@getpochi/common/tool-utils";
 import type {
   SkillFile,
@@ -52,12 +52,19 @@ async function readSkillsFromDir(dir: string): Promise<SkillFile[]> {
   return skills;
 }
 
+export const builtInSkillFiles: ValidSkillFile[] = builtInSkills.map(
+  (skill) => ({
+    ...skill,
+    filePath: BuiltInSkillPath,
+  }),
+);
+
 export async function loadSkills(
   workingDirectory?: string,
   includeSystemSkills = true,
 ): Promise<ValidSkillFile[]> {
   try {
-    const allSkills: SkillFile[] = [];
+    const allSkills: SkillFile[] = [...builtInSkillFiles];
 
     // Load project skills if working directory is provided
     if (workingDirectory) {
@@ -84,17 +91,19 @@ export async function loadSkills(
     }
 
     // Filter out invalid skills for CLI usage
-    const validSkills = uniqueBy(allSkills, (skill) => skill.name).filter(
-      (skill): skill is ValidSkillFile => {
-        if (isValidSkillFile(skill)) {
-          return true;
-        }
-        logger.warn(
-          `Ignoring invalid skill file ${skill.filePath}: [${skill.error}] ${skill.message}`,
-        );
-        return false;
-      },
-    );
+    const validSkills = uniqueBy(allSkills, (skill) =>
+      skill.filePath === BuiltInSkillPath
+        ? skill.name + BuiltInSkillPath
+        : skill.name,
+    ).filter((skill): skill is ValidSkillFile => {
+      if (isValidSkillFile(skill)) {
+        return true;
+      }
+      logger.warn(
+        `Ignoring invalid skill file ${skill.filePath}: [${skill.error}] ${skill.message}`,
+      );
+      return false;
+    });
 
     logger.debug(
       `Loaded ${allSkills.length} skills (${validSkills.length} valid, ${allSkills.length - validSkills.length} invalid)`,

--- a/packages/cli/src/tools/use-skill.ts
+++ b/packages/cli/src/tools/use-skill.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { prompts } from "@getpochi/common";
+import { BuiltInSkillPath, prompts } from "@getpochi/common";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 import type { ToolCallOptions } from "../types";
 
@@ -24,6 +24,16 @@ export const useSkill =
       throw new Error(
         `Skill '${skillName}' not found. Available skills: ${availableSkills}`,
       );
+    }
+
+    // Builtin skills don't have a real file path — return instructions directly
+    if (skill.filePath === BuiltInSkillPath) {
+      return {
+        result: prompts.createUseSkillResult(skill),
+        _meta: {
+          filePath: BuiltInSkillPath,
+        },
+      };
     }
 
     // Resolve the file path

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -22,6 +22,8 @@ export { toErrorMessage } from "./error";
 
 export { builtInAgents } from "./agents";
 
+export { builtInSkills, BuiltInSkillPath } from "./skills";
+
 export const PochiProviderOptions = z.object({
   taskId: z.string(),
   client: z.string(),

--- a/packages/common/src/base/skills/create-skill.ts
+++ b/packages/common/src/base/skills/create-skill.ts
@@ -1,0 +1,161 @@
+import type { Skill } from "@getpochi/tools";
+
+export const createSkill: Skill = {
+  name: "create-skill",
+  description:
+    "Helps users create new custom agent skills. Use when the user wants to create a new skill, automate a workflow, or package specialized knowledge for reuse.",
+  filePath: "_builtIn_",
+  instructions: `# Create Skill
+
+This skill guides you through authoring a new Pochi skill from scratch and saving it to the project or user-level skills directory.
+
+## When to Use This Skill
+
+Invoke this skill when the user:
+
+- Says "create a skill", "make a skill", or "add a skill"
+- Wants to package a recurring workflow into a reusable skill
+- Says "turn this into a skill" after completing a task
+- Wants to automate something they do repeatedly
+
+## Anatomy of a Skill
+
+Every skill lives in its own directory and requires at minimum a \`SKILL.md\` file:
+
+\`\`\`
+<skill-name>/
+├── SKILL.md          (required)
+└── references/       (optional) - on-demand documentation loaded into context
+    └── REFERENCE.md
+\`\`\`
+
+The \`SKILL.md\` file has two parts:
+
+1. **YAML frontmatter** (between \`---\` delimiters): metadata fields
+2. **Markdown body**: the instructions the agent follows when the skill is invoked
+
+### Frontmatter Fields
+
+\`\`\`yaml
+---
+name: my-skill           # required: kebab-case identifier
+description: |           # required: when to trigger and what it does
+  One or two sentences. Include specific trigger phrases.
+compatibility: node      # optional: runtime requirements (node, python, bun, etc.)
+---
+\`\`\`
+
+**Description writing tips:**
+- Include both what the skill does AND when to use it
+- List concrete trigger phrases (e.g. "Use when the user says 'deploy to staging'")
+- Be slightly "pushy" — err on the side of triggering when in doubt, rather than missing opportunities
+
+### Body Structure
+
+The body is markdown that the agent reads and follows when the skill triggers. Keep it:
+- Under 500 lines for fast loading
+- Action-oriented (use imperative form: "Run X", "Ask the user Y")
+- Focused on the workflow, not explanations of why
+
+## Skill Creation Workflow
+
+### Step 1: Gather Requirements
+
+Ask the user:
+1. What should the skill enable the agent to do?
+2. When should the skill trigger? (What phrases/contexts?)
+3. What tools does the skill need? (file access, shell commands, etc.)
+4. Project-level (\`.pochi/skills/\`) or user-level (\`~/.pochi/skills/\`)? Default to project-level.
+
+If the user says "turn this into a skill" after a task, extract the workflow from the conversation history first — tools used, sequence of steps, any corrections — then confirm with the user before writing.
+
+### Step 2: Draft the SKILL.md
+
+Based on the gathered requirements, write the complete \`SKILL.md\`:
+
+\`\`\`markdown
+---
+name: <kebab-case-name>
+description: |
+  <What it does and when to trigger. Include specific user phrases.>
+allowed-tools: <space-separated tool names if restricted>
+---
+
+# <Skill Title>
+
+<Brief intro: what this skill does and the outcome it produces>
+
+## Workflow
+
+### Step 1: <First action>
+<Instructions...>
+
+### Step 2: <Second action>
+<Instructions...>
+
+## Notes
+<Edge cases, tips, or important constraints>
+\`\`\`
+
+### Step 3: Review with the User
+
+Show the draft to the user and ask:
+- Does this capture the workflow correctly?
+- Are there edge cases to handle?
+- Any tool restrictions to add?
+
+Revise based on feedback.
+
+### Step 4: Write the Files
+
+Determine the target directory:
+- **Project-level**: \`.pochi/skills/<skill-name>/SKILL.md\` (relative to workspace root)
+- **User-level**: \`~/.pochi/skills/<skill-name>/SKILL.md\`
+
+Write the \`SKILL.md\` using the \`writeToFile\` tool.
+
+If the user mentioned reference docs or templates, create them in subdirectories:
+- \`references/\` for documentation loaded on demand
+- \`assets/\` for static files (templates, schemas)
+
+### Step 5: Confirm
+
+Tell the user:
+- Where the skill was saved
+- How to trigger it (the description/trigger phrases)
+- That Pochi will automatically pick it up without restarting
+
+## Skill Writing Patterns
+
+### Output Format Pattern
+\`\`\`markdown
+## Output format
+ALWAYS use this exact structure:
+# [Title]
+## Summary
+## Details
+\`\`\`
+
+### Example Pattern
+\`\`\`markdown
+## Examples
+**Input**: User asks "deploy to staging"
+**Output**: Runs \`./deploy.sh staging\` and reports the result
+\`\`\`
+
+## Skill Locations
+
+| Scope   | Path                              | Visible to          |
+|---------|-----------------------------------|---------------------|
+| Project | \`.pochi/skills/<name>/SKILL.md\`  | This workspace only |
+| User    | \`~/.pochi/skills/<name>/SKILL.md\`| All workspaces      |
+
+## Reserved Skill Names
+
+The following names are reserved for built-in Pochi skills and cannot be used for custom skills:
+
+- \`find-skills\`
+- \`create-skill\`
+- \`validator\`
+- \`create-issue\``,
+};

--- a/packages/common/src/base/skills/find-skills.ts
+++ b/packages/common/src/base/skills/find-skills.ts
@@ -1,0 +1,147 @@
+import type { Skill } from "@getpochi/tools";
+
+export const findSkills: Skill = {
+  name: "find-skills",
+  description:
+    'Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.',
+  filePath: "_builtIn_",
+  instructions: `# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (\`npx skills\`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- \`npx --yes skills find <query>\` — Search for skills by keyword. **Must include a query**; running without arguments enters interactive mode.
+- \`npx --yes skills add <package> --agent pochi -y --copy\` — Install a skill by copying files directly (no symlinks).
+- \`npx --yes skills check\` — Check for skill updates.
+- \`npx --yes skills update\` — Update all installed skills.
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Search for Skills
+
+Run the find command with a relevant query. **Always use \`npx --yes\`** to avoid interactive prompts on first install, and **always include a query** — running without arguments enters interactive mode:
+
+\`\`\`bash
+npx --yes skills find <query>
+\`\`\`
+
+For example:
+
+- User asks "how do I make my React app faster?" → \`npx --yes skills find react performance\`
+- User asks "can you help me with PR reviews?" → \`npx --yes skills find pr review\`
+- User asks "I need to create a changelog" → \`npx --yes skills find changelog\`
+
+The command prints results directly:
+
+\`\`\`
+Install with npx skills add <owner/repo@skill>
+
+vercel-labs/agent-skills@vercel-react-best-practices
+└ https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices
+\`\`\`
+
+### Step 3: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install command they can run
+3. A link to learn more at skills.sh
+
+Example response:
+
+\`\`\`
+I found a skill that might help! The "vercel-react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+
+To install it:
+npx --yes skills add vercel-labs/agent-skills@vercel-react-best-practices --agent pochi -y
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices
+\`\`\`
+
+### Step 4: Ask Where to Install
+
+Before running any install command, use \`askFollowupQuestion\` to ask the user where to install the skill:
+
+> "Where would you like to install this skill?"
+>
+> - **Project-level** — available only in this workspace (\`.pochi/skills/\`)
+> - **User-level (global)** — available in all your workspaces (\`~/.pochi/skills/\`)
+
+Once the user answers, run the appropriate command. Always use \`--copy\` to copy files directly — do not use the default symlink mode:
+
+\`\`\`bash
+# Project-level
+npx --yes skills add <owner/repo@skill> --agent pochi -y --copy
+
+# User-level (global)
+npx --yes skills add <owner/repo@skill> --agent pochi -y -g --copy
+\`\`\`
+
+Pochi picks up new skills automatically — no restart needed.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from \`vercel-labs/agent-skills\` or \`ComposioHQ/awesome-claude-skills\`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill using the \`create-skill\` skill
+
+Example:
+
+\`\`\`
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill — just ask me to
+help you create a skill and I'll guide you through the process using the \`create-skill\` skill.
+\`\`\``,
+};

--- a/packages/common/src/base/skills/index.ts
+++ b/packages/common/src/base/skills/index.ts
@@ -1,0 +1,7 @@
+import type { Skill } from "@getpochi/tools";
+import { createSkill } from "./create-skill";
+import { findSkills } from "./find-skills";
+
+export const BuiltInSkillPath = "_builtIn_";
+
+export const builtInSkills: Skill[] = [findSkills, createSkill];

--- a/packages/common/src/tool-utils/skill-parser.ts
+++ b/packages/common/src/tool-utils/skill-parser.ts
@@ -4,12 +4,17 @@ import remarkFrontmatter from "remark-frontmatter";
 import { remove } from "unist-util-remove";
 import { matter } from "vfile-matter";
 import z from "zod/v4";
-import { toErrorMessage } from "../base";
+import { builtInSkills, toErrorMessage } from "../base";
 import type {
   InvalidSkillFile,
   SkillFile,
   ValidSkillFile,
 } from "../vscode-webui-bridge";
+
+/**
+ * Names reserved by builtin skills — user-defined skills cannot use these names.
+ */
+const ReservedSkillNames = new Set(builtInSkills.map((s) => s.name));
 
 type VFile = Parameters<typeof matter>[0];
 
@@ -82,6 +87,16 @@ export async function parseSkillFile(
 
   const frontmatterData = parseResult.data;
   const skillName = frontmatterData.name || defaultName;
+
+  if (ReservedSkillNames.has(skillName)) {
+    return {
+      name: skillName,
+      filePath,
+      error: "validationError",
+      message: `Skill name "${skillName}" is reserved by a built-in Pochi skill and cannot be used for custom skills.`,
+      instructions,
+    } satisfies InvalidSkillFile;
+  }
 
   return {
     filePath,

--- a/packages/vscode-webui/src/features/settings/components/sections/skill-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/skill-section.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useSkills } from "@/lib/hooks/use-skills";
 import { vscodeHost } from "@/lib/vscode";
+import { BuiltInSkillPath } from "@getpochi/common";
 import type {
   InvalidSkillFile,
   SkillFile,
@@ -28,7 +29,10 @@ const SkillParseErrorMap: Record<
 
 export const SkillSection: React.FC = () => {
   const { t } = useTranslation();
-  const { skills = [], isLoading } = useSkills();
+  const { skills: allSkills = [], isLoading } = useSkills();
+  const skills = allSkills.filter(
+    (skill) => skill.filePath !== BuiltInSkillPath,
+  );
 
   const handleEditSkill = (skill: SkillFile) => {
     vscodeHost.openFile(skill.filePath);

--- a/packages/vscode/src/lib/skill-manager.ts
+++ b/packages/vscode/src/lib/skill-manager.ts
@@ -1,6 +1,6 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import { getLogger } from "@getpochi/common";
+import { BuiltInSkillPath, builtInSkills, getLogger } from "@getpochi/common";
 import { parseSkillFile } from "@getpochi/common/tool-utils";
 import {
   type SkillFile,
@@ -123,7 +123,12 @@ export class SkillManager implements vscode.Disposable {
 
   private async loadSkills() {
     try {
-      const allSkills: SkillFile[] = [];
+      const allSkills: SkillFile[] = [
+        ...builtInSkills.map((skill) => ({
+          ...skill,
+          filePath: BuiltInSkillPath,
+        })),
+      ];
       if (this.cwd) {
         const projectSkillsDir = path.join(this.cwd, ".pochi", "skills");
         const cwd = this.cwd;
@@ -144,7 +149,11 @@ export class SkillManager implements vscode.Disposable {
         })),
       );
 
-      this.skills.value = uniqueBy(allSkills, (skill) => skill.name);
+      this.skills.value = uniqueBy(allSkills, (skill) =>
+        skill.filePath === BuiltInSkillPath
+          ? skill.name + BuiltInSkillPath
+          : skill.name,
+      );
       logger.debug(`Loaded ${allSkills.length} skills`);
     } catch (error) {
       logger.error("Failed to load skills", error);

--- a/packages/vscode/src/tools/use-skill.ts
+++ b/packages/vscode/src/tools/use-skill.ts
@@ -1,4 +1,4 @@
-import { getLogger, prompts } from "@getpochi/common";
+import { BuiltInSkillPath, getLogger, prompts } from "@getpochi/common";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 import { container } from "tsyringe";
 import { SkillManager } from "../lib/skill-manager";
@@ -30,8 +30,9 @@ export const useSkill: ToolFunctionType<ClientTools["useSkill"]> = async (
 
   return {
     result: prompts.createUseSkillResult(skill),
-    _meta: {
-      filePath: skill.filePath,
-    },
+    _meta:
+      skill.filePath === BuiltInSkillPath
+        ? undefined
+        : { filePath: skill.filePath },
   };
 };


### PR DESCRIPTION
## Summary

- Introduces a `builtInSkills` system mirroring the existing `builtInAgents` pattern, shipping two skills with Pochi out of the box:
  - **`find-skills`**: discovers and installs community skills via `npx --yes skills find <query>` and the [skills.sh](https://skills.sh/) registry; asks user to confirm project-level vs user-level scope before installing
  - **`create-skill`**: guides users through authoring new custom SKILL.md files from scratch with an interview → draft → review → write workflow
- Builtin skills are defined as in-memory TypeScript `Skill` objects (no bundled files), tagged with `filePath: "_builtIn_"` sentinel
- Settings panel filters out builtin skills (they are not user-editable files)
- `skill-parser.ts` guards against user skills shadowing reserved builtin names

## Changes

| File | Description |
|------|-------------|
| `packages/common/src/base/skills/` | New: TypeScript skill definitions + `BuiltInSkillPath` sentinel |
| `packages/common/src/base/index.ts` | Export `builtInSkills` and `BuiltInSkillPath` |
| `packages/cli/src/lib/load-skills.ts` | Prepend `builtInSkillFiles` before filesystem skills |
| `packages/vscode/src/lib/skill-manager.ts` | Same for VSCode skill loader |
| `packages/cli/src/tools/use-skill.ts` | Skip `fs.access` for builtin skills |
| `packages/vscode/src/tools/use-skill.ts` | Return `_meta: undefined` for builtin skills |
| `packages/common/src/tool-utils/skill-parser.ts` | Guard reserved builtin skill names |
| `packages/vscode-webui/.../skill-section.tsx` | Hide builtin skills from settings panel |

## Test plan

- [ ] `bun check` passes (no lint/type errors)
- [ ] Verify `find-skills` and `create-skill` appear in the `useSkill` tool description
- [ ] Verify builtin skills do **not** appear in the VSCode settings panel Skills section
- [ ] Verify a custom skill named `find-skills` in `.pochi/skills/` is rejected with a clear error
- [ ] Verify `npx --yes skills find react` runs non-interactively and returns results

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-a7b1af09a8ec4b50a19b4bcc4d21792b)