### PR TITLE
feat: add hotkeys to select suggestion between FIM and NES providers

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -414,6 +414,26 @@
         "when": "editorTextFocus && (pochiTabCompletionState || inlineSuggestionVisible)"
       },
       {
+        "command": "pochi.tabCompletion.nextChoice",
+        "key": "alt+]",
+        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible'"
+      },
+      {
+        "command": "pochi.tabCompletion.prevChoice",
+        "key": "alt+[",
+        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible'"
+      },
+      {
+        "command": "pochi.tabCompletion.nextChoice",
+        "key": "right",
+        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible' && pochiTabCompletionHasMultipleChoices"
+      },
+      {
+        "command": "pochi.tabCompletion.prevChoice",
+        "key": "left",
+        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible' && pochiTabCompletionHasMultipleChoices"
+      },
+      {
         "command": "pochi.applyPochiLayoutWithCycleFocus",
         "key": "ctrl+l",
         "mac": "cmd+l"

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -617,6 +617,20 @@ export class CommandManager implements vscode.Disposable {
         },
       ),
 
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.nextChoice",
+        async () => {
+          this.tabCompletionManager.nextChoice();
+        },
+      ),
+
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.prevChoice",
+        async () => {
+          this.tabCompletionManager.prevChoice();
+        },
+      ),
+
       vscode.commands.registerCommand("pochi.openTerminal", async (...args) => {
         let taskUri: vscode.Uri | undefined = undefined;
         // Take args first

--- a/packages/vscode/src/tab-completion/completion-manager.ts
+++ b/packages/vscode/src/tab-completion/completion-manager.ts
@@ -596,13 +596,16 @@ export class TabCompletionManager implements vscode.Disposable {
 
     if (
       triggerEvent.kind === "inline-completion" &&
-      triggerEvent.selectedCompletionInfo
+      triggerEvent.selectedCompletionInfo &&
+      solution.items.length === 1
     ) {
       return;
     }
 
     if (this.current.decorationItemIndex === undefined) {
-      const index = solution.items.length - 1;
+      // First time we switch to custom decoration
+      // Always show the first item, but now with DecorationManager (to show the toolbar)
+      const index = 0;
       const tokenSource = new vscode.CancellationTokenSource();
       this.current.decorationItemIndex = index;
       this.current.decorationTokenSource = tokenSource;
@@ -619,8 +622,75 @@ export class TabCompletionManager implements vscode.Disposable {
           requestId: item.responseItem.requestId,
         }),
       );
-      this.decorationManager.show(editor, item, tokenSource.token);
+      this.decorationManager.show(
+        editor,
+        item,
+        tokenSource.token,
+        index,
+        solution.items.length,
+      );
+    } else {
+      // We are already showing custom decoration, just update the toolbar
+      const item = solution.items[this.current.decorationItemIndex];
+      this.decorationManager.updateToolbar(
+        editor,
+        this.current.decorationItemIndex,
+        solution.items.length,
+        item.context.selection.active,
+      );
     }
+  }
+
+  async nextChoice() {
+    if (!this.current) return;
+    const { solution, decorationItemIndex } = this.current;
+    if (solution.items.length <= 1) return;
+
+    let nextIndex = (decorationItemIndex ?? 0) + 1;
+    if (nextIndex >= solution.items.length) {
+      nextIndex = 0;
+    }
+
+    this.showChoice(nextIndex);
+  }
+
+  async prevChoice() {
+    if (!this.current) return;
+    const { solution, decorationItemIndex } = this.current;
+    if (solution.items.length <= 1) return;
+
+    let prevIndex = (decorationItemIndex ?? 0) - 1;
+    if (prevIndex < 0) {
+      prevIndex = solution.items.length - 1;
+    }
+
+    this.showChoice(prevIndex);
+  }
+
+  private showChoice(index: number) {
+    if (!this.current) return;
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    if (this.current.decorationTokenSource) {
+      this.current.decorationTokenSource.cancel();
+      this.current.decorationTokenSource.dispose();
+    }
+
+    const tokenSource = new vscode.CancellationTokenSource();
+    this.current.decorationItemIndex = index;
+    this.current.decorationTokenSource = tokenSource;
+    const item = this.current.solution.items[index];
+
+    vscode.commands.executeCommand("editor.action.inlineSuggest.hide");
+
+    this.decorationManager.show(
+      editor,
+      item,
+      tokenSource.token,
+      index,
+      this.current.solution.items.length,
+    );
   }
 
   private removeCurrent() {

--- a/packages/vscode/src/tab-completion/decoration-manager.ts
+++ b/packages/vscode/src/tab-completion/decoration-manager.ts
@@ -64,6 +64,15 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
   // mark a position where lines insertion is previewed in image decoration
   private lineInsertionMarkerDecorationType: vscode.TextEditorDecorationType;
 
+  // Toolbar decoration
+  // show choices switch
+  private toolbarDecorationType: vscode.TextEditorDecorationType;
+  private currentToolbarInfo?: {
+    index: number;
+    total: number;
+    position: vscode.Position;
+  };
+
   private allDecorationTypes: vscode.TextEditorDecorationType[];
 
   constructor(
@@ -314,6 +323,11 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
         ),
       });
 
+    // Toolbar decoration
+    this.toolbarDecorationType = vscode.window.createTextEditorDecorationType(
+      {},
+    );
+
     this.allDecorationTypes = [
       this.scrollIndicatorUpDecorationType,
       this.scrollIndicatorDownDecorationType,
@@ -331,6 +345,7 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
       this.lineRemovalMidLinesDecorationType,
       this.wordInsertionMarkerDecorationType,
       this.lineInsertionMarkerDecorationType,
+      this.toolbarDecorationType,
     ];
   }
 
@@ -345,15 +360,27 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
     editor: vscode.TextEditor,
     item: TabCompletionSolutionItem,
     token: vscode.CancellationToken, // cancel to hide
+    choiceIndex?: number,
+    totalChoices?: number,
   ) {
     if (token.isCancellationRequested) {
       return;
     }
 
+    this.currentToolbarInfo =
+      choiceIndex !== undefined && totalChoices !== undefined
+        ? {
+            index: choiceIndex,
+            total: totalChoices,
+            position: item.context.selection.active,
+          }
+        : undefined;
+
     const disposables: vscode.Disposable[] = [];
     const cleanup = () => {
       updatePochiTabCompletionState(undefined);
       this.clearDecoration(editor);
+      this.currentToolbarInfo = undefined;
       for (const disposable of disposables) {
         disposable.dispose();
       }
@@ -473,6 +500,7 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
           decoration,
         ]);
         updatePochiTabCompletionState("scrollIndicatorVisible");
+        this.renderToolbar(editor);
         logger.debug("Decoration updated: scroll indicator up visible.");
         return;
       }
@@ -503,6 +531,7 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
           decoration,
         ]);
         updatePochiTabCompletionState("scrollIndicatorVisible");
+        this.renderToolbar(editor);
         logger.debug("Decoration updated: scroll indicator down visible.");
         return;
       }
@@ -737,6 +766,7 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
           lineInsertionMarkers,
         );
         updatePochiTabCompletionState("diffVisible");
+        this.renderToolbar(editor);
         logger.debug("Decoration updated: image decoration visible.");
         return;
       }
@@ -858,6 +888,7 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
         lineRemovalsMidLines,
       );
       updatePochiTabCompletionState("diffVisible");
+      this.renderToolbar(editor);
       logger.debug("Decoration updated: inline diff decoration visible.");
     };
 
@@ -1008,6 +1039,66 @@ export class TabCompletionDecorationManager implements vscode.Disposable {
     for (const type of this.allDecorationTypes) {
       editor.setDecorations(type, []);
     }
+    vscode.commands.executeCommand(
+      "setContext",
+      "pochiTabCompletionHasMultipleChoices",
+      false,
+    );
+  }
+
+  updateToolbar(
+    editor: vscode.TextEditor,
+    choiceIndex: number,
+    totalChoices: number,
+    position: vscode.Position,
+  ) {
+    this.currentToolbarInfo = {
+      index: choiceIndex,
+      total: totalChoices,
+      position,
+    };
+    this.renderToolbar(editor);
+  }
+
+  private renderToolbar(editor: vscode.TextEditor) {
+    if (!this.currentToolbarInfo || this.currentToolbarInfo.total <= 1) {
+      editor.setDecorations(this.toolbarDecorationType, []);
+      vscode.commands.executeCommand(
+        "setContext",
+        "pochiTabCompletionHasMultipleChoices",
+        false,
+      );
+      return;
+    }
+
+    const { index, total, position } = this.currentToolbarInfo;
+
+    // Use a single decoration with before and after, placed exactly at the cursor position
+    // and using position: absolute to float above the completion content.
+    const textStr = ` < ${index + 1}/${total} >   Accept [Tab] `;
+    const decorationOptions: vscode.DecorationOptions = {
+      range: new vscode.Range(position, position),
+      renderOptions: {
+        before: {
+          contentText: textStr,
+          color: new vscode.ThemeColor("editorWidget.foreground"),
+          backgroundColor: new vscode.ThemeColor(
+            "editorSuggestWidget.background",
+          ),
+          border: "1px solid",
+          borderColor: new vscode.ThemeColor("editorWidget.border"),
+          textDecoration:
+            "none; position: absolute; top: -30px; padding: 4px 8px; border-radius: 4px; box-shadow: 0 2px 6px rgba(0, 0, 0, 0.16); font-size: 12px; font-weight: normal; vertical-align: middle; z-index: 10000; font-family: var(--vscode-editor-font-family);",
+        },
+      },
+    };
+
+    editor.setDecorations(this.toolbarDecorationType, [decorationOptions]);
+    vscode.commands.executeCommand(
+      "setContext",
+      "pochiTabCompletionHasMultipleChoices",
+      true,
+    );
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- Adds hotkeys to switch between multiple tab completion suggestions (e.g., FIM provider and NES provider).
- Added `alt+]` / `right` for the next choice and `alt+[` / `left` for the previous choice.
- Displays a small toolbar to indicate when multiple choices are available and the current index.

## Screen recording
https://jam.dev/c/87f2b4a5-725a-45d4-9606-a086ec7a403c

## Test plan
- Trigger a tab completion that returns multiple suggestions.
- Verify the toolbar appears showing ` < 1/N >   Accept [Tab] `.
- Use `alt+]` or `right` arrow to navigate to the next suggestion.
- Use `alt+[` or `left` arrow to navigate to the previous suggestion.
- Verify the suggestion view updates accordingly.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-653b07ec7c7c46b287183964aa44478b)