### PR TITLE
chore: bump vscode extension version to 0.37.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.35.0-dev",
+  "version": "0.37.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bumps the VSCode extension version from `0.35.0-dev` to `0.37.0-dev` in `packages/vscode/package.json`

## Test plan
- [ ] Verify the extension version is correctly updated

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4851c3a90b484db69831ee97cd83f241)