### PR TITLE
refactor(vscode): remove runExclusive from executeToolCall

### DIFF
--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -157,7 +157,6 @@ const logger = getLogger("VSCodeHostImpl");
 @scoped(Lifecycle.ContainerScoped)
 @injectable()
 export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
-  private toolCallGroup = runExclusive.createGroupRef();
   private checkpointGroup = runExclusive.createGroupRef();
   private disposables: vscode.Disposable[] = [];
 
@@ -452,86 +451,83 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     return envs;
   };
 
-  executeToolCall = runExclusive.build(
-    this.toolCallGroup,
-    async (
-      toolName: string,
-      args: unknown,
-      options: {
-        toolCallId: string;
-        abortSignal: ThreadAbortSignalSerialization;
-        contentType?: string[];
-        builtinSubAgentInfo?: BuiltinSubAgentInfo;
-        storeId: string;
-      },
-    ) => {
-      let tool: ToolFunctionType<Tool> | undefined;
-
-      if (toolName in ToolMap) {
-        tool = ToolMap[toolName];
-      } else if (toolName in this.mcpHub.executeFns.value) {
-        const execute = this.mcpHub.executeFns.value[toolName];
-        tool = (args, options) => execute(args, options);
-      }
-
-      if (!tool) {
-        return {
-          error: `Tool ${toolName} not found.`,
-        };
-      }
-
-      if (!this.cwd) {
-        return {
-          error: "No workspace folder found.",
-        };
-      }
-
-      const abortSignal = new ThreadAbortSignal(options.abortSignal);
-      const envs = this.resolveToolCallEnvs(
-        toolName,
-        options.builtinSubAgentInfo,
-      );
-      const toolCallStart = Date.now();
-      const resolvedArgs = resolveToolCallArgs(
-        args,
-        options.storeId,
-        options.builtinSubAgentInfo,
-      );
-      const result = await safeCall(
-        tool(resolvedArgs, {
-          abortSignal,
-          messages: [],
-          toolCallId: options.toolCallId,
-          cwd: this.cwd,
-          contentType: options.contentType,
-          envs,
-        }),
-      );
-
-      const status = abortSignal.aborted
-        ? "aborted"
-        : typeof result === "object" && result && "error" in result
-          ? "error"
-          : "success";
-
-      const durationMs = Date.now() - toolCallStart;
-      logger.debug(
-        `executeToolCall: ${toolName}(${options.toolCallId}) took ${durationMs}ms => ${status}`,
-      );
-
-      this.capture({
-        event: "executeToolCall",
-        properties: {
-          toolName,
-          durationMs,
-          batched: options.toolCallId.startsWith("batch-"),
-          status,
-        },
-      });
-
-      return result;
+  executeToolCall = async (
+    toolName: string,
+    args: unknown,
+    options: {
+      toolCallId: string;
+      abortSignal: ThreadAbortSignalSerialization;
+      contentType?: string[];
+      builtinSubAgentInfo?: BuiltinSubAgentInfo;
+      storeId: string;
     },
-  );
+  ) => {
+    let tool: ToolFunctionType<Tool> | undefined;
+
+    if (toolName in ToolMap) {
+      tool = ToolMap[toolName];
+    } else if (toolName in this.mcpHub.executeFns.value) {
+      const execute = this.mcpHub.executeFns.value[toolName];
+      tool = (args, options) => execute(args, options);
+    }
+
+    if (!tool) {
+      return {
+        error: `Tool ${toolName} not found.`,
+      };
+    }
+
+    if (!this.cwd) {
+      return {
+        error: "No workspace folder found.",
+      };
+    }
+
+    const abortSignal = new ThreadAbortSignal(options.abortSignal);
+    const envs = this.resolveToolCallEnvs(
+      toolName,
+      options.builtinSubAgentInfo,
+    );
+    const toolCallStart = Date.now();
+    const resolvedArgs = resolveToolCallArgs(
+      args,
+      options.storeId,
+      options.builtinSubAgentInfo,
+    );
+    const result = await safeCall(
+      tool(resolvedArgs, {
+        abortSignal,
+        messages: [],
+        toolCallId: options.toolCallId,
+        cwd: this.cwd,
+        contentType: options.contentType,
+        envs,
+      }),
+    );
+
+    const status = abortSignal.aborted
+      ? "aborted"
+      : typeof result === "object" && result && "error" in result
+        ? "error"
+        : "success";
+
+    const durationMs = Date.now() - toolCallStart;
+    logger.debug(
+      `executeToolCall: ${toolName}(${options.toolCallId}) took ${durationMs}ms => ${status}`,
+    );
+
+    this.capture({
+      event: "executeToolCall",
+      properties: {
+        toolName,
+        durationMs,
+        batched: options.toolCallId.startsWith("batch-"),
+        status,
+      },
+    });
+
+    return result;
+  };
 
   openFile = async (
     filePath: string,


### PR DESCRIPTION
## Summary
- Remove `runExclusive.build` wrapping from `executeToolCall` in `VSCodeHostImpl`
- Remove unused `toolCallGroup` exclusive group ref
- Tool calls can now run concurrently instead of being serialized

## Test plan
- [ ] Verify existing vscode extension tests pass
- [ ] Manually confirm tool calls execute correctly in the extension

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c15a91717230471cba6d7f22a8917df5)