### PR TITLE
fix(cli): improve result extraction for new-task tool

### DIFF
--- a/packages/cli/src/tools/new-task.ts
+++ b/packages/cli/src/tools/new-task.ts
@@ -136,20 +136,32 @@ export const newTask =
     const finalState = subTaskRunner.state;
     const lastMessage = finalState.messages.at(-1);
 
-    let result = "Sub-task completed";
+    // FIXME(@zhiming): refactor to explicitly check the task state and reuse `extractTaskResult`
+    let result: string | object = "Sub-task finished without result.";
+
     if (lastMessage?.role === "assistant") {
       for (const part of lastMessage.parts || []) {
-        if (part.type === "tool-attemptCompletion") {
-          if (part.input) {
-            result = (part.input as { result: string }).result;
-          }
+        if (
+          part.type === "tool-attemptCompletion" &&
+          (part.state === "input-available" ||
+            part.state === "output-available")
+        ) {
+          result = part.input.result;
+          break;
+        }
+
+        if (
+          part.type === "tool-askFollowupQuestion" &&
+          (part.state === "input-available" ||
+            part.state === "output-available")
+        ) {
+          result = part.input.question;
           break;
         }
       }
     }
 
     return {
-      result:
-        typeof result === "string" ? result : "Sub-task completed successfully",
+      result: typeof result === "string" ? result : JSON.stringify(result),
     };
   };


### PR DESCRIPTION
## Summary
- Improved result extraction from sub-tasks in the `new-task` tool.
- Added support for extracting questions from `askFollowupQuestion` tool calls.
- Simplified result extraction logic and ensured the output is a string.

## Test plan
- Manually verified the logic changes.
- The changes are primarily in the `new-task` tool's result processing, which is used when one agent launches another.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e8a50d4b55f344dab3f6c412e0fc31b4)