### PR TITLE
feat(cli): increase max steps for browser sub-task agent

### DIFF
--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -36,7 +36,10 @@ import { createSpinner } from "./lib/spinner";
 import { StepCount } from "./lib/step-count";
 import { Chat } from "./livekit";
 import { executeToolCall } from "./tools";
-import type { ToolCallOptions } from "./types";
+import type {
+  CreateSubTaskRunnerOverrideOptions,
+  ToolCallOptions,
+} from "./types";
 
 export interface RunnerOptions {
   /**
@@ -188,19 +191,26 @@ export class TaskRunner {
       createSubTaskRunner: (
         taskId: string,
         runAsync: boolean,
-        customAgent?: CustomAgent,
+        overrideOptions?: CreateSubTaskRunnerOverrideOptions,
       ) => {
         // create sub task
         if (runAsync) {
           this.asyncSubTaskManager.registerTask(taskId);
         }
-
+        const definedOverrideOptions =
+          overrideOptions == null
+            ? undefined
+            : Object.fromEntries(
+                Object.entries(overrideOptions).filter(
+                  ([, value]) => value !== undefined,
+                ),
+              );
         const runner = new TaskRunner({
           ...options,
+          ...(definedOverrideOptions ?? {}),
           parts: undefined, // should not use parts from parent
           uid: taskId,
           isSubTask: true,
-          customAgent,
         });
         this.attemptCompletionHook = options.attemptCompletionHook;
 

--- a/packages/cli/src/tools/new-task.ts
+++ b/packages/cli/src/tools/new-task.ts
@@ -15,6 +15,9 @@ import {
 } from "../lib/ffmpeg-mjpeg-to-mp4";
 import type { ToolCallOptions } from "../types";
 
+// @FIXME(@zhiming): extract to cli options
+const SubTaskBrowserAgentMaxSteps = 65535;
+
 /**
  * Creates the newTask tool for CLI runner with custom agent support.
  * Creates and executes sub-tasks autonomously.
@@ -107,10 +110,19 @@ export const newTask =
     }
 
     const isAsync = !!runAsync && constants.EnableAsyncNewTask;
+
+    const overrideOptions: { customAgent?: CustomAgent; maxSteps?: number } = {
+      customAgent,
+    };
+
+    if (customAgent?.name === "browser") {
+      overrideOptions.maxSteps = SubTaskBrowserAgentMaxSteps;
+    }
+
     const subTaskRunner = options.createSubTaskRunner(
       taskId,
       isAsync,
-      customAgent,
+      overrideOptions,
     );
 
     // Check if this is an async task

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -40,7 +40,7 @@ export interface ToolCallOptions {
   createSubTaskRunner?: (
     taskId: string,
     runAsync: boolean,
-    customAgent?: CustomAgent,
+    overrideOptions?: CreateSubTaskRunnerOverrideOptions,
   ) => TaskRunner;
 
   /**
@@ -62,4 +62,10 @@ export interface ToolCallOptions {
    * Store for managing browser sessions
    */
   browserSessionStore?: BrowserSessionStore;
+}
+
+export interface CreateSubTaskRunnerOverrideOptions {
+  customAgent?: CustomAgent;
+  maxSteps?: number;
+  maxRetries?: number;
 }


### PR DESCRIPTION
## Summary
- Increased `SubTaskBrowserAgentMaxSteps` to 65535
- Updated `TaskRunner` to use this higher limit specifically for the browser agent when it's running as a sub-task.

## Test plan
- Manually verified the logic in `packages/cli/src/task-runner.ts` correctly identifies the browser agent and applies the new `maxSteps` limit.
- Verified that other agents still use the default `options.maxSteps`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-564e366f1d634ca795242ae4b82c082f)