### PR TITLE
fix(vscode-webui): use vscode theme colors for diff viewer

### DIFF
--- a/packages/vscode-webui/src/components/message/diff-viewer.tsx
+++ b/packages/vscode-webui/src/components/message/diff-viewer.tsx
@@ -173,6 +173,14 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({ patch, filePath }) => {
               "--diffs-font-family": "JetBrains Mono, monospace",
               "--diffs-font-size": "11px",
               "--diffs-line-height": 1.5,
+              "--diffs-addition-color-override":
+                "var(--vscode-editorGutter-addedBackground)",
+              "--diffs-deletion-color-override":
+                "var(--vscode-editorGutter-deletedBackground)",
+              "--diffs-fg-number-addition-override":
+                "var(--vscode-editorGutter-addedBackground)",
+              "--diffs-fg-number-deletion-override":
+                "var(--vscode-editorGutter-deletedBackground)",
             } as React.CSSProperties
           }
         />


### PR DESCRIPTION
## Summary
- This PR improves the integration of the diff viewer with the VS Code theme.
- It overrides the addition and deletion colors in the diff viewer to use `var(--vscode-editorGutter-addedBackground)` and `var(--vscode-editorGutter-deletedBackground)`.

## Test plan
1. Open a diff view in the VS Code extension.
2. Verify that the addition and deletion colors match the VS Code theme's gutter colors.

## Screenshot

### Before
<img width="1246" height="540" alt="image" src="https://github.com/user-attachments/assets/cc337fe3-ee9a-44e2-a8b6-1e05922bf4e7" />

### After
<img width="1202" height="470" alt="image" src="https://github.com/user-attachments/assets/3c598404-b9e4-46fb-af40-b0e33d28fa34" />


🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-92c940f9aa51489193874c81c259dc7f)