### PR TITLE
refactor(common): extract withTimeout utility and use in GitStatusReader

### DIFF
--- a/packages/common/src/base/async-utils.ts
+++ b/packages/common/src/base/async-utils.ts
@@ -1,0 +1,30 @@
+import { getLogger } from "./logger";
+
+const logger = getLogger("AsyncUtils");
+
+/**
+ * Races a promise against a timeout.
+ * If the promise resolves before the timeout, its value is returned.
+ * If the timeout fires first, `undefined` is returned and an optional warning is logged.
+ *
+ * @param promise - The promise to race against the timeout.
+ * @param timeoutMs - The timeout in milliseconds.
+ * @param timeoutMessage - Optional message to log when the timeout fires.
+ * @returns The resolved value of the promise, or `undefined` on timeout.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage?: string,
+): Promise<T | undefined> {
+  const timeoutPromise = new Promise<undefined>((resolve) => {
+    setTimeout(() => {
+      if (timeoutMessage) {
+        logger.warn(timeoutMessage);
+      }
+      resolve(undefined);
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]);
+}

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -24,6 +24,8 @@ export { builtInAgents } from "./agents";
 
 export { builtInSkills, BuiltInSkillPath } from "./skills";
 
+export { withTimeout } from "./async-utils";
+
 export const PochiProviderOptions = z.object({
   taskId: z.string(),
   client: z.string(),

--- a/packages/common/src/tool-utils/git-status.ts
+++ b/packages/common/src/tool-utils/git-status.ts
@@ -1,6 +1,6 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { constants, type GitStatus, getLogger } from "../base";
+import { constants, type GitStatus, getLogger, withTimeout } from "../base";
 import { parseGitOriginUrl } from "../git-utils";
 
 export interface GitStatusReaderOptions {
@@ -195,16 +195,11 @@ export class GitStatusReader {
         path: this.cwd,
       });
 
-      const timeoutPromise = new Promise<undefined>((resolve) => {
-        setTimeout(() => {
-          logger.warn(
-            `readGitStatus timed out after ${ReadGitStatusTimeoutMs}ms, returning undefined`,
-          );
-          resolve(undefined);
-        }, ReadGitStatusTimeoutMs);
-      });
-
-      return await Promise.race([this.readGitStatusImpl(), timeoutPromise]);
+      return await withTimeout(
+        this.readGitStatusImpl(),
+        ReadGitStatusTimeoutMs,
+        `readGitStatus timed out after ${ReadGitStatusTimeoutMs}ms, returning undefined`,
+      );
     } catch (error) {
       logger.error("Error reading Git status", error);
       return undefined;


### PR DESCRIPTION
## Summary

- Add a generic `withTimeout<T>(promise, timeoutMs, timeoutMessage?)` helper in `packages/common/src/base/async-utils.ts` that races a promise against a configurable timeout, resolving to `undefined` (with an optional warning log) if the timeout fires first
- Export `withTimeout` from `packages/common/src/base/index.ts`
- Replace the inline `timeoutPromise` + `Promise.race` pattern in `GitStatusReader.readGitStatus` with the new shared utility

## Test plan

- [ ] All 442 existing tests in `packages/common` pass (`bun run test`)
- [ ] TypeScript compiles cleanly (`bun tsc`)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3c1ed8f67a704ea6be3187d56b589069)