### PR TITLE
feat(vscode-webui): add migrate worktree changes button to main worktree toolbar

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -61,6 +61,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { VscGitMerge } from "react-icons/vsc";
 import * as R from "remeda";
 import { TaskRow } from "./task-row";
 import { ScrollArea } from "./ui/scroll-area";
@@ -522,6 +523,25 @@ function WorktreeSection({
                   {t("tasksPage.openWorktreeInTerminal")}
                 </TooltipContent>
               </Tooltip>
+              {group.isMain && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 w-6 p-0"
+                      asChild
+                    >
+                      <a href="command:git.migrateWorktreeChanges">
+                        <VscGitMerge className="size-4" />
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t("tasksPage.migrateWorktreeChanges")}
+                  </TooltipContent>
+                </Tooltip>
+              )}
               {!group.isMain && isOpenMainWorktree && (
                 <Popover
                   open={showDeleteConfirm}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -250,6 +250,7 @@
     "tasksCount": "{{count}} tasks",
     "openWorktreeDiff": "Review changes",
     "openWorktreeInTerminal": "Open worktree in terminal",
+    "migrateWorktreeChanges": "Migrate worktree changes",
     "deleteWorktree": "Delete worktree",
     "deleteWorktreeTitle": "Delete worktree",
     "deleteWorktreeConfirm": "Are you sure you want to delete the worktree \"{{name}}\"?",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -251,6 +251,7 @@
     "tasksCount": "{{count}} 件のタスク",
     "openWorktreeDiff": "変更を確認",
     "openWorktreeInTerminal": "ターミナルでワークツリーを開く",
+    "migrateWorktreeChanges": "ワークツリーの変更を移行",
     "deleteWorktree": "ワークツリーを削除",
     "deleteWorktreeTitle": "ワークツリーを削除",
     "deleteWorktreeConfirm": "ワークツリー \"{{name}}\" を削除してもよろしいですか？",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -250,6 +250,7 @@
     "tasksCount": "{{count}}개 작업",
     "openWorktreeDiff": "변경 사항 보기",
     "openWorktreeInTerminal": "터미널에서 워크트리 열기",
+    "migrateWorktreeChanges": "워크트리 변경 사항 마이그레이션",
     "deleteWorktree": "워크트리 삭제",
     "deleteWorktreeTitle": "워크트리 삭제",
     "deleteWorktreeConfirm": "워크트리 \"{{name}}\"을(를) 삭제하시겠습니까?",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -249,6 +249,7 @@
     "tasksCount": "{{count}} 个任务",
     "openWorktreeDiff": "查看更改",
     "openWorktreeInTerminal": "在终端中打开工作树",
+    "migrateWorktreeChanges": "迁移工作树更改",
     "deleteWorktree": "删除工作树",
     "deleteWorktreeTitle": "删除工作树",
     "deleteWorktreeConfirm": "确定要删除工作树 \"{{name}}\" 吗？",


### PR DESCRIPTION

<img width="2430" height="922" alt="image" src="https://github.com/user-attachments/assets/6cb448ae-5a46-4d53-8e59-f136c75e074a" />


## Summary

- Adds a new icon button to the main worktree group header toolbar that triggers the VSCode `git.migrateWorktreeChanges` command
- Button is only shown when `group.isMain === true`
- Uses `VscGitMerge` icon from `react-icons/vsc`
- Tooltip text is i18n'd with `tasksPage.migrateWorktreeChanges` key added for EN, ZH, KO, and JP locales

Closes #1348

## Test plan

- [ ] Hover over the main worktree row and verify the migrate button appears
- [ ] Verify the button does NOT appear on non-main worktree rows
- [ ] Click the button and verify it triggers the migrate worktree changes command

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fa768c44d823436c84a95a6be9aedbb6)