### PR TITLE
refactor(common): extract withTimeout utility and use in GitStatusReader

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/cli": {
       "name": "@getpochi/cli",
-      "version": "0.5.0-dev",
+      "version": "0.6.0-dev",
       "bin": {
         "pochi": "src/cli.ts",
       },

--- a/packages/common/src/base/async-utils.ts
+++ b/packages/common/src/base/async-utils.ts
@@ -1,0 +1,27 @@
+import { getLogger } from "./logger";
+
+const logger = getLogger("AsyncUtils");
+
+/**
+ * Wraps a promise with a timeout. Returns null if the timeout is reached.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operationName: string,
+): Promise<T | null> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timeoutId = setTimeout(() => {
+      logger.warn(`${operationName} timed out after ${timeoutMs}ms`);
+      resolve(null);
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -20,6 +20,8 @@ export { WebsiteTaskCreateEvent } from "./event";
 
 export { toErrorMessage } from "./error";
 
+export { withTimeout } from "./async-utils";
+
 export { builtInAgents } from "./agents";
 
 export { builtInSkills, BuiltInSkillPath } from "./skills";

--- a/packages/common/src/tool-utils/git-status.ts
+++ b/packages/common/src/tool-utils/git-status.ts
@@ -1,6 +1,6 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { constants, type GitStatus, getLogger } from "../base";
+import { constants, type GitStatus, getLogger, withTimeout } from "../base";
 import { parseGitOriginUrl } from "../git-utils";
 
 export interface GitStatusReaderOptions {
@@ -195,16 +195,13 @@ export class GitStatusReader {
         path: this.cwd,
       });
 
-      const timeoutPromise = new Promise<undefined>((resolve) => {
-        setTimeout(() => {
-          logger.warn(
-            `readGitStatus timed out after ${ReadGitStatusTimeoutMs}ms, returning undefined`,
-          );
-          resolve(undefined);
-        }, ReadGitStatusTimeoutMs);
-      });
-
-      return await Promise.race([this.readGitStatusImpl(), timeoutPromise]);
+      return (
+        (await withTimeout(
+          this.readGitStatusImpl(),
+          ReadGitStatusTimeoutMs,
+          "readGitStatus",
+        )) ?? undefined
+      );
     } catch (error) {
       logger.error("Error reading Git status", error);
       return undefined;

--- a/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
+++ b/packages/vscode/src/integrations/checkpoint/checkpoint-service.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { Deferred } from "@/lib/defered";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { WorkspaceScope } from "@/lib/workspace-scoped";
-import { getLogger, toErrorMessage } from "@getpochi/common";
+import { getLogger, toErrorMessage, withTimeout } from "@getpochi/common";
 import type {
   DiffCheckpointOptions,
   FileDiff,
@@ -28,30 +28,6 @@ const checkpointCommitPrefix = (cwd: string) => `checkpoint-${cwd}-msg-`;
 
 /** Timeout (ms) for the saveCheckpoint operation. */
 const SaveCheckpointTimeoutMs = 10_000;
-
-/**
- * Wraps a promise with a timeout. Returns null if the timeout is reached.
- */
-async function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  operationName: string,
-): Promise<T | null> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<null>((resolve) => {
-    timeoutId = setTimeout(() => {
-      logger.warn(`${operationName} timed out after ${timeoutMs}ms`);
-      resolve(null);
-    }, timeoutMs);
-  });
-  try {
-    return await Promise.race([promise, timeoutPromise]);
-  } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  }
-}
 
 @scoped(Lifecycle.ContainerScoped)
 @injectable()


### PR DESCRIPTION
## Summary

- Extracts the `withTimeout<T>(promise, timeoutMs, operationName)` helper into a new shared module `packages/common/src/base/async-utils.ts` and exports it from `@getpochi/common`
- Removes the local `withTimeout` function from `checkpoint-service.ts` and imports the shared one instead
- Replaces the manual inline `Promise.race` + `setTimeout` timeout pattern in `GitStatusReader.readGitStatus` with the shared `withTimeout` utility

## Test plan

- [ ] `bun run test` passes in `packages/common` and `packages/vscode`
- [ ] `bun tsc` passes in both packages
- [ ] Timeout behaviour for `saveCheckpoint` and `readGitStatus` is unchanged

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-3414c10b9c2846cebc2cb79c1978f181)