### PR TITLE
fix(common): keep empty reasoning parts with providerMetadata

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -112,6 +112,46 @@ describe('formatters', () => {
       const assistantMsg = formatted.find((m) => m.id === 'assistant-1');
       expect(assistantMsg?.parts.some((p) => p.type === 'reasoning')).toBe(true);
     });
+
+    it('should remove empty reasoning parts without providerMetadata', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            { type: 'reasoning', text: '' },
+            { type: 'text', text: 'Response' },
+          ],
+        },
+      ];
+      const formatted = formatters.llm(clone(messages));
+      const assistantMsg = formatted.find((m) => m.id === 'assistant-1');
+      expect(assistantMsg?.parts.some((p) => p.type === 'reasoning')).toBe(false);
+    });
+
+    it('should keep empty reasoning parts that have providerMetadata (e.g. OpenAI itemId)', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: '',
+              providerMetadata: { openai: { itemId: 'rs_abc123' } },
+            },
+            {
+              type: 'text',
+              text: 'Response',
+              providerMetadata: { openai: { itemId: 'msg_abc123' } },
+            },
+          ],
+        },
+      ];
+      const formatted = formatters.llm(clone(messages));
+      const assistantMsg = formatted.find((m) => m.id === 'assistant-1');
+      expect(assistantMsg?.parts.some((p) => p.type === 'reasoning')).toBe(true);
+    });
   });
 
   describe('formatters.storage', () => {

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -234,7 +234,19 @@ function extractCompactMessages(messages: UIMessage[]) {
 function removeEmptyTextParts(messages: UIMessage[]) {
   return messages.map((message) => {
     message.parts = message.parts.filter((part) => {
-      if (part.type === "text" || part.type === "reasoning") {
+      if (part.type === "text") {
+        return part.text.trim().length > 0;
+      }
+      if (part.type === "reasoning") {
+        // Keep reasoning parts that have providerMetadata (e.g. OpenAI itemId),
+        // because they need to be included as item_reference in subsequent API calls,
+        // even if their text content is empty.
+        if (
+          part.providerMetadata &&
+          Object.keys(part.providerMetadata).length > 0
+        ) {
+          return true;
+        }
         return part.text.trim().length > 0;
       }
       return true;


### PR DESCRIPTION
## Summary

- `removeEmptyTextParts` previously filtered out all reasoning parts with empty text
- Reasoning parts that carry `providerMetadata` (e.g. OpenAI `itemId`) must be retained even when their text is empty, because they are referenced as `item_reference` in subsequent API calls
- Added two new test cases covering both the removal of empty reasoning parts without metadata and the retention of empty reasoning parts with `providerMetadata`

## Test plan

- [ ] Run `bun run test` in `packages/common` to verify the new test cases pass
- [ ] Test with OpenAI models that use reasoning to confirm multi-turn conversations work correctly after this fix

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0fc29804f1c943868d621e3dea6db595)