### PR TITLE
fix(cli): improve browser stream recording and ffmpeg conversion

### DIFF
--- a/packages/cli/src/lib/ffmpeg-mjpeg-to-mp4.ts
+++ b/packages/cli/src/lib/ffmpeg-mjpeg-to-mp4.ts
@@ -70,8 +70,8 @@ type Options = {
   videoBitrate?: string; // e.g. "2500k"
 
   // Video dimensions
-  width?: number;
-  height?: number;
+  width?: number; // 1280
+  height?: number; // 720
 };
 
 export function startMjpegToMp4Converter(
@@ -85,8 +85,8 @@ export function startMjpegToMp4Converter(
     preset = "veryfast",
     crf = 23,
     videoBitrate,
-    width,
-    height,
+    width = 1280,
+    height = 720,
   } = opts;
 
   // Feed ffmpeg a stream of JPEG images (MJPEG) via stdin.
@@ -104,16 +104,19 @@ export function startMjpegToMp4Converter(
     .inputFormat("mjpeg")
     .inputOptions([`-r ${nominalFps}`])
     .outputOptions([
-      "-vsync vfr",
       "-pix_fmt yuv420p",
       "-movflags +faststart",
       `-preset ${preset}`,
       `-crf ${crf}`,
+      "-an", // no audio
       ...(videoBitrate ? [`-b:v ${videoBitrate}`] : []),
-      ...(width && height ? [`-vf scale=${width}:${height}`] : []),
     ])
     .videoCodec("libx264")
+    .fps(nominalFps)
     .format("mp4")
+    .videoFilter(
+      `scale=${width}:${height}:force_original_aspect_ratio=decrease,pad=${width}:${height}:(ow-iw)/2:(oh-ih)/2:color=black`,
+    )
     .output(outputPath);
 
   // Logging
@@ -139,7 +142,7 @@ export function startMjpegToMp4Converter(
     const ts = frame.ts;
     const jpeg = decodeBase64JpegToBuffer(frame.data);
 
-    if (prevTs && pendingJpeg) {
+    if (prevTs !== null && pendingJpeg) {
       // Duration for pending frame = time until current frame
       const rawDurSec = ts - prevTs;
       const durMs = Math.min(rawDurSec * 1000, maxGapMs);

--- a/packages/cli/src/tools/new-task.ts
+++ b/packages/cli/src/tools/new-task.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { constants } from "@getpochi/common";
+import { getLogger } from "@getpochi/common";
 import { formatFollowupQuestions } from "@getpochi/livekit";
 import type {
   ClientTools,
@@ -15,6 +16,8 @@ import {
   startMjpegToMp4Converter,
 } from "../lib/ffmpeg-mjpeg-to-mp4";
 import type { ToolCallOptions } from "../types";
+
+const logger = getLogger("newTask");
 
 // @FIXME(@zhiming): extract to cli options
 const SubTaskBrowserAgentMaxSteps = 65535;
@@ -76,14 +79,19 @@ export const newTask =
         });
         rws.binaryType = "arraybuffer";
 
+        rws.addEventListener("open", () => {
+          logger.debug("Browser stream webSocket connected.");
+        });
+
         rws.addEventListener("message", (e) => {
           if (e.type === "message") {
             try {
               const data = JSON.parse(e.data);
               if (data.type === "frame") {
+                const now = Date.now() / 1000;
                 rec.handleFrame({
                   data: data.data,
-                  ts: data.metadata.timestamp,
+                  ts: data.metadata.timestamp || now,
                 });
               }
             } catch (e) {


### PR DESCRIPTION
## Summary
- Add default resolution (1280x720) and letterboxing to ffmpeg conversion to ensure consistent output quality and aspect ratio.
- Disable audio in ffmpeg output and set an explicit frame rate to match the browser stream.
- Fix a potential bug where `prevTs` check could fail if it was 0 (now explicitly checks for `null`).
- Add WebSocket connection logging and use current time as a fallback for missing frame timestamps in the browser stream.

## Test plan
- Verified that the browser agent stream is correctly recorded and converted to MP4.
- Checked that the output video has the correct resolution and handles different aspect ratios with letterboxing.
- Confirmed that the CLI logs WebSocket connection status during recording.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-06bb579e87a3427dab2512e02b3ddaa2)