### PR TITLE
fix(vscode-webui): change log level from error to warn for tutorial counter storage

### DIFF
--- a/packages/vscode-webui/src/lib/hooks/use-review-plan-tutorial-counter.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-review-plan-tutorial-counter.ts
@@ -15,7 +15,7 @@ const vscodeStorage: StateStorage = {
       const value = await vscodeHost.getGlobalState(name);
       return value ? JSON.stringify(value) : null;
     } catch (error) {
-      logger.error(`Failed to get item: ${name}`, error);
+      logger.warn(`Failed to get item: ${name}`, error);
       return null;
     }
   },
@@ -24,14 +24,14 @@ const vscodeStorage: StateStorage = {
       const parsed = JSON.parse(value);
       await vscodeHost.setGlobalState(name, parsed);
     } catch (error) {
-      logger.error(`Failed to set item: ${name}`, error);
+      logger.warn(`Failed to set item: ${name}`, error);
     }
   },
   removeItem: async (name: string): Promise<void> => {
     try {
       await vscodeHost.setGlobalState(name, undefined);
     } catch (error) {
-      logger.error(`Failed to remove item: ${name}`, error);
+      logger.warn(`Failed to remove item: ${name}`, error);
     }
   },
 };


### PR DESCRIPTION
## Summary
- Changed `logger.error` to `logger.warn` in `use-review-plan-tutorial-counter.ts` for storage operations.
- This reduces noise in the logs for non-critical failures when interacting with the VS Code global state for the tutorial counter.

## Test plan
- Verified the code change in `packages/vscode-webui/src/lib/hooks/use-review-plan-tutorial-counter.ts`.
- The functionality remains unchanged, only the log level is downgraded.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7c60f8c4c95b4ee09728204a21a691a5)