### PR TITLE
fix(vscode): properly reload configuration, agents, and skills when `.pochi` folder is deleted

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -118,7 +118,16 @@ function createWorkspaceConfigWatcher(cwd: string | undefined) {
       setPochiConfigWorkspacePath(undefined);
     });
 
-    return configWatcher;
+    const rootDir = pochiConfigRelativePath.split("/")[0];
+    const rootWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(cwd, rootDir),
+    );
+    rootWatcher.onDidDelete(() => {
+      logger.debug(`Workspace ${rootDir} directory deleted.`);
+      setPochiConfigWorkspacePath(undefined);
+    });
+
+    return vscode.Disposable.from(configWatcher, rootWatcher);
   }
 
   return {

--- a/packages/vscode/src/lib/custom-agent.ts
+++ b/packages/vscode/src/lib/custom-agent.ts
@@ -71,40 +71,52 @@ export class CustomAgentManager implements vscode.Disposable {
   }
 
   private initWatchers() {
+    const watchDir = (base: string, prefix: string, pattern: string) => {
+      const baseUri = vscode.Uri.file(base);
+
+      const fileWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(baseUri, pattern),
+      );
+      fileWatcher.onDidCreate(() => this.loadAgents());
+      fileWatcher.onDidChange(() => this.loadAgents());
+      fileWatcher.onDidDelete(() => this.loadAgents());
+      this.disposables.push(fileWatcher);
+
+      const dirWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(baseUri, `${prefix}/*`),
+      );
+      dirWatcher.onDidCreate(() => this.loadAgents());
+      dirWatcher.onDidDelete(() => this.loadAgents());
+      this.disposables.push(dirWatcher);
+
+      const parentWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(baseUri, prefix),
+      );
+      parentWatcher.onDidCreate(() => this.loadAgents());
+      parentWatcher.onDidDelete(() => this.loadAgents());
+      this.disposables.push(parentWatcher);
+
+      const rootDir = prefix.split("/")[0];
+      if (rootDir && rootDir !== prefix) {
+        const rootWatcher = vscode.workspace.createFileSystemWatcher(
+          new vscode.RelativePattern(baseUri, rootDir),
+        );
+        rootWatcher.onDidCreate(() => this.loadAgents());
+        rootWatcher.onDidDelete(() => this.loadAgents());
+        this.disposables.push(rootWatcher);
+      }
+    };
+
     try {
       if (this.cwd) {
-        const projectAgentsPattern = new vscode.RelativePattern(
-          this.cwd,
-          ".pochi/agents/**/*.md",
-        );
-        const projectWatcher =
-          vscode.workspace.createFileSystemWatcher(projectAgentsPattern);
-
-        projectWatcher.onDidCreate(() => this.loadAgents());
-        projectWatcher.onDidChange(() => this.loadAgents());
-        projectWatcher.onDidDelete(() => this.loadAgents());
-
-        this.disposables.push(projectWatcher);
+        watchDir(this.cwd, ".pochi/agents", ".pochi/agents/**/*.md");
       }
     } catch (error) {
       logger.error("Failed to initialize project agents watcher", error);
     }
 
     try {
-      // Watch system .pochi/agents directory
-      const systemAgentsDir = path.join(os.homedir(), ".pochi", "agents");
-      const systemAgentsPattern = new vscode.RelativePattern(
-        systemAgentsDir,
-        "**/*.md",
-      );
-      const systemWatcher =
-        vscode.workspace.createFileSystemWatcher(systemAgentsPattern);
-
-      systemWatcher.onDidCreate(() => this.loadAgents());
-      systemWatcher.onDidChange(() => this.loadAgents());
-      systemWatcher.onDidDelete(() => this.loadAgents());
-
-      this.disposables.push(systemWatcher);
+      watchDir(os.homedir(), ".pochi/agents", ".pochi/agents/**/*.md");
     } catch (error) {
       logger.error("Failed to initialize system agents watcher", error);
     }

--- a/packages/vscode/src/lib/skill-manager.ts
+++ b/packages/vscode/src/lib/skill-manager.ts
@@ -82,18 +82,20 @@ export class SkillManager implements vscode.Disposable {
   }
 
   /**
-   * Creates watchers for a skills directory and pushes them to disposables.
-   * Two watchers are created:
-   * 1. "*\/SKILL.md" — fires on file create/change/delete
-   * 2. "*" — fires on skill folder create/delete (directory removal does not
-   *    propagate a delete event to contained files on all platforms, so this
-   *    is required to reliably catch folder deletions)
+   * Creates watchers for a skills directory anchored at a base directory.
+   * Three watchers are created:
+   * 1. "{prefix}/STAR/SKILL.md" - fires on file create/change/delete
+   * 2. "{prefix}/STAR" - fires on skill folder create/delete (directory
+   *    removal does not propagate a delete event to contained files on all
+   *    platforms, so this is required to reliably catch folder deletions)
+   * 3. "{prefix}" - fires on the skills parent directory itself being
+   *    created/deleted (e.g. when the entire .pochi folder is removed)
    */
-  private watchSkillsDir(dir: string) {
-    const base = vscode.Uri.file(dir);
+  private watchSkillsDir(base: string, prefix: string) {
+    const baseUri = vscode.Uri.file(base);
 
     const fileWatcher = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(base, "*/SKILL.md"),
+      new vscode.RelativePattern(baseUri, `${prefix}/*/SKILL.md`),
     );
     fileWatcher.onDidCreate(() => this.scheduleReload.call());
     fileWatcher.onDidChange(() => this.scheduleReload.call());
@@ -101,31 +103,52 @@ export class SkillManager implements vscode.Disposable {
     this.disposables.push(fileWatcher);
 
     const dirWatcher = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(base, "*"),
+      new vscode.RelativePattern(baseUri, `${prefix}/*`),
     );
     dirWatcher.onDidCreate(() => this.scheduleReload.call());
     dirWatcher.onDidDelete(() => this.scheduleReload.call());
     this.disposables.push(dirWatcher);
+
+    // Watch the skills directory itself so that deleting a parent directory
+    // (e.g. the entire .pochi folder) also triggers a reload.
+    const parentWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(baseUri, prefix),
+    );
+    parentWatcher.onDidCreate(() => this.scheduleReload.call());
+    parentWatcher.onDidDelete(() => this.scheduleReload.call());
+    this.disposables.push(parentWatcher);
+
+    // Watch the root directory of the skills path (e.g. .pochi or .agents)
+    // to catch when the entire folder is deleted.
+    const rootDir = prefix.split("/")[0];
+    if (rootDir && rootDir !== prefix) {
+      const rootWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(baseUri, rootDir),
+      );
+      rootWatcher.onDidCreate(() => this.scheduleReload.call());
+      rootWatcher.onDidDelete(() => this.scheduleReload.call());
+      this.disposables.push(rootWatcher);
+    }
   }
 
   private initWatchers() {
     try {
       if (this.cwd) {
-        this.watchSkillsDir(path.join(this.cwd, ".pochi", "skills"));
-        this.watchSkillsDir(path.join(this.cwd, ".agents", "skills"));
+        this.watchSkillsDir(this.cwd, ".pochi/skills");
+        this.watchSkillsDir(this.cwd, ".agents/skills");
       }
     } catch (error) {
       logger.error("Failed to initialize project skills watcher", error);
     }
 
     try {
-      this.watchSkillsDir(path.join(os.homedir(), ".pochi", "skills"));
+      this.watchSkillsDir(os.homedir(), ".pochi/skills");
     } catch (error) {
       logger.error("Failed to initialize system skills watcher", error);
     }
 
     try {
-      this.watchSkillsDir(path.join(os.homedir(), ".agents", "skills"));
+      this.watchSkillsDir(os.homedir(), ".agents/skills");
     } catch (error) {
       logger.error("Failed to initialize global .agents/skills watcher", error);
     }


### PR DESCRIPTION
## Summary
- Fixes issue where `.pochi` folder deletion did not trigger updates for skills, custom agents, and workspace configuration
- Adds explicit watchers on the `.pochi` and `.agents` root directories, since VS Code's `createFileSystemWatcher` doesn't reliably propagate `delete` events to child folder watchers on all platforms when a parent directory is deleted.

## Test plan
- Delete the `.pochi` folder and verify that skills, agents, and configuration are properly reloaded/cleared.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-df501e040f4842518f12713d7f57a5fc)