### PR TITLE
feat(vendor-pochi): pass providerOptions through model gateway and disable thinking for repair/schema calls

### DIFF
--- a/packages/livekit/src/chat/llm/repair-tool-call.ts
+++ b/packages/livekit/src/chat/llm/repair-tool-call.ts
@@ -27,6 +27,9 @@ export const makeRepairToolCall: (
           version: globalThis.POCHI_CLIENT,
           useCase: "repair-tool-call",
         },
+        anthropic: {
+          thinking: { type: "disabled" },
+        },
       },
       model,
       schema: tool.inputSchema,

--- a/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
@@ -102,6 +102,9 @@ async function ensureOutputSchema(
           version: globalThis.POCHI_CLIENT,
           useCase: "output-schema",
         },
+        anthropic: {
+          thinking: { type: "disabled" },
+        },
       },
       model,
       schema,

--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -58,6 +58,7 @@ export function createPochiModel({
             model: modelId,
             options: {
               prompt: convertFilePartDataToBase64(prompt),
+              providerOptions,
               ...options,
             },
           },
@@ -99,6 +100,7 @@ export function createPochiModel({
           prompt: convertFilePartDataToBase64(prompt),
           stopSequences,
           tools,
+          providerOptions,
         },
       };
       const resp = await apiClient.api.chat.stream.$post(

--- a/packages/vendor-pochi/src/pochi-api.ts
+++ b/packages/vendor-pochi/src/pochi-api.ts
@@ -15,6 +15,9 @@ export const ModelGatewayRequest = z.object({
     prompt: z.custom<LanguageModelV2Prompt>(),
     stopSequences: z.array(z.string()).optional(),
     tools: z.custom<LanguageModelV2CallOptions["tools"]>(),
+    providerOptions: z
+      .custom<LanguageModelV2CallOptions["providerOptions"]>()
+      .optional(),
   }),
 });
 export type ModelGatewayRequest = z.infer<typeof ModelGatewayRequest>;


### PR DESCRIPTION
## Summary

- Add `providerOptions` field to `ModelGatewayRequest` schema in `pochi-api.ts` so provider-specific options can be forwarded to the backend
- Forward `providerOptions` in `createPochiModel` for both streaming and non-streaming request paths
- Disable Anthropic extended thinking (`thinking: { type: "disabled" }`) for `repair-tool-call` and `output-schema` middleware to prevent unexpected behavior during these utility LLM calls

## Test plan

- [ ] Verify that repair-tool-call works correctly with Anthropic models (no thinking tokens emitted)
- [ ] Verify that output-schema middleware works correctly with Anthropic models
- [ ] Verify that providerOptions passed by callers are correctly forwarded through the Pochi model gateway

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3bab72ef019f49dcbc653af2b82a4546)