### PR TITLE
fix(vscode-webui): hide migrate worktree button when only workspace group exists

### DIFF
--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -435,7 +435,7 @@ function WorktreeSection({
                   {t("tasksPage.openWorktreeInTerminal")}
                 </TooltipContent>
               </Tooltip>
-              {group.isMain && (
+              {group.isMain && !containsOnlyWorkspaceGroup && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button


### PR DESCRIPTION
## Summary

- Hide the "migrate worktree changes" button on the main worktree section when it is the only workspace group (i.e., `containsOnlyWorkspaceGroup` is true) — the button is irrelevant in that context
- Remove unnecessary `asChild` prop from the `Button` wrapping the migrate action anchor

## Test plan

- [ ] Open Pochi with a single workspace (no additional worktrees) and verify the migrate button is not shown on the main group
- [ ] Open Pochi with multiple worktrees and verify the migrate button still appears on the main group

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-abfefc24140449edafdcc3241f9d1949)