### PR TITLE
fix(vscode-webui): skip showFileChanges for archived tasks and fix max-height constraint

### DIFF
--- a/packages/vscode-webui/src/components/task-row.tsx
+++ b/packages/vscode-webui/src/components/task-row.tsx
@@ -55,9 +55,11 @@ export function TaskRow({
         storeId,
       });
 
-      showFileChanges();
+      if (!archived) {
+        showFileChanges();
+      }
     }
-  }, [task.cwd, task.id, storeId, showFileChanges]);
+  }, [task.cwd, task.id, storeId, showFileChanges, archived]);
 
   const handleArchiveClick = useCallback(
     (e: React.MouseEvent) => {

--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -268,6 +268,7 @@ export function WorktreeList({
           containsOnlyWorkspaceGroup={containsOnlyWorkspaceGroup}
           isOpenMainWorktree={isOpenMainWorktree}
           isGitWorkspace={isGitWorkspace}
+          showArchivedTasks={showArchivedTasks}
         />
       ))}
       {showArchivedTasks && archivedTasks.length > 0 && (
@@ -284,6 +285,7 @@ function WorktreeSection({
   containsOnlyWorkspaceGroup,
   isOpenMainWorktree,
   isGitWorkspace,
+  showArchivedTasks,
 }: {
   group: WorktreeGroup;
   isLoadingWorktrees: boolean;
@@ -293,6 +295,7 @@ function WorktreeSection({
   containsOnlyWorkspaceGroup?: boolean;
   isOpenMainWorktree?: boolean;
   isGitWorkspace?: boolean;
+  showArchivedTasks: boolean;
 }) {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -522,7 +525,9 @@ function WorktreeSection({
         <ScrollArea
           viewportClassname={cn("px-1 py-1", {
             "max-h-[180px]": !group.isMain && !containsOnlyWorkspaceGroup,
-            "max-h-[60cqh]": group.isMain && !containsOnlyWorkspaceGroup,
+            "max-h-[60cqh]":
+              group.isMain &&
+              (!containsOnlyWorkspaceGroup || showArchivedTasks),
             // When there is only one workspace group, we let it grow naturally without max-height constraint
           })}
         >


### PR DESCRIPTION
## Summary
- Skip `showFileChanges()` when a task is archived to prevent unnecessary file diff views from opening when selecting archived tasks
- Pass `showArchivedTasks` prop down to `WorktreeSection` so the `max-h-[60cqh]` constraint is correctly applied when archived tasks are visible (previously the height constraint was dropped when only one workspace group existed, even when archived tasks were shown)

## Test plan
- [ ] Open a workspace with archived tasks
- [ ] Toggle "Show archived tasks" and verify the task list height adjusts correctly
- [ ] Click on an archived task and verify no file diff view is opened
- [ ] Click on a non-archived task and verify file diff view still opens normally

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8359edafd69a46aa8b6c1f5113e6808f)