### PR TITLE
fix(vscode-webui): fix share popup background blending into input

### DIFF
--- a/packages/vscode-webui/src/components/public-share-button.tsx
+++ b/packages/vscode-webui/src/components/public-share-button.tsx
@@ -141,7 +141,10 @@ ${environmentInfo}
           <Share2Icon className="size-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent
+        align="end"
+        className="dropdown-menu animate-in overflow-hidden rounded-md border bg-background p-1 text-popover-foreground shadow"
+      >
         <DropdownMenuItem
           onClick={handleUpdatePublicShare}
           disabled={!shareId}


### PR DESCRIPTION
## Summary

- The share dropdown popup was using the default `bg-popover` background, causing it to blend into the input area
- Updated `DropdownMenuContent` in `public-share-button.tsx` to use `bg-background` with consistent styling, matching other popup components (`submit-dropdown-button`, `dev-mode-button`, `model-select`, `worktree-select`)

## Test plan

- [ ] Open the share popup in the chat toolbar
- [ ] Verify the dropdown has a distinct, opaque background that does not blend into the input area

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9c7fb45f41a842098b3732637e2890c9)