### PR TITLE
fix(vscode-webui): polish ask-followup-question option styles

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/ask-followup-question.tsx
+++ b/packages/vscode-webui/src/features/tools/components/ask-followup-question.tsx
@@ -217,7 +217,7 @@ function OptionRow({
         <span
           className={cn(
             "font-medium text-sm",
-            active ? "font-semibold text-foreground" : "text-muted-foreground",
+            active ? "text-foreground" : "text-muted-foreground",
           )}
         >
           {opt.label}
@@ -359,7 +359,7 @@ function OtherRow({
   return (
     <div
       className={cn(
-        "flex w-full items-center gap-3 border-l-2 py-1.5 pr-3 transition-colors",
+        "flex h-8 w-full items-center gap-3 border-l-2 pr-3 transition-colors",
         isFocused ? "pl-[10px]" : "pl-3",
         isOpen ? "bg-muted" : isFocused ? "bg-muted/60" : "hover:bg-muted/30",
         isFocused ? "border-l-foreground/40" : "border-l-transparent",
@@ -401,7 +401,7 @@ function OtherRow({
       {showInput ? (
         <Input
           ref={inputRef}
-          className="h-7 flex-1 text-sm"
+          className="h-6 flex-1 border-none bg-transparent px-0 text-sm shadow-none outline-none focus-visible:ring-0"
           placeholder="Type your answer..."
           value={value === " " ? "" : value}
           onChange={(e) => onChange(e.target.value)}
@@ -431,10 +431,10 @@ function OtherRow({
           type="button"
           disabled={!isInteractive}
           className={cn(
-            "flex-1 text-left text-sm transition-colors",
+            "flex-1 text-left font-medium text-sm transition-colors",
             isOpen || isFocused
-              ? "font-semibold text-foreground"
-              : "font-medium text-muted-foreground",
+              ? "text-foreground"
+              : "text-muted-foreground/50",
             !isInteractive && "cursor-not-allowed",
           )}
           onClick={() => {

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -317,7 +317,7 @@
     "usingSkill": "Using skill",
     "moreTools_one": ", and {{count}} more tool",
     "moreTools_other": ", and {{count}} more tools",
-    "other": "Other",
+    "other": "Other, tell Pochi...",
     "submit": "Submit",
     "recommended": "Recommended",
     "dismiss": "Dismiss",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -316,7 +316,7 @@
     "updatingToDos": "TODOを更新中",
     "editing": "編集しています ",
     "moreTools": "、他{{count}}個のツール",
-    "other": "その他",
+    "other": "その他、Pochiに伝えてください...",
     "submit": "送信",
     "recommended": "おすすめ",
     "dismiss": "閉じる",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -315,7 +315,7 @@
     "updatingToDos": "할 일 업데이트 중",
     "editing": "편집하는 중 ",
     "moreTools": ", 그리고 {{count}}개의 다른 도구들",
-    "other": "기타",
+    "other": "기타, Pochi에게 알려주세요...",
     "submit": "제출",
     "recommended": "추천",
     "dismiss": "닫기",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -314,7 +314,7 @@
     "updatingToDos": "更新待办事项中",
     "editing": "正在编辑 ",
     "moreTools": "，以及另外 {{count}} 个工具",
-    "other": "其他",
+    "other": "其他，告诉 Pochi...",
     "submit": "提交",
     "recommended": "推荐",
     "dismiss": "忽略",


### PR DESCRIPTION
## Summary

- Prevent option label text from changing font-weight (`font-semibold`) on hover/focus — only color changes now
- Fix "Other" row to use explicit `h-8` height (matching regular options) so it never grows when the inline input appears
- Style the inline input as borderless/transparent so it fits flush within the fixed row height
- Rename "Other" label to "Other, tell Pochi..." (+ i18n for zh, ko, jp) and render it at `text-muted-foreground/50` (lighter) when not selected

## Test plan

- [ ] Open a question card and hover/focus options — verify no font-weight jump
- [ ] Click "Other, tell Pochi..." — verify row height stays the same as regular options while typing
- [ ] Verify the lighter color of the "Other" option when not selected

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0fc3a5c5af4846f7b48292e2b77be5fa)