### PR TITLE
fix(vscode): move showFileChanges logic to host and wait for pochi layout

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -261,6 +261,7 @@ const VSCodeHostStub = {
       keepEditor?: boolean;
       preserveFocus?: boolean;
       preview?: boolean;
+      showFileChanges?: boolean;
     },
   ): Promise<void> => {},
 

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -318,6 +318,11 @@ export interface VSCodeHostApi {
       keepEditor?: boolean;
       preserveFocus?: boolean;
       preview?: boolean;
+      /**
+       * If true, show the file changes diff view after opening the task panel.
+       * When pochi layout is enabled, waits for the layout to be applied first.
+       */
+      showFileChanges?: boolean;
     },
   ): Promise<void>;
 

--- a/packages/vscode-webui/src/components/task-row.tsx
+++ b/packages/vscode-webui/src/components/task-row.tsx
@@ -8,7 +8,6 @@ import { EditSummary } from "@/features/tools";
 import { ToolCallLite } from "@/features/tools";
 import { usePochiCredentials } from "@/lib/hooks/use-pochi-credentials";
 import { useTaskArchived } from "@/lib/hooks/use-task-archived";
-import { useTaskChangedFiles } from "@/lib/hooks/use-task-changed-files";
 import { cn } from "@/lib/utils";
 import { vscodeHost } from "@/lib/vscode";
 import { parseTitle } from "@getpochi/common/message-utils";
@@ -32,9 +31,6 @@ export function TaskRow({
   const { jwt } = usePochiCredentials();
   const { t } = useTranslation();
   const [isHovered, setIsHovered] = useState(false);
-
-  const { showFileChanges } = useTaskChangedFiles(task.id, []);
-
   const { isTaskArchived, setTaskArchived } = useTaskArchived();
 
   const archived = useMemo(
@@ -48,18 +44,19 @@ export function TaskRow({
 
   const openTaskInPanel = useCallback(async () => {
     if (task.cwd) {
-      vscodeHost.openTaskInPanel({
-        type: "open-task",
-        cwd: task.cwd,
-        uid: task.id,
-        storeId,
-      });
-
-      if (!archived) {
-        showFileChanges();
-      }
+      vscodeHost.openTaskInPanel(
+        {
+          type: "open-task",
+          cwd: task.cwd,
+          uid: task.id,
+          storeId,
+        },
+        {
+          showFileChanges: !archived,
+        },
+      );
     }
-  }, [task.cwd, task.id, storeId, showFileChanges, archived]);
+  }, [task.cwd, task.id, storeId, archived]);
 
   const handleArchiveClick = useCallback(
     (e: React.MouseEvent) => {

--- a/packages/vscode/src/integrations/layout/layout-manager.ts
+++ b/packages/vscode/src/integrations/layout/layout-manager.ts
@@ -315,6 +315,36 @@ export class LayoutManager implements vscode.Disposable {
     });
   }
 
+  /**
+   * Returns a promise that resolves when the layout reaches `pochi-layout` state.
+   * If the layout is already in `pochi-layout` state, resolves immediately.
+   * If not enabled, resolves immediately.
+   * Falls back after `timeoutMs` if the layout never reaches `pochi-layout`.
+   */
+  waitForPochiLayout(timeoutMs = 10000): Promise<void> {
+    if (!this.enabled) {
+      return Promise.resolve();
+    }
+    if (this.fsm.state.value === "pochi-layout") {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      const timeoutId = setTimeout(() => {
+        unsubscribe();
+        resolve();
+      }, timeoutMs);
+      const { unsubscribe } = this.fsm.subscribe((state) => {
+        if (state.value === "pochi-layout") {
+          clearTimeout(timeoutId);
+          unsubscribe();
+          resolve();
+        }
+        // For `non-pochi-layout` and `initial` states, keep waiting until timeout.
+        // The tab opening will trigger the layout to apply shortly.
+      });
+    });
+  }
+
   getViewColumnForTerminal() {
     if (this.enabled && this.fsm.state.value === "pochi-layout") {
       return vscode.ViewColumn.Three;

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -140,6 +140,8 @@ import { GithubPullRequestState } from "../github/github-pull-request-state";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { GlobalStateSignals } from "../global-state";
 // biome-ignore lint/style/useImportType: needed for dependency injection
+import { LayoutManager } from "../layout/layout-manager";
+// biome-ignore lint/style/useImportType: needed for dependency injection
 import { ThirdMcpImporter } from "../mcp/third-party-mcp";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { ReviewController } from "../review-controller";
@@ -189,6 +191,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     private readonly lang: PochiLanguage,
     private readonly browserSessionStore: BrowserSessionStore,
     private readonly forkTaskStatus: ForkTaskStatus,
+    private readonly layoutManager: LayoutManager,
   ) {}
 
   private get cwd() {
@@ -924,9 +927,31 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       keepEditor?: boolean;
       preserveFocus?: boolean;
       preview?: boolean;
+      showFileChanges?: boolean;
     },
   ): Promise<void> => {
-    await PochiTaskEditorProvider.openTaskEditor(params, options);
+    const isPochiLayoutEnabled =
+      !!this.pochiConfiguration.advancedSettings.value.pochiLayout?.enabled;
+    await PochiTaskEditorProvider.openTaskEditor(params, {
+      ...options,
+      preview: isPochiLayoutEnabled ? options?.preview : false,
+    });
+
+    if (options?.showFileChanges && params.type === "open-task" && params.uid) {
+      const taskId = params.uid;
+      if (isPochiLayoutEnabled) {
+        // Wait for the layout to be fully applied before showing file changes
+        await this.layoutManager.waitForPochiLayout();
+      }
+      if (this.cwd) {
+        await this.taskChangedFilesManager.showChangedFiles(
+          taskId,
+          this.cwd,
+          undefined,
+          this.checkpointService,
+        );
+      }
+    }
   };
 
   sendTaskNotification = async (


### PR DESCRIPTION
## Summary

- Adds `showFileChanges` option to `openTaskInPanel` in the VSCode host bridge (`webview.ts`, `webview-stub.ts`)
- Moves the file-changes diff view trigger from the webui `TaskRow` component into `VSCodeHostImpl`, so it can be properly coordinated with the layout state
- Adds `waitForPochiLayout()` helper on `LayoutManager` that resolves once the layout FSM reaches `pochi-layout` state (with a configurable timeout fallback)
- When `showFileChanges: true` and pochi layout is enabled, the host now awaits the layout before calling `showChangedFiles`, preventing the diff panel from opening in the wrong column
- Skips `showFileChanges` for archived tasks (preserving the previous behavior from #1389)

## Test plan

- [ ] Open a task from the task history list — file changes diff should appear in the correct panel column
- [ ] Open an archived task — file changes diff should NOT appear
- [ ] Toggle pochi layout on/off and verify file changes panel placement is correct in both modes
- [ ] Verify no regression in task panel opening behavior

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-455f14244db140cc9828cf0cbeefd0c3)