### PR TITLE
fix(vscode): reset view locations when disabling Pochi layout

### DIFF
--- a/packages/vscode/src/integrations/layout/layout-manager.ts
+++ b/packages/vscode/src/integrations/layout/layout-manager.ts
@@ -89,6 +89,7 @@ export class LayoutManager implements vscode.Disposable {
           } else if (prevEnabled && !enabled) {
             this.disposeListeners();
             this.fsm.stop();
+            executeVSCodeCommand("workbench.action.resetViewLocations");
           }
         }),
       },


### PR DESCRIPTION
## Summary

- Call `workbench.action.resetViewLocations` when the Pochi layout is disabled so that VS Code restores its default panel/view positions after the custom layout is turned off.

## Test plan

- [ ] Enable Pochi layout via settings
- [ ] Disable Pochi layout — verify VS Code panels/views reset to their default locations

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a1870d7a4af6427a9d87556a31fe160d)