### PR TITLE
feat(cli): add --agent flag to run top-level task as a sub-agent

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -151,6 +151,10 @@ const program = new Command()
     parseNonNegativeInt,
     60000,
   )
+  .option(
+    "--agent <name>",
+    "Run the task as a sub-agent using the specified custom agent. This applies the agent's system prompt and tool restrictions, matching the behavior of sub-tasks created via the newTask tool.",
+  )
   .addOption(
     new Option(
       "--experimental-output-schema <schema>",
@@ -198,6 +202,21 @@ const program = new Command()
     // Load custom agents and skills
     const customAgents = await loadAgents(process.cwd());
     const skills = await loadSkills(process.cwd());
+
+    // Resolve the --agent flag to a custom agent
+    let selectedAgent: (typeof customAgents)[number] | undefined;
+    if (options.agent) {
+      const agentName = options.agent;
+      selectedAgent = customAgents.find(
+        (a) => a.name.toLowerCase() === agentName.toLowerCase(),
+      );
+      if (!selectedAgent) {
+        const available = customAgents.map((a) => `  • ${a.name}`).join("\n");
+        return program.error(
+          `Agent '${agentName}' not found.\n\nAvailable agents:\n${available || "  (none)"}`,
+        );
+      }
+    }
 
     const { uid, prompt, attachments } = await parseTaskInput(
       options,
@@ -288,6 +307,8 @@ const program = new Command()
       skills,
       mcpHub,
       abortSignal: abortController.signal,
+      isSubTask: selectedAgent !== undefined,
+      customAgent: selectedAgent,
       outputSchema: options.experimentalOutputSchema
         ? parseOutputSchema(options.experimentalOutputSchema)
         : undefined,


### PR DESCRIPTION
## Summary

- Adds `--agent <name>` CLI option to `packages/cli/src/cli.ts`
- When set, resolves the named agent (case-insensitive) from the loaded custom agents list; exits with a helpful error listing available agents if not found
- Passes `isSubTask: true` and `customAgent` to `TaskRunner`, giving the top-level task identical behavior to sub-tasks spawned via the `newTask` tool (sub-agent system prompt, tool restrictions via `selectClientTools`, no recursive `newTask` middleware)

## Usage

```sh
pochi --agent planner -p "Design the auth system"
```

## Test plan

- [ ] Run `pochi --agent <valid-agent> -p "..."` and verify the agent's system prompt is applied and tool set is restricted as expected
- [ ] Run `pochi --agent unknown-agent -p "..."` and verify a clear error is shown listing available agents
- [ ] Run `pochi -p "..."` (no `--agent`) and verify default behavior is unchanged

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-51d0090465934f27a697ca154ad3c8de)