### PR TITLE
fix(vscode-webui): replace auto-approve text button with icon button

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -33,15 +33,11 @@ import { constants } from "@getpochi/common";
 import type { McpConfigOverride } from "@getpochi/common/vscode-webui-bridge";
 import type { Message, Task } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
-import {
-  ChevronDownIcon,
-  PaperclipIcon,
-  SendHorizonal,
-  StopCircleIcon,
-} from "lucide-react";
+import { PaperclipIcon, SendHorizonal, StopCircleIcon } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { TbShieldCog } from "react-icons/tb";
 import {
   type BlockingOperation,
   useBlockingOperations,
@@ -361,27 +357,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
 
       <div className={FooterContainerClassName}>
         <div className={FooterLeftClassName}>
-          <AutoApproveMenu
-            isSubTask={isSubTask}
-            mcpConfigOverride={mcpConfigOverride}
-            trigger={
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className={cn(
-                  "button-focus !gap-0.5 !px-1 h-6 font-normal",
-                  autoApproveActive && "text-foreground",
-                )}
-                aria-label={t("settings.autoApprove.approvals")}
-              >
-                <span className="truncate whitespace-nowrap transition-colors duration-200">
-                  {t("settings.autoApprove.approvals")}
-                </span>
-                <ChevronDownIcon className="size-4 shrink-0 transition-colors duration-200" />
-              </Button>
-            }
-          />
           <ModelSelect
             value={selectedModel || selectedModelFromStore}
             models={groupedModels}
@@ -404,6 +379,24 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             />
           )}
           <DevModeButton messages={messages} todos={todos} />
+          <AutoApproveMenu
+            isSubTask={isSubTask}
+            mcpConfigOverride={mcpConfigOverride}
+            trigger={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "button-focus h-6 w-6 p-0",
+                  autoApproveActive && "text-foreground",
+                )}
+                aria-label={t("settings.autoApprove.approvals")}
+              >
+                <TbShieldCog className="size-4 shrink-0 transition-colors duration-200" />
+              </Button>
+            }
+          />
           {!isSubTask && (
             <PublicShareButton
               task={task}
@@ -491,7 +484,6 @@ const SubmitStopButton: React.FC<SubmitStopButtonProps> = ({
 
 export function ChatToolBarSkeleton() {
   const { input, setInput } = useChatInputState();
-  const { t } = useTranslation();
   return (
     <>
       <div className={PopupContainerClassName}>
@@ -532,23 +524,6 @@ export function ChatToolBarSkeleton() {
 
       <div className={FooterContainerClassName}>
         <div className={FooterLeftClassName}>
-          <AutoApproveMenu
-            isSubTask={false}
-            trigger={
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="button-focus h-6 gap-1 px-1.5 text-xs"
-                aria-label={t("settings.autoApprove.approvals")}
-              >
-                <span className="truncate whitespace-nowrap transition-colors duration-200">
-                  {t("settings.autoApprove.approvals")}
-                </span>
-                <ChevronDownIcon className="size-4 shrink-0 transition-colors duration-200" />
-              </Button>
-            }
-          />
           <ModelSelect
             isLoading={true}
             value={undefined}

--- a/packages/vscode-webui/src/features/settings/components/auto-approve-menu.tsx
+++ b/packages/vscode-webui/src/features/settings/components/auto-approve-menu.tsx
@@ -226,6 +226,7 @@ export function AutoApproveMenu({
       <PopoverContent
         className="[@media(min-width:400px)]:w-[400px]"
         side="top"
+        align="end"
       >
         <div className="grid grid-cols-1 gap-2.5 [@media(min-width:400px)]:grid-cols-2">
           {coreActionSettings


### PR DESCRIPTION

<img width="1316" height="364" alt="image" src="https://github.com/user-attachments/assets/8146d78c-76b1-4449-95a9-d97a7cc25925" />
<img width="1320" height="462" alt="image" src="https://github.com/user-attachments/assets/edbc6e22-24df-4a87-b22b-ccdee48254a7" />



## Summary
- Replace the "Approvals" text+chevron button in the chat toolbar with a compact `TbShieldCog` icon-only button
- Reposition `AutoApproveMenu` to after `DevModeButton` in the toolbar layout
- Add `align="end"` to `PopoverContent` so the dropdown aligns to the right edge of the trigger
- Remove `AutoApproveMenu` from `ChatToolBarSkeleton` (skeleton no longer shows it)

## Test plan
- [ ] Open the chat toolbar and verify the auto-approve button shows as a shield-cog icon instead of "Approvals" text
- [ ] Click the icon to open the auto-approve menu and verify it opens aligned to the right
- [ ] Verify the skeleton state no longer renders the auto-approve button

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-23fd4460d3bb4e80935c697ed6979a46)