### PR TITLE
fix(vscode): trigger layout apply when waiting for pochi layout state

### DIFF
--- a/packages/vscode/src/integrations/layout/layout-manager.ts
+++ b/packages/vscode/src/integrations/layout/layout-manager.ts
@@ -329,6 +329,10 @@ export class LayoutManager implements vscode.Disposable {
     if (this.fsm.state.value === "pochi-layout") {
       return Promise.resolve();
     }
+    this.fsm.send({
+      type: "start-apply",
+      trigger: "manual",
+    });
     return new Promise<void>((resolve) => {
       const timeoutId = setTimeout(() => {
         unsubscribe();


### PR DESCRIPTION
## Summary

- Proactively send the `start-apply` FSM event inside `waitForPochiLayout` so the layout transitions to `pochi-layout` state immediately rather than relying on a tab-open side-effect to drive the transition.
- This prevents `waitForPochiLayout` from hanging indefinitely when called in contexts where no tab-open event would naturally fire.

## Test plan

- [ ] Enable Pochi layout in VS Code settings
- [ ] Trigger a flow that calls `waitForPochiLayout` (e.g. `showFileChanges`) and verify the layout applies correctly
- [ ] Verify that calling `waitForPochiLayout` when already in `pochi-layout` state still resolves immediately

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0fec1753e2df4faf9028e6e7df0e7f08)