### PR TITLE
fix(livekit): assign shareId to forked root tasks so share button is enabled

### DIFF
--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -466,7 +466,11 @@ const materializers = State.SQLite.materializers(events, {
     ),
   "v1.ForkTaskInited": ({ tasks, messages, files }) => [
     ...tasks.map((task) =>
-      tables.tasks.insert({ ...task, updatedAt: task.createdAt }),
+      tables.tasks.insert({
+        ...task,
+        shareId: task.parentId ? undefined : `p-${task.id.replaceAll("-", "")}`,
+        updatedAt: task.createdAt,
+      }),
     ),
     ...messages.map((message) => tables.messages.insert(message)),
     ...files.map((file) => tables.files.insert(file)),


### PR DESCRIPTION
## Summary

- Forked tasks were missing a `shareId` because the `v1.ForkTaskInited` materializer inserted tasks as-is without assigning one
- The `PublicShareButton` is disabled when `!shareId`, so the share button was always disabled on forked tasks
- Root forked tasks (those without `parentId`) now receive a `shareId` using the same `p-${id.replaceAll("-", "")}` pattern as `v1.TaskInited`

## Test plan

- [ ] Fork a task from a checkpoint
- [ ] Verify the share button is enabled on the forked task
- [ ] Verify sub-tasks within a forked task do not have a share button enabled (they have a `parentId`)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-eeeb22b4ac4e4331b4c2a76fc00bf089)