### PR TITLE
feat: Specify name of skill in CLI

### DIFF
--- a/packages/cli/src/output-renderer.ts
+++ b/packages/cli/src/output-renderer.ts
@@ -154,7 +154,7 @@ export class OutputRenderer {
   }
 }
 
-export function renderToolPart(
+function renderToolPart(
   part: ToolUIPart<UITools>,
   attemptCompletionSchemaOverride = false,
 ): {


### PR DESCRIPTION
- Updated OutputRenderer to change rendered skill from `Tool useSkill` to `Using skill {skill-name}` on Pochi CLI

Output of demo skill is shown:
<img width="456" height="135" alt="Screenshot 2026-03-24 at 4 26 11 PM" src="https://github.com/user-attachments/assets/6fa60900-65cb-476c-819e-397fd7aa0e7d" />
