### PR TITLE
fix(cli): improve error handling in executeCommand tool

### DIFF
--- a/packages/cli/src/tools/__tests__/execute-command.test.ts
+++ b/packages/cli/src/tools/__tests__/execute-command.test.ts
@@ -59,11 +59,11 @@ describe("executeCommand", () => {
   });
 
   it("should handle command errors", async () => {
-    const result = await executeCommand()(
+    const promise = executeCommand()(
         { command: "nonexistentcommand" },
         mockToolExecutionOptions,
       );
-    expect(result.output).toMatch(/command not found|Command exited with code/);
+    await expect(promise).rejects.toThrow(/command not found|Command exited with code/);
   });
 
   it("should indicate when output is truncated", async () => {
@@ -109,11 +109,11 @@ describe("executeCommand", () => {
   });
 
   it("should handle generic errors correctly with proper formatting", async () => {
-    const result = await executeCommand()(
+    const promise = executeCommand()(
       { command: "invalidcommandthatdoesnotexist" },
       mockToolExecutionOptions,
     )
-    expect(result.output).toMatch(/command not found|Command exited with code/);
+    await expect(promise).rejects.toThrow(/command not found|Command exited with code/);
   });
 
   it("should set GIT_COMMITTER environment variables", async () => {

--- a/packages/cli/src/tools/execute-command.ts
+++ b/packages/cli/src/tools/execute-command.ts
@@ -12,6 +12,29 @@ import {
 } from "@getpochi/common/tool-utils";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 
+export class ExecuteCommandError extends Error {
+  public code: number;
+  public stdout: string;
+  public stderr: string;
+
+  constructor({
+    message,
+    code,
+    stdout,
+    stderr,
+  }: { message: string; code: number; stdout: string; stderr: string }) {
+    super(message);
+    this.name = "ExecuteCommandError";
+    this.code = code;
+    this.stdout = stdout;
+    this.stderr = stderr;
+  }
+
+  asOutput() {
+    return processCommandOutput(this.stdout, this.stderr, this.message);
+  }
+}
+
 export const executeCommand =
   (): ToolFunctionType<ClientTools["executeCommand"]> =>
   async (
@@ -30,11 +53,7 @@ export const executeCommand =
     }
 
     try {
-      const {
-        code,
-        stdout = "",
-        stderr = "",
-      } = await execWithExitCode(timeout, command, {
+      const { stdout = "", stderr = "" } = await execWithExitCode(command, {
         shell: getShellPath(),
         timeout: timeout * 1000, // Convert to milliseconds
         cwd: resolvedCwd,
@@ -42,22 +61,15 @@ export const executeCommand =
         env: { ...process.env, ...envs, ...getTerminalEnv() },
       });
 
-      const { output, isTruncated } = processCommandOutput(
-        stdout,
-        stderr,
-        code,
-      );
-
-      return {
-        output,
-        isTruncated,
-      };
+      return processCommandOutput(stdout, stderr);
     } catch (error) {
-      if (error instanceof Error) {
-        // Handle abort signal
-        if (error.name === "AbortError") {
-          throw new Error("Command execution was aborted");
-        }
+      if (error instanceof ExecuteCommandError) {
+        throw error;
+      }
+
+      // Handle abort signal
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error("Command execution was aborted");
       }
 
       // Handle other execution errors
@@ -78,11 +90,10 @@ function isExecException(error: unknown): error is ExecException {
 }
 
 async function execWithExitCode(
-  timeout: number,
   command: string,
   options: ExecOptionsWithStringEncoding,
-): Promise<{ stdout: string; stderr: string; code: number }> {
-  return await new Promise<{ stdout: string; stderr: string; code: number }>(
+): Promise<{ stdout: string; stderr: string; code: 0 }> {
+  return await new Promise<{ stdout: string; stderr: string; code: 0 }>(
     (resolve, reject) => {
       const child = exec(command, options, (err, stdout = "", stderr = "") => {
         if (!err) {
@@ -95,20 +106,31 @@ async function execWithExitCode(
         }
 
         if (isExecException(err)) {
-          if (err.signal === "SIGTERM" && err.killed) {
+          if (
+            err.signal === "SIGTERM" &&
+            err.killed &&
+            options.timeout &&
+            options.timeout > 0
+          ) {
             reject(
-              new Error(
-                `Command execution timed out after ${timeout} seconds.`,
-              ),
+              new ExecuteCommandError({
+                message: `Command execution timed out after ${options.timeout / 1000} seconds.`,
+                stdout: err.stdout ?? stdout ?? "",
+                stderr: err.stderr ?? stderr ?? "",
+                code: err.code ?? 1,
+              }),
             );
             return;
           }
 
-          resolve({
-            stdout: err.stdout || "",
-            stderr: err.stderr || "",
-            code: err.code || 1,
-          });
+          reject(
+            new ExecuteCommandError({
+              message: `Command exited with code ${err.code ?? 1}`,
+              stdout: err.stdout ?? stdout ?? "",
+              stderr: err.stderr ?? stderr ?? "",
+              code: err.code ?? 1,
+            }),
+          );
           return;
         }
 
@@ -124,16 +146,21 @@ async function execWithExitCode(
 function processCommandOutput(
   stdout: string,
   stderr: string,
-  code: number,
-): { output: string; isTruncated: boolean } {
-  let fullOutput = fixExecuteCommandOutput(stdout + stderr);
-  if (code !== 0) {
-    fullOutput += `\nCommand exited with code ${code}`;
-  }
+  errorMessage?: string,
+): { output: string; isTruncated: boolean; error?: string } {
+  const fullOutput = fixExecuteCommandOutput(stdout + stderr);
   const isTruncated = fullOutput.length > MaxTerminalOutputSize;
   const output = isTruncated
     ? fullOutput.slice(-MaxTerminalOutputSize)
     : fullOutput;
+
+  if (errorMessage) {
+    return {
+      output,
+      isTruncated,
+      error: errorMessage,
+    };
+  }
 
   return { output, isTruncated };
 }

--- a/packages/cli/src/tools/index.ts
+++ b/packages/cli/src/tools/index.ts
@@ -5,7 +5,7 @@ import { type ToolUIPart, getToolName } from "ai";
 import type { ToolCallOptions } from "../types";
 import { applyDiff } from "./apply-diff";
 import { editNotebook } from "./edit-notebook";
-import { executeCommand } from "./execute-command";
+import { ExecuteCommandError, executeCommand } from "./execute-command";
 import { globFiles } from "./glob-files";
 import { killBackgroundJob } from "./kill-background-job";
 import { listFiles } from "./list-files";
@@ -64,6 +64,10 @@ export async function executeToolCall(
         envs,
       });
     } catch (e) {
+      if (e instanceof ExecuteCommandError) {
+        return e.asOutput();
+      }
+
       return {
         error: toErrorMessage(e),
       };


### PR DESCRIPTION
## Summary
- Introduce `ExecuteCommandError` to better propagate command failure details (exit code, stdout, stderr).
- Refactor `execWithExitCode` to reject with `ExecuteCommandError` instead of resolving with an error code, ensuring consistent error handling.
- Update `processCommandOutput` to handle error messages and return them in the result object.
- Update tests to reflect the change from resolved error results to rejected exceptions.

## Test plan
- Run `bun test` in `packages/cli` to verify that all tests, including the updated `execute-command.test.ts`, pass.
- Verified that command timeouts and non-zero exit codes are now correctly caught as exceptions.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a17a3762b19f482c8697f84d5c63d721)