### PR TITLE
docs: update create-issue skill with project field management instructions

### DIFF
--- a/.pochi/skills/create-issue/SKILL.md
+++ b/.pochi/skills/create-issue/SKILL.md
@@ -16,6 +16,16 @@ description: Help create a github issue given the request
     ```bash
     gh issue edit <issue-number> --add-project "Pochi Tasks"
     ```
-7. If `gh issue edit` failed to add project, should ask user to refresh their gh token to authorize it with the project scope (`gh auth refresh -s project`).
+7. If the user specifies an Assignee, Priority (e.g., P1, P2), or Release (e.g., v0.42), update those as well:
+    - Add Assignee: `gh issue edit <issue-number> --add-assignee <username>`
+    - To update project fields (Priority, Release), you must find the relevant IDs and update the project item:
+      1. Get Project Number/ID: `gh project list --owner TabbyML`
+      2. Get Field and Option IDs: `gh project field-list <project-number> --owner TabbyML --format json`
+      3. Get Project Item ID for the issue:
+         ```bash
+         gh project item-list <project-number> --owner TabbyML --format json | jq -r '.items[] | select(.content.number == <issue-number>) | .id'
+         ```
+      4. Update the field: `gh project item-edit --id <item-id> --field-id <field-id> --project-id <project-id> --single-select-option-id <option-id>`
+8. If `gh issue edit` failed to add project, should ask user to refresh their gh token to authorize it with the project scope (`gh auth refresh -s project`).
 
 IMPORTANT: You only need to create the issue, DO NOT attempt to fix the issue or implement the feature.


### PR DESCRIPTION
## Summary
- Updated the `create-issue` skill to include detailed instructions for managing project fields such as Priority, Release, and Assignee using the `gh` CLI.
- Simplified the process of retrieving project item IDs by switching from the GraphQL API to `gh project item-list`.

## Test plan
- Verified the `gh project item-list` command and `jq` filter manually.
- Ensured the instructions are clear and actionable.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c750ddbcc811434f950ae0476aabb5d1)