### PR TITLE
test(vscode): verify user message is displayed in task panel after task creation

### DIFF
--- a/packages/vscode/tests/pageobjects/pochi-panel.ts
+++ b/packages/vscode/tests/pageobjects/pochi-panel.ts
@@ -57,6 +57,27 @@ export class PochiPanel {
   }
 
   /**
+   * Wait for at least one user message to appear in the task panel.
+   * This confirms the task panel is properly displaying the conversation.
+   */
+  async waitForUserMessage(timeout = 30000) {
+    const userMessage = $('[aria-label="chat-message-user"]');
+    await userMessage.waitForExist({
+      timeout,
+      timeoutMsg: "User message did not appear in task panel",
+    });
+  }
+
+  /**
+   * Get the text content of the first user message displayed in the task panel.
+   */
+  async getUserMessageText(): Promise<string> {
+    const userMessage = $('[aria-label="chat-message-user"]');
+    await userMessage.waitForExist({ timeout: 10000 });
+    return userMessage.getText();
+  }
+
+  /**
    * Wait for at least one assistant message to appear.
    * This indicates the request was successful.
    */

--- a/packages/vscode/tests/specs/git-workspace/create-task.test.ts
+++ b/packages/vscode/tests/specs/git-workspace/create-task.test.ts
@@ -1,6 +1,9 @@
 import { browser, expect } from "@wdio/globals";
 import type { Workbench } from "wdio-vscode-service";
+import { PochiPanel } from "../../pageobjects/pochi-panel";
 import { PochiSidebar } from "../../pageobjects/pochi-sidebar";
+
+const TestMessage = "Hello Pochi test task";
 
 describe("Create Task Tests", () => {
   let workbench: Workbench;
@@ -11,13 +14,14 @@ describe("Create Task Tests", () => {
 
   it("should be able to create a new task from sidebar", async () => {
     const pochi = new PochiSidebar();
+    const panel = new PochiPanel();
 
     await pochi.open();
-    await pochi.sendMessage("Hello Pochi test task");
+    await pochi.sendMessage(TestMessage);
 
     // Wait for the task to appear in the sidebar task list
     await pochi.waitForTaskToAppear();
-    
+
     // Verify the task appears in the sidebar list
     const taskTitles = await pochi.getTaskTitles();
     console.log("[Test Debug] Task titles in sidebar:", taskTitles);
@@ -47,5 +51,25 @@ describe("Create Task Tests", () => {
       (t: string) => t !== "Untitled-1" && t !== "Welcome",
     );
     expect(taskTab).toBeDefined();
+
+    // Switch to the task panel frame and verify user message is displayed
+    await browser.waitUntil(
+      async () => {
+        return await panel.findAndSwitchToPanelFrame();
+      },
+      {
+        timeout: 30000,
+        timeoutMsg: "Could not find and switch to task panel frame",
+      },
+    );
+
+    // Verify the user message is visible in the task panel
+    await panel.waitForUserMessage(30000);
+    const userMessageText = await panel.getUserMessageText();
+    console.log("[Test Debug] User message text in panel:", userMessageText);
+    expect(userMessageText).toContain(TestMessage);
+
+    // Switch back to main frame for clean state
+    await panel.close();
   });
 });

--- a/packages/vscode/tests/specs/git-worktrees-workspace/create-task.test.ts
+++ b/packages/vscode/tests/specs/git-worktrees-workspace/create-task.test.ts
@@ -1,6 +1,9 @@
 import { browser, expect } from "@wdio/globals";
 import type { Workbench } from "wdio-vscode-service";
+import { PochiPanel } from "../../pageobjects/pochi-panel";
 import { PochiSidebar } from "../../pageobjects/pochi-sidebar";
+
+const TestMessage = "Hello Pochi test task";
 
 describe("Create Task Tests", () => {
   let workbench: Workbench;
@@ -11,13 +14,14 @@ describe("Create Task Tests", () => {
 
   it("should be able to create a new task from sidebar", async () => {
     const pochi = new PochiSidebar();
+    const panel = new PochiPanel();
 
     await pochi.open();
-    await pochi.sendMessage("Hello Pochi test task");
+    await pochi.sendMessage(TestMessage);
 
     // Wait for the task to appear in the sidebar task list
     await pochi.waitForTaskToAppear();
-    
+
     // Verify the task appears in the sidebar list
     const taskTitles = await pochi.getTaskTitles();
     console.log("[Test Debug] Task titles in sidebar:", taskTitles);
@@ -47,5 +51,25 @@ describe("Create Task Tests", () => {
       (t: string) => t !== "Untitled-1" && t !== "Welcome",
     );
     expect(taskTab).toBeDefined();
+
+    // Switch to the task panel frame and verify user message is displayed
+    await browser.waitUntil(
+      async () => {
+        return await panel.findAndSwitchToPanelFrame();
+      },
+      {
+        timeout: 30000,
+        timeoutMsg: "Could not find and switch to task panel frame",
+      },
+    );
+
+    // Verify the user message is visible in the task panel
+    await panel.waitForUserMessage(30000);
+    const userMessageText = await panel.getUserMessageText();
+    console.log("[Test Debug] User message text in panel:", userMessageText);
+    expect(userMessageText).toContain(TestMessage);
+
+    // Switch back to main frame for clean state
+    await panel.close();
   });
 });

--- a/packages/vscode/tests/specs/plain-workspace/create-task.test.ts
+++ b/packages/vscode/tests/specs/plain-workspace/create-task.test.ts
@@ -1,6 +1,9 @@
 import { browser, expect } from "@wdio/globals";
 import type { Workbench } from "wdio-vscode-service";
+import { PochiPanel } from "../../pageobjects/pochi-panel";
 import { PochiSidebar } from "../../pageobjects/pochi-sidebar";
+
+const TestMessage = "Hello Pochi test task";
 
 describe("Create Task Tests", () => {
   let workbench: Workbench;
@@ -11,13 +14,14 @@ describe("Create Task Tests", () => {
 
   it("should be able to create a new task from sidebar", async () => {
     const pochi = new PochiSidebar();
+    const panel = new PochiPanel();
 
     await pochi.open();
-    await pochi.sendMessage("Hello Pochi test task");
+    await pochi.sendMessage(TestMessage);
 
     // Wait for the task to appear in the sidebar task list
     await pochi.waitForTaskToAppear(60000);
-    
+
     // Verify the task appears in the sidebar list
     const taskTitles = await pochi.getTaskTitles();
     console.log("[Test Debug] Task titles in sidebar:", taskTitles);
@@ -47,5 +51,25 @@ describe("Create Task Tests", () => {
       (t: string) => t !== "Untitled-1" && t !== "Welcome",
     );
     expect(taskTab).toBeDefined();
+
+    // Switch to the task panel frame and verify user message is displayed
+    await browser.waitUntil(
+      async () => {
+        return await panel.findAndSwitchToPanelFrame();
+      },
+      {
+        timeout: 30000,
+        timeoutMsg: "Could not find and switch to task panel frame",
+      },
+    );
+
+    // Verify the user message is visible in the task panel
+    await panel.waitForUserMessage(30000);
+    const userMessageText = await panel.getUserMessageText();
+    console.log("[Test Debug] User message text in panel:", userMessageText);
+    expect(userMessageText).toContain(TestMessage);
+
+    // Switch back to main frame for clean state
+    await panel.close();
   });
 });


### PR DESCRIPTION
## Summary

- Extends all three `create-task` e2e tests (git, git-worktrees, plain workspace) to switch into the task panel WebView after the tab opens and assert the user message is rendered
- Adds `waitForUserMessage(timeout)` and `getUserMessageText()` methods to the `PochiPanel` page object, using the stable `[aria-label="chat-message-user"]` selector from `message-list.tsx`

## Test plan

- [ ] Run `bun turbo test:integration` and confirm create-task tests pass across all workspace types
- [ ] Verify the user message text assertion (`toContain("Hello Pochi test task")`) passes

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c8a9e527689b404db8f810b1fe1981b5)