### PR TITLE
chore(vscode): bump version to 0.39.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.37.0-dev",
+  "version": "0.39.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary

- Bumps the VS Code extension version from `0.37.0-dev` to `0.39.0-dev` in `packages/vscode/package.json`

## Test plan

- [ ] Verify the extension builds successfully with the new version

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a0c795cdb6374da58676994feee361ee)