### PR TITLE
fix(common): vendor tools not properly loaded when mcpConfigOverride is set

### DIFF
--- a/packages/common/src/vscode-webui-bridge/__tests__/mcp-util.test.ts
+++ b/packages/common/src/vscode-webui-bridge/__tests__/mcp-util.test.ts
@@ -1,0 +1,68 @@
+import type { McpServerConnection } from "../../mcp-utils";
+import { describe, expect, it } from "vitest";
+import { buildTaskScopedMcpInfo } from "../mcp-util";
+
+describe("buildTaskScopedMcpInfo", () => {
+  it("keeps vendor tools when task-scoped MCP overrides are applied", () => {
+    const connections: Record<string, McpServerConnection> = {
+      pochi: {
+        kind: "vendor",
+        status: "ready",
+        error: undefined,
+        tools: {
+          webFetch: {
+            description: "Fetch web content",
+            disabled: false,
+            inputSchema: {
+              jsonSchema: { type: "object" },
+            },
+          },
+        },
+      },
+      context7: {
+        status: "ready",
+        error: undefined,
+        instructions: "Use Context7 docs.",
+        tools: {
+          resolveLibraryId: {
+            description: "Resolve library id",
+            disabled: false,
+            inputSchema: {
+              jsonSchema: { type: "object" },
+            },
+          },
+          getLibraryDocs: {
+            description: "Fetch library docs",
+            disabled: false,
+            inputSchema: {
+              jsonSchema: { type: "object" },
+            },
+          },
+        },
+      },
+    };
+
+    const result = buildTaskScopedMcpInfo(connections, {
+      context7: {
+        disabledTools: ["getLibraryDocs"],
+      },
+    });
+
+    expect(result.toolset.webFetch).toEqual({
+      description: "Fetch web content",
+      inputSchema: {
+        jsonSchema: { type: "object" },
+      },
+    });
+    expect(result.toolset.resolveLibraryId).toEqual({
+      description: "Resolve library id",
+      inputSchema: {
+        jsonSchema: { type: "object" },
+      },
+    });
+    expect(result.toolset.getLibraryDocs).toBeUndefined();
+    expect(result.instructions).toBe(
+      "# Instructions from context7 mcp server\nUse Context7 docs.",
+    );
+  });
+});

--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -69,6 +69,7 @@ export {
 export { ActiveSelection, BashOutputs, UserEdits } from "./types/message";
 export type { VSCodeSettings } from "./types/vscode-settings";
 export {
+  buildTaskScopedMcpInfo,
   buildInstructionsFromConnections,
   buildToolsetFromConnections,
 } from "./mcp-util";

--- a/packages/common/src/vscode-webui-bridge/mcp-util.ts
+++ b/packages/common/src/vscode-webui-bridge/mcp-util.ts
@@ -1,6 +1,7 @@
 import type { McpTool } from "@getpochi/tools";
 import * as R from "remeda";
 import type { McpServerConnection } from "../mcp-utils";
+import type { McpConfigOverride } from "./types/task";
 
 export const buildInstructionsFromConnections = (
   connections: Record<string, McpServerConnection>,
@@ -27,4 +28,38 @@ export const buildToolsetFromConnections = (
       .map((connection) => R.pickBy(connection.tools, (tool) => !tool.disabled))
       .map((tool) => R.mapValues(tool, (tool) => R.omit(tool, ["disabled"]))),
   );
+};
+
+export const buildTaskScopedMcpInfo = (
+  connections: Record<string, McpServerConnection>,
+  mcpConfigOverride: McpConfigOverride,
+) => {
+  const filteredConnections: typeof connections = {};
+
+  for (const [serverName, connection] of Object.entries(connections)) {
+    if (connection.kind === "vendor") {
+      filteredConnections[serverName] = connection;
+      continue;
+    }
+
+    const serverConfig = mcpConfigOverride[serverName];
+    if (!serverConfig) {
+      continue;
+    }
+
+    const newConn = { ...connection };
+    const newTools: typeof newConn.tools = {};
+    for (const [toolName, tool] of Object.entries(connection.tools)) {
+      if (!serverConfig.disabledTools.includes(toolName)) {
+        newTools[toolName] = tool;
+      }
+    }
+    newConn.tools = newTools;
+    filteredConnections[serverName] = newConn;
+  }
+
+  return {
+    toolset: buildToolsetFromConnections(filteredConnections),
+    instructions: buildInstructionsFromConnections(filteredConnections),
+  };
 };

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -16,10 +16,9 @@ import { constants, type Environment } from "@getpochi/common";
 import { createModel } from "@getpochi/common/vendor/edge";
 import {
   type DisplayModel,
-  buildInstructionsFromConnections,
-  buildToolsetFromConnections,
+  type McpConfigOverride,
+  buildTaskScopedMcpInfo,
 } from "@getpochi/common/vscode-webui-bridge";
-import type { McpConfigOverride } from "@getpochi/common/vscode-webui-bridge";
 import type { LLMRequestData } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
 import { useCallback } from "react";
@@ -78,35 +77,11 @@ export function useLiveChatKitGetters({
         mcpInfo.current;
 
       // If no per-task mcpConfigOverride, return global state
-      if (!mcpConfigOverride) {
+      if (!mcpConfigOverride || Object.keys(mcpConfigOverride).length === 0) {
         return { toolset, instructions };
       }
 
-      const filteredConnections: typeof connections = {};
-
-      for (const [serverName, connection] of Object.entries(connections)) {
-        if (!mcpConfigOverride[serverName]) {
-          continue;
-        }
-
-        const serverConfig = mcpConfigOverride[serverName];
-        const serverTools = connection.tools;
-
-        const newConn = { ...connection };
-        const newTools: typeof newConn.tools = {};
-        for (const [toolName, tool] of Object.entries(serverTools)) {
-          if (!serverConfig.disabledTools.includes(toolName)) {
-            newTools[toolName] = tool;
-          }
-        }
-        newConn.tools = newTools;
-        filteredConnections[serverName] = newConn;
-      }
-
-      return {
-        toolset: buildToolsetFromConnections(filteredConnections),
-        instructions: buildInstructionsFromConnections(filteredConnections),
-      };
+      return buildTaskScopedMcpInfo(connections, mcpConfigOverride);
     }, []),
 
     // biome-ignore lint/correctness/useExhaustiveDependencies(customAgentsRef.current): customAgentsRef is ref.


### PR DESCRIPTION
## Summary
- Fixes a bug where vendor connections (built-in tools) were excluded from the MCP tool set when a task had a non-empty `mcpConfigOverride`, causing vendor tools to disappear
- Fixes a secondary bug where an empty `mcpConfigOverride` object (`{}`) would bypass global MCP state and return no connections
- Extracts the fix into a shared `buildTaskScopedMcpInfo` utility with unit tests

## Test plan
- [ ] Verify vendor tools (e.g. built-in tools) are always available in tasks even when `mcpConfigOverride` is set
- [ ] Verify task-scoped MCP tool filtering still works correctly for non-vendor connections
- [ ] Run `bun run test` in `packages/common` to verify new tests pass

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7adfa152d7a34f76823ff85bdf0a94e0)