### PR TITLE
chore: update UI styles and follow-up question component

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/ask-followup-question.tsx
+++ b/packages/vscode-webui/src/features/tools/components/ask-followup-question.tsx
@@ -177,8 +177,8 @@ function OptionRow({
         isSelected
           ? "bg-muted"
           : isFocused
-            ? "bg-muted/60"
-            : "hover:bg-muted/30",
+            ? "bg-muted/80"
+            : "hover:bg-muted/50",
         isFocused ? "border-l-foreground/40" : "border-l-transparent",
         !isInteractive && "cursor-not-allowed opacity-60",
       )}
@@ -363,7 +363,7 @@ function OtherRow({
       className={cn(
         "flex min-h-8 w-full items-center gap-3 border-l-2 py-1.5 pr-3 transition-colors",
         isFocused ? "pl-[10px]" : "pl-3",
-        isOpen ? "bg-muted" : isFocused ? "bg-muted/60" : "hover:bg-muted/30",
+        isOpen ? "bg-muted" : isFocused ? "bg-muted/80" : "hover:bg-muted/50",
         isFocused ? "border-l-foreground/40" : "border-l-transparent",
         !isInteractive && "opacity-60",
       )}

--- a/packages/vscode-webui/src/styles.css
+++ b/packages/vscode-webui/src/styles.css
@@ -155,6 +155,7 @@ code {
   --background: var(--vscode-editor-background);
   --foreground: var(--vscode-foreground);
 
+  --muted: var(--vscode-editor-inactiveSelectionBackground);
   --muted-foreground: var(--vscode-descriptionForeground);
 
   --card: var(--vscode-toolbar-hoverBackground);
@@ -167,8 +168,8 @@ code {
   --primary: var(--vscode-button-background);
   --primary-foreground: var(--vscode-button-foreground);
 
-  --secondary: var(--vscode-button-secondaryBackground);
-  --secondary-foreground: var(--vscode-button-secondaryForeground);
+  --secondary: var(--vscode-list-hoverBackground);
+  --secondary-foreground: var(--vscode-foreground);
 
   --popover: var(--vscode-dropdown-background);
   --popover-foreground: var(--vscode-dropdown-foreground);


### PR DESCRIPTION
## Summary
- Update background colors in `ask-followup-question.tsx` for better visibility during interaction.
- Refine CSS variables for `--muted` and `--secondary` in `styles.css` to better match VSCode theme expectations.

## Test plan
- Verify the follow-up question component's focus/hover states in the UI.
- Ensure the muted and secondary colors are correctly applied across the webview.

## Screenshot

### Default Dark
<img width="2000" height="810" alt="image" src="https://github.com/user-attachments/assets/931893b5-6e95-4e4e-b062-4e870936b56a" />
<img width="1120" height="590" alt="image" src="https://github.com/user-attachments/assets/91ff35a1-a097-45d3-9025-cfa5eed5e028" />


### Dark Modern
<img width="1722" height="888" alt="image" src="https://github.com/user-attachments/assets/b74226be-edaf-493a-b597-54112de62fb9" />
<img width="1116" height="582" alt="image" src="https://github.com/user-attachments/assets/0398681d-26df-4ec4-af7d-ddc6a7908720" />



🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8552008d8b6a448f86b382c8318af363)