### PR TITLE
chore(vscode-webui): support language selection from URL hash in share page

### DIFF
--- a/packages/vscode-webui/src/share.tsx
+++ b/packages/vscode-webui/src/share.tsx
@@ -1,4 +1,4 @@
-import "./i18n/config";
+import i18n from "./i18n/config";
 import "./styles.css";
 import { StrictMode, useEffect } from "react";
 import ReactDOM from "react-dom/client";
@@ -45,6 +45,15 @@ function App() {
 // Render the app
 const rootElement = document.getElementById("app");
 if (rootElement && !rootElement.innerHTML) {
+  const hash = window.location.hash.substring(1);
+  if (hash) {
+    const hashParams = new URLSearchParams(hash);
+    const langParam = hashParams.get("lang");
+    if (langParam) {
+      i18n.changeLanguage(langParam);
+    }
+  }
+
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <StrictMode>


### PR DESCRIPTION
## Summary
- Import `i18n` configuration in `share.tsx`.
- Add logic to check for the `lang` parameter in the URL hash.
- Automatically update the app language based on the `lang` parameter before rendering.

## Test plan
1. Open a shared page URL with `#lang=zh` (e.g., `https://app.getpochi.com/share/some-id#lang=zh`).
2. Verify that the UI is displayed in Chinese.
3. Open a shared page URL with `#lang=en`.
4. Verify that the UI is displayed in English.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-514ebb1bbea64182a656b57448b165d6)