### PR TITLE
fix(vscode): keep terminal open after background job completes

### DIFF
--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -106,7 +106,6 @@ export class TerminalJob implements vscode.Disposable {
       }
     } finally {
       this.outputManager.finalize(executionError);
-      this.terminal.dispose();
       this.dispose();
     }
   }


### PR DESCRIPTION
## Summary

- Removed `this.terminal.dispose()` from the `finally` block in `TerminalJob.execute()` so background job terminals remain open after the job finishes
- Users can now inspect terminal output after a job completes without the terminal disappearing
- Terminal still closes when explicitly killed via `killBackgroundJob` or when the user manually closes it

## Test plan

- [ ] Start a background job (e.g. `sleep 2 && echo done`) and verify the terminal stays open after it completes
- [ ] Verify `killBackgroundJob` still closes the terminal
- [ ] Verify manually closing the terminal still triggers proper job cleanup

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b5edb0fcb4904fec9d47ee6a103c052e)