### PR TITLE
fix(vscode): restrict file watcher to .pochi or .agents directories

### DIFF
--- a/packages/vscode/src/lib/custom-agent.ts
+++ b/packages/vscode/src/lib/custom-agent.ts
@@ -109,14 +109,14 @@ export class CustomAgentManager implements vscode.Disposable {
 
     try {
       if (this.cwd) {
-        watchDir(this.cwd, ".pochi/agents", ".pochi/agents/**/*.md");
+        watchDir(path.join(this.cwd, ".pochi"), "agents", "agents/**/*.md");
       }
     } catch (error) {
       logger.error("Failed to initialize project agents watcher", error);
     }
 
     try {
-      watchDir(os.homedir(), ".pochi/agents", ".pochi/agents/**/*.md");
+      watchDir(path.join(os.homedir(), ".pochi"), "agents", "agents/**/*.md");
     } catch (error) {
       logger.error("Failed to initialize system agents watcher", error);
     }

--- a/packages/vscode/src/lib/skill-manager.ts
+++ b/packages/vscode/src/lib/skill-manager.ts
@@ -134,21 +134,21 @@ export class SkillManager implements vscode.Disposable {
   private initWatchers() {
     try {
       if (this.cwd) {
-        this.watchSkillsDir(this.cwd, ".pochi/skills");
-        this.watchSkillsDir(this.cwd, ".agents/skills");
+        this.watchSkillsDir(path.join(this.cwd, ".pochi"), "skills");
+        this.watchSkillsDir(path.join(this.cwd, ".agents"), "skills");
       }
     } catch (error) {
       logger.error("Failed to initialize project skills watcher", error);
     }
 
     try {
-      this.watchSkillsDir(os.homedir(), ".pochi/skills");
+      this.watchSkillsDir(path.join(os.homedir(), ".pochi"), "skills");
     } catch (error) {
       logger.error("Failed to initialize system skills watcher", error);
     }
 
     try {
-      this.watchSkillsDir(os.homedir(), ".agents/skills");
+      this.watchSkillsDir(path.join(os.homedir(), ".agents"), "skills");
     } catch (error) {
       logger.error("Failed to initialize global .agents/skills watcher", error);
     }


### PR DESCRIPTION
## Summary
- Restrict file watchers in `CustomAgentManager` and `SkillManager` to watch specific subdirectories (`.pochi`, `.agents`) instead of the entire home directory or workspace root.
- This prevents potential performance issues and excessive file system events when the home directory contains many files.

## Test plan
- Verify that custom agents are still loaded from `~/.pochi/agents` and project `.pochi/agents`.
- Verify that skills are still loaded from `~/.pochi/skills`, `~/.agents/skills`, and project equivalents.
- Ensure no regressions in agent/skill discovery.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-2651ced61960433799ce7a3463b89038)