### PR TITLE
fix(cli): improve task retry and subtask rendering

### DIFF
--- a/packages/cli/src/renderers/utils.ts
+++ b/packages/cli/src/renderers/utils.ts
@@ -9,7 +9,11 @@ export async function inlineSubTask(
   message: Message,
 ): Promise<Message> {
   const partsWithSubtasks = message.parts.map((part) => {
-    if (part.type === "tool-newTask" && part.state !== "input-streaming") {
+    if (
+      part.type === "tool-newTask" &&
+      part.state !== "input-streaming" &&
+      part.input
+    ) {
       const input = part.input as InferToolInput<ClientTools["newTask"]>;
       const subtaskId = input._meta?.uid;
       if (subtaskId) {

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -511,6 +511,12 @@ export class TaskRunner {
         "Task is failed, trying to resend last message to resume it.",
         task.error,
       );
+      const processed = prepareLastMessageForRetry(message);
+      if (processed) {
+        this.chat.appendOrReplaceMessage(processed);
+      } else {
+        // skip, the last message is ready to be resent
+      }
       return "retry";
     }
 


### PR DESCRIPTION
## Summary
- Added a check for `part.input` in `inlineSubTask` to avoid potential errors in `packages/cli/src/renderers/utils.ts`.
- Updated `packages/cli/src/task-runner.ts` to use `prepareLastMessageForRetry` when a task fails, ensuring consistent retry behavior.

## Test plan
- Manually verified that the task retry logic correctly processes the last message.
- Verified that subtask rendering handles cases where `input` might be missing.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-58b96ad2367c4c29957cfc8a76501b81)