### PR TITLE
fix(livekit-cf): restore DO in-memory state after hibernate wakeup

### DIFF
--- a/packages/livekit-cf/src/do/livestore-client/do.ts
+++ b/packages/livekit-cf/src/do/livestore-client/do.ts
@@ -37,8 +37,36 @@ export class LiveStoreClientDO
     await this.state.storage.put("user", user);
   }
 
+  /**
+   * Restore in-memory state (storeId, webhook) from durable storage.
+   * Called on any entry point that may run after hibernate wakeup.
+   */
+  private async ensureStateRestored(): Promise<void> {
+    if (!this.storeId) {
+      const persisted = await this.state.storage.get<string>("storeId");
+      if (persisted) {
+        this.storeId = persisted;
+      }
+    }
+    if (
+      this.storeId &&
+      this.env.WEBHOOK_URL &&
+      this.env.WEBHOOK_SECRET &&
+      !this.webhook
+    ) {
+      this.webhook = new WebhookDelivery(
+        this.storeId,
+        this.env.WEBHOOK_URL,
+        this.env.WEBHOOK_SECRET,
+      );
+    }
+  }
+
   async signalKeepAlive(storeId: string): Promise<void> {
     this.storeId = storeId;
+    // Persist storeId so it survives hibernate/wakeup
+    await this.state.storage.put("storeId", storeId);
+
     if (this.env.WEBHOOK_URL && this.env.WEBHOOK_SECRET && !this.webhook) {
       this.webhook = new WebhookDelivery(
         this.storeId,
@@ -53,6 +81,8 @@ export class LiveStoreClientDO
   }
 
   async fetch(request: Request): Promise<Response> {
+    // Restore state from durable storage in case this fetch arrives after hibernate
+    await this.ensureStateRestored();
     return app.fetch(request, {
       getStore: async () => {
         return this.getStore();
@@ -60,8 +90,9 @@ export class LiveStoreClientDO
       getOwner: async () => {
         return await this.state.storage.get<User>("user");
       },
-      setStoreId: (storeId: string) => {
+      setStoreId: async (storeId: string) => {
         this.storeId = storeId;
+        await this.state.storage.put("storeId", storeId);
       },
       forceUpdateTasks: async () => {
         return (await this.onTasksUpdate(true)) || 0;
@@ -112,10 +143,24 @@ export class LiveStoreClientDO
   }
 
   alarm(_alarmInfo?: AlarmInvocationInfo): void | Promise<void> {
-    this.onTasksUpdateThrottled.call();
+    // Use ctx.waitUntil so Cloudflare does not kill the worker before the
+    // async work finishes, even if alarm() itself returns quickly.
+    this.ctx.waitUntil(
+      (async () => {
+        await this.ensureStateRestored();
+        await this.onTasksUpdateThrottled.call();
+      })(),
+    );
   }
 
   async syncUpdateRpc(payload: unknown) {
+    // Restore storeId/webhook in case this RPC arrives after a hibernate wakeup
+    // where cachedStore is still undefined.
+    await this.ensureStateRestored();
+    if (this.storeId && !this.cachedStore) {
+      // Warm up the store so handleSyncUpdateRpc can find it
+      await this.getStore();
+    }
     await handleSyncUpdateRpc(payload);
   }
 

--- a/packages/livekit-cf/src/do/livestore-client/types.ts
+++ b/packages/livekit-cf/src/do/livestore-client/types.ts
@@ -5,7 +5,7 @@ import type { CfTypes } from "@livestore/sync-cf/cf-worker";
 
 export type Env = {
   getStore: () => Promise<Store<typeof catalog.schema>>;
-  setStoreId: (storeId: string) => void;
+  setStoreId: (storeId: string) => void | Promise<void>;
   getOwner: () => Promise<User | undefined>;
   forceUpdateTasks: () => Promise<number>;
   ASSETS: CfTypes.Fetcher;


### PR DESCRIPTION
## Note to Reviewer

> ⚠️ **Testing note**: This was tested locally by @zwpaper. However, Cloudflare DO hibernate behaviour **cannot be fully simulated locally** — the fixes are targeted specifically at post-hibernate wakeup scenarios. The changes are backward-compatible and should not break any existing functionality. We will need to verify the fix on **prod** to confirm it resolves the sync error where tasks were not being synced to the website (observed as `No mailbox found for 0` in logs).

## Summary

- `storeId` is an in-memory field lost on hibernate; persist it to durable storage in `signalKeepAlive` and `setStoreId` so it survives wakeup
- Add `ensureStateRestored()` helper that rehydrates `storeId` and lazily reconstructs `WebhookDelivery` from durable storage; called at all entry points that can fire after hibernate (`alarm`, `syncUpdateRpc`, `fetch`)
- In `syncUpdateRpc`: warm up `cachedStore` via `getStore()` before delegating to `handleSyncUpdateRpc`, so the LiveStore internal can find the store context when woken from hibernate
- In `alarm`: wrap async body in `ctx.waitUntil(...)` so Cloudflare runtime does not terminate the isolate before `onTasksUpdateThrottled` finishes
- Update `setStoreId` type to `void | Promise<void>` to allow async persistence

## Test plan

- [ ] Deploy to prod and monitor logs for `No mailbox found for 0` errors
- [ ] Confirm webhook task-update events are delivered after the DO has been idle (hibernated) for >30s
- [ ] Confirm alarm-triggered task sync completes successfully after hibernate wakeup

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8c5cfd5935d2467aa88eadaa4d130d5f)
