### PR TITLE
[codex] fix Lemonade tool-call fallback for custom OpenAI providers

### DIFF
--- a/packages/livekit/src/chat/__tests__/should-use-tool-call-middleware.test.ts
+++ b/packages/livekit/src/chat/__tests__/should-use-tool-call-middleware.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { shouldUseToolCallMiddleware } from "../should-use-tool-call-middleware";
+import type { RequestData } from "../../types";
+
+function createOpenAILlm(
+  overrides: Partial<Extract<RequestData["llm"], { type: "openai" }>> = {},
+): Extract<RequestData["llm"], { type: "openai" }> {
+  return {
+    id: "test/openai-model",
+    type: "openai",
+    modelId: "test-model",
+    contextWindow: 128_000,
+    maxOutputTokens: 4_096,
+    ...overrides,
+  };
+}
+
+describe("shouldUseToolCallMiddleware", () => {
+  it("enables the middleware for custom OpenAI-compatible base URLs by default", () => {
+    expect(
+      shouldUseToolCallMiddleware(
+        createOpenAILlm({ baseURL: "https://lemonade.example.com/v1" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not force the middleware for the official OpenAI API", () => {
+    expect(
+      shouldUseToolCallMiddleware(
+        createOpenAILlm({ baseURL: "https://api.openai.com/v1" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("respects an explicit opt-out for custom OpenAI-compatible base URLs", () => {
+    expect(
+      shouldUseToolCallMiddleware(
+        createOpenAILlm({
+          baseURL: "https://lemonade.example.com/v1",
+          useToolCallMiddleware: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("respects an explicit opt-in", () => {
+    expect(
+      shouldUseToolCallMiddleware(
+        createOpenAILlm({ useToolCallMiddleware: true }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -37,6 +37,7 @@ import {
 } from "./middlewares";
 import { createOutputSchemaMiddleware } from "./middlewares/output-schema-middleware";
 import { createModel } from "./models";
+import { shouldUseToolCallMiddleware } from "./should-use-tool-call-middleware";
 import { ImageEstimatedTokens, estimateTokens } from "./token-utils";
 
 export type OnStartCallback = (options: {
@@ -150,7 +151,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       );
     }
 
-    if (llm.useToolCallMiddleware) {
+    if (shouldUseToolCallMiddleware(llm)) {
       middlewares.push(
         createToolCallMiddleware(llm.type !== "google-vertex-tuning"),
       );

--- a/packages/livekit/src/chat/should-use-tool-call-middleware.ts
+++ b/packages/livekit/src/chat/should-use-tool-call-middleware.ts
@@ -4,9 +4,7 @@ function isOfficialOpenAIBaseURL(baseURL?: string): boolean {
   return baseURL?.includes("openai.com") ?? false;
 }
 
-export function shouldUseToolCallMiddleware(
-  llm: RequestData["llm"],
-): boolean {
+export function shouldUseToolCallMiddleware(llm: RequestData["llm"]): boolean {
   if (llm.useToolCallMiddleware !== undefined) {
     return llm.useToolCallMiddleware;
   }
@@ -14,7 +12,11 @@ export function shouldUseToolCallMiddleware(
   // Many OpenAI-compatible servers still have fragile native tool-call
   // handling. When the user points Pochi at a custom baseURL and hasn't
   // explicitly opted in/out, prefer the middleware-based ReAct transport.
-  if (llm.type === "openai" && llm.baseURL && !isOfficialOpenAIBaseURL(llm.baseURL)) {
+  if (
+    llm.type === "openai" &&
+    llm.baseURL &&
+    !isOfficialOpenAIBaseURL(llm.baseURL)
+  ) {
     return true;
   }
 

--- a/packages/livekit/src/chat/should-use-tool-call-middleware.ts
+++ b/packages/livekit/src/chat/should-use-tool-call-middleware.ts
@@ -1,0 +1,22 @@
+import type { RequestData } from "../types";
+
+function isOfficialOpenAIBaseURL(baseURL?: string): boolean {
+  return baseURL?.includes("openai.com") ?? false;
+}
+
+export function shouldUseToolCallMiddleware(
+  llm: RequestData["llm"],
+): boolean {
+  if (llm.useToolCallMiddleware !== undefined) {
+    return llm.useToolCallMiddleware;
+  }
+
+  // Many OpenAI-compatible servers still have fragile native tool-call
+  // handling. When the user points Pochi at a custom baseURL and hasn't
+  // explicitly opted in/out, prefer the middleware-based ReAct transport.
+  if (llm.type === "openai" && llm.baseURL && !isOfficialOpenAIBaseURL(llm.baseURL)) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

This change makes Pochi default to the middleware-based tool-call transport for custom OpenAI-compatible `baseURL` providers when `useToolCallMiddleware` is not explicitly configured.

## Why

A user reported that Lemonade fails once the agent reaches a write-file tool call. The Lemonade server logs show its tool-call template trying to iterate `tool_call.arguments|items`, but `arguments` is a string for these requests, which raises a server error and leaves the chat stuck on retry.

## Root Cause

For `type: "openai"` models, Pochi previously sent native OpenAI tool calls unless `useToolCallMiddleware` was explicitly enabled. That default is unsafe for some OpenAI-compatible servers that advertise compatibility but still have fragile native tool-call handling.

## What Changed

- Added a dedicated helper to decide when tool-call middleware should be used.
- Defaulted custom OpenAI-compatible `baseURL` providers to the middleware path.
- Kept explicit `useToolCallMiddleware: true|false` behavior unchanged.
- Added regression tests covering custom providers, official OpenAI, and explicit overrides.

## Impact

Pochi now works around broken native tool-call implementations on third-party OpenAI-compatible backends without requiring users to discover and set a config flag themselves.

## Validation

- `bunx biome check packages/livekit/src/chat/flexible-chat-transport.ts packages/livekit/src/chat/should-use-tool-call-middleware.ts packages/livekit/src/chat/__tests__/should-use-tool-call-middleware.test.ts`
- `bunx vitest --run packages/livekit/src/chat/__tests__/should-use-tool-call-middleware.test.ts packages/livekit/src/chat/__tests__/filter-completion-tools.test.ts packages/livekit/src/chat/__tests__/fork-task-tools.test.ts`

## Notes

`bun --cwd packages/livekit test` did not work in this workspace because the package-local script could not resolve `vitest`, so validation was run from the repo root instead.
