### PR TITLE
fix(livekit): default custom OpenAI providers to tool call middleware

### DIFF
--- a/packages/livekit/src/chat/__tests__/should-use-tool-call-middleware.test.ts
+++ b/packages/livekit/src/chat/__tests__/should-use-tool-call-middleware.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { shouldUseToolCallMiddleware } from "../should-use-tool-call-middleware";
+import type { RequestData } from "../../types";
+
+function createOpenAILlm(
+  overrides: Partial<Extract<RequestData["llm"], { type: "openai" }>> = {},
+): Extract<RequestData["llm"], { type: "openai" }> {
+  return {
+    id: "test/openai-model",
+    type: "openai",
+    modelId: "test-model",
+    contextWindow: 128_000,
+    maxOutputTokens: 4_096,
+    ...overrides,
+  };
+}
+
+describe("shouldUseToolCallMiddleware", () => {
+  it("enables the middleware for custom OpenAI-compatible base URLs by default", () => {
+    expect(
+      shouldUseToolCallMiddleware(
+        createOpenAILlm({ baseURL: "https://lemonade.example.com/v1" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not force the middleware for the official OpenAI API", () => {
+    expect(
+      shouldUseToolCallMiddleware(
+        createOpenAILlm({ baseURL: "https://api.openai.com/v1" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("respects an explicit opt-out for custom OpenAI-compatible base URLs", () => {
+    expect(
+      shouldUseToolCallMiddleware(
+        createOpenAILlm({
+          baseURL: "https://lemonade.example.com/v1",
+          useToolCallMiddleware: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("respects an explicit opt-in", () => {
+    expect(
+      shouldUseToolCallMiddleware(
+        createOpenAILlm({ useToolCallMiddleware: true }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -37,6 +37,7 @@ import {
 } from "./middlewares";
 import { createOutputSchemaMiddleware } from "./middlewares/output-schema-middleware";
 import { createModel } from "./models";
+import { shouldUseToolCallMiddleware } from "./should-use-tool-call-middleware";
 import { ImageEstimatedTokens, estimateTokens } from "./token-utils";
 
 export type OnStartCallback = (options: {
@@ -150,7 +151,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       );
     }
 
-    if (llm.useToolCallMiddleware) {
+    if (shouldUseToolCallMiddleware(llm)) {
       middlewares.push(
         createToolCallMiddleware(llm.type !== "google-vertex-tuning"),
       );

--- a/packages/livekit/src/chat/should-use-tool-call-middleware.ts
+++ b/packages/livekit/src/chat/should-use-tool-call-middleware.ts
@@ -4,9 +4,7 @@ function isOfficialOpenAIBaseURL(baseURL?: string): boolean {
   return baseURL?.includes("openai.com") ?? false;
 }
 
-export function shouldUseToolCallMiddleware(
-  llm: RequestData["llm"],
-): boolean {
+export function shouldUseToolCallMiddleware(llm: RequestData["llm"]): boolean {
   if (llm.useToolCallMiddleware !== undefined) {
     return llm.useToolCallMiddleware;
   }
@@ -14,7 +12,11 @@ export function shouldUseToolCallMiddleware(
   // Many OpenAI-compatible servers still have fragile native tool-call
   // handling. When the user points Pochi at a custom baseURL and hasn't
   // explicitly opted in/out, prefer the middleware-based ReAct transport.
-  if (llm.type === "openai" && llm.baseURL && !isOfficialOpenAIBaseURL(llm.baseURL)) {
+  if (
+    llm.type === "openai" &&
+    llm.baseURL &&
+    !isOfficialOpenAIBaseURL(llm.baseURL)
+  ) {
     return true;
   }
 

--- a/packages/livekit/src/chat/should-use-tool-call-middleware.ts
+++ b/packages/livekit/src/chat/should-use-tool-call-middleware.ts
@@ -1,0 +1,22 @@
+import type { RequestData } from "../types";
+
+function isOfficialOpenAIBaseURL(baseURL?: string): boolean {
+  return baseURL?.includes("openai.com") ?? false;
+}
+
+export function shouldUseToolCallMiddleware(
+  llm: RequestData["llm"],
+): boolean {
+  if (llm.useToolCallMiddleware !== undefined) {
+    return llm.useToolCallMiddleware;
+  }
+
+  // Many OpenAI-compatible servers still have fragile native tool-call
+  // handling. When the user points Pochi at a custom baseURL and hasn't
+  // explicitly opted in/out, prefer the middleware-based ReAct transport.
+  if (llm.type === "openai" && llm.baseURL && !isOfficialOpenAIBaseURL(llm.baseURL)) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

- Extracts the tool-call middleware decision into a dedicated `shouldUseToolCallMiddleware` helper
- Custom OpenAI-compatible providers (i.e. those with a non-`openai.com` `baseURL`) now default to using the middleware-based ReAct transport, since many local/third-party servers have fragile native tool-call handling (e.g. Lemonade)
- Explicit `useToolCallMiddleware: true/false` overrides are still respected

## Test plan

- [ ] Verify that a custom `baseURL` (e.g. a local Lemonade server) automatically uses the tool-call middleware without any extra config
- [ ] Verify that `https://api.openai.com/v1` does **not** force the middleware
- [ ] Verify that an explicit `useToolCallMiddleware: false` opt-out is honoured even for custom base URLs
- [ ] Run unit tests: `bun run test` in `packages/livekit`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ef38cafbeaba438e9fae993c5770ca99)