### PR TITLE
feat(agents): encourage parallel explore agent execution

### DIFF
--- a/packages/common/src/base/agents/explore.ts
+++ b/packages/common/src/base/agents/explore.ts
@@ -74,6 +74,13 @@ When completing your exploration, structure your findings in attemptCompletion a
 4. **Patterns and Insights**: Notable patterns, potential issues, or architectural observations
 5. **Recommendations** (if applicable): Suggestions based on your findings
 
+## Performance: Parallel Execution
+
+NOTE: You are meant to be a fast agent that returns output as quickly as possible. In order to achieve this you must:
+
+- Make efficient use of the tools that you have at your disposal: be smart about how you search for files and implementations
+- Wherever possible you should try to spawn multiple parallel tool calls for grepping and reading files
+
 ## Important Reminders
 
 - Be thorough but efficient - don't read every file if search tools can narrow down the scope

--- a/packages/common/src/base/agents/planner.ts
+++ b/packages/common/src/base/agents/planner.ts
@@ -38,7 +38,7 @@ Follow this strict sequence:
 ### Phase 1: Environment Grounding (Explore First)
 1. **Explore**: Use \`listFiles\` and \`globFiles\` to map project structure.
 2. **Inspect**: Use \`readFile\` and \`searchFiles\` to gather concrete implementation facts.
-3. **Delegate Exploration**: For deep or wide-ranging codebase exploration, you can use the \`newTask\` tool with \`agentType: "explore"\` to delegate the investigation.
+3. **Delegate Exploration**: For deep or wide-ranging codebase exploration, delegate to Explore agents via \`newTask\` with \`agentType: "explore"\`. **Launch up to 3 Explore agents IN PARALLEL (single message, multiple tool calls)** to efficiently cover distinct investigation areas simultaneously.
 4. **Reuse-aware analysis**: Identify existing utilities, patterns, and modules that should be reused.
 5. **Ask only after exploration**: Before asking the user questions, complete at least one targeted exploration pass, unless the user's prompt itself is inherently ambiguous.
 


### PR DESCRIPTION
## Summary

- Add a **Performance: Parallel Execution** section to the explore agent prompt, instructing it to use parallel tool calls (grep, file reads) to return results faster
- Update the planner agent's delegation step to explicitly launch **up to 3 explore agents in parallel** (single message, multiple tool calls) to cover distinct investigation areas simultaneously

## Test plan

- [ ] Verify planner agent spawns multiple explore agents in parallel when investigating broad codebases
- [ ] Verify explore agent uses parallel tool calls when searching files

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-21a4b0f8c9ab4ad685fc205fa86fc6aa)