### PR TITLE
fix(tools): use TextDecoder to decode Uint8Array instead of toString()

### DIFF
--- a/packages/cli/src/tools/apply-diff.ts
+++ b/packages/cli/src/tools/apply-diff.ts
@@ -25,7 +25,7 @@ export const applyDiff =
       doWork: async () => {
         const fileBuffer = await fileSystem.readFile(path);
         validateTextFile(fileBuffer);
-        const fileContent = fileBuffer.toString();
+        const fileContent = new TextDecoder().decode(fileBuffer);
 
         const updatedContent = await parseDiffAndApply(
           fileContent,

--- a/packages/cli/src/tools/read-file.ts
+++ b/packages/cli/src/tools/read-file.ts
@@ -43,7 +43,7 @@ export const readFile =
           throw new Error("Reading binary files is not supported.");
         }
 
-        const fileContent = fileBuffer.toString();
+        const fileContent = new TextDecoder().decode(fileBuffer);
         const addLineNumbers = !!process.env.VSCODE_TEST_OPTIONS;
 
         const result = selectFileContent(fileContent, {

--- a/packages/vscode/src/tools/apply-diff.ts
+++ b/packages/vscode/src/tools/apply-diff.ts
@@ -30,7 +30,7 @@ export const applyDiff: ToolFunctionType<ClientTools["applyDiff"]> = async (
       const fileBuffer = await vscode.workspace.fs.readFile(fileUri);
       validateTextFile(fileBuffer);
 
-      const fileContent = fileBuffer.toString();
+      const fileContent = new TextDecoder().decode(fileBuffer);
 
       const updatedContent = await parseDiffAndApply(
         fileContent,

--- a/packages/vscode/src/tools/read-file.ts
+++ b/packages/vscode/src/tools/read-file.ts
@@ -55,7 +55,7 @@ export const readFile: ToolFunctionType<ClientTools["readFile"]> = async (
         throw new Error("Reading binary files is not supported.");
       }
 
-      const fileContent = fileBuffer.toString();
+      const fileContent = new TextDecoder().decode(fileBuffer);
       const addLineNumbers = !!process.env.VSCODE_TEST_OPTIONS;
 
       const result = selectFileContent(fileContent, {


### PR DESCRIPTION
## Summary

- `Uint8Array.toString()` joins byte values with commas (e.g. `"35,32,73,..."`) instead of decoding as UTF-8 text
- This caused `pochi://` virtual files (e.g. `plan.md`) to return garbled content, because `TaskFileSystem.readFile` returns a `Uint8Array` from `TextEncoder.encode()` — unlike Node's `Buffer` which `.toString()` decodes as UTF-8 correctly
- Fixed by replacing `fileBuffer.toString()` with `new TextDecoder().decode(fileBuffer)` in all four affected files across CLI and VSCode packages

## Files changed

- `packages/cli/src/tools/read-file.ts`
- `packages/cli/src/tools/apply-diff.ts`
- `packages/vscode/src/tools/read-file.ts`
- `packages/vscode/src/tools/apply-diff.ts`

## Test plan

- [ ] Read a `pochi://` virtual file (e.g. `pochi://-/plan.md`) and verify the content is returned as readable text, not comma-separated byte values
- [ ] Verify `applyDiff` works correctly on `pochi://` virtual files

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1c7fc3df127c44af82a45287be517132)