### PR TITLE
docs: exclude developer-updates and tutorials from llms.txt

### DIFF
--- a/packages/docs/src/app/llms.txt/route.ts
+++ b/packages/docs/src/app/llms.txt/route.ts
@@ -5,7 +5,11 @@ import { getLLMText } from "@/lib/get-llm-text";
 export const revalidate = false;
 
 export async function GET() {
-  const scan = source.getPages().map(getLLMText);
+  const scan = source
+    .getPages()
+    // exclude developer-updates and tutorials from LLM context
+    .filter((page) => !page.url.includes("/developer-updates") && !page.url.includes("/tutorials"))
+    .map(getLLMText);
   const scanned = await Promise.all(scan);
 
   return new Response(scanned.join("\n\n"));


### PR DESCRIPTION
## Summary
- Excludes `developer-updates` and `tutorials` pages from the generated `llms.txt` to save LLM context window.

## Test plan
- Verify that `llms.txt` no longer includes pages from `/developer-updates` and `/tutorials`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f7355cf731534dca8fbf6eae7bfb7c7f)