### PR TITLE
feat(tools): improve command parsing for executeCommand whitelist

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -198,7 +198,11 @@
       "dependencies": {
         "ai": "catalog:",
         "json-schema": "^0.4.0",
+        "shell-quote": "^1.8.3",
         "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@types/shell-quote": "^1.7.5",
       },
     },
     "packages/vendor-codex": {
@@ -1744,6 +1748,8 @@
     "@types/resolve": ["@types/resolve@1.20.6", "", {}, "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="],
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
+    "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
     "@types/sinon": ["@types/sinon@17.0.4", "", { "dependencies": { "@types/sinonjs__fake-timers": "*" } }, "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew=="],
 
@@ -4021,7 +4027,7 @@
 
     "shebang-regex": ["shebang-regex@1.0.0", "", {}, "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="],
 
-    "shell-quote": ["shell-quote@1.8.2", "", {}, "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA=="],
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "shiki": ["shiki@3.13.0", "https://registry.npmmirror.com/shiki/-/shiki-3.13.0.tgz", { "dependencies": { "@shikijs/core": "3.13.0", "@shikijs/engine-javascript": "3.13.0", "@shikijs/engine-oniguruma": "3.13.0", "@shikijs/langs": "3.13.0", "@shikijs/themes": "3.13.0", "@shikijs/types": "3.13.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-aZW4l8Og16CokuCLf8CF8kq+KK2yOygapU5m3+hoGw0Mdosc6fPitjM+ujYarppj5ZIKGyPDPP1vqmQhr+5/0g=="],
 
@@ -5314,6 +5320,8 @@
     "npm-run-all/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "npm-run-all/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "npm-run-all/shell-quote": ["shell-quote@1.8.2", "", {}, "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "https://registry.npmmirror.com/path-key/-/path-key-4.0.0.tgz", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -5,8 +5,12 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "ai": "catalog:",
     "json-schema": "^0.4.0",
-    "zod": "catalog:",
-    "ai": "catalog:"
+    "shell-quote": "^1.8.3",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/shell-quote": "^1.7.5"
   }
 }

--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -1,0 +1,41 @@
+import * as assert from "node:assert";
+import { describe, it } from "mocha";
+import { validateExecuteCommandWhitelist } from "../utils";
+
+describe("validateExecuteCommandWhitelist", () => {
+  it("should not split commands inside quotes", () => {
+    assert.doesNotThrow(() => {
+      validateExecuteCommandWhitelist(
+        'uv run python -c "def fib(n): a,b=0,1; [a:=b or b:=a+b for _ in range(n)]; return a; print(fib(21))"',
+        ["uv *"]
+      );
+    });
+  });
+
+  it("should split commands outside quotes", () => {
+    assert.doesNotThrow(() => {
+      validateExecuteCommandWhitelist(
+        'uv run python -c "test" ; echo "hello"',
+        ["uv *", "echo *"]
+      );
+    });
+  });
+
+  it("should correctly parse commands with semicolons inside quotes", () => {
+    assert.doesNotThrow(() => {
+      validateExecuteCommandWhitelist(
+        'uv run python -c "def fib(n): a,b=0,1; [a:=b or b:=a+b for _ in range(n)]; return a; print(fib(21))"',
+        ["uv *"]
+      );
+    });
+  });
+
+  it("should throw for not allowed commands", () => {
+    assert.throws(() => {
+      validateExecuteCommandWhitelist(
+        'uv run python -c "test" ; rm -rf /',
+        ["uv *", "echo *"]
+      );
+    });
+  });
+});

--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -1,41 +1,45 @@
-import * as assert from "node:assert";
-import { describe, it } from "mocha";
+import { describe, it, expect } from "vitest";
 import { validateExecuteCommandWhitelist } from "../utils";
 
 describe("validateExecuteCommandWhitelist", () => {
-  it("should not split commands inside quotes", () => {
-    assert.doesNotThrow(() => {
+  it("should correctly parse commands with semicolons inside quotes", () => {
+    expect(() => {
       validateExecuteCommandWhitelist(
         'uv run python -c "def fib(n): a,b=0,1; [a:=b or b:=a+b for _ in range(n)]; return a; print(fib(21))"',
         ["uv *"]
       );
-    });
+    }).not.toThrow();
   });
 
   it("should split commands outside quotes", () => {
-    assert.doesNotThrow(() => {
+    expect(() => {
       validateExecuteCommandWhitelist(
         'uv run python -c "test" ; echo "hello"',
         ["uv *", "echo *"]
       );
-    });
+    }).not.toThrow();
   });
 
-  it("should correctly parse commands with semicolons inside quotes", () => {
-    assert.doesNotThrow(() => {
+  it("should correctly parse multi-line commands inside quotes", () => {
+    expect(() => {
       validateExecuteCommandWhitelist(
-        'uv run python -c "def fib(n): a,b=0,1; [a:=b or b:=a+b for _ in range(n)]; return a; print(fib(21))"',
+        `uv run --quiet python3 -c "
+def fibonacci(n):
+    a, b = 0, 1
+    for _ in range(n - 1):
+        a, b = b, a + b
+"`,
         ["uv *"]
       );
-    });
+    }).not.toThrow();
   });
 
   it("should throw for not allowed commands", () => {
-    assert.throws(() => {
+    expect(() => {
       validateExecuteCommandWhitelist(
         'uv run python -c "test" ; rm -rf /',
         ["uv *", "echo *"]
       );
-    });
+    }).toThrow();
   });
 });

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -1,3 +1,5 @@
+import { parse } from "shell-quote";
+
 export type ParsedToolSpec = {
   name: string;
   args: string[];
@@ -108,10 +110,26 @@ export function getAllowedToolNames(
 }
 
 function splitCommandSegments(command: string): string[] {
-  return command
-    .split(/&&|\|\||\||;/)
-    .map((x) => x.trim())
-    .filter((x) => x.length > 0);
+  const parsed = parse(command);
+  const segments: string[] = [];
+  let currentSegment: string[] = [];
+
+  for (const token of parsed) {
+    if (typeof token === "object" && "op" in token) {
+      if (currentSegment.length > 0) {
+        segments.push(currentSegment.join(" "));
+        currentSegment = [];
+      }
+    } else {
+      currentSegment.push(String(token));
+    }
+  }
+
+  if (currentSegment.length > 0) {
+    segments.push(currentSegment.join(" "));
+  }
+
+  return segments.map((x) => x.trim()).filter((x) => x.length > 0);
 }
 
 function escapeRegex(input: string): string {


### PR DESCRIPTION
## Summary
- Use `shell-quote` to correctly parse command segments in `executeCommand` whitelist validation.
- Ensures that delimiters like `;`, `&&`, and `||` are ignored when they appear inside quoted strings (e.g., in `python -c "..."`).
- Added unit tests to verify correct parsing of complex commands with quoted semicolons.

## Test plan
- Added unit tests in `packages/tools/src/__test__/utils.test.ts`.
- Ran `bun run test` in `packages/tools` (implicitly via pre-push hooks).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e297c20f46784331a865ae7b7ac36621)