### PR TITLE
feat(vendor-pochi): add domain filter support to web-search tool

### DIFF
--- a/packages/vendor-pochi/src/tools/web-search.ts
+++ b/packages/vendor-pochi/src/tools/web-search.ts
@@ -33,10 +33,21 @@ Usage notes:
           .describe(
             "Country code to filter search results by, e.g. 'US', 'GB', 'JP'",
           ),
+        searchDomainFilter: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "List of domains to filter search results. Use allowlist mode (e.g. ['github.com', 'stackoverflow.com']) to include only those domains, or denylist mode (e.g. ['-reddit.com', '-pinterest.com']) to exclude domains. Cannot mix both modes. Maximum 20 domains.",
+          ),
       }),
     ) as JSONSchema7,
   },
-  execute: async (args: { query: string; country?: string }) => {
+  execute: async (args: {
+    query: string;
+    country?: string;
+    searchDomainFilter?: string[];
+  }) => {
+    const { searchDomainFilter, ...rest } = args;
     const token = await getToken();
     const response = await fetch(
       "https://api-gateway.getpochi.com/https/api.perplexity.ai/search",
@@ -47,7 +58,10 @@ Usage notes:
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          ...args,
+          ...rest,
+          ...(searchDomainFilter && searchDomainFilter.length > 0
+            ? { search_domain_filter: searchDomainFilter }
+            : {}),
           max_tokens_per_page: 256,
         }),
       },


### PR DESCRIPTION
## Summary

- Add optional `searchDomainFilter` parameter to the `web-search` tool in `packages/vendor-pochi`
- Maps to the Perplexity Search API's `search_domain_filter` field
- Supports **allowlist** mode (e.g. `['github.com', 'stackoverflow.com']`) to restrict results to specific domains
- Supports **denylist** mode (e.g. `['-reddit.com', '-pinterest.com']`) to exclude domains from results
- Cannot mix allowlist and denylist in the same request; maximum 20 domains per request

## Test plan

- [ ] Verify that omitting `searchDomainFilter` behaves identically to the previous behavior
- [ ] Verify allowlist filtering returns results only from specified domains
- [ ] Verify denylist filtering excludes specified domains from results

Generated with [Pochi](https://app.getpochi.com/share/p-b0bcdca5c7cc4d06bca23639fda29276)