### PR TITLE
fix(agents): replace 'vendor' with 'provider' in guide agent description

### DIFF
--- a/packages/common/src/base/agents/guide/agent.ts
+++ b/packages/common/src/base/agents/guide/agent.ts
@@ -12,7 +12,7 @@ This agent helps users understand how to use Pochi effectively, fetch documentat
 
 Trigger examples:
 - General info: "what can Pochi do?", "what agents/tools are available?", "how does Pochi work?"
-- Configuration: "how do I configure Pochi?", "explain config options", "help me modify my config", "set up a new vendor", "add an MCP server"
+- Configuration: "how do I configure Pochi?", "explain config options", "help me modify my config", "set up a new provider", "add an MCP server"
 - Help & feedback: "join the discord", "report a bug", "where can I get help?"
 `.trim(),
   tools: ["readFile", "writeToFile", "askFollowupQuestion"],


### PR DESCRIPTION
## Summary
- Replaced the term 'vendor' with 'provider' in the guide agent's description to reflect updated terminology.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d9f75d0378e245dba9bf0b343d752b9a)