### PR TITLE
chore(vscode): bump version to 0.43.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.41.0-dev",
+  "version": "0.43.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump VSCode extension version from `0.41.0-dev` to `0.43.0-dev`

## Test plan
- [ ] Verify the extension version is correctly updated in `packages/vscode/package.json`

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-14e6fbe0aa6e4476bb6c48eaeaa8d063)