### PR TITLE
fix(install): add fixed cli version fallback to avoid rate limits

### DIFF
--- a/.github/workflows/update-install-fallback.yml
+++ b/.github/workflows/update-install-fallback.yml
@@ -1,0 +1,30 @@
+name: Update Latest CLI Release in install.sh
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-fallback:
+    if: startsWith(github.event.release.tag_name, 'cli@')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Update fallback version in install.sh
+        run: |
+          NEW_VERSION="${{ github.event.release.tag_name }}"
+          sed -i "s/version=\"cli@[^\"]*\" # UPDATED_BY_CI/version=\"$NEW_VERSION\" # UPDATED_BY_CI/g" assets/install.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          commit-message: "chore(install): update latest cli version to ${{ github.event.release.tag_name }}"
+          title: "chore(install): update latest cli version to ${{ github.event.release.tag_name }}"
+          body: "Automatically generated PR to update the latest CLI version in `assets/install.sh` to `${{ github.event.release.tag_name }}`."
+          branch: "chore/update-cli-version-${{ github.event.release.tag_name }}"
+          base: main

--- a/assets/install.sh
+++ b/assets/install.sh
@@ -182,7 +182,7 @@ print_shell_setup_instructions() {
   eprintf ""
   eprintf "    fish ~/.config/fish/config.fish:"
   eprintf ""
-  eprintf "        export PATH=\"$bin_dir:\$PATH\""
+  eprintf "        fish_add_path \"$bin_dir\""
   eprintf "        pochi --completion --fish | source"
   eprintf ""
 }
@@ -292,11 +292,16 @@ get_latest_version() {
   local version
   version=$(curl -s https://api.github.com/repos/TabbyML/pochi/releases | grep 'tag_name' | grep 'cli@' | head -1 | cut -d '"' -f 4)
   if [ -z "$version" ]; then
-    version=$(git ls-remote --tags --refs https://github.com/TabbyML/pochi.git "cli@*" |
-      awk '{print $2}' |
-      sed 's|refs/tags/||' |
-      sort -V |
-      tail -n1)
+    if command -v git >/dev/null 2>&1; then
+      version=$(git ls-remote --tags --refs https://github.com/TabbyML/pochi.git "cli@*" |
+        awk '{print $2}' |
+        sed 's|refs/tags/||' |
+        sort -V |
+        tail -n1)
+    fi
+  fi
+  if [ -z "$version" ]; then
+    version="cli@0.6.7" # UPDATED_BY_CI
   fi
   echo "$version"
 }


### PR DESCRIPTION
## Notes to Reviewer
This fixes the system (mostly container) hit rate limit and without git installed, putting the fixed version latest as fallback. After validated, this could be the primary solution.

## Summary
- Use `fish_add_path` for fish shell path setup in `install.sh`
- Add fallback to `cli@0.6.7` if `curl` fails to fetch from GitHub API and `git` is not available
- Add GitHub workflow to automatically update the fallback version on new CLI releases

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-acf9c1b68d7641e4b7ce72595566bcc3)