### PR TITLE
feat(tools): refactor agent tool selection into selectAgentTools

### DIFF
--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -8,9 +8,7 @@ import {
   type CustomAgent,
   type McpTool,
   type Skill,
-  getAllowedToolNames,
-  overrideCustomAgentTools,
-  selectClientTools,
+  selectAgentTools,
 } from "@getpochi/tools";
 import {
   APICallError,
@@ -24,7 +22,6 @@ import {
   tool,
   wrapLanguageModel,
 } from "ai";
-import { pickBy } from "remeda";
 import type z from "zod/v4";
 import type { BlobStore } from "../blob-store";
 import { findBlob, makeDownloadFunction } from "../store-blob";
@@ -86,7 +83,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     this.isSubTask = options.isSubTask;
     this.store = options.store;
     this.blobStore = options.blobStore;
-    this.customAgent = overrideCustomAgentTools(options.customAgent);
+    this.customAgent = options.customAgent;
     this.outputSchema = options.outputSchema;
     this.attemptCompletionSchema = options.attemptCompletionSchema;
   }
@@ -150,28 +147,16 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
 
     const mcpTools =
       mcpInfo?.toolset && parseMcpToolSet(this.blobStore, mcpInfo.toolset);
-    const enabledToolNames = getAllowedToolNames(this.customAgent?.tools);
 
-    const tools = pickBy(
-      {
-        ...selectClientTools({
-          isSubTask: !!this.isSubTask,
-          customAgents,
-          contentType: llm.contentType,
-          skills,
-          attemptCompletionSchema: this.attemptCompletionSchema,
-          agent: this.customAgent,
-        }),
-        ...(mcpTools || {}),
-      },
-
-      (_val, key) => {
-        if (this.customAgent?.tools) {
-          return enabledToolNames.has(key);
-        }
-        return true;
-      },
-    );
+    const tools = selectAgentTools({
+      agent: this.customAgent,
+      isSubTask: !!this.isSubTask,
+      customAgents,
+      contentType: llm.contentType,
+      skills,
+      attemptCompletionSchema: this.attemptCompletionSchema,
+      mcpTools,
+    });
     if (tools.readFile) {
       tools.readFile = handleReadFileOutput(this.blobStore, tools.readFile);
     }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@getpochi/tools",
   "version": "0.1.1",
+  "scripts": {
+    "test": "bun vitest --run"
+  },
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/tools/src/__test__/select-agent-tools.test.ts
+++ b/packages/tools/src/__test__/select-agent-tools.test.ts
@@ -1,0 +1,252 @@
+import type { Tool } from "ai";
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { type CustomAgent, selectAgentTools } from "../index";
+
+const ClientToolNames = [
+  "applyDiff",
+  "askFollowupQuestion",
+  "attemptCompletion",
+  "editNotebook",
+  "executeCommand",
+  "globFiles",
+  "killBackgroundJob",
+  "listFiles",
+  "newTask",
+  "readBackgroundJobOutput",
+  "readFile",
+  "searchFiles",
+  "startBackgroundJob",
+  "todoWrite",
+  "useSkill",
+  "writeToFile",
+].sort();
+
+const RequiredAgentToolNames = [
+  "attemptCompletion",
+  "todoWrite",
+  "useSkill",
+].sort();
+
+function createAgent(overrides: Partial<CustomAgent> = {}): CustomAgent {
+  return {
+    name: "test-agent",
+    description: "Test agent",
+    systemPrompt: "Test system prompt",
+    ...overrides,
+  };
+}
+
+function createTool(description: string): Tool {
+  return { description } as Tool;
+}
+
+function toolNames(tools: Record<string, unknown>): string[] {
+  return Object.keys(tools).sort();
+}
+
+describe("selectAgentTools", () => {
+  it("returns all client tools and MCP tools when no agent filter is configured", () => {
+    const mcpTool = createTool("MCP search");
+
+    const tools = selectAgentTools({
+      isSubTask: false,
+      mcpTools: { mcpSearch: mcpTool },
+    });
+
+    expect(toolNames(tools)).toEqual([...ClientToolNames, "mcpSearch"].sort());
+    expect(tools.mcpSearch).toBe(mcpTool);
+    expect(tools).not.toHaveProperty("createReview");
+  });
+
+  it.each<[string[] | undefined]>([[undefined], [[]]])(
+    "does not filter tools when agent tools are %s",
+    (agentTools) => {
+      const mcpTool = createTool("MCP lookup");
+
+      const tools = selectAgentTools({
+        agent: createAgent({ tools: agentTools }),
+        isSubTask: false,
+        mcpTools: { mcpLookup: mcpTool },
+      });
+
+      expect(toolNames(tools)).toEqual(
+        [...ClientToolNames, "mcpLookup"].sort(),
+      );
+      expect(tools.mcpLookup).toBe(mcpTool);
+    },
+  );
+
+  it("filters to declared agent tools plus required completion tools", () => {
+    const mcpTool = createTool("MCP lookup");
+
+    const tools = selectAgentTools({
+      agent: createAgent({
+        tools: [
+          "readFile",
+          "searchFiles",
+          "executeCommand(git status)",
+          "mcpLookup",
+          "missingTool",
+        ],
+      }),
+      isSubTask: false,
+      mcpTools: { mcpLookup: mcpTool },
+    });
+
+    expect(toolNames(tools)).toEqual(
+      [
+        ...RequiredAgentToolNames,
+        "executeCommand",
+        "mcpLookup",
+        "readFile",
+        "searchFiles",
+      ].sort(),
+    );
+    expect(tools.mcpLookup).toBe(mcpTool);
+    expect(tools).not.toHaveProperty("executeCommand(git status)");
+    expect(tools).not.toHaveProperty("missingTool");
+  });
+
+  it("only enables askFollowupQuestion for planner and guide agents", () => {
+    const disallowed = selectAgentTools({
+      agent: createAgent({
+        name: "test-agent",
+        tools: ["askFollowupQuestion", "readFile"],
+      }),
+      isSubTask: false,
+    });
+
+    expect(toolNames(disallowed)).toEqual(
+      [...RequiredAgentToolNames, "readFile"].sort(),
+    );
+
+    for (const agentName of ["planner", "guide"]) {
+      const allowed = selectAgentTools({
+        agent: createAgent({
+          name: agentName,
+          tools: ["askFollowupQuestion", "readFile"],
+        }),
+        isSubTask: false,
+      });
+
+      expect(toolNames(allowed)).toEqual(
+        [
+          ...RequiredAgentToolNames,
+          "askFollowupQuestion",
+          "readFile",
+        ].sort(),
+      );
+    }
+  });
+
+  it("removes newTask from subtasks but keeps it for top-level agents", () => {
+    const agent = createAgent({ tools: ["newTask", "readFile"] });
+
+    const topLevelTools = selectAgentTools({
+      agent,
+      isSubTask: false,
+    });
+    const subTaskTools = selectAgentTools({
+      agent,
+      isSubTask: true,
+    });
+
+    expect(toolNames(topLevelTools)).toEqual(
+      [...RequiredAgentToolNames, "newTask", "readFile"].sort(),
+    );
+    expect(toolNames(subTaskTools)).toEqual(
+      [...RequiredAgentToolNames, "readFile"].sort(),
+    );
+  });
+
+  it("exposes createReview only for reviewer agents that declare it", () => {
+    const reviewerTools = selectAgentTools({
+      agent: createAgent({
+        name: "reviewer",
+        tools: ["createReview", "readFile"],
+      }),
+      isSubTask: false,
+    });
+    const reviewerWithoutCreateReview = selectAgentTools({
+      agent: createAgent({
+        name: "reviewer",
+        tools: ["readFile"],
+      }),
+      isSubTask: false,
+    });
+    const nonReviewerTools = selectAgentTools({
+      agent: createAgent({
+        name: "not-reviewer",
+        tools: ["createReview", "readFile"],
+      }),
+      isSubTask: false,
+    });
+
+    expect(toolNames(reviewerTools)).toEqual(
+      [...RequiredAgentToolNames, "createReview", "readFile"].sort(),
+    );
+    expect(toolNames(reviewerWithoutCreateReview)).toEqual(
+      [...RequiredAgentToolNames, "readFile"].sort(),
+    );
+    expect(toolNames(nonReviewerTools)).toEqual(
+      [...RequiredAgentToolNames, "readFile"].sort(),
+    );
+  });
+
+  it("lets MCP tools override client tools with the same name", () => {
+    const mcpReadFile = createTool("MCP readFile override");
+
+    const tools = selectAgentTools({
+      agent: createAgent({ tools: ["readFile"] }),
+      isSubTask: false,
+      mcpTools: { readFile: mcpReadFile },
+    });
+
+    expect(toolNames(tools)).toEqual(
+      [...RequiredAgentToolNames, "readFile"].sort(),
+    );
+    expect(tools.readFile).toBe(mcpReadFile);
+  });
+
+  it("passes tool creation options through selected client tools", () => {
+    const customAgent = createAgent({
+      name: "child-agent",
+      description: "Runs child tasks",
+    });
+    const customResultSchema = z.object({
+      ok: z.boolean(),
+    });
+
+    const tools = selectAgentTools({
+      isSubTask: false,
+      contentType: ["image/png"],
+      customAgents: [customAgent],
+      skills: [
+        {
+          name: "demo-skill",
+          description: "Demonstrates skill injection",
+          filePath: "/tmp/demo-skill/SKILL.md",
+          instructions: "Do the thing.",
+        },
+      ],
+      attemptCompletionSchema: customResultSchema as unknown as z.ZodAny,
+    });
+    const completionInputSchema = tools.attemptCompletion
+      ?.inputSchema as z.ZodType;
+
+    expect(tools.readFile?.description).toContain("image/png");
+    expect(tools.newTask?.description).toContain("child-agent");
+    expect(tools.useSkill?.description).toContain("demo-skill");
+    expect(
+      completionInputSchema.safeParse({
+        result: { ok: true },
+      }).success,
+    ).toBe(true);
+    expect(
+      completionInputSchema.safeParse({
+        result: "plain text",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,5 +1,6 @@
 export { McpTool } from "./mcp-tools";
 import {
+  type Tool,
   type UIDataTypes,
   type UIMessagePart,
   type UITools,
@@ -33,11 +34,11 @@ import { readBackgroundJobOutput } from "./read-background-job-output";
 import { createReadFileTool } from "./read-file";
 import { startBackgroundJob } from "./start-background-job";
 import { type Skill, createSkillTool } from "./use-skill";
+import { parseToolSpec } from "./utils";
 import { writeToFile } from "./write-to-file";
 
 export {
   CustomAgent,
-  overrideCustomAgentTools,
   type SubTask,
   inputSchema as newTaskInputSchema,
 } from "./new-task";
@@ -109,7 +110,15 @@ export const ToolsByPermission = {
 
 export const ServerToolApproved = "<server-tool-approved>";
 
-const createCliTools = (options?: CreateToolOptions) => ({
+export interface CreateClientToolOptions {
+  customAgents?: CustomAgent[];
+  skills?: Skill[];
+  contentType?: string[];
+  attemptCompletionSchema?: z.ZodAny;
+  agent?: CustomAgent;
+}
+
+const createCliTools = (options?: CreateClientToolOptions) => ({
   applyDiff,
   askFollowupQuestion,
   attemptCompletion: createAttemptCompletionTool(
@@ -127,15 +136,7 @@ const createCliTools = (options?: CreateToolOptions) => ({
   newTask: createNewTaskTool(options?.customAgents),
 });
 
-export interface CreateToolOptions {
-  customAgents?: CustomAgent[];
-  skills?: Skill[];
-  contentType?: string[];
-  attemptCompletionSchema?: z.ZodAny;
-  agent?: CustomAgent;
-}
-
-export const createClientTools = (options?: CreateToolOptions) => {
+export const createClientTools = (options?: CreateClientToolOptions) => {
   return {
     ...createCliTools(options),
     startBackgroundJob,
@@ -149,23 +150,87 @@ export type ClientTools = ReturnType<typeof createClientTools> & {
   createReview: createReview;
 };
 
-export const selectClientTools = (
-  options: {
-    isSubTask: boolean;
-  } & CreateToolOptions,
-) => {
-  const clientTools = createClientTools(options);
+type ToolMap = Record<string, Tool>;
 
-  if (options?.isSubTask) {
-    const { newTask, ...rest } = clientTools;
-    if (options.agent?.name === "reviewer") {
-      return {
-        ...rest,
-        createReview,
-      };
+type AgentTools = ToolMap &
+  Partial<
+    ReturnType<typeof createClientTools> & {
+      createReview: createReview;
     }
-    return rest;
+  >;
+
+type SelectAgentToolsOptions = {
+  isSubTask: boolean;
+  mcpTools?: ToolMap;
+} & CreateClientToolOptions;
+
+const RequiredAgentTools = ["todoWrite", "attemptCompletion", "useSkill"];
+
+function isAgentToolDisabled(
+  agentName: string,
+  toolName: string,
+  isSubTask: boolean,
+): boolean {
+  if (isSubTask && toolName === "newTask") return true;
+
+  const canAskFollowupQuestion =
+    agentName === "planner" || agentName === "guide";
+  return toolName === "askFollowupQuestion" && !canAskFollowupQuestion;
+}
+
+function getAgentToolAllowList(
+  agent: CustomAgent | undefined,
+  isSubTask: boolean,
+): Set<string> | undefined {
+  /**
+   * if no agent or no tools specified, we don't filter any tools.
+   * TODO(zhanba): for subagent with no tools specified, we should inherit the parent agent's tools instead of allowing all tools.
+   */
+  if (!agent?.tools?.length) {
+    return undefined;
   }
 
-  return clientTools;
+  const allowed = new Set<string>();
+
+  for (const tool of agent.tools) {
+    const { name } = parseToolSpec(tool);
+    if (isAgentToolDisabled(agent.name, name, isSubTask)) continue;
+    if (RequiredAgentTools.includes(name)) continue;
+    allowed.add(name);
+  }
+
+  for (const name of RequiredAgentTools) {
+    allowed.add(name);
+  }
+
+  return allowed;
+}
+
+function filterTools(
+  tools: AgentTools,
+  allowList: Set<string> | undefined,
+): AgentTools {
+  if (!allowList) return tools;
+
+  return Object.fromEntries(
+    Object.entries(tools).filter(([name]) => allowList.has(name)),
+  ) as AgentTools;
+}
+
+export const selectAgentTools = (
+  options: SelectAgentToolsOptions,
+): AgentTools => {
+  const { agent, mcpTools, isSubTask, ...toolOptions } = options;
+  const allowList = getAgentToolAllowList(agent, options.isSubTask);
+
+  const avaliableTools: AgentTools = {
+    ...createClientTools(toolOptions),
+    ...(mcpTools ?? {}),
+  };
+
+  if (agent?.name === "reviewer") {
+    avaliableTools.createReview = createReview;
+  }
+
+  return filterTools(avaliableTools, allowList);
 };

--- a/packages/tools/src/new-task.ts
+++ b/packages/tools/src/new-task.ts
@@ -2,7 +2,6 @@ import type { UIMessage } from "ai";
 import { z } from "zod";
 import type { Todo } from "./todo-write";
 import { defineClientTool } from "./types";
-import { parseToolSpec } from "./utils";
 
 export type SubTask = {
   clientTaskId: string;
@@ -31,32 +30,6 @@ export const CustomAgent = z.object({
 });
 
 export type CustomAgent = z.infer<typeof CustomAgent>;
-
-export const overrideCustomAgentTools = (
-  customAgent: CustomAgent | undefined,
-): CustomAgent | undefined => {
-  if (!customAgent) return undefined;
-  if (!customAgent.tools || customAgent.tools.length === 0) {
-    return { ...customAgent, tools: undefined };
-  }
-
-  const toAddTools = ["todoWrite", "attemptCompletion", "useSkill"];
-  const toDeleteTools = ["newTask"];
-
-  // planner auto jump into manual run node, so it's ok to utilize askFollowupQuestion
-  // guide needs askFollowupQuestion to confirm config changes
-  if (customAgent.name !== "planner" && customAgent.name !== "guide") {
-    toDeleteTools.push("askFollowupQuestion");
-  }
-
-  const updatedTools = customAgent.tools.filter((tool) => {
-    const parsed = parseToolSpec(tool);
-    return (
-      !toDeleteTools.includes(parsed.name) && !toAddTools.includes(parsed.name)
-    );
-  });
-  return { ...customAgent, tools: [...updatedTools, ...toAddTools] };
-};
 
 function makeCustomAgentToolDescription(customAgents?: CustomAgent[]) {
   if (!customAgents || customAgents.length === 0)


### PR DESCRIPTION
## Summary

- Replace scattered `overrideCustomAgentTools` + `selectClientTools` + `getAllowedToolNames` + `pickBy` with a single unified `selectAgentTools` function in `packages/tools/src/index.ts`
- The new function handles tool allow-listing (from `CustomAgent.tools`), required tool injection (`todoWrite`, `attemptCompletion`, `useSkill`), sub-task restrictions (`newTask` disabled), agent-specific overrides (reviewer gets `createReview`, non-planner/guide agents lose `askFollowupQuestion`), and MCP tool merging — all in one place
- Update `FlexibleChatTransport` in `packages/livekit` to use `selectAgentTools` directly, removing the now-redundant `overrideCustomAgentTools` call and the `remeda` `pickBy` dependency
- Add `packages/tools/src/__test__/select-agent-tools.test.ts` with unit tests covering the new logic

## Test plan

- [ ] Run `bun run test` in `packages/tools` to verify unit tests pass
- [ ] Verify sub-task agents no longer receive `newTask` tool
- [ ] Verify agents with an explicit tools list are filtered correctly while required tools remain available

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-1095250f4ac04c9692ce5d5297bee7d5)