### PR TITLE
chore(cli): improve shutdown and exit logging

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -85,6 +85,11 @@ const logger = getLogger("Pochi");
 globalThis.POCHI_CLIENT = `PochiCli/${packageJson.version}`;
 logger.debug(`pochi v${packageJson.version}`);
 
+// Setup fallback exit logging hook
+process.once("exit", (exitCode) => {
+  logger.debug(`Process exiting with code ${exitCode}`);
+});
+
 const parsePositiveInt = (input: string): number => {
   if (!input) {
     return program.error(
@@ -378,10 +383,14 @@ const program = new Command()
 
     let runtimeError: Error | undefined = undefined;
     try {
+      logger.debug("Starting task runner...");
       await runner.run();
+      logger.debug("Task runner finished successfully.");
     } catch (error) {
       runtimeError = error instanceof Error ? error : new Error(String(error));
+      logger.debug(`Task runner exit with error: ${runtimeError.message}.`);
     } finally {
+      logger.debug("Shutting down...");
       // Cleanup resources
       outputRenderer.shutdown();
       await streamRenderer?.shutdown();
@@ -393,6 +402,7 @@ const program = new Command()
       browserSessionStore.dispose();
       await store.shutdownPromise();
 
+      logger.debug("Shutdown completed. Process will exit.");
       if (runtimeError) {
         program.error(runtimeError.message, {
           code:

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -293,8 +293,6 @@ export class TaskRunner {
   }
 
   async run(): Promise<void> {
-    logger.debug("Starting TaskRunner...");
-
     try {
       logger.trace("Start step loop.");
       this.stepCount.reset();


### PR DESCRIPTION
## Summary
- Adds a fallback exit logging hook to `cli.ts` to capture the process exit code.
- Adds granular debug logging throughout the task runner execution and shutdown sequence.
- Consolidates "Starting TaskRunner..." logging into `cli.ts` for consistency.

## Test plan
- Run the CLI and verify that debug logs show the start, success/error, shutdown steps, and final exit code.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-575afaaf44df460891d5776fed4f8066)