### PR TITLE
fix(livestore): properly flatten decoded arrays in do-rpc client

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "ai@5.0.169": "patches/ai@5.0.169.patch",
     "@ai-sdk/google-vertex@3.0.127": "patches/@ai-sdk%2Fgoogle-vertex@3.0.127.patch",
     "@ai-sdk/mcp@0.0.16": "patches/@ai-sdk%2Fmcp@0.0.16.patch",
-    "ai@6.0.146": "patches/ai@6.0.146.patch"
+    "ai@6.0.146": "patches/ai@6.0.146.patch",
+    "@livestore/common-cf@0.4.0-dev.22": "patches/@livestore%2Fcommon-cf@0.4.0-dev.22.patch"
   }
 }

--- a/patches/@livestore%2Fcommon-cf@0.4.0-dev.22.patch
+++ b/patches/@livestore%2Fcommon-cf@0.4.0-dev.22.patch
@@ -1,0 +1,46 @@
+diff --git a/dist/do-rpc/client.js b/dist/do-rpc/client.js
+index b2114abad7d08592673938d5c8ae58b9f1c2bc43..7a9bc689a1a158ba1e22524bfc650006e0ccba0b 100644
+--- a/dist/do-rpc/client.js
++++ b/dist/do-rpc/client.js
+@@ -15,16 +15,10 @@ const processReadableStream = (stream, parser, writeResponse) => Effect.gen(func
+             const decoded = parser.decode(value);
+             // Handle array of messages - we get [[message]] from server
+             let messages;
+-            if (Array.isArray(decoded) && decoded.length === 1 && Array.isArray(decoded[0])) {
+-                // Double-wrapped array [[message]] -> [message]
+-                messages = decoded[0];
+-            }
+-            else if (Array.isArray(decoded)) {
+-                // Single array [message]
+-                messages = decoded;
+-            }
+-            else {
+-                messages = [decoded];
++            if (Array.isArray(decoded) === true) {
++                messages = decoded.flat(1)
++            } else {
++                messages = [decoded]
+             }
+             // Write each message
+             for (const message of messages) {
+@@ -75,16 +69,10 @@ const makeProtocolDurableObject = ({ callRpc, }) => RpcClient.Protocol.make(Effe
+             const decoded = parser.decode(serializedResponse);
+             // Handle potential nested array from server serialization
+             let responseArray;
+-            if (Array.isArray(decoded) && decoded.length === 1 && Array.isArray(decoded[0])) {
+-                // Double-wrapped array [[Exit]] -> [Exit]
+-                responseArray = decoded[0];
+-            }
+-            else if (Array.isArray(decoded)) {
+-                // Single array [Exit]
+-                responseArray = decoded;
+-            }
+-            else {
+-                responseArray = [decoded];
++            if (Array.isArray(decoded) === true) {
++                responseArray = decoded.flat(1)
++            } else {
++                responseArray = [decoded]
+             }
+             // Process each response
+             for (const response of responseArray) {


### PR DESCRIPTION
This patch simplifies the array unwrapping logic in `@livestore/common-cf`'s `do-rpc/client.js` by using `.flat(1)` instead of checking for specific nested arrays of length 1. This prevents issues with incorrectly nested or unexpectedly formatted response arrays.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0927ed6d727a41528684412c0aab4673)

Co-Authored-By: Pochi <noreply@getpochi.com>
