### PR TITLE
feat(common): include tool name in persisted tool result filename

### DIFF
--- a/packages/common/src/tool-utils/__tests__/tool-result-persistence.test.ts
+++ b/packages/common/src/tool-utils/__tests__/tool-result-persistence.test.ts
@@ -66,7 +66,7 @@ describe("maybePersistToolResult", () => {
       expect(result.isTruncated).toBe(false);
 
       // File written with full JSON-stringified output
-      const filePath = path.join(tmpDir, ".pochi", "tasks", TASK_ID, "tool-results", `${TOOL_CALL_ID}.json`);
+      const filePath = path.join(tmpDir, ".pochi", "tasks", TASK_ID, "tool-results", `executeCommand-${TOOL_CALL_ID}.json`);
       const fileContent = await fs.readFile(filePath, "utf-8");
       expect(fileContent).toBe(JSON.stringify(output));
     });
@@ -107,7 +107,7 @@ describe("maybePersistToolResult", () => {
       expect(result.content[0].text).toContain("[Output too large:");
 
       // File contains full original output
-      const filePath = path.join(tmpDir, ".pochi", "tasks", TASK_ID, "tool-results", `${TOOL_CALL_ID}.json`);
+      const filePath = path.join(tmpDir, ".pochi", "tasks", TASK_ID, "tool-results", `someMcpTool-${TOOL_CALL_ID}.json`);
       const fileContent = await fs.readFile(filePath, "utf-8");
       expect(fileContent).toBe(JSON.stringify(output));
     });

--- a/packages/common/src/tool-utils/tool-result-persistence.ts
+++ b/packages/common/src/tool-utils/tool-result-persistence.ts
@@ -61,7 +61,7 @@ export async function maybePersistToolResult(
 
     // Lazily write the full output once; both cases share the same file.
     const dir = getToolResultsDir(taskId);
-    const filePath = path.join(dir, `${toolCallId}.json`);
+    const filePath = path.join(dir, `${toolName}-${toolCallId}.json`);
     let fileWritten = false;
     const ensureFile = async () => {
       if (!fileWritten) {


### PR DESCRIPTION
## Summary

- When a tool result is too large and persisted to disk, the saved filename now includes the tool name: `${toolName}-${toolCallId}.json` (e.g. `executeCommand-call-abc.json`) instead of just `${toolCallId}.json`
- Makes it easier to identify which tool produced the output when browsing saved tool results
- Updated tests to reflect the new filename format

## Test plan

- [x] All existing `maybePersistToolResult` tests pass with the new filename format
- [x] Verified both Case 1 (top-level string fields) and Case 2 (MCP content array) use the new naming

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b0ec8776ce3647588152989d457a6bbb)