### PR TITLE
fix(cli): correct subtask rendering in OutputRenderer

### DIFF
--- a/packages/cli/src/renderers/output-renderer.ts
+++ b/packages/cli/src/renderers/output-renderer.ts
@@ -17,6 +17,8 @@ import type { TaskRunner } from "../task-runner";
 
 export class OutputRenderer {
   private renderingSubTask = false;
+  private subTaskQueue: Promise<void> = Promise.resolve();
+  private pendingSubTasks = 0;
   private unsubscribe: (() => void) | undefined;
 
   constructor(
@@ -103,9 +105,9 @@ export class OutputRenderer {
             this.spinner[stop]();
           }
           this.nextSpinner(true);
-        } else {
-          break;
+          continue;
         }
+        break;
       }
 
       if (this.pendingPartIndex < lastMessage.parts.length - 1) {
@@ -119,19 +121,27 @@ export class OutputRenderer {
   }
 
   renderSubTask(runner: TaskRunner) {
+    this.pendingSubTasks++;
     this.renderingSubTask = true;
-    this.withoutSpinner(() => {
-      const listr = makeListr(
-        this.stream,
-        runner.taskId,
-        this.state,
-        runner.state,
-      );
+    this.subTaskQueue = this.subTaskQueue
+      .then(async () => {
+        await this.withoutSpinner(async () => {
+          const listr = makeListr(
+            this.stream,
+            runner.taskId,
+            this.state,
+            runner.state,
+          );
 
-      return listr.run();
-    }).finally(() => {
-      this.renderingSubTask = false;
-    });
+          await listr.run();
+        });
+      })
+      .finally(() => {
+        this.pendingSubTasks--;
+        if (this.pendingSubTasks === 0) {
+          this.renderingSubTask = false;
+        }
+      });
   }
 
   private nextSpinner(nextPendingPart = false) {
@@ -142,13 +152,18 @@ export class OutputRenderer {
   }
 
   private async withoutSpinner(callback: () => Promise<void>) {
-    this.spinner?.stop();
-    this.spinner = undefined;
+    const oldSpinner = this.spinner;
+    if (oldSpinner) {
+      oldSpinner.stop();
+      this.spinner = undefined;
+    }
 
     try {
       await callback();
     } finally {
-      this.nextSpinner();
+      if (oldSpinner) {
+        this.nextSpinner();
+      }
     }
   }
 

--- a/packages/cli/src/renderers/output-renderer.ts
+++ b/packages/cli/src/renderers/output-renderer.ts
@@ -389,12 +389,20 @@ function makeListr(
               }
             };
 
-            const unsubscribe1 = subtask.signal.messages.subscribe(() => {
-              onUpdate(() => unsubscribe1());
+            // subscribe() invokes its callback synchronously before returning the
+            // unsubscribe fn, so the unsubscribe reference must resolve lazily.
+            // `const u = subscribe(...)` throws TDZ when the callback reads `u`.
+            // `let u; u = subscribe(...)` avoids TDZ but biome's useConst flags it
+            // because `u` is assigned exactly once. An object with a mutable
+            // property satisfies both: const binding + late-bound reference.
+            const ref1: { unsubscribe?: () => void } = {};
+            ref1.unsubscribe = subtask.signal.messages.subscribe(() => {
+              onUpdate(() => ref1.unsubscribe?.());
             });
 
-            const unsubscribe2 = task.signal.messages.subscribe(() => {
-              onUpdate(() => unsubscribe2());
+            const ref2: { unsubscribe?: () => void } = {};
+            ref2.unsubscribe = task.signal.messages.subscribe(() => {
+              onUpdate(() => ref2.unsubscribe?.());
             });
 
             return;


### PR DESCRIPTION
## Changes

### 1. `renderLastMessage` — drop the double-advance on finalized tool parts

After a finalized tool (`output-available`/`output-error`/auto-success `input-available`), `nextSpinner(true)` already advances `pendingPartIndex` and starts a fresh spinner. The post-block then advanced a second time, silently skipping the next part whenever multiple parts arrived in a single signal update.

**Fix:** `continue` after `nextSpinner(true)` so only reasoning/text parts fall through to the post-block.

### 2. `renderSubTask` — serialize listr renderers

The old fire-and-forget pattern let a second `renderSubTask` start its listr before the previous listr's `run()` had resolved. Two concurrent ora/listr renderers on the same stream interleave and can lose output.

**Fix:** chain each `renderSubTask` onto a shared `subTaskQueue` promise and reference-count `pendingSubTasks` so `renderingSubTask` only flips back to `false` after the last queued listr completes. Also guards `withoutSpinner` to only re-create a spinner if one existed on entry.

### 3. `makeListr` — avoid TDZ on synchronous subscribe callbacks

`@preact/signals` fires subscribers synchronously before `subscribe()` returns the unsubscribe fn. When `extractNewTaskTool` couldn't locate the part (e.g., nested subtasks whose `newTask` lives in a parent state other than `this.state`), `finalize()` invoked `unsubscribe1()` during the synchronous fire, hitting TDZ on the `const`. This surfaced as `Cannot access 'unsubscribe1' before initialization.` logged inside the subtask's rendered output.

**Fix:** store the unsubscribe fn on a mutable property of a `const` object ref; the closure reads it lazily at call time. A comment documents why `const`/`let`/split-`let` all have issues here (TDZ vs biome `useConst`).
