### PR TITLE
feat: Support multi-query web search

### DIFF
--- a/packages/vendor-pochi/src/tools/web-search.ts
+++ b/packages/vendor-pochi/src/tools/web-search.ts
@@ -22,11 +22,19 @@ CRITICAL REQUIREMENT - You MUST follow this:
 
 Usage notes:
   - Account for "Today's date" in <system-reminder>. For example, if <system-reminder> says "Today's date: 2025-07-01", and the user wants the latest docs, do not use 2024 in the search query. Use 2025.
+  - To research several related facets in one round-trip, pass "query" as an array of up to 5 query strings instead of a single string. Prefer a single string for focused lookups.
 `.trim(),
   inputSchema: {
     jsonSchema: z.toJSONSchema(
       z.object({
-        query: z.string().describe("The search query to perform"),
+        query: z
+          .union([
+            z.string().min(2),
+            z.array(z.string().min(2)).min(1).max(5),
+          ])
+          .describe(
+            "A single search query string, OR an array of up to 5 related query strings to batch in one request. Prefer a single string for focused lookups; use an array when you want to research several related facets in one call.",
+          ),
         country: z
           .string()
           .optional()
@@ -43,7 +51,7 @@ Usage notes:
     ) as JSONSchema7,
   },
   execute: async (args: {
-    query: string;
+    query: string | string[];
     country?: string;
     searchDomainFilter?: string[];
   }) => {

--- a/packages/vendor-pochi/src/tools/web-search.ts
+++ b/packages/vendor-pochi/src/tools/web-search.ts
@@ -28,10 +28,7 @@ Usage notes:
     jsonSchema: z.toJSONSchema(
       z.object({
         query: z
-          .union([
-            z.string().min(2),
-            z.array(z.string().min(2)).min(1).max(5),
-          ])
+          .union([z.string().min(2), z.array(z.string().min(2)).min(1).max(5)])
           .describe(
             "A single search query string, OR an array of up to 5 related query strings to batch in one request. Prefer a single string for focused lookups; use an array when you want to research several related facets in one call.",
           ),


### PR DESCRIPTION
## Summary
  - Widen `webSearch` tool's `query` input from `string` to `string | string[]` (up to 5 queries) so the model can batch related searches into one Perplexity `/search` call instead of N
  sequential tool calls.
  - Perplexity's `/search` endpoint natively accepts `query` as an array; the response shape is unchanged (flat `results[]`), so no downstream processing changes are needed.
  - Tool description and usage note updated to nudge the model toward batching when researching several related facets.
