### PR TITLE
feat: task memory extraction for background session notes

### DIFF
--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -18,6 +18,13 @@ export const PochiRequestUseCaseHeader = "x-pochi-request-use-case";
 export const EnableAsyncNewTask = false;
 
 /**
+ * Task Memory thresholds — background extraction of session notes.
+ */
+export const TaskMemoryInitTokenThreshold = 10_000;
+export const TaskMemoryUpdateTokenIncrement = 5_000;
+export const TaskMemoryUpdateToolCallThreshold = 3;
+
+/**
  * Timeout (ms) for any single git operation.
  * Used across all git invocations (simple-git block timeout, exec timeout)
  * to prevent hangs when git itself is broken or unresponsive.

--- a/packages/common/src/base/prompts/__tests__/task-memory.test.ts
+++ b/packages/common/src/base/prompts/__tests__/task-memory.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "vitest";
+import { buildMemoryExtractionDirective } from "../task-memory";
+
+test("task memory directive writes to the task file URI", () => {
+  const directive = buildMemoryExtractionDirective();
+
+  expect(directive).toContain(
+    "Use writeToFile with path pochi://-/memory.md",
+  );
+});
+
+test("task memory update directive writes to the task file URI", () => {
+  const directive = buildMemoryExtractionDirective("# Session Title\nExisting");
+
+  expect(directive).toContain(
+    "Use writeToFile with path pochi://-/memory.md",
+  );
+});

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -8,6 +8,10 @@ import { generateTitle } from "./generate-title";
 import { renderReviewComments } from "./review-comments";
 import { createSkillPrompt, createUseSkillResult } from "./skill";
 import { createSystemPrompt } from "./system";
+import {
+  buildMemoryExtractionDirective,
+  taskMemoryTemplate,
+} from "./task-memory";
 import { renderUserEdits } from "./user-edits";
 
 export const prompts = {
@@ -30,6 +34,10 @@ export const prompts = {
   renderBashOutputs,
   fixMermaidError,
   createUseSkillResult,
+  taskMemory: {
+    template: taskMemoryTemplate,
+    buildExtractionDirective: buildMemoryExtractionDirective,
+  },
 };
 
 function createSystemReminder(content: string) {

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -70,12 +70,16 @@ function inlineCompact(
   summary: string,
   messageCount: number,
   appendix?: string,
+  options?: { verbatimTail?: boolean },
 ) {
   const appendixText = appendix ? `\n\n${appendix}` : "";
+  const epilogue = options?.verbatimTail
+    ? "This section summarizes the older portion of the conversation. The most recent turns that follow this block have NOT been condensed — they are the original messages preserved verbatim. Use them as the source of truth for recent activity."
+    : "This section contains a summary of the conversation up to this point to save context. The full conversation history has been preserved but condensed for efficiency.";
   return `<compact>
 Previous conversation summary (${messageCount} messages):
 ${summary}
-This section contains a summary of the conversation up to this point to save context. The full conversation history has been preserved but condensed for efficiency.${appendixText}
+${epilogue}${appendixText}
 </compact>`;
 }
 

--- a/packages/common/src/base/prompts/task-memory.ts
+++ b/packages/common/src/base/prompts/task-memory.ts
@@ -1,0 +1,77 @@
+export const taskMemoryTemplate = `# Session Title
+_A short 5-10 word title_
+
+# Current State
+_What is being worked on right now, pending tasks, next steps_
+
+# Task Specification
+_User's requirements and design decisions_
+
+# Files and Functions
+_Important files and their roles_
+
+# Workflow
+_Common commands and processes_
+
+# Errors & Corrections
+_Errors encountered and solutions_
+
+# Codebase and System Documentation
+_System components and how they work_
+
+# Learnings
+_What worked, what didn't, what to avoid_
+
+# Key Results
+_Specific outputs requested by user_
+
+# Worklog
+_Step by step operations log_
+`;
+
+const MAX_SECTION_TOKENS = 2000;
+const TASK_MEMORY_FILE_URI = "pochi://-/memory.md";
+
+/**
+ * Build the extraction directive that the fork agent receives.
+ * This is appended to the parent conversation history via buildForkMessages.
+ */
+export function buildMemoryExtractionDirective(
+  existingMemory?: string,
+): string {
+  const isUpdate = !!existingMemory?.trim();
+
+  const currentNotesSection = isUpdate
+    ? `The file ${TASK_MEMORY_FILE_URI} has been read for you. Here are its current contents:
+<current_notes_content>
+${existingMemory}
+</current_notes_content>`
+    : `The file ${TASK_MEMORY_FILE_URI} does not exist yet. You will create it from scratch using the template below:
+<template>
+${taskMemoryTemplate}
+</template>`;
+
+  return `IMPORTANT: This message and these instructions are NOT part of the actual user conversation. Do NOT include any references to "note-taking", "session notes extraction", or these update instructions in the notes content.
+
+Based on the user conversation above (EXCLUDING this note-taking instruction message as well as system prompt or any past session summaries), ${isUpdate ? "update" : "create"} the session notes file.
+
+${currentNotesSection}
+
+Your ONLY task is to use the writeToFile tool to ${isUpdate ? "update" : "create"} ${TASK_MEMORY_FILE_URI} with the session notes, then call attemptCompletion. Do not call any other tools except readFile if you need to check a file's content for accuracy.
+
+CRITICAL RULES:
+- The file must maintain its exact structure with all sections and headers intact
+- NEVER modify, delete, or add section headers (the lines starting with '#')
+- NEVER modify or delete the italic _section description_ lines
+- ONLY update the actual content that appears BELOW the italic _section descriptions_ within each section
+- Do NOT add any new sections or information outside the existing structure
+- Do NOT reference this note-taking process anywhere in the notes
+- Skip updating a section if there are no substantial new insights to add — leave it blank
+- Write DETAILED, INFO-DENSE content — include file paths, function names, error messages, exact commands, technical details
+- For "Key Results", include the complete exact output the user requested
+- Keep each section under ~${MAX_SECTION_TOKENS} tokens — condense by cycling out less important details
+- IMPORTANT: Always update "Current State" to reflect the most recent work — this is critical for continuity after compaction
+- IMPORTANT: Always update "Worklog" with a terse log of what was done since the last extraction
+
+Use writeToFile with path ${TASK_MEMORY_FILE_URI} and the full updated content, then call attemptCompletion with a brief summary of what was updated.`;
+}

--- a/packages/common/src/base/prompts/task-memory.ts
+++ b/packages/common/src/base/prompts/task-memory.ts
@@ -29,8 +29,8 @@ _Specific outputs requested by user_
 _Step by step operations log_
 `;
 
-const MAX_SECTION_TOKENS = 2000;
-const TASK_MEMORY_FILE_URI = "pochi://-/memory.md";
+const MaxSectionTokens = 2000;
+const TaskMemoryFileUri = "pochi://-/memory.md";
 
 /**
  * Build the extraction directive that the fork agent receives.
@@ -42,11 +42,11 @@ export function buildMemoryExtractionDirective(
   const isUpdate = !!existingMemory?.trim();
 
   const currentNotesSection = isUpdate
-    ? `The file ${TASK_MEMORY_FILE_URI} has been read for you. Here are its current contents:
+    ? `The file ${TaskMemoryFileUri} has been read for you. Here are its current contents:
 <current_notes_content>
 ${existingMemory}
 </current_notes_content>`
-    : `The file ${TASK_MEMORY_FILE_URI} does not exist yet. You will create it from scratch using the template below:
+    : `The file ${TaskMemoryFileUri} does not exist yet. You will create it from scratch using the template below:
 <template>
 ${taskMemoryTemplate}
 </template>`;
@@ -57,7 +57,7 @@ Based on the user conversation above (EXCLUDING this note-taking instruction mes
 
 ${currentNotesSection}
 
-Your ONLY task is to use the writeToFile tool to ${isUpdate ? "update" : "create"} ${TASK_MEMORY_FILE_URI} with the session notes, then call attemptCompletion. Do not call any other tools except readFile if you need to check a file's content for accuracy.
+Your ONLY task is to use the writeToFile tool to ${isUpdate ? "update" : "create"} ${TaskMemoryFileUri} with the session notes, then call attemptCompletion. Do not call any other tools except readFile if you need to check a file's content for accuracy.
 
 CRITICAL RULES:
 - The file must maintain its exact structure with all sections and headers intact
@@ -69,9 +69,9 @@ CRITICAL RULES:
 - Skip updating a section if there are no substantial new insights to add — leave it blank
 - Write DETAILED, INFO-DENSE content — include file paths, function names, error messages, exact commands, technical details
 - For "Key Results", include the complete exact output the user requested
-- Keep each section under ~${MAX_SECTION_TOKENS} tokens — condense by cycling out less important details
+- Keep each section under ~${MaxSectionTokens} tokens — condense by cycling out less important details
 - IMPORTANT: Always update "Current State" to reflect the most recent work — this is critical for continuity after compaction
 - IMPORTANT: Always update "Worklog" with a terse log of what was done since the last extraction
 
-Use writeToFile with path ${TASK_MEMORY_FILE_URI} and the full updated content, then call attemptCompletion with a brief summary of what was updated.`;
+Use writeToFile with path ${TaskMemoryFileUri} and the full updated content, then call attemptCompletion with a brief summary of what was updated.`;
 }

--- a/packages/common/src/pochi-file-system/validate-task-file-path.ts
+++ b/packages/common/src/pochi-file-system/validate-task-file-path.ts
@@ -2,14 +2,16 @@ export function validateTaskFilePath(filePath: string) {
   if (
     filePath === "/plan.md" ||
     filePath === "/walkthrough.md" ||
+    filePath === "/memory.md" ||
     /^\/browser-session\/.*\.mp4$/.test(filePath)
   ) {
     return filePath as
       | "/plan.md"
       | "/walkthrough.md"
+      | "/memory.md"
       | `/browser-session/${string}.mp4`;
   }
   throw new Error(
-    `Only /plan.md, /walkthrough.md, /browser-session/*.mp4 are supported for task file system, got: ${filePath}`,
+    `Only /plan.md, /walkthrough.md, /memory.md, /browser-session/*.mp4 are supported for task file system, got: ${filePath}`,
   );
 }

--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -25,6 +25,8 @@ export type {
   McpConfigOverride,
   TaskArchivedParams,
   ContextWindowUsage,
+  TaskMemoryState,
+  AsyncAgentState,
 } from "./types/task";
 export type {
   VSCodeLmModel,

--- a/packages/common/src/vscode-webui-bridge/mcp-util.ts
+++ b/packages/common/src/vscode-webui-bridge/mcp-util.ts
@@ -3,10 +3,21 @@ import * as R from "remeda";
 import type { McpServerConnection } from "../mcp-utils";
 import type { McpConfigOverride } from "./types/task";
 
+/**
+ * Sort entries of a Record alphabetically by key. Used to make the MCP
+ * server / tool enumeration order deterministic so the resulting prompt
+ * (system instructions + tools JSON) is byte-identical across requests
+ * regardless of MCP server registration order. This is required for stable
+ * Anthropic prompt-cache hits across parent/fork tasks, parallel tasks, and
+ * cross-session shared caches.
+ */
+const sortedEntries = <T>(record: Record<string, T>): [string, T][] =>
+  Object.entries(record).sort(([a], [b]) => a.localeCompare(b));
+
 export const buildInstructionsFromConnections = (
   connections: Record<string, McpServerConnection>,
 ) => {
-  return Object.entries(connections)
+  return sortedEntries(connections)
     .filter(([, conn]) => !!conn.instructions)
     .map(
       ([name, conn]) =>
@@ -18,16 +29,18 @@ export const buildInstructionsFromConnections = (
 export const buildToolsetFromConnections = (
   connections: Record<string, McpServerConnection>,
 ): Record<string, McpTool> => {
-  return R.mergeAll(
-    R.values(
-      R.pickBy(
-        connections,
-        (connection) => connection.status === "ready" && !!connection.tools,
-      ),
-    )
-      .map((connection) => R.pickBy(connection.tools, (tool) => !tool.disabled))
-      .map((tool) => R.mapValues(tool, (tool) => R.omit(tool, ["disabled"]))),
-  );
+  // Iterate connections in name-sorted order, and within each connection
+  // iterate its tools in name-sorted order, so the merged toolset has a
+  // deterministic key order.
+  const merged: Record<string, McpTool> = {};
+  for (const [, connection] of sortedEntries(connections)) {
+    if (connection.status !== "ready" || !connection.tools) continue;
+    for (const [toolName, tool] of sortedEntries(connection.tools)) {
+      if (tool.disabled) continue;
+      merged[toolName] = R.omit(tool, ["disabled"]) as McpTool;
+    }
+  }
+  return merged;
 };
 
 export const buildTaskScopedMcpInfo = (

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -1,3 +1,4 @@
+import type { ToolSpecInput } from "@getpochi/tools";
 import type { ActiveSelection } from "./message";
 
 export type FileUIPart = {
@@ -119,6 +120,6 @@ export interface TaskMemoryState {
 }
 
 export interface AsyncAgentState {
-  allowedTools?: readonly string[];
+  tools?: readonly ToolSpecInput[];
   parentTaskId?: string;
 }

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -108,3 +108,17 @@ export type TaskStates = Record<string, TaskState>;
 export type TaskArchivedParams =
   | { type: "single"; taskId: string; archived: boolean }
   | { type: "batch"; cwd?: string };
+
+export interface TaskMemoryState {
+  initialized: boolean;
+  lastExtractionTokens: number;
+  lastExtractionToolCalls: number;
+  isExtracting: boolean;
+  extractionCount: number;
+  activeTaskId?: string;
+}
+
+export interface AsyncAgentState {
+  allowedTools?: readonly string[];
+  parentTaskId?: string;
+}

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -114,6 +114,23 @@ export interface TaskMemoryState {
   initialized: boolean;
   lastExtractionTokens: number;
   lastExtractionToolCalls: number;
+  /**
+   * UUID of the last message incorporated into memory.md by the most recent
+   * successful extraction. Compaction uses this as the boundary to know
+   * which messages are already covered by the curated session notes and
+   * which still need to be preserved verbatim. Stored as a UUID rather
+   * than a numeric index so it remains stable across any in-place
+   * mutations of the messages array (compact tag insertion, fork/restore,
+   * etc.).
+   */
+  lastExtractionMessageId?: string;
+  /**
+   * Snapshot of the trailing message UUID at the moment the in-flight
+   * extraction was started. Promoted to `lastExtractionMessageId` once the
+   * fork agent finishes successfully (and the snapshot was on a clean turn
+   * boundary at promotion time).
+   */
+  pendingExtractionMessageId?: string;
   isExtracting: boolean;
   extractionCount: number;
   activeTaskId?: string;

--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -5,6 +5,7 @@ import type { Environment } from "../base";
 import type { BrowserSession } from "../browser/types";
 import type { UserInfo } from "../configuration";
 import type {
+  AsyncAgentState,
   BuiltinSubAgentInfo,
   CaptureEvent,
   ChangedFileContent,
@@ -25,6 +26,7 @@ import type {
   SkillFile,
   TaskArchivedParams,
   TaskChangedFile,
+  TaskMemoryState,
   TaskStates,
   VSCodeHostApi,
   VSCodeSettings,
@@ -78,6 +80,7 @@ const VSCodeHostStub = {
       toolPolicies?: CompiledToolPolicies;
       storeId: string;
       taskId: string;
+      fileStateCacheSourceTaskId?: string;
     },
   ): Promise<unknown> => {
     return Promise.resolve(undefined);
@@ -372,6 +375,28 @@ const VSCodeHostStub = {
       value: {} as ThreadSignalSerialization<ContextWindowUsage | undefined>,
       setContextWindowUsage: (_contextWindowUsage: ContextWindowUsage) =>
         Promise.resolve(),
+    };
+  },
+  readTaskMemoryState: async (
+    _taskId: string,
+  ): Promise<{
+    value: ThreadSignalSerialization<TaskMemoryState | undefined>;
+    setTaskMemoryState: (state: TaskMemoryState) => Promise<void>;
+  }> => {
+    return {
+      value: {} as ThreadSignalSerialization<TaskMemoryState | undefined>,
+      setTaskMemoryState: (_state: TaskMemoryState) => Promise.resolve(),
+    };
+  },
+  readAsyncAgentState: async (
+    _taskId: string,
+  ): Promise<{
+    value: ThreadSignalSerialization<AsyncAgentState | undefined>;
+    setAsyncAgentState: (state: AsyncAgentState) => Promise<void>;
+  }> => {
+    return {
+      value: {} as ThreadSignalSerialization<AsyncAgentState | undefined>,
+      setAsyncAgentState: (_state: AsyncAgentState) => Promise.resolve(),
     };
   },
   readTaskArchived(): Promise<{

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -6,6 +6,7 @@ import type { BrowserSession } from "../browser/types";
 import type { UserInfo } from "../configuration";
 import type { RecentFileState } from "../tool-utils";
 import type {
+  AsyncAgentState,
   BuiltinSubAgentInfo,
   CaptureEvent,
   ChangedFileContent,
@@ -25,6 +26,7 @@ import type {
   SkillFile,
   TaskArchivedParams,
   TaskChangedFile,
+  TaskMemoryState,
   TaskStates,
   WorkspaceState,
 } from "./index";
@@ -91,6 +93,7 @@ export interface VSCodeHostApi {
       toolPolicies?: CompiledToolPolicies;
       storeId: string;
       taskId: string;
+      fileStateCacheSourceTaskId?: string;
     },
   ): Promise<unknown>;
 
@@ -410,6 +413,16 @@ export interface VSCodeHostApi {
     setContextWindowUsage: (
       contextWindowUsage: ContextWindowUsage,
     ) => Promise<void>;
+  }>;
+
+  readTaskMemoryState(taskId: string): Promise<{
+    value: ThreadSignalSerialization<TaskMemoryState | undefined>;
+    setTaskMemoryState: (state: TaskMemoryState) => Promise<void>;
+  }>;
+
+  readAsyncAgentState(taskId: string): Promise<{
+    value: ThreadSignalSerialization<AsyncAgentState | undefined>;
+    setAsyncAgentState: (state: AsyncAgentState) => Promise<void>;
   }>;
 
   /**

--- a/packages/livekit/src/chat/__tests__/compact-task.test.ts
+++ b/packages/livekit/src/chat/__tests__/compact-task.test.ts
@@ -44,6 +44,20 @@ describe("findVerbatimAttachIndex", () => {
     expect(findVerbatimAttachIndex(messages, "u0")).toBeUndefined();
   });
 
+  it("returns undefined when the only reachable user message is index 0", () => {
+    // Boundary lands on the first assistant message; walking back to
+    // index 0 would keep everything verbatim and free no context.
+    // Falling back to trailing-message attach is preferable.
+    const messages = [
+      userMsg("u0"),
+      assistantMsg("a0"),
+      assistantMsg("a1"),
+      userMsg("u1"),
+      assistantMsg("a2"),
+    ];
+    expect(findVerbatimAttachIndex(messages, "a0")).toBeUndefined();
+  });
+
   it("returns undefined when the boundary equals or exceeds the trailing index", () => {
     const messages = [userMsg("u0"), assistantMsg("a0"), userMsg("u1")];
     // boundary at the last index leaves no room for verbatim retention

--- a/packages/livekit/src/chat/__tests__/compact-task.test.ts
+++ b/packages/livekit/src/chat/__tests__/compact-task.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "../../types";
+import { findVerbatimAttachIndex } from "../llm/compact-task";
+
+function userMsg(id: string, text = "hi"): Message {
+  return {
+    id,
+    role: "user",
+    parts: [{ type: "text", text }],
+  } as unknown as Message;
+}
+
+function assistantMsg(id: string, text = "ok"): Message {
+  return {
+    id,
+    role: "assistant",
+    parts: [{ type: "text", text }],
+  } as unknown as Message;
+}
+
+function compactUserMsg(id: string): Message {
+  return {
+    id,
+    role: "user",
+    parts: [{ type: "text", text: "<compact>old summary</compact>" }],
+  } as unknown as Message;
+}
+
+describe("findVerbatimAttachIndex", () => {
+  it("returns undefined when no boundary id is provided", () => {
+    const messages = [userMsg("u0"), assistantMsg("a0"), userMsg("u1")];
+    expect(findVerbatimAttachIndex(messages, undefined)).toBeUndefined();
+    expect(findVerbatimAttachIndex(messages, "")).toBeUndefined();
+  });
+
+  it("returns undefined when the boundary id is not present", () => {
+    const messages = [userMsg("u0"), assistantMsg("a0"), userMsg("u1")];
+    expect(findVerbatimAttachIndex(messages, "ghost")).toBeUndefined();
+  });
+
+  it("returns undefined when the boundary is the very first message", () => {
+    const messages = [userMsg("u0"), assistantMsg("a0"), userMsg("u1")];
+    // boundary at index 0 leaves no curated summary before it
+    expect(findVerbatimAttachIndex(messages, "u0")).toBeUndefined();
+  });
+
+  it("returns undefined when the boundary equals or exceeds the trailing index", () => {
+    const messages = [userMsg("u0"), assistantMsg("a0"), userMsg("u1")];
+    // boundary at the last index leaves no room for verbatim retention
+    expect(findVerbatimAttachIndex(messages, "u1")).toBeUndefined();
+  });
+
+  it("returns the boundary itself when it is already a user message", () => {
+    const messages = [
+      userMsg("u0"),
+      assistantMsg("a0"),
+      userMsg("u1"),
+      assistantMsg("a1"),
+      userMsg("u2"),
+    ];
+    expect(findVerbatimAttachIndex(messages, "u1")).toBe(2);
+  });
+
+  it("walks backwards to the nearest user message when boundary is on assistant", () => {
+    const messages = [
+      userMsg("u0"),
+      assistantMsg("a0"),
+      userMsg("u1"),
+      assistantMsg("a1"),
+      userMsg("u2"),
+    ];
+    // boundary points to the assistant turn; should walk back to u1
+    expect(findVerbatimAttachIndex(messages, "a1")).toBe(2);
+  });
+
+  it("returns undefined when an existing compact block is at or after the boundary", () => {
+    const messages = [
+      userMsg("u0"),
+      assistantMsg("a0"),
+      compactUserMsg("u1-compact"),
+      assistantMsg("a1"),
+      userMsg("u2"),
+    ];
+    // existing compact at index 2; boundary u1-compact would shadow it
+    expect(findVerbatimAttachIndex(messages, "u1-compact")).toBeUndefined();
+    // boundary u0 (index 0) is before the previous compact — also rejected
+    expect(findVerbatimAttachIndex(messages, "u0")).toBeUndefined();
+  });
+
+  it("attaches strictly after a previous compact block", () => {
+    const messages = [
+      userMsg("u0"),
+      assistantMsg("a0"),
+      compactUserMsg("u1-compact"),
+      assistantMsg("a1"),
+      userMsg("u2"),
+      assistantMsg("a2"),
+      userMsg("u3"),
+    ];
+    // previous compact at 2; boundary u2 is at index 4, a user message
+    expect(findVerbatimAttachIndex(messages, "u2")).toBe(4);
+  });
+
+  it("returns undefined when no user message exists between previous compact and boundary", () => {
+    const messages = [
+      userMsg("u0"),
+      assistantMsg("a0"),
+      compactUserMsg("u1-compact"),
+      assistantMsg("a1"),
+      assistantMsg("a2"),
+      userMsg("u3"),
+    ];
+    // previous compact at 2; boundary a2 (index 4) — no user msg between
+    expect(findVerbatimAttachIndex(messages, "a2")).toBeUndefined();
+  });
+});

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -15,6 +15,7 @@ import {
   type ChatRequestOptions,
   type ChatTransport,
   type ModelMessage,
+  type SystemModelMessage,
   type UIMessageChunk,
   convertToModelMessages,
   isStaticToolUIPart,
@@ -148,6 +149,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     const mcpTools =
       mcpInfo?.toolset && parseMcpToolSet(this.blobStore, mcpInfo.toolset);
 
+    // Tool ordering should be deterministic
     const tools = selectAgentTools({
       agent: this.customAgent,
       isSubTask: !!this.isSubTask,
@@ -179,6 +181,23 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
         { tools },
       ),
     )) as ModelMessage[];
+
+    // Mark cache breakpoints for Anthropic prompt caching. The provider order
+    // is `tools → system → messages`, so a breakpoint on the system block
+    // caches both tools and system, and a breakpoint on the last message
+    // caches the entire prefix up to (and including) that message.
+    const cacheControl = {
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    } as const;
+
+    const systemMessage: SystemModelMessage = {
+      role: "system",
+      content: systemPrompt,
+      providerOptions: cacheControl,
+    };
+
+    const cachedModelMessages = withCacheBreakpointOnLastMessage(modelMessages);
+
     const stream = streamText({
       providerOptions: {
         pochi: {
@@ -187,8 +206,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
           useCase: "agent",
         } satisfies PochiProviderOptions,
       },
-      system: systemPrompt,
-      messages: modelMessages,
+      system: systemMessage,
+      messages: cachedModelMessages,
       model: wrapLanguageModel({
         model,
         middleware: middlewares,
@@ -239,6 +258,34 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
 
 function prepareMessages(inputMessages: Message[]): Message[] {
   return convertDataReviewsToText(inputMessages);
+}
+
+/**
+ * Attach an Anthropic ephemeral cache breakpoint to the last message of the
+ * conversation. Combined with a breakpoint on the system block, this caches
+ * the entire request prefix (tools + system + message history). On the next
+ * request that adds new messages, the previous boundary becomes a cache hit.
+ *
+ * For fork agents this is what makes the parent task's prefix reusable: the
+ * fork's `[...parentMessages, newDirective]` will hit the cache up to the end
+ * of `parentMessages` (the last message at the time of the parent's request),
+ * even though the new directive itself is uncached.
+ */
+function withCacheBreakpointOnLastMessage(
+  messages: ModelMessage[],
+): ModelMessage[] {
+  if (messages.length === 0) return messages;
+  const lastIndex = messages.length - 1;
+  return messages.map((m, i) => {
+    if (i !== lastIndex) return m;
+    return {
+      ...m,
+      providerOptions: {
+        ...(m.providerOptions ?? {}),
+        anthropic: { cacheControl: { type: "ephemeral" } },
+      },
+    } as ModelMessage;
+  });
 }
 
 function isWellKnownReasoningModel(model?: string): boolean {

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -291,6 +291,7 @@ export class LiveChatKit<
             ),
             abortSignal,
             inline: true,
+            store: this.store,
           });
           await onCompact?.();
         } catch (err) {
@@ -324,6 +325,7 @@ export class LiveChatKit<
         model,
         messages,
         recentFiles: await readRecentFilesForCompact(getRecentFilesForCompact),
+        store: this.store,
       });
 
       if (!summary) {

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -18,7 +18,10 @@ import {
 import { events, tables } from "../livestore/default-schema";
 import { toTaskError, toTaskGitInfo, toTaskStatus } from "../task";
 
-import type { ContextWindowUsage } from "@getpochi/common/vscode-webui-bridge";
+import type {
+  ContextWindowUsage,
+  TaskMemoryState,
+} from "@getpochi/common/vscode-webui-bridge";
 import type { LiveKitStore, Message, Task } from "../types";
 import { scheduleGenerateTitleJob } from "./background-job";
 import { filterCompletionTools } from "./filter-completion-tools";
@@ -34,10 +37,15 @@ import { ImageEstimatedTokens, estimateTokens } from "./token-utils";
 
 const logger = getLogger("LiveChatKit");
 const OverrideMessagesSideEffectTimeoutMs = 12_000;
+/** Compaction waits up to this long for an in-flight task-memory extraction. */
+const TaskMemorySettleTimeoutMs = 5_000;
+const TaskMemorySettlePollIntervalMs = 200;
 
 type GetRecentFilesForCompact = () =>
   | RecentFileState[]
   | Promise<RecentFileState[]>;
+
+type GetTaskMemoryState = () => TaskMemoryState | undefined;
 
 async function readRecentFilesForCompact(
   getRecentFilesForCompact: GetRecentFilesForCompact | undefined,
@@ -48,6 +56,22 @@ async function readRecentFilesForCompact(
     logger.warn(
       "Failed to read recent files for compaction. Continue compacting without file restoration.",
       error,
+    );
+  }
+}
+
+/** Polls until no extraction is in progress or `timeoutMs` elapses. */
+async function settleTaskMemoryExtraction(
+  getTaskMemoryState: GetTaskMemoryState | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  if (!getTaskMemoryState) return;
+  if (!getTaskMemoryState()?.isExtracting) return;
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!getTaskMemoryState()?.isExtracting) return;
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, TaskMemorySettlePollIntervalMs),
     );
   }
 }
@@ -163,6 +187,9 @@ export type LiveChatKitOptions<T> = {
    */
   getRecentFilesForCompact?: GetRecentFilesForCompact;
 
+  /** Latest `TaskMemoryState` snapshot — provides the verbatim boundary and the `isExtracting` flag. */
+  getTaskMemoryState?: GetTaskMemoryState;
+
   customAgent?: CustomAgent;
   outputSchema?: z.ZodAny;
   attemptCompletionSchema?: z.ZodAny;
@@ -230,6 +257,7 @@ export class LiveChatKit<
 
     onStreamFinish,
     getRecentFilesForCompact,
+    getTaskMemoryState,
     ...chatInit
   }: LiveChatKitOptions<T>) {
     this.taskId = taskId;
@@ -280,6 +308,11 @@ export class LiveChatKit<
         lastMessage.metadata.compact
       ) {
         try {
+          // Wait briefly so memory.md and boundary id are fresh.
+          await settleTaskMemoryExtraction(
+            getTaskMemoryState,
+            TaskMemorySettleTimeoutMs,
+          );
           const model = createModel({ llm: getters.getLLM() });
           await compactTask({
             blobStore: this.blobStore,
@@ -289,6 +322,8 @@ export class LiveChatKit<
             recentFiles: await readRecentFilesForCompact(
               getRecentFilesForCompact,
             ),
+            taskMemoryBoundaryMessageId:
+              getTaskMemoryState?.()?.lastExtractionMessageId,
             abortSignal,
             inline: true,
             store: this.store,
@@ -318,6 +353,11 @@ export class LiveChatKit<
 
     this.compact = async () => {
       const { messages } = this.chat;
+      // Wait briefly so memory.md and boundary id are fresh.
+      await settleTaskMemoryExtraction(
+        getTaskMemoryState,
+        TaskMemorySettleTimeoutMs,
+      );
       const model = createModel({ llm: getters.getLLM() });
       const summary = await compactTask({
         blobStore: this.blobStore,
@@ -325,6 +365,8 @@ export class LiveChatKit<
         model,
         messages,
         recentFiles: await readRecentFilesForCompact(getRecentFilesForCompact),
+        taskMemoryBoundaryMessageId:
+          getTaskMemoryState?.()?.lastExtractionMessageId,
         store: this.store,
       });
 

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -117,8 +117,9 @@ export async function compactTask({
 /**
  * Find the index at which to attach the compact block so trailing messages
  * survive verbatim. Returns `undefined` when the boundary is missing,
- * shadowed by a previous `<compact>` tag, or when no user-role message
- * exists between the previous compact and the boundary.
+ * shadowed by a previous `<compact>` tag, or when the only reachable
+ * user-role message would be index 0 (which would keep the whole
+ * conversation verbatim and free no context).
  */
 export function findVerbatimAttachIndex(
   messages: Message[],
@@ -127,28 +128,22 @@ export function findVerbatimAttachIndex(
   if (!boundaryMessageId) return;
 
   const boundary = messages.findIndex((m) => m?.id === boundaryMessageId);
-  const tail = messages.length - 1;
-  if (boundary <= 0 || boundary >= tail) return;
+  if (boundary <= 0 || boundary >= messages.length - 1) return;
 
-  // Floor at the latest pre-existing compact block, if any.
-  let previousCompactIndex = -1;
-  for (let i = tail - 1; i >= 0; i--) {
-    if (
-      messages[i]?.parts.some(
-        (p) => p.type === "text" && prompts.isCompact(p.text),
-      )
-    ) {
-      previousCompactIndex = i;
-      break;
-    }
-  }
+  // Bail when an existing `<compact>` tag at or after the boundary would
+  // shadow the new one (the formatter honours the highest-index tag).
+  const previousCompactIndex = messages.findLastIndex((m) =>
+    m?.parts.some((p) => p.type === "text" && prompts.isCompact(p.text)),
+  );
   if (previousCompactIndex >= boundary) return;
 
-  // Walk backwards from `boundary` to find a `user`-role message.
-  for (let i = boundary; i > previousCompactIndex; i--) {
-    if (messages[i]?.role === "user") return i;
-  }
-  return;
+  // Highest user-role index in `(floor, boundary]`. The floor ensures at
+  // least one curated message remains before the attach point.
+  const floor = Math.max(previousCompactIndex, 0);
+  const attachIndex = messages.findLastIndex(
+    (m, i) => i > floor && i <= boundary && m?.role === "user",
+  );
+  return attachIndex === -1 ? undefined : attachIndex;
 }
 
 async function createSummary(

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -8,8 +8,9 @@ import {
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { convertToModelMessages, generateText } from "ai";
 import type { BlobStore } from "../../blob-store";
+import { makeStoreFileQuery } from "../../livestore/default-queries";
 import { makeDownloadFunction } from "../../store-blob";
-import type { Message } from "../../types";
+import type { LiveKitStore, Message } from "../../types";
 
 const logger = getLogger("compactTask");
 const PostCompactMaxFilesToRestore = 5;
@@ -24,6 +25,7 @@ export async function compactTask({
   recentFiles,
   abortSignal,
   inline,
+  store,
 }: {
   blobStore: BlobStore;
   taskId: string;
@@ -32,6 +34,7 @@ export async function compactTask({
   recentFiles?: RecentFileState[];
   abortSignal?: AbortSignal;
   inline?: boolean;
+  store?: LiveKitStore;
 }): Promise<string | undefined> {
   const lastMessage = messages.at(-1);
   if (!lastMessage) {
@@ -39,14 +42,28 @@ export async function compactTask({
   }
 
   try {
-    const text = prompts.inlineCompact(
-      await createSummary(
+    // Prefer task memory if available
+    let summaryText: string | undefined;
+    if (store) {
+      const memoryFile = store.query(makeStoreFileQuery("/memory.md"));
+      if (memoryFile?.content?.trim()) {
+        summaryText = memoryFile.content;
+      }
+    }
+
+    // Fall back to LLM-generated summary
+    if (!summaryText) {
+      summaryText = await createSummary(
         blobStore,
         taskId,
         model,
         abortSignal,
         messages.slice(0, -1),
-      ),
+      );
+    }
+
+    const text = prompts.inlineCompact(
+      summaryText,
       messages.length - 1,
       formatRecentFileContext(recentFiles),
     );

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -23,6 +23,7 @@ export async function compactTask({
   model,
   messages,
   recentFiles,
+  taskMemoryBoundaryMessageId,
   abortSignal,
   inline,
   store,
@@ -32,6 +33,8 @@ export async function compactTask({
   model: LanguageModelV3;
   messages: Message[];
   recentFiles?: RecentFileState[];
+  /** UUID of the last message covered by memory.md; messages after it are kept verbatim. */
+  taskMemoryBoundaryMessageId?: string;
   abortSignal?: AbortSignal;
   inline?: boolean;
   store?: LiveKitStore;
@@ -44,10 +47,12 @@ export async function compactTask({
   try {
     // Prefer task memory if available
     let summaryText: string | undefined;
+    let usedTaskMemory = false;
     if (store) {
       const memoryFile = store.query(makeStoreFileQuery("/memory.md"));
       if (memoryFile?.content?.trim()) {
         summaryText = memoryFile.content;
+        usedTaskMemory = true;
       }
     }
 
@@ -62,23 +67,88 @@ export async function compactTask({
       );
     }
 
-    const text = prompts.inlineCompact(
-      summaryText,
-      messages.length - 1,
-      formatRecentFileContext(recentFiles),
-    );
+    const recentFileContext = formatRecentFileContext(recentFiles);
+
     if (inline) {
-      lastMessage.parts.unshift({
-        type: "text",
-        text,
-      });
+      // Preferred: attach at the boundary so trailing messages survive verbatim.
+      const attachIndex = usedTaskMemory
+        ? findVerbatimAttachIndex(messages, taskMemoryBoundaryMessageId)
+        : undefined;
+      const attachMessage =
+        attachIndex !== undefined ? messages[attachIndex] : undefined;
+      if (attachIndex !== undefined && attachMessage) {
+        const text = prompts.inlineCompact(
+          summaryText,
+          attachIndex,
+          recentFileContext,
+          { verbatimTail: true },
+        );
+        attachMessage.parts.unshift({ type: "text", text });
+        logger.debug(
+          `Inline compact attached at index ${attachIndex}; preserving ${
+            messages.length - attachIndex
+          } trailing messages verbatim.`,
+        );
+        return;
+      }
+
+      // Fallback: attach at the trailing message; tail is dropped.
+      const text = prompts.inlineCompact(
+        summaryText,
+        messages.length - 1,
+        recentFileContext,
+      );
+      lastMessage.parts.unshift({ type: "text", text });
       return;
     }
-    return text;
+
+    // Non-inline: return the summary for callers seeding a fresh task.
+    return prompts.inlineCompact(
+      summaryText,
+      messages.length - 1,
+      recentFileContext,
+    );
   } catch (err) {
     logger.warn("Failed to create summary", err);
     throw err;
   }
+}
+
+/**
+ * Find the index at which to attach the compact block so trailing messages
+ * survive verbatim. Returns `undefined` when the boundary is missing,
+ * shadowed by a previous `<compact>` tag, or when no user-role message
+ * exists between the previous compact and the boundary.
+ */
+export function findVerbatimAttachIndex(
+  messages: Message[],
+  boundaryMessageId: string | undefined,
+): number | undefined {
+  if (!boundaryMessageId) return;
+
+  const boundary = messages.findIndex((m) => m?.id === boundaryMessageId);
+  const tail = messages.length - 1;
+  if (boundary <= 0 || boundary >= tail) return;
+
+  // Floor at the latest pre-existing compact block, if any.
+  let previousCompactIndex = -1;
+  for (let i = tail - 1; i >= 0; i--) {
+    if (
+      messages[i]?.parts.some(
+        (p) => p.type === "text" && prompts.isCompact(p.text),
+      )
+    ) {
+      previousCompactIndex = i;
+      break;
+    }
+  }
+  if (previousCompactIndex >= boundary) return;
+
+  // Walk backwards from `boundary` to find a `user`-role message.
+  for (let i = boundary; i > previousCompactIndex; i--) {
+    if (messages[i]?.role === "user") return i;
+  }
+  return;
 }
 
 async function createSummary(

--- a/packages/livekit/src/livestore/default-queries.ts
+++ b/packages/livekit/src/livestore/default-queries.ts
@@ -30,6 +30,21 @@ export const makeSubTaskQuery = (taskId: string) =>
     deps: [taskId],
   });
 
+export const runnableTasks$ = queryDb(
+  () =>
+    tables.tasks.where({
+      runAsync: true,
+      parentId: null,
+      status: {
+        op: "IN",
+        value: ["pending-model", "pending-tool"],
+      },
+    }),
+  {
+    label: "runnableTasks",
+  },
+);
+
 export const makeStoreFileQuery = (filePath: string) =>
   queryDb(
     () => tables.files.where("filePath", "=", filePath).first(undefined),

--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -224,7 +224,7 @@ export const events = {
     schema: Schema.Struct({
       taskId: Schema.String,
       filePath: Schema.Union(
-        Schema.Literal("/plan.md", "/walkthrough.md"),
+        Schema.Literal("/plan.md", "/walkthrough.md", "/memory.md"),
         Schema.TemplateLiteral("/browser-session/", Schema.String, ".mp4"),
       ),
       content: Schema.String,
@@ -235,7 +235,7 @@ export const events = {
     name: "v1.WriteStoreFile",
     schema: Schema.Struct({
       filePath: Schema.Union(
-        Schema.Literal("/plan.md", "/walkthrough.md"),
+        Schema.Literal("/plan.md", "/walkthrough.md", "/memory.md"),
         Schema.TemplateLiteral("/browser-session/", Schema.String, ".mp4"),
       ),
       content: Schema.String,

--- a/packages/vscode-webui/src/features/chat/components/async-agent-runner.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-runner.tsx
@@ -9,10 +9,13 @@
  * remounting this component will resume execution automatically.
  */
 
+import { useCustomAgents } from "@/lib/hooks/use-custom-agents";
+import { useLatest } from "@/lib/hooks/use-latest";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { getLogger } from "@getpochi/common";
 import { catalog } from "@getpochi/livekit";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { BatchExecuteManager } from "../lib/batch-execute-manager";
 import { AsyncAgentWorker } from "./async-agent-worker";
 
 const logger = getLogger("AsyncAgentRunner");
@@ -20,6 +23,12 @@ const logger = getLogger("AsyncAgentRunner");
 export function AsyncAgentRunner() {
   const store = useDefaultStore();
   const runnableTasks = store.useQuery(catalog.queries.runnableTasks$);
+
+  const { customAgents } = useCustomAgents(true);
+  const customAgentsRef = useLatest(customAgents);
+  const batchExecuteManager = useRef(
+    new BatchExecuteManager(() => customAgentsRef.current),
+  ).current;
 
   useEffect(() => {
     logger.debug(
@@ -36,7 +45,11 @@ export function AsyncAgentRunner() {
   return (
     <>
       {runnableTasks.map((task) => (
-        <AsyncAgentWorker key={task.id} taskId={task.id} />
+        <AsyncAgentWorker
+          key={task.id}
+          taskId={task.id}
+          batchExecuteManager={batchExecuteManager}
+        />
       ))}
     </>
   );

--- a/packages/vscode-webui/src/features/chat/components/async-agent-runner.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-runner.tsx
@@ -9,8 +9,6 @@
  * remounting this component will resume execution automatically.
  */
 
-import { useCustomAgents } from "@/lib/hooks/use-custom-agents";
-import { useLatest } from "@/lib/hooks/use-latest";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { getLogger } from "@getpochi/common";
 import { catalog } from "@getpochi/livekit";
@@ -24,11 +22,7 @@ export function AsyncAgentRunner() {
   const store = useDefaultStore();
   const runnableTasks = store.useQuery(catalog.queries.runnableTasks$);
 
-  const { customAgents } = useCustomAgents(true);
-  const customAgentsRef = useLatest(customAgents);
-  const batchExecuteManager = useRef(
-    new BatchExecuteManager(() => customAgentsRef.current),
-  ).current;
+  const batchExecuteManager = useRef(new BatchExecuteManager()).current;
 
   useEffect(() => {
     logger.debug(

--- a/packages/vscode-webui/src/features/chat/components/async-agent-runner.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-runner.tsx
@@ -1,0 +1,43 @@
+/**
+ * AsyncAgentRunner — headless React component that discovers and drives
+ * async fork agents in the background.
+ *
+ * It queries the store for top-level tasks with runAsync=true and a runnable
+ * status, then runs each one using a headless LiveChatKit + useChat loop.
+ *
+ * Task creation is NOT done here. If a task was interrupted (e.g. page closed),
+ * remounting this component will resume execution automatically.
+ */
+
+import { useDefaultStore } from "@/lib/use-default-store";
+import { getLogger } from "@getpochi/common";
+import { catalog } from "@getpochi/livekit";
+import { useEffect } from "react";
+import { AsyncAgentWorker } from "./async-agent-worker";
+
+const logger = getLogger("AsyncAgentRunner");
+
+export function AsyncAgentRunner() {
+  const store = useDefaultStore();
+  const runnableTasks = store.useQuery(catalog.queries.runnableTasks$);
+
+  useEffect(() => {
+    logger.debug(
+      {
+        runnableTaskCount: runnableTasks.length,
+        taskIds: runnableTasks.map((task) => task.id),
+      },
+      "Async runnable tasks updated",
+    );
+  }, [runnableTasks]);
+
+  if (runnableTasks.length === 0) return null;
+
+  return (
+    <>
+      {runnableTasks.map((task) => (
+        <AsyncAgentWorker key={task.id} taskId={task.id} />
+      ))}
+    </>
+  );
+}

--- a/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
@@ -21,7 +21,12 @@ import { useChat } from "@ai-sdk/react";
 import { getLogger } from "@getpochi/common";
 import { catalog } from "@getpochi/livekit";
 import { useLiveChatKit } from "@getpochi/livekit/react";
-import type { Todo } from "@getpochi/tools";
+import {
+  type Todo,
+  type ToolSpecInput,
+  compileToolPolicies,
+  getAllowedToolNames,
+} from "@getpochi/tools";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { BatchExecuteManager } from "../lib/batch-execute-manager";
@@ -53,7 +58,7 @@ export function AsyncAgentWorker({
         isLoading,
         hasAsyncAgentState: asyncAgentState !== undefined,
         parentTaskId: asyncAgentState?.parentTaskId,
-        allowedTools: asyncAgentState?.allowedTools?.length,
+        tools: asyncAgentState?.tools?.length,
       },
       "Async agent state updated",
     );
@@ -64,7 +69,7 @@ export function AsyncAgentWorker({
   return (
     <AsyncAgentWorkerInner
       taskId={taskId}
-      allowedTools={asyncAgentState?.allowedTools}
+      tools={asyncAgentState?.tools}
       parentTaskId={asyncAgentState?.parentTaskId}
       batchExecuteManager={batchExecuteManager}
     />
@@ -73,11 +78,11 @@ export function AsyncAgentWorker({
 
 function AsyncAgentWorkerInner({
   taskId,
-  allowedTools,
+  tools,
   parentTaskId,
   batchExecuteManager,
 }: AsyncAgentWorkerProps & {
-  allowedTools?: readonly string[];
+  tools?: readonly ToolSpecInput[];
   parentTaskId?: string;
 }) {
   const store = useDefaultStore();
@@ -97,8 +102,12 @@ function AsyncAgentWorkerInner({
   );
   const chatStatusRef = useRef<string | null>(null);
   const allowedToolsSet = useMemo(
-    () => (allowedTools ? new Set(allowedTools) : undefined),
-    [allowedTools],
+    () => (tools ? getAllowedToolNames([...tools]) : undefined),
+    [tools],
+  );
+  const toolPolicies = useMemo(
+    () => (tools ? compileToolPolicies([...tools]) : undefined),
+    [tools],
   );
 
   const writeToolOutput = useCallback(
@@ -247,7 +256,7 @@ function AsyncAgentWorkerInner({
             taskId,
             toolName: toolCall.toolName,
             toolCallId: toolCall.toolCallId,
-            allowedTools: allowedTools?.length,
+            allowedToolCount: allowedToolsSet.size,
             rejectionCount: toolRejectionCountRef.current,
           },
           "Async agent tool call rejected by allow-list",
@@ -293,6 +302,7 @@ function AsyncAgentWorkerInner({
           parentTaskId,
           storeId: store.storeId,
           abortSignal: abortController.current.signal,
+          toolPolicies,
           addToolOutput: adapterAddToolOutput,
         }),
       );

--- a/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
@@ -19,28 +19,31 @@ import { useDefaultStore } from "@/lib/use-default-store";
 import { vscodeHost } from "@/lib/vscode";
 import { useChat } from "@ai-sdk/react";
 import { getLogger } from "@getpochi/common";
-import type { ExecuteCommandResult } from "@getpochi/common/vscode-webui-bridge";
 import { catalog } from "@getpochi/livekit";
 import { useLiveChatKit } from "@getpochi/livekit/react";
 import type { Todo } from "@getpochi/tools";
-import { ThreadAbortSignal } from "@quilted/threads";
-import {
-  type ThreadSignalSerialization,
-  threadSignal,
-} from "@quilted/threads/signals";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { BatchExecuteManager } from "../lib/batch-execute-manager";
+import { createAsyncAgentBatchedToolCall } from "../lib/batched-tool-call-adapters";
 import { useLiveChatKitGetters } from "../lib/use-live-chat-kit-getters";
 
-const AsyncAgentMaxStep = 65535;
+const AsyncAgentMaxStep = 50;
 const AsyncAgentMaxRetry = 8;
+// After this many consecutive rejected (allow-list) tool calls we stop the agent
+// to avoid the model getting stuck in a loop calling forbidden tools.
+const AsyncAgentMaxToolRejections = 5;
 const logger = getLogger("AsyncAgentWorker");
 
 interface AsyncAgentWorkerProps {
   taskId: string;
+  batchExecuteManager: BatchExecuteManager;
 }
 
-export function AsyncAgentWorker({ taskId }: AsyncAgentWorkerProps) {
+export function AsyncAgentWorker({
+  taskId,
+  batchExecuteManager,
+}: AsyncAgentWorkerProps) {
   const { asyncAgentState, isLoading } = useAsyncAgentState(taskId);
 
   useEffect(() => {
@@ -63,6 +66,7 @@ export function AsyncAgentWorker({ taskId }: AsyncAgentWorkerProps) {
       taskId={taskId}
       allowedTools={asyncAgentState?.allowedTools}
       parentTaskId={asyncAgentState?.parentTaskId}
+      batchExecuteManager={batchExecuteManager}
     />
   );
 }
@@ -71,6 +75,7 @@ function AsyncAgentWorkerInner({
   taskId,
   allowedTools,
   parentTaskId,
+  batchExecuteManager,
 }: AsyncAgentWorkerProps & {
   allowedTools?: readonly string[];
   parentTaskId?: string;
@@ -83,10 +88,36 @@ function AsyncAgentWorkerInner({
   const abortController = useRef(new AbortController());
   const todosRef = useRef<Todo[] | undefined>(undefined);
   const completedRef = useRef(false);
+  const toolRejectionCountRef = useRef(0);
+  // Refs that bridge values defined later in the component body into callbacks
+  // passed to `useLiveChatKit` (which is created before those values exist).
+  // This avoids accidental TDZ access if the callbacks ever ran synchronously.
+  const addToolOutputRef = useRef<((args: AddToolOutputArgs) => void) | null>(
+    null,
+  );
+  const chatStatusRef = useRef<string | null>(null);
   const allowedToolsSet = useMemo(
     () => (allowedTools ? new Set(allowedTools) : undefined),
     [allowedTools],
   );
+
+  const writeToolOutput = useCallback(
+    (toolName: string, toolCallId: string, output: unknown) => {
+      addToolOutputRef.current?.({
+        tool: toolName,
+        toolCallId,
+        output,
+      });
+    },
+    [],
+  );
+
+  // Wrap the latest `addToolOutput` (delivered via ref) so adapters can invoke
+  // it even though they're constructed inside `onToolCall` before
+  // `useChat`-bound `addToolOutput` exists in the closure.
+  const adapterAddToolOutput = useCallback((args: AddToolOutputArgs) => {
+    addToolOutputRef.current?.(args);
+  }, []);
 
   useEffect(() => {
     const signal = abortController.current.signal;
@@ -98,12 +129,34 @@ function AsyncAgentWorkerInner({
         },
         "Async agent aborted",
       );
+      // Cancel all queued / in-flight tool calls for this task so that the
+      // batch manager doesn't leave dangling subscriptions or pending items.
+      batchExecuteManager.abort(taskId, "user-abort");
     };
     signal.addEventListener("abort", onAbort);
     return () => {
       signal.removeEventListener("abort", onAbort);
     };
-  }, [taskId]);
+  }, [taskId, batchExecuteManager]);
+
+  // NOTE: Intentionally do NOT abort on unmount.
+  //
+  // Async agents are designed to be resumable: if the webview / page is
+  // closed mid-task, the next time it is opened `AsyncAgentRunner` will
+  // re-discover the task via `runnableTasks$` (status is still
+  // `pending-model` / `pending-tool`) and re-mount this worker, which will
+  // pick up from the last persisted message.
+  //
+  // Calling `abortController.abort()` here would propagate through the chat
+  // and trigger `markAsFailed({ kind: "AbortError" })`, taking the task out
+  // of `runnableTasks$` permanently. Letting the browser context tear down
+  // is sufficient to terminate in-flight work when the page actually closes;
+  // for React re-mounts (StrictMode, hot reload, etc.) the next mount will
+  // resume cleanly.
+  //
+  // In-flight `executeCommand` ThreadSignal subscriptions are still released
+  // through the worker's own abort paths (`failWorker`, max-retry,
+  // max-step, max-tool-rejection), so we don't leak in those scenarios.
 
   const getters = useLiveChatKitGetters({
     todos: todosRef,
@@ -125,26 +178,29 @@ function AsyncAgentWorkerInner({
         completedRef.current ||
         isModelsLoading ||
         !selectedModel ||
-        chatKit.chat.status === "error"
+        chatStatusRef.current === "error"
       ) {
         return false;
       }
       return lastAssistantMessageIsCompleteWithToolCalls(x);
     },
     onStreamFinish: (data) => {
-      if (data.status !== "completed") {
-        return;
+      if (data.status === "completed") {
+        logger.debug(
+          {
+            taskId,
+            messageCount: data.messages.length,
+            messages: data.messages,
+          },
+          "Async agent completed with messages",
+        );
       }
 
-      console.log(data.messages);
-      logger.debug(
-        {
-          taskId,
-          messageCount: data.messages.length,
-          messages: data.messages,
-        },
-        "Async agent completed with messages",
-      );
+      // Kick off the queued tool calls (if any) so that batch-eligible items
+      // run concurrently while stateful items remain serial barriers.
+      if (!abortController.current.signal.aborted) {
+        batchExecuteManager.processQueue(taskId);
+      }
     },
     onToolCall: async ({ toolCall }) => {
       logger.debug(
@@ -185,153 +241,61 @@ function AsyncAgentWorkerInner({
       }
 
       if (allowedToolsSet && !allowedToolsSet.has(toolCall.toolName)) {
+        toolRejectionCountRef.current += 1;
         logger.warn(
           {
             taskId,
             toolName: toolCall.toolName,
             toolCallId: toolCall.toolCallId,
             allowedTools: allowedTools?.length,
+            rejectionCount: toolRejectionCountRef.current,
           },
           "Async agent tool call rejected by allow-list",
         );
-        addToolOutput({
-          // @ts-expect-error dynamic tool name
-          tool: toolCall.toolName,
-          toolCallId: toolCall.toolCallId,
-          output: {
-            output: `Tool ${toolCall.toolName} is not allowed for this async agent.`,
-          },
+        writeToolOutput(toolCall.toolName, toolCall.toolCallId, {
+          output: `Tool ${toolCall.toolName} is not allowed for this async agent.`,
         });
+
+        if (toolRejectionCountRef.current >= AsyncAgentMaxToolRejections) {
+          failWorkerRef.current?.(
+            `The async agent kept calling disallowed tools (${toolRejectionCountRef.current}). Stopping.`,
+          );
+        }
         return;
       }
 
-      try {
-        logger.debug(
-          {
-            taskId,
-            toolName: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            parentTaskId,
-          },
-          "Executing async agent tool call",
-        );
-        const result = await vscodeHost.executeToolCall(
-          toolCall.toolName,
-          toolCall.input,
-          {
-            toolCallId: toolCall.toolCallId,
-            abortSignal: ThreadAbortSignal.serialize(
-              abortController.current.signal,
-            ),
-            storeId: store.storeId,
-            taskId,
-            fileStateCacheSourceTaskId: parentTaskId,
-          },
-        );
+      // Reset the rejection counter once the model recovers and calls an
+      // allowed tool again.
+      toolRejectionCountRef.current = 0;
 
-        if (
-          toolCall.toolName === "executeCommand" &&
-          typeof result === "object" &&
-          result !== null &&
-          "output" in result
-        ) {
-          const signal = threadSignal(
-            result.output as ThreadSignalSerialization<ExecuteCommandResult>,
-          );
-
-          logger.debug(
-            {
-              taskId,
-              toolName: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-            },
-            "Async agent executeCommand streaming result attached",
-          );
-
-          let lastStatus: ExecuteCommandResult["status"] | undefined;
-          const unsubscribe = signal.subscribe((output) => {
-            if (output.status !== lastStatus) {
-              lastStatus = output.status;
-              logger.debug(
-                {
-                  taskId,
-                  toolName: toolCall.toolName,
-                  toolCallId: toolCall.toolCallId,
-                  status: output.status,
-                },
-                "Async agent executeCommand status updated",
-              );
-            }
-
-            if (output.status !== "completed") {
-              return;
-            }
-
-            unsubscribe();
-            const finalResult: Record<string, unknown> = {
-              output: output.content,
-              isTruncated: output.isTruncated ?? false,
-            };
-            if (output.error) {
-              finalResult.error = output.error;
-            }
-            logger.debug(
-              {
-                taskId,
-                toolName: toolCall.toolName,
-                toolCallId: toolCall.toolCallId,
-                hasError: Boolean(output.error),
-                outputLength: output.content.length,
-                isTruncated: output.isTruncated ?? false,
-              },
-              "Async agent executeCommand completed",
-            );
-            addToolOutput({
-              // @ts-expect-error dynamic tool name
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: finalResult,
-            });
-          });
-          return;
-        }
-
-        logger.debug(
-          {
-            taskId,
-            toolName: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            result: summarizeResult(result),
-          },
-          "Async agent tool call completed",
-        );
-        addToolOutput({
-          // @ts-expect-error dynamic tool name
-          tool: toolCall.toolName,
-          toolCallId: toolCall.toolCallId,
-          // @ts-expect-error dynamic result type
-          output: result,
-        });
-      } catch (error) {
-        logger.warn(
-          {
-            taskId,
-            toolName: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            error: formatLogValue(error),
-          },
-          "Async agent tool call failed",
-        );
-        addToolOutput({
-          // @ts-expect-error dynamic tool name
-          tool: toolCall.toolName,
-          toolCallId: toolCall.toolCallId,
-          output: {
-            output:
-              error instanceof Error ? error.message : "Unknown error occurred",
-          },
-        });
+      if (abortController.current.signal.aborted) {
+        return;
       }
+
+      logger.debug(
+        {
+          taskId,
+          toolName: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          parentTaskId,
+        },
+        "Enqueueing async agent tool call",
+      );
+
+      // Defer execution to the BatchExecuteManager: consecutive safe-to-batch
+      // calls (read-only, runAsync newTask, startBackgroundJob) run as one
+      // concurrent batch; stateful calls remain serial barriers.
+      batchExecuteManager.enqueue(
+        taskId,
+        createAsyncAgentBatchedToolCall({
+          toolCall,
+          taskId,
+          parentTaskId,
+          storeId: store.storeId,
+          abortSignal: abortController.current.signal,
+          addToolOutput: adapterAddToolOutput,
+        }),
+      );
     },
   });
 
@@ -346,6 +310,18 @@ function AsyncAgentWorkerInner({
   } = useChat({
     chat: chatKit.chat,
   });
+
+  // Keep refs in sync so callbacks captured by `useLiveChatKit` always read
+  // the latest values without re-creating the chat kit.
+  useEffect(() => {
+    addToolOutputRef.current = addToolOutput as unknown as (
+      args: AddToolOutputArgs,
+    ) => void;
+  }, [addToolOutput]);
+
+  useEffect(() => {
+    chatStatusRef.current = status;
+  }, [status]);
 
   useEffect(() => {
     logger.debug({ taskId }, "Async agent worker mounted");
@@ -364,11 +340,19 @@ function AsyncAgentWorkerInner({
     (message: string) => {
       logger.warn({ taskId, message }, "Failing async agent worker");
       completedRef.current = true;
-      abortController.current.abort(message);
+      if (!abortController.current.signal.aborted) {
+        abortController.current.abort(message);
+      }
       chatKit.markAsFailed(new Error(message));
     },
     [chatKit, taskId],
   );
+  // Bridge `failWorker` into the `onToolCall` closure (which is created via
+  // `useLiveChatKit` before `failWorker` exists).
+  const failWorkerRef = useRef(failWorker);
+  useEffect(() => {
+    failWorkerRef.current = failWorker;
+  }, [failWorker]);
 
   const retryImpl = useRetry({
     messages,
@@ -435,11 +419,17 @@ function AsyncAgentWorkerInner({
     [failWorker, retry, retryCount, taskId],
   );
 
+  // The retry pipeline:
+  // 1. `errorForRetry` becomes truthy when chat reports a recoverable error.
+  // 2. Debounce the error for 1s so transient flips don't trigger spurious retries.
+  // 3. After debounce, the second effect picks up `pendingErrorForRetry`,
+  //    immediately clears it (so this only fires once per error), and kicks off
+  //    `retryWithCount`.
   const errorForRetry = useMixinReadyForRetryError(messages, error);
   const [
     pendingErrorForRetry,
-    setPendingErrorForRetry,
-    setDebouncedPendingErrorForRetry,
+    debouncedSetPendingErrorForRetry,
+    setPendingErrorForRetryNow,
   ] = useDebounceState<Error | undefined>(undefined, 1000);
   useEffect(() => {
     if (
@@ -455,9 +445,9 @@ function AsyncAgentWorkerInner({
         },
         "Async agent error became ready for retry",
       );
-      setPendingErrorForRetry(errorForRetry);
+      debouncedSetPendingErrorForRetry(errorForRetry);
     }
-  }, [errorForRetry, setPendingErrorForRetry, status, taskId]);
+  }, [errorForRetry, debouncedSetPendingErrorForRetry, status, taskId]);
   useEffect(() => {
     if (
       completedRef.current ||
@@ -466,9 +456,9 @@ function AsyncAgentWorkerInner({
     ) {
       return;
     }
-    setDebouncedPendingErrorForRetry(undefined);
+    setPendingErrorForRetryNow(undefined);
     retryWithCount(pendingErrorForRetry);
-  }, [pendingErrorForRetry, retryWithCount, setDebouncedPendingErrorForRetry]);
+  }, [pendingErrorForRetry, retryWithCount, setPendingErrorForRetryNow]);
 
   useEffect(() => {
     if (status === "ready" && errorForRetry === undefined) {
@@ -509,6 +499,8 @@ function AsyncAgentWorkerInner({
   }, [currentStepCount, failWorker]);
 
   // Auto-start / resume the agent from its current last message.
+  // Only kicks in when the task already has at least one message, since async
+  // agents are initialized by their parent task before this worker mounts.
   const initStarted = useRef(false);
   useEffect(() => {
     if (
@@ -566,6 +558,14 @@ function AsyncAgentWorkerInner({
   return null;
 }
 
+// Loose type alias: the full `addToolOutput` signature in `useChat` is
+// over-constrained for our dynamic tool-call dispatch, so we widen it here.
+type AddToolOutputArgs = {
+  tool: string;
+  toolCallId: string;
+  output: unknown;
+};
+
 function formatLogValue(value: unknown): string | undefined {
   if (value === undefined) {
     return undefined;
@@ -581,18 +581,4 @@ function formatLogValue(value: unknown): string | undefined {
   } catch {
     return String(value);
   }
-}
-
-function summarizeResult(result: unknown): Record<string, unknown> {
-  if (result === null || typeof result !== "object") {
-    return { type: typeof result };
-  }
-
-  const objectResult = result as Record<string, unknown>;
-  return {
-    type: "object",
-    keys: Object.keys(objectResult),
-    hasOutput: "output" in objectResult,
-    hasError: "error" in objectResult,
-  };
 }

--- a/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
@@ -1,0 +1,598 @@
+/**
+ * AsyncAgentWorker — drives a single async task to completion.
+ *
+ * Headless component (renders null). Receives a taskId and an optional tool
+ * allow-list, then drives the task from the store.
+ */
+
+import {
+  ReadyForRetryError,
+  useMixinReadyForRetryError,
+  useRetry,
+} from "@/features/retry";
+import { useSelectedModels } from "@/features/settings";
+import { useTodos } from "@/features/todo";
+import { useAsyncAgentState } from "@/lib/hooks/use-async-agent-state";
+import { useDebounceState } from "@/lib/hooks/use-debounce-state";
+import { blobStore } from "@/lib/remote-blob-store";
+import { useDefaultStore } from "@/lib/use-default-store";
+import { vscodeHost } from "@/lib/vscode";
+import { useChat } from "@ai-sdk/react";
+import { getLogger } from "@getpochi/common";
+import type { ExecuteCommandResult } from "@getpochi/common/vscode-webui-bridge";
+import { catalog } from "@getpochi/livekit";
+import { useLiveChatKit } from "@getpochi/livekit/react";
+import type { Todo } from "@getpochi/tools";
+import { ThreadAbortSignal } from "@quilted/threads";
+import {
+  type ThreadSignalSerialization,
+  threadSignal,
+} from "@quilted/threads/signals";
+import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLiveChatKitGetters } from "../lib/use-live-chat-kit-getters";
+
+const AsyncAgentMaxStep = 65535;
+const AsyncAgentMaxRetry = 8;
+const logger = getLogger("AsyncAgentWorker");
+
+interface AsyncAgentWorkerProps {
+  taskId: string;
+}
+
+export function AsyncAgentWorker({ taskId }: AsyncAgentWorkerProps) {
+  const { asyncAgentState, isLoading } = useAsyncAgentState(taskId);
+
+  useEffect(() => {
+    logger.debug(
+      {
+        taskId,
+        isLoading,
+        hasAsyncAgentState: asyncAgentState !== undefined,
+        parentTaskId: asyncAgentState?.parentTaskId,
+        allowedTools: asyncAgentState?.allowedTools?.length,
+      },
+      "Async agent state updated",
+    );
+  }, [taskId, isLoading, asyncAgentState]);
+
+  if (isLoading) return null;
+
+  return (
+    <AsyncAgentWorkerInner
+      taskId={taskId}
+      allowedTools={asyncAgentState?.allowedTools}
+      parentTaskId={asyncAgentState?.parentTaskId}
+    />
+  );
+}
+
+function AsyncAgentWorkerInner({
+  taskId,
+  allowedTools,
+  parentTaskId,
+}: AsyncAgentWorkerProps & {
+  allowedTools?: readonly string[];
+  parentTaskId?: string;
+}) {
+  const store = useDefaultStore();
+  const task = store.useQuery(catalog.queries.makeTaskQuery(taskId));
+  const { isLoading: isModelsLoading, selectedModel } = useSelectedModels({
+    isSubTask: false,
+  });
+  const abortController = useRef(new AbortController());
+  const todosRef = useRef<Todo[] | undefined>(undefined);
+  const completedRef = useRef(false);
+  const allowedToolsSet = useMemo(
+    () => (allowedTools ? new Set(allowedTools) : undefined),
+    [allowedTools],
+  );
+
+  useEffect(() => {
+    const signal = abortController.current.signal;
+    const onAbort = () => {
+      logger.debug(
+        {
+          taskId,
+          reason: formatLogValue(signal.reason),
+        },
+        "Async agent aborted",
+      );
+    };
+    signal.addEventListener("abort", onAbort);
+    return () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+  }, [taskId]);
+
+  const getters = useLiveChatKitGetters({
+    todos: todosRef,
+    isSubTask: false,
+    modelOverride: selectedModel,
+    taskId,
+  });
+
+  const chatKit = useLiveChatKit({
+    store,
+    blobStore,
+    taskId,
+    abortSignal: abortController.current.signal,
+    getters,
+    isSubTask: false,
+    sendAutomaticallyWhen: (x) => {
+      if (
+        abortController.current.signal.aborted ||
+        completedRef.current ||
+        isModelsLoading ||
+        !selectedModel ||
+        chatKit.chat.status === "error"
+      ) {
+        return false;
+      }
+      return lastAssistantMessageIsCompleteWithToolCalls(x);
+    },
+    onStreamFinish: (data) => {
+      if (data.status !== "completed") {
+        return;
+      }
+
+      console.log(data.messages);
+      logger.debug(
+        {
+          taskId,
+          messageCount: data.messages.length,
+          messages: data.messages,
+        },
+        "Async agent completed with messages",
+      );
+    },
+    onToolCall: async ({ toolCall }) => {
+      logger.debug(
+        {
+          taskId,
+          toolName: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+        },
+        "Async agent tool call received",
+      );
+
+      if (completedRef.current) {
+        logger.debug(
+          {
+            taskId,
+            toolName: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+          },
+          "Ignoring async agent tool call after completion",
+        );
+        return;
+      }
+
+      if (
+        toolCall.toolName === "attemptCompletion" ||
+        toolCall.toolName === "askFollowupQuestion"
+      ) {
+        completedRef.current = true;
+        logger.debug(
+          {
+            taskId,
+            toolName: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+          },
+          "Async agent completed by terminal tool call",
+        );
+        return;
+      }
+
+      if (allowedToolsSet && !allowedToolsSet.has(toolCall.toolName)) {
+        logger.warn(
+          {
+            taskId,
+            toolName: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            allowedTools: allowedTools?.length,
+          },
+          "Async agent tool call rejected by allow-list",
+        );
+        addToolOutput({
+          // @ts-expect-error dynamic tool name
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: {
+            output: `Tool ${toolCall.toolName} is not allowed for this async agent.`,
+          },
+        });
+        return;
+      }
+
+      try {
+        logger.debug(
+          {
+            taskId,
+            toolName: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            parentTaskId,
+          },
+          "Executing async agent tool call",
+        );
+        const result = await vscodeHost.executeToolCall(
+          toolCall.toolName,
+          toolCall.input,
+          {
+            toolCallId: toolCall.toolCallId,
+            abortSignal: ThreadAbortSignal.serialize(
+              abortController.current.signal,
+            ),
+            storeId: store.storeId,
+            taskId,
+            fileStateCacheSourceTaskId: parentTaskId,
+          },
+        );
+
+        if (
+          toolCall.toolName === "executeCommand" &&
+          typeof result === "object" &&
+          result !== null &&
+          "output" in result
+        ) {
+          const signal = threadSignal(
+            result.output as ThreadSignalSerialization<ExecuteCommandResult>,
+          );
+
+          logger.debug(
+            {
+              taskId,
+              toolName: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+            },
+            "Async agent executeCommand streaming result attached",
+          );
+
+          let lastStatus: ExecuteCommandResult["status"] | undefined;
+          const unsubscribe = signal.subscribe((output) => {
+            if (output.status !== lastStatus) {
+              lastStatus = output.status;
+              logger.debug(
+                {
+                  taskId,
+                  toolName: toolCall.toolName,
+                  toolCallId: toolCall.toolCallId,
+                  status: output.status,
+                },
+                "Async agent executeCommand status updated",
+              );
+            }
+
+            if (output.status !== "completed") {
+              return;
+            }
+
+            unsubscribe();
+            const finalResult: Record<string, unknown> = {
+              output: output.content,
+              isTruncated: output.isTruncated ?? false,
+            };
+            if (output.error) {
+              finalResult.error = output.error;
+            }
+            logger.debug(
+              {
+                taskId,
+                toolName: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                hasError: Boolean(output.error),
+                outputLength: output.content.length,
+                isTruncated: output.isTruncated ?? false,
+              },
+              "Async agent executeCommand completed",
+            );
+            addToolOutput({
+              // @ts-expect-error dynamic tool name
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: finalResult,
+            });
+          });
+          return;
+        }
+
+        logger.debug(
+          {
+            taskId,
+            toolName: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            result: summarizeResult(result),
+          },
+          "Async agent tool call completed",
+        );
+        addToolOutput({
+          // @ts-expect-error dynamic tool name
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          // @ts-expect-error dynamic result type
+          output: result,
+        });
+      } catch (error) {
+        logger.warn(
+          {
+            taskId,
+            toolName: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            error: formatLogValue(error),
+          },
+          "Async agent tool call failed",
+        );
+        addToolOutput({
+          // @ts-expect-error dynamic tool name
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: {
+            output:
+              error instanceof Error ? error.message : "Unknown error occurred",
+          },
+        });
+      }
+    },
+  });
+
+  const {
+    messages,
+    status,
+    error,
+    setMessages,
+    addToolOutput,
+    sendMessage,
+    regenerate,
+  } = useChat({
+    chat: chatKit.chat,
+  });
+
+  useEffect(() => {
+    logger.debug({ taskId }, "Async agent worker mounted");
+    return () => {
+      logger.debug({ taskId }, "Async agent worker unmounted");
+    };
+  }, [taskId]);
+
+  useTodos({
+    initialTodos: task?.todos,
+    messages,
+    todosRef,
+  });
+
+  const failWorker = useCallback(
+    (message: string) => {
+      logger.warn({ taskId, message }, "Failing async agent worker");
+      completedRef.current = true;
+      abortController.current.abort(message);
+      chatKit.markAsFailed(new Error(message));
+    },
+    [chatKit, taskId],
+  );
+
+  const retryImpl = useRetry({
+    messages,
+    setMessages,
+    sendMessage,
+    regenerate,
+    clearFileStateCache: () => vscodeHost.clearFileStateCache(taskId),
+  });
+  const retry = useCallback(
+    (retryError?: Error) => {
+      if (
+        completedRef.current ||
+        abortController.current.signal.aborted ||
+        !(status === "ready" || status === "error")
+      ) {
+        logger.debug(
+          {
+            taskId,
+            status,
+            completed: completedRef.current,
+            aborted: abortController.current.signal.aborted,
+          },
+          "Skipping async agent retry",
+        );
+        return;
+      }
+      logger.debug(
+        {
+          taskId,
+          status,
+          error: retryError ? formatLogValue(retryError) : undefined,
+        },
+        "Retrying async agent",
+      );
+      void retryImpl(retryError ?? new ReadyForRetryError());
+    },
+    [retryImpl, status, taskId],
+  );
+
+  const [retryCount, setRetryCount] = useState(0);
+  const retryWithCount = useCallback(
+    (retryError?: Error) => {
+      if (completedRef.current || abortController.current.signal.aborted) {
+        return;
+      }
+      if (retryCount >= AsyncAgentMaxRetry) {
+        failWorker(
+          "The async agent failed to complete, max retry count reached.",
+        );
+        return;
+      }
+      logger.debug(
+        {
+          taskId,
+          retryCount: retryCount + 1,
+          maxRetry: AsyncAgentMaxRetry,
+          error: retryError ? formatLogValue(retryError) : undefined,
+        },
+        "Scheduling async agent retry",
+      );
+      setRetryCount((count) => count + 1);
+      retry(retryError);
+    },
+    [failWorker, retry, retryCount, taskId],
+  );
+
+  const errorForRetry = useMixinReadyForRetryError(messages, error);
+  const [
+    pendingErrorForRetry,
+    setPendingErrorForRetry,
+    setDebouncedPendingErrorForRetry,
+  ] = useDebounceState<Error | undefined>(undefined, 1000);
+  useEffect(() => {
+    if (
+      !completedRef.current &&
+      errorForRetry &&
+      (status === "ready" || status === "error")
+    ) {
+      logger.debug(
+        {
+          taskId,
+          status,
+          error: formatLogValue(errorForRetry),
+        },
+        "Async agent error became ready for retry",
+      );
+      setPendingErrorForRetry(errorForRetry);
+    }
+  }, [errorForRetry, setPendingErrorForRetry, status, taskId]);
+  useEffect(() => {
+    if (
+      completedRef.current ||
+      abortController.current.signal.aborted ||
+      !pendingErrorForRetry
+    ) {
+      return;
+    }
+    setDebouncedPendingErrorForRetry(undefined);
+    retryWithCount(pendingErrorForRetry);
+  }, [pendingErrorForRetry, retryWithCount, setDebouncedPendingErrorForRetry]);
+
+  useEffect(() => {
+    if (status === "ready" && errorForRetry === undefined) {
+      if (retryCount > 0) {
+        logger.debug(
+          { taskId, retryCount },
+          "Resetting async agent retry count",
+        );
+      }
+      setRetryCount(0);
+    }
+  }, [status, errorForRetry, retryCount, taskId]);
+
+  const stepCount = useMemo(() => {
+    return messages
+      .flatMap((message) => message.parts)
+      .filter((part) => part.type === "step-start").length;
+  }, [messages]);
+  const [currentStepCount, setCurrentStepCount] = useState(0);
+  useEffect(() => {
+    if (stepCount > currentStepCount) {
+      logger.debug(
+        {
+          taskId,
+          stepCount,
+          previousStepCount: currentStepCount,
+        },
+        "Async agent advanced steps",
+      );
+      setCurrentStepCount(stepCount);
+    }
+  }, [stepCount, currentStepCount, taskId]);
+
+  useEffect(() => {
+    if (currentStepCount > AsyncAgentMaxStep) {
+      failWorker("The async agent failed to complete, max step count reached.");
+    }
+  }, [currentStepCount, failWorker]);
+
+  // Auto-start / resume the agent from its current last message.
+  const initStarted = useRef(false);
+  useEffect(() => {
+    if (
+      !initStarted.current &&
+      status === "ready" &&
+      !isModelsLoading &&
+      !!selectedModel &&
+      messages.length > 0 &&
+      !completedRef.current &&
+      !abortController.current.signal.aborted &&
+      !(
+        (task?.status === "failed" && task.error?.kind === "AbortError") ||
+        task?.status === "completed"
+      )
+    ) {
+      initStarted.current = true;
+      logger.debug(
+        {
+          taskId,
+          status,
+          taskStatus: task?.status,
+          modelId: selectedModel.id,
+          messageCount: messages.length,
+          stepCount: currentStepCount,
+        },
+        "Starting async agent from current task state",
+      );
+      retry();
+    }
+  }, [
+    status,
+    isModelsLoading,
+    selectedModel,
+    messages.length,
+    retry,
+    task?.status,
+    task?.error,
+    taskId,
+    currentStepCount,
+  ]);
+
+  useEffect(() => {
+    logger.debug(
+      {
+        taskId,
+        chatStatus: status,
+        taskStatus: task?.status,
+        messageCount: messages.length,
+        error: error ? formatLogValue(error) : undefined,
+      },
+      "Async agent chat status updated",
+    );
+  }, [taskId, status, task?.status, messages.length, error]);
+
+  return null;
+}
+
+function formatLogValue(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value instanceof Error) {
+    return value.message;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function summarizeResult(result: unknown): Record<string, unknown> {
+  if (result === null || typeof result !== "object") {
+    return { type: typeof result };
+  }
+
+  const objectResult = result as Record<string, unknown>;
+  return {
+    type: "object",
+    keys: Object.keys(objectResult),
+    hasOutput: "output" in objectResult,
+    hasError: "error" in objectResult,
+  };
+}

--- a/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
@@ -51,19 +51,6 @@ export function AsyncAgentWorker({
 }: AsyncAgentWorkerProps) {
   const { asyncAgentState, isLoading } = useAsyncAgentState(taskId);
 
-  useEffect(() => {
-    logger.debug(
-      {
-        taskId,
-        isLoading,
-        hasAsyncAgentState: asyncAgentState !== undefined,
-        parentTaskId: asyncAgentState?.parentTaskId,
-        tools: asyncAgentState?.tools?.length,
-      },
-      "Async agent state updated",
-    );
-  }, [taskId, isLoading, asyncAgentState]);
-
   if (isLoading) return null;
 
   return (
@@ -131,13 +118,6 @@ function AsyncAgentWorkerInner({
   useEffect(() => {
     const signal = abortController.current.signal;
     const onAbort = () => {
-      logger.debug(
-        {
-          taskId,
-          reason: formatLogValue(signal.reason),
-        },
-        "Async agent aborted",
-      );
       // Cancel all queued / in-flight tool calls for this task so that the
       // batch manager doesn't leave dangling subscriptions or pending items.
       batchExecuteManager.abort(taskId, "user-abort");
@@ -195,13 +175,10 @@ function AsyncAgentWorkerInner({
     },
     onStreamFinish: (data) => {
       if (data.status === "completed") {
+        const conversation = summarizeMessages(data.messages);
         logger.debug(
-          {
-            taskId,
-            messageCount: data.messages.length,
-            messages: data.messages,
-          },
-          "Async agent completed with messages",
+          { taskId, messageCount: data.messages.length },
+          `✔ stream-finish (${data.messages.length} msgs)\n${conversation}`,
         );
       }
 
@@ -212,24 +189,7 @@ function AsyncAgentWorkerInner({
       }
     },
     onToolCall: async ({ toolCall }) => {
-      logger.debug(
-        {
-          taskId,
-          toolName: toolCall.toolName,
-          toolCallId: toolCall.toolCallId,
-        },
-        "Async agent tool call received",
-      );
-
       if (completedRef.current) {
-        logger.debug(
-          {
-            taskId,
-            toolName: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-          },
-          "Ignoring async agent tool call after completion",
-        );
         return;
       }
 
@@ -239,12 +199,8 @@ function AsyncAgentWorkerInner({
       ) {
         completedRef.current = true;
         logger.debug(
-          {
-            taskId,
-            toolName: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-          },
-          "Async agent completed by terminal tool call",
+          { taskId, toolName: toolCall.toolName },
+          `✔ terminal tool ${toolCall.toolName}`,
         );
         return;
       }
@@ -284,11 +240,10 @@ function AsyncAgentWorkerInner({
       logger.debug(
         {
           taskId,
-          toolName: toolCall.toolName,
           toolCallId: toolCall.toolCallId,
-          parentTaskId,
+          input: summarizeToolPayload((toolCall as { input?: unknown }).input),
         },
-        "Enqueueing async agent tool call",
+        `→ tool ${toolCall.toolName}`,
       );
 
       // Defer execution to the BatchExecuteManager: consecutive safe-to-batch
@@ -333,13 +288,6 @@ function AsyncAgentWorkerInner({
     chatStatusRef.current = status;
   }, [status]);
 
-  useEffect(() => {
-    logger.debug({ taskId }, "Async agent worker mounted");
-    return () => {
-      logger.debug({ taskId }, "Async agent worker unmounted");
-    };
-  }, [taskId]);
-
   useTodos({
     initialTodos: task?.todos,
     messages,
@@ -378,28 +326,11 @@ function AsyncAgentWorkerInner({
         abortController.current.signal.aborted ||
         !(status === "ready" || status === "error")
       ) {
-        logger.debug(
-          {
-            taskId,
-            status,
-            completed: completedRef.current,
-            aborted: abortController.current.signal.aborted,
-          },
-          "Skipping async agent retry",
-        );
         return;
       }
-      logger.debug(
-        {
-          taskId,
-          status,
-          error: retryError ? formatLogValue(retryError) : undefined,
-        },
-        "Retrying async agent",
-      );
       void retryImpl(retryError ?? new ReadyForRetryError());
     },
-    [retryImpl, status, taskId],
+    [retryImpl, status],
   );
 
   const [retryCount, setRetryCount] = useState(0);
@@ -418,10 +349,9 @@ function AsyncAgentWorkerInner({
         {
           taskId,
           retryCount: retryCount + 1,
-          maxRetry: AsyncAgentMaxRetry,
           error: retryError ? formatLogValue(retryError) : undefined,
         },
-        "Scheduling async agent retry",
+        `↻ retry #${retryCount + 1}`,
       );
       setRetryCount((count) => count + 1);
       retry(retryError);
@@ -447,17 +377,9 @@ function AsyncAgentWorkerInner({
       errorForRetry &&
       (status === "ready" || status === "error")
     ) {
-      logger.debug(
-        {
-          taskId,
-          status,
-          error: formatLogValue(errorForRetry),
-        },
-        "Async agent error became ready for retry",
-      );
       debouncedSetPendingErrorForRetry(errorForRetry);
     }
-  }, [errorForRetry, debouncedSetPendingErrorForRetry, status, taskId]);
+  }, [errorForRetry, debouncedSetPendingErrorForRetry, status]);
   useEffect(() => {
     if (
       completedRef.current ||
@@ -472,15 +394,9 @@ function AsyncAgentWorkerInner({
 
   useEffect(() => {
     if (status === "ready" && errorForRetry === undefined) {
-      if (retryCount > 0) {
-        logger.debug(
-          { taskId, retryCount },
-          "Resetting async agent retry count",
-        );
-      }
       setRetryCount(0);
     }
-  }, [status, errorForRetry, retryCount, taskId]);
+  }, [status, errorForRetry]);
 
   const stepCount = useMemo(() => {
     return messages
@@ -490,17 +406,9 @@ function AsyncAgentWorkerInner({
   const [currentStepCount, setCurrentStepCount] = useState(0);
   useEffect(() => {
     if (stepCount > currentStepCount) {
-      logger.debug(
-        {
-          taskId,
-          stepCount,
-          previousStepCount: currentStepCount,
-        },
-        "Async agent advanced steps",
-      );
       setCurrentStepCount(stepCount);
     }
-  }, [stepCount, currentStepCount, taskId]);
+  }, [stepCount, currentStepCount]);
 
   useEffect(() => {
     if (currentStepCount > AsyncAgentMaxStep) {
@@ -530,13 +438,10 @@ function AsyncAgentWorkerInner({
       logger.debug(
         {
           taskId,
-          status,
-          taskStatus: task?.status,
           modelId: selectedModel.id,
           messageCount: messages.length,
-          stepCount: currentStepCount,
         },
-        "Starting async agent from current task state",
+        "▶ start async agent",
       );
       retry();
     }
@@ -549,21 +454,7 @@ function AsyncAgentWorkerInner({
     task?.status,
     task?.error,
     taskId,
-    currentStepCount,
   ]);
-
-  useEffect(() => {
-    logger.debug(
-      {
-        taskId,
-        chatStatus: status,
-        taskStatus: task?.status,
-        messageCount: messages.length,
-        error: error ? formatLogValue(error) : undefined,
-      },
-      "Async agent chat status updated",
-    );
-  }, [taskId, status, task?.status, messages.length, error]);
 
   return null;
 }
@@ -591,4 +482,124 @@ function formatLogValue(value: unknown): string | undefined {
   } catch {
     return String(value);
   }
+}
+
+const TextPreviewMaxLen = 160;
+const ToolInputPreviewMaxLen = 120;
+const ToolOutputPreviewMaxLen = 120;
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}…(+${text.length - max})`;
+}
+
+/** Collapse whitespace so previews stay on a single line. */
+function flattenWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Strip / collapse `<system-reminder>...</system-reminder>` blocks (and other
+ * Pochi-injected wrappers) from a user-visible text snippet so logs focus on
+ * what the user actually asked.
+ */
+function stripSystemBlocks(text: string): string {
+  return text
+    .replace(
+      /<system-reminder>[\s\S]*?<\/system-reminder>/g,
+      "<system-reminder/>",
+    )
+    .replace(/<environment_details>[\s\S]*?<\/environment_details>/g, "<env/>");
+}
+
+/**
+ * Render a value (object / string / etc.) into a single-line preview suitable
+ * for log output. JSON-encodes objects and truncates long payloads.
+ */
+function summarizeToolPayload(
+  value: unknown,
+  max = ToolInputPreviewMaxLen,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") {
+    return truncate(flattenWhitespace(value), max);
+  }
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    serialized = String(value);
+  }
+  return truncate(flattenWhitespace(serialized), max);
+}
+
+/**
+ * Walk the messages array and produce a flat, human-friendly summary that
+ * interleaves text turns with tool-call invocations and their outputs. Useful
+ * for tracing async-agent behavior in logs without dumping raw message JSON.
+ *
+ * Returns a single string (newline-joined) so that tslog renders it as one
+ * readable block rather than a JS array literal with escape sequences.
+ */
+function summarizeMessages(
+  messages: ReadonlyArray<{
+    role: string;
+    parts: ReadonlyArray<Record<string, unknown>>;
+  }>,
+): string {
+  const lines: string[] = [];
+  let stepIndex = 0;
+  for (const message of messages) {
+    const role = message.role;
+    for (const rawPart of message.parts) {
+      const part = rawPart as Record<string, unknown> & { type: string };
+      const type = part.type;
+      if (type === "step-start") {
+        stepIndex += 1;
+        lines.push(`-- step ${stepIndex} --`);
+        continue;
+      }
+      if (type === "text") {
+        const raw = typeof part.text === "string" ? part.text : "";
+        const cleaned = flattenWhitespace(stripSystemBlocks(raw));
+        if (!cleaned) continue;
+        lines.push(`[${role}] ${truncate(cleaned, TextPreviewMaxLen)}`);
+        continue;
+      }
+      if (type === "reasoning") {
+        const raw = typeof part.text === "string" ? part.text : "";
+        const cleaned = flattenWhitespace(raw);
+        if (!cleaned) continue;
+        lines.push(
+          `[${role}:reasoning] ${truncate(cleaned, TextPreviewMaxLen)}`,
+        );
+        continue;
+      }
+      if (typeof type === "string" && type.startsWith("tool-")) {
+        const toolName = type.slice("tool-".length);
+        const state =
+          typeof part.state === "string" ? (part.state as string) : "unknown";
+        const callId =
+          typeof part.toolCallId === "string"
+            ? (part.toolCallId as string)
+            : "";
+        const shortId = callId ? callId.slice(-6) : "";
+        const inputPreview = summarizeToolPayload(
+          part.input,
+          ToolInputPreviewMaxLen,
+        );
+        const outputKey =
+          "output" in part ? "output" : "result" in part ? "result" : undefined;
+        const outputPreview = outputKey
+          ? summarizeToolPayload(part[outputKey], ToolOutputPreviewMaxLen)
+          : undefined;
+        const header = `[${role}] ${toolName}${shortId ? `#${shortId}` : ""} (${state})`;
+        const segments = [header];
+        if (inputPreview) segments.push(`in=${inputPreview}`);
+        if (outputPreview) segments.push(`out=${outputPreview}`);
+        lines.push(segments.join(" "));
+      }
+    }
+  }
+  return lines.join("\n");
 }

--- a/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
@@ -1,0 +1,210 @@
+import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
+import { useDefaultStore } from "@/lib/use-default-store";
+import { vscodeHost } from "@/lib/vscode";
+import { constants, getLogger, prompts } from "@getpochi/common";
+import type {
+  ContextWindowUsage,
+  TaskMemoryState,
+} from "@getpochi/common/vscode-webui-bridge";
+import { type Message, catalog } from "@getpochi/livekit";
+import { useCallback, useEffect } from "react";
+import { createForkAgent } from "../lib/create-fork-agent";
+
+const logger = getLogger("useTaskMemory");
+
+/** Tools the memory extraction fork agent is allowed to call */
+const TaskMemoryAllowedTools = ["writeToFile", "readFile"];
+
+/** Statuses that mean the fork agent task is still running */
+const ActiveStatuses = new Set(["pending-model", "pending-tool"]);
+const IdleTaskId = "__task_memory_idle__";
+
+type ExtractionData = {
+  messages: Message[];
+  contextWindowUsage?: ContextWindowUsage;
+};
+
+type ExtractionMetrics = {
+  tokens: number;
+  toolCalls: number;
+};
+
+function getExtractionMetrics(data: ExtractionData): ExtractionMetrics {
+  return {
+    tokens: computeTotalTokens(data.contextWindowUsage),
+    toolCalls: countToolCalls(data.messages),
+  };
+}
+
+function computeTotalTokens(usage?: ContextWindowUsage) {
+  if (!usage) return 0;
+  return (
+    usage.system +
+    usage.tools +
+    usage.messages +
+    usage.files +
+    usage.toolResults
+  );
+}
+
+function countToolCalls(messages: Message[]): number {
+  let count = 0;
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const part of message.parts) {
+      if (part.type.startsWith("tool-")) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+function shouldExtractTaskMemory(
+  state: TaskMemoryState,
+  metrics: ExtractionMetrics,
+): boolean {
+  if (state.isExtracting) return false;
+
+  if (!state.initialized) {
+    return metrics.tokens >= constants.TaskMemoryInitTokenThreshold;
+  }
+
+  const tokenDelta = metrics.tokens - state.lastExtractionTokens;
+  const toolCallDelta = metrics.toolCalls - state.lastExtractionToolCalls;
+
+  return (
+    tokenDelta >= constants.TaskMemoryUpdateTokenIncrement &&
+    toolCallDelta >= constants.TaskMemoryUpdateToolCallThreshold
+  );
+}
+
+function toExtractingState(
+  state: TaskMemoryState,
+  metrics: ExtractionMetrics,
+): TaskMemoryState {
+  return {
+    ...state,
+    initialized: true,
+    isExtracting: true,
+    lastExtractionTokens: metrics.tokens,
+    lastExtractionToolCalls: metrics.toolCalls,
+  };
+}
+
+export function useTaskMemory({
+  isSubTask,
+  taskId,
+  parentCwd,
+}: {
+  isSubTask: boolean;
+  taskId: string;
+  parentCwd: string | undefined;
+}) {
+  const store = useDefaultStore();
+  const { taskMemoryState, setTaskMemoryState } = useTaskMemoryState(taskId);
+
+  // Watch the active fork agent task for completion
+  const activeTaskId = taskMemoryState.activeTaskId;
+  const activeTask = store.useQuery(
+    catalog.queries.makeTaskQuery(activeTaskId ?? IdleTaskId),
+  );
+
+  useEffect(() => {
+    if (
+      !activeTaskId ||
+      isSubTask ||
+      !taskMemoryState.isExtracting ||
+      !setTaskMemoryState
+    )
+      return;
+
+    if (activeTask && ActiveStatuses.has(activeTask.status)) return;
+
+    // The active task is no longer running, so we mark extraction as complete
+    setTaskMemoryState({
+      ...taskMemoryState,
+      isExtracting: false,
+      extractionCount: activeTask
+        ? taskMemoryState.extractionCount + 1
+        : taskMemoryState.extractionCount,
+      activeTaskId: undefined,
+    });
+  }, [
+    activeTaskId,
+    activeTask,
+    isSubTask,
+    setTaskMemoryState,
+    taskMemoryState,
+  ]);
+
+  const tryExtractTaskMemory = useCallback(
+    (data: ExtractionData) => {
+      logger.debug("Attempting to extract task memory...");
+      if (isSubTask || !setTaskMemoryState) return false;
+
+      const metrics = getExtractionMetrics(data);
+
+      logger.debug("Task memory extraction metrics:", metrics, taskMemoryState);
+
+      if (!shouldExtractTaskMemory(taskMemoryState, metrics)) {
+        return false;
+      }
+
+      const nextState = toExtractingState(taskMemoryState, metrics);
+
+      logger.debug(
+        "Task memory extraction will proceed with next state:",
+        nextState,
+      );
+      setTaskMemoryState(nextState);
+
+      const memoryFile = store.query(
+        catalog.queries.makeStoreFileQuery("/memory.md"),
+      );
+      const existingMemory = memoryFile?.content ?? undefined;
+
+      logger.debug("Existing task memory content:", existingMemory);
+
+      void createForkAgent({
+        store,
+        label: "task-memory",
+        parentTaskId: taskId,
+        parentMessages: data.messages,
+        parentCwd,
+        directive: prompts.taskMemory.buildExtractionDirective(existingMemory),
+        allowedTools: TaskMemoryAllowedTools,
+        setAsyncAgentState: async (asyncTaskId, state) => {
+          const result = await vscodeHost.readAsyncAgentState(asyncTaskId);
+          await result.setAsyncAgentState(state);
+        },
+      })
+        .then((config) => {
+          logger.debug(
+            "Task memory extraction fork agent created with config:",
+            config,
+          );
+          // AsyncAgentRunner observes runnableTasks$ via store.useQuery, so the
+          // taskInited commit in createForkAgent is picked up on the next render.
+          setTaskMemoryState({
+            ...nextState,
+            activeTaskId: config.taskId,
+          });
+        })
+        .catch(() => {
+          setTaskMemoryState({
+            ...nextState,
+            isExtracting: false,
+            activeTaskId: undefined,
+          });
+        });
+
+      return true;
+    },
+    [isSubTask, store, taskId, parentCwd, setTaskMemoryState, taskMemoryState],
+  );
+
+  return {
+    tryExtractTaskMemory,
+  };
+}

--- a/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
@@ -7,13 +7,17 @@ import type {
   TaskMemoryState,
 } from "@getpochi/common/vscode-webui-bridge";
 import { type Message, catalog } from "@getpochi/livekit";
+import type { ToolSpecInput } from "@getpochi/tools";
 import { useCallback, useEffect } from "react";
 import { createForkAgent } from "../lib/create-fork-agent";
 
 const logger = getLogger("useTaskMemory");
 
 /** Tools the memory extraction fork agent is allowed to call */
-const TaskMemoryAllowedTools = ["writeToFile", "readFile"];
+const TaskMemoryAllowedTools: readonly ToolSpecInput[] = [
+  "readFile",
+  "writeToFile(pochi://-/memory.md)",
+];
 
 /** Statuses that mean the fork agent task is still running */
 const ActiveStatuses = new Set(["pending-model", "pending-tool"]);
@@ -173,7 +177,7 @@ export function useTaskMemory({
         parentMessages: data.messages,
         parentCwd,
         directive: prompts.taskMemory.buildExtractionDirective(existingMemory),
-        allowedTools: TaskMemoryAllowedTools,
+        tools: TaskMemoryAllowedTools,
         setAsyncAgentState: async (asyncTaskId, state) => {
           const result = await vscodeHost.readAsyncAgentState(asyncTaskId);
           await result.setAsyncAgentState(state);

--- a/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
@@ -13,13 +13,13 @@ import { createForkAgent } from "../lib/create-fork-agent";
 
 const logger = getLogger("useTaskMemory");
 
-/** Tools the memory extraction fork agent is allowed to call */
+/** Tools the extraction fork agent may call. */
 const TaskMemoryAllowedTools: readonly ToolSpecInput[] = [
   "readFile",
   "writeToFile(pochi://-/memory.md)",
 ];
 
-/** Statuses that mean the fork agent task is still running */
+/** Fork-agent statuses that mean it is still running. */
 const ActiveStatuses = new Set(["pending-model", "pending-tool"]);
 const IdleTaskId = "__task_memory_idle__";
 
@@ -31,12 +31,17 @@ type ExtractionData = {
 type ExtractionMetrics = {
   tokens: number;
   toolCalls: number;
+  trailingMessageId: string | undefined;
+  trailingMessageHasOpenToolCall: boolean;
 };
 
 function getExtractionMetrics(data: ExtractionData): ExtractionMetrics {
+  const last = data.messages.at(-1);
   return {
     tokens: computeTotalTokens(data.contextWindowUsage),
     toolCalls: countToolCalls(data.messages),
+    trailingMessageId: last?.id,
+    trailingMessageHasOpenToolCall: lastMessageHasOpenToolCall(data.messages),
   };
 }
 
@@ -64,6 +69,18 @@ function countToolCalls(messages: Message[]): number {
   return count;
 }
 
+/** True if the trailing assistant turn has tool calls without output yet. */
+function lastMessageHasOpenToolCall(messages: Message[]): boolean {
+  const last = messages.at(-1);
+  if (!last || last.role !== "assistant") return false;
+  return last.parts.some((part) => {
+    if (!part.type.startsWith("tool-")) return false;
+    if (!("state" in part)) return false;
+    const state = (part as { state: string }).state;
+    return state !== "output-available" && state !== "output-error";
+  });
+}
+
 function shouldExtractTaskMemory(
   state: TaskMemoryState,
   metrics: ExtractionMetrics,
@@ -87,12 +104,17 @@ function toExtractingState(
   state: TaskMemoryState,
   metrics: ExtractionMetrics,
 ): TaskMemoryState {
+  // Skip the boundary when the snapshot is mid-tool-call to avoid
+  // slicing through a tool_use/tool_result pair on the next compaction.
   return {
     ...state,
     initialized: true,
     isExtracting: true,
     lastExtractionTokens: metrics.tokens,
     lastExtractionToolCalls: metrics.toolCalls,
+    pendingExtractionMessageId: metrics.trailingMessageHasOpenToolCall
+      ? undefined
+      : metrics.trailingMessageId,
   };
 }
 
@@ -108,7 +130,7 @@ export function useTaskMemory({
   const store = useDefaultStore();
   const { taskMemoryState, setTaskMemoryState } = useTaskMemoryState(taskId);
 
-  // Watch the active fork agent task for completion
+  // Watch the active fork-agent task for completion.
   const activeTaskId = taskMemoryState.activeTaskId;
   const activeTask = store.useQuery(
     catalog.queries.makeTaskQuery(activeTaskId ?? IdleTaskId),
@@ -125,13 +147,19 @@ export function useTaskMemory({
 
     if (activeTask && ActiveStatuses.has(activeTask.status)) return;
 
-    // The active task is no longer running, so we mark extraction as complete
+    // Extraction finished — on success, promote the pending boundary id.
+    const succeeded = !!activeTask;
     setTaskMemoryState({
       ...taskMemoryState,
       isExtracting: false,
-      extractionCount: activeTask
+      extractionCount: succeeded
         ? taskMemoryState.extractionCount + 1
         : taskMemoryState.extractionCount,
+      lastExtractionMessageId: succeeded
+        ? (taskMemoryState.pendingExtractionMessageId ??
+          taskMemoryState.lastExtractionMessageId)
+        : taskMemoryState.lastExtractionMessageId,
+      pendingExtractionMessageId: undefined,
       activeTaskId: undefined,
     });
   }, [
@@ -188,8 +216,7 @@ export function useTaskMemory({
             "Task memory extraction fork agent created with config:",
             config,
           );
-          // AsyncAgentRunner observes runnableTasks$ via store.useQuery, so the
-          // taskInited commit in createForkAgent is picked up on the next render.
+          // AsyncAgentRunner picks up the taskInited commit on the next render.
           setTaskMemoryState({
             ...nextState,
             activeTaskId: config.taskId,
@@ -200,6 +227,7 @@ export function useTaskMemory({
             ...nextState,
             isExtracting: false,
             activeTaskId: undefined,
+            pendingExtractionMessageId: undefined,
           });
         });
 
@@ -210,5 +238,7 @@ export function useTaskMemory({
 
   return {
     tryExtractTaskMemory,
+    taskMemoryState,
+    setTaskMemoryState,
   };
 }

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/create-fork-agent.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/create-fork-agent.test.ts
@@ -1,4 +1,9 @@
 import type { Message } from "@getpochi/livekit";
+import {
+  type ToolSpecInput,
+  compileToolPolicies,
+  getAllowedToolNames,
+} from "@getpochi/tools";
 import { describe, expect, it } from "vitest";
 import { buildForkMessages } from "../create-fork-agent";
 
@@ -31,5 +36,30 @@ describe("buildForkMessages", () => {
       role: "user",
       parts: [{ type: "text", text: "extract memory" }],
     });
+  });
+});
+
+describe("task-memory tool policy", () => {
+  const TaskMemoryAllowedTools: readonly ToolSpecInput[] = [
+    "readFile",
+    "writeToFile(pochi://-/memory.md)",
+  ];
+
+  it("derives the allowed tool name set", () => {
+    const allowed = getAllowedToolNames([...TaskMemoryAllowedTools]);
+
+    expect(allowed.has("readFile")).toBe(true);
+    expect(allowed.has("writeToFile")).toBe(true);
+    expect(allowed.has("executeCommand")).toBe(false);
+  });
+
+  it("compiles a writeToFile path policy scoped to memory.md", () => {
+    const policies = compileToolPolicies([...TaskMemoryAllowedTools]);
+
+    expect(policies?.writeToFile).toEqual({
+      kind: "path-pattern",
+      patterns: ["pochi://-/memory.md"],
+    });
+    expect(policies?.readFile).toBeUndefined();
   });
 });

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/create-fork-agent.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/create-fork-agent.test.ts
@@ -1,0 +1,35 @@
+import type { Message } from "@getpochi/livekit";
+import { describe, expect, it } from "vitest";
+import { buildForkMessages } from "../create-fork-agent";
+
+describe("buildForkMessages", () => {
+  it("clones parent messages with fresh ids", () => {
+    const parentMessages = [
+      {
+        id: "parent-message-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "hello" },
+          { type: "data-checkpoint", data: { commit: "abc123" } },
+        ],
+      },
+      {
+        id: "parent-message-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "done" }],
+      },
+    ] as Message[];
+
+    const result = buildForkMessages(parentMessages, "extract memory");
+
+    expect(result).toHaveLength(3);
+    expect(result[0].id).not.toBe(parentMessages[0].id);
+    expect(result[1].id).not.toBe(parentMessages[1].id);
+    expect(result[0].parts).toEqual(parentMessages[0].parts);
+    expect(result[1].parts).toEqual(parentMessages[1].parts);
+    expect(result[2]).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", text: "extract memory" }],
+    });
+  });
+});

--- a/packages/vscode-webui/src/features/chat/lib/batched-tool-call-adapters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/batched-tool-call-adapters.ts
@@ -57,6 +57,7 @@ type CreateAsyncAgentToolCallAdapterOptions = {
   parentTaskId?: string;
   storeId: string;
   abortSignal: AbortSignal;
+  toolPolicies?: CompiledToolPolicies;
   addToolOutput: (args: {
     tool: string;
     toolCallId: string;
@@ -311,6 +312,7 @@ export function createAsyncAgentBatchedToolCall({
   parentTaskId,
   storeId,
   abortSignal,
+  toolPolicies,
   addToolOutput,
 }: CreateAsyncAgentToolCallAdapterOptions): BatchedToolCall {
   return {
@@ -331,6 +333,7 @@ export function createAsyncAgentBatchedToolCall({
           {
             toolCallId: toolCall.toolCallId,
             abortSignal: ThreadAbortSignal.serialize(abortSignal),
+            toolPolicies,
             storeId,
             taskId,
             fileStateCacheSourceTaskId: parentTaskId,

--- a/packages/vscode-webui/src/features/chat/lib/batched-tool-call-adapters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/batched-tool-call-adapters.ts
@@ -51,6 +51,19 @@ type CreateExecutorToolCallAdapterOptions = {
   toolCallStatusRegistry: ToolCallStatusRegistry;
 };
 
+type CreateAsyncAgentToolCallAdapterOptions = {
+  toolCall: ToolCall;
+  taskId: string;
+  parentTaskId?: string;
+  storeId: string;
+  abortSignal: AbortSignal;
+  addToolOutput: (args: {
+    tool: string;
+    toolCallId: string;
+    output: unknown;
+  }) => void;
+};
+
 /** Backed by a ToolCallLifeCycle; execution and cancellation delegate to the lifecycle. */
 export function createBatchedToolCallFromLifecycle({
   toolCall,
@@ -273,6 +286,160 @@ export function createSubtaskBatchedToolCall({
     },
     cancel: (reason: ToolCallCancelReason) => {
       toolCallStatusRegistry.set(toolCall, { isExecuting: false });
+      addToolOutput({
+        tool: toolCall.toolName,
+        toolCallId: toolCall.toolCallId,
+        output: {
+          error: getToolCallErrorMessage(reason),
+        },
+      });
+    },
+  };
+}
+
+/**
+ * For async-agent workers: directly executes via vscodeHost and reports
+ * results with addToolOutput, with support for executeCommand streaming and
+ * a parentTaskId-driven file-state cache.
+ *
+ * Unlike the subtask adapter, this does not depend on a UI-side
+ * ToolCallStatusRegistry.
+ */
+export function createAsyncAgentBatchedToolCall({
+  toolCall,
+  taskId,
+  parentTaskId,
+  storeId,
+  abortSignal,
+  addToolOutput,
+}: CreateAsyncAgentToolCallAdapterOptions): BatchedToolCall {
+  return {
+    toolCallId: toolCall.toolCallId,
+    toolName: toolCall.toolName,
+    input: toolCall.input,
+    run: async () => {
+      try {
+        if (abortSignal.aborted) {
+          throw new Error(
+            getToolCallErrorMessage(abortSignal.reason as ToolCallCancelReason),
+          );
+        }
+
+        const result = await vscodeHost.executeToolCall(
+          toolCall.toolName,
+          toolCall.input,
+          {
+            toolCallId: toolCall.toolCallId,
+            abortSignal: ThreadAbortSignal.serialize(abortSignal),
+            storeId,
+            taskId,
+            fileStateCacheSourceTaskId: parentTaskId,
+          },
+        );
+
+        if (
+          toolCall.toolName === "executeCommand" &&
+          typeof result === "object" &&
+          result !== null &&
+          "output" in result
+        ) {
+          const executeCommandError = await new Promise<string | undefined>(
+            (streamResolve) => {
+              const signal = threadSignal(
+                result.output as ThreadSignalSerialization<ExecuteCommandResult>,
+              );
+
+              let resolved = false;
+
+              const finalize = (
+                output: ExecuteCommandResult,
+                reason: "completed" | "aborted",
+              ) => {
+                if (resolved) return;
+                resolved = true;
+                unsubscribe();
+                abortSignal.removeEventListener("abort", onAbort);
+
+                const finalResult: Record<string, unknown> = {
+                  output: output.content,
+                  isTruncated: output.isTruncated ?? false,
+                };
+                if (output.error) {
+                  finalResult.error = output.error;
+                } else if (reason === "aborted") {
+                  finalResult.error = "Aborted by async agent worker";
+                }
+
+                addToolOutput({
+                  tool: toolCall.toolName,
+                  toolCallId: toolCall.toolCallId,
+                  output: finalResult,
+                });
+
+                streamResolve(finalResult.error as string | undefined);
+              };
+
+              const onAbort = () => {
+                finalize(signal.value, "aborted");
+              };
+
+              const unsubscribe = signal.subscribe((output) => {
+                if (output.status === "completed") {
+                  finalize(output, "completed");
+                }
+              });
+
+              if (abortSignal.aborted) {
+                finalize(signal.value, "aborted");
+              } else {
+                abortSignal.addEventListener("abort", onAbort);
+              }
+            },
+          );
+
+          if (executeCommandError) {
+            return {
+              kind: "error",
+              error: executeCommandError,
+            } satisfies BatchedToolCallResult;
+          }
+
+          return {
+            kind: "success",
+          } satisfies BatchedToolCallResult;
+        }
+
+        addToolOutput({
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: result,
+        });
+
+        const error = getToolResultError(result);
+        if (error) {
+          return {
+            kind: "error",
+            error,
+          } satisfies BatchedToolCallResult;
+        }
+
+        return {
+          kind: "success",
+        } satisfies BatchedToolCallResult;
+      } catch (error) {
+        const normalizedError =
+          error instanceof Error
+            ? error
+            : new Error("Async agent batch execution failed");
+        addToolOutput({
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: { error: normalizedError.message },
+        });
+        throw normalizedError;
+      }
+    },
+    cancel: (reason: ToolCallCancelReason) => {
       addToolOutput({
         tool: toolCall.toolName,
         toolCallId: toolCall.toolCallId,

--- a/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
+++ b/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
@@ -1,0 +1,93 @@
+import { buildForkMessages, getLogger } from "@getpochi/common";
+import { type LiveKitStore, type Message, catalog } from "@getpochi/livekit";
+
+const logger = getLogger("CreateForkAgent");
+
+export interface ForkAgentConfig {
+  taskId: string;
+  cwd: string | undefined;
+  label: string;
+}
+
+export interface CreateForkAgentOptions {
+  store: LiveKitStore;
+  label: string;
+  parentTaskId?: string;
+  parentMessages: Message[];
+  parentCwd: string | undefined;
+  directive: string;
+  allowedTools?: readonly string[];
+  setAsyncAgentState?: (
+    taskId: string,
+    state: { allowedTools?: readonly string[]; parentTaskId?: string },
+  ) => Promise<void> | void;
+}
+
+export async function createForkAgent(
+  options: CreateForkAgentOptions,
+): Promise<ForkAgentConfig> {
+  const taskId = crypto.randomUUID();
+  const initMessages = buildForkMessages(
+    options.parentMessages,
+    options.directive,
+  ) as Message[];
+
+  if (
+    (options.allowedTools || options.parentTaskId) &&
+    !options.setAsyncAgentState
+  ) {
+    throw new Error("setAsyncAgentState is required for async agent state");
+  }
+
+  logger.debug(
+    {
+      taskId,
+      label: options.label,
+      parentTaskId: options.parentTaskId,
+      parentCwd: options.parentCwd,
+      parentMessages: options.parentMessages.length,
+      initMessages: initMessages.length,
+      allowedTools: options.allowedTools?.length,
+    },
+    "Creating async fork agent",
+  );
+
+  if (options.allowedTools || options.parentTaskId) {
+    const asyncAgentState = {
+      parentTaskId: options.parentTaskId,
+      allowedTools: options.allowedTools
+        ? Array.from(new Set([...options.allowedTools, "attemptCompletion"]))
+        : undefined,
+    };
+    logger.debug(
+      {
+        taskId,
+        parentTaskId: asyncAgentState.parentTaskId,
+        allowedTools: asyncAgentState.allowedTools?.length,
+      },
+      "Persisting async fork agent state",
+    );
+    await options.setAsyncAgentState?.(taskId, asyncAgentState);
+  }
+
+  options.store.commit(
+    catalog.events.taskInited({
+      id: taskId,
+      cwd: options.parentCwd,
+      runAsync: true,
+      createdAt: new Date(),
+      initMessages,
+    }),
+  );
+
+  logger.debug(
+    { taskId, label: options.label },
+    "Async fork agent initialized",
+  );
+
+  return {
+    taskId,
+    cwd: options.parentCwd,
+    label: options.label,
+  };
+}

--- a/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
+++ b/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@getpochi/common";
 import { type LiveKitStore, type Message, catalog } from "@getpochi/livekit";
+import { type ToolSpecInput, parseToolSpec } from "@getpochi/tools";
 
 const logger = getLogger("CreateForkAgent");
 
@@ -37,10 +38,10 @@ export interface CreateForkAgentOptions {
   parentMessages: Message[];
   parentCwd: string | undefined;
   directive: string;
-  allowedTools?: readonly string[];
+  tools?: readonly ToolSpecInput[];
   setAsyncAgentState?: (
     taskId: string,
-    state: { allowedTools?: readonly string[]; parentTaskId?: string },
+    state: { tools?: readonly ToolSpecInput[]; parentTaskId?: string },
   ) => Promise<void> | void;
 }
 
@@ -53,10 +54,7 @@ export async function createForkAgent(
     options.directive,
   ) as Message[];
 
-  if (
-    (options.allowedTools || options.parentTaskId) &&
-    !options.setAsyncAgentState
-  ) {
+  if ((options.tools || options.parentTaskId) && !options.setAsyncAgentState) {
     throw new Error("setAsyncAgentState is required for async agent state");
   }
 
@@ -68,23 +66,21 @@ export async function createForkAgent(
       parentCwd: options.parentCwd,
       parentMessages: options.parentMessages.length,
       initMessages: initMessages.length,
-      allowedTools: options.allowedTools?.length,
+      tools: options.tools?.length,
     },
     "Creating async fork agent",
   );
 
-  if (options.allowedTools || options.parentTaskId) {
+  if (options.tools || options.parentTaskId) {
     const asyncAgentState = {
       parentTaskId: options.parentTaskId,
-      allowedTools: options.allowedTools
-        ? Array.from(new Set([...options.allowedTools, "attemptCompletion"]))
-        : undefined,
+      tools: options.tools ? ensureAttemptCompletion(options.tools) : undefined,
     };
     logger.debug(
       {
         taskId,
         parentTaskId: asyncAgentState.parentTaskId,
-        allowedTools: asyncAgentState.allowedTools?.length,
+        tools: asyncAgentState.tools?.length,
       },
       "Persisting async fork agent state",
     );
@@ -111,4 +107,13 @@ export async function createForkAgent(
     cwd: options.parentCwd,
     label: options.label,
   };
+}
+
+function ensureAttemptCompletion(
+  tools: readonly ToolSpecInput[],
+): readonly ToolSpecInput[] {
+  const hasAttemptCompletion = tools.some(
+    (tool) => parseToolSpec(tool).name === "attemptCompletion",
+  );
+  return hasAttemptCompletion ? tools : [...tools, "attemptCompletion"];
 }

--- a/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
+++ b/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
@@ -1,7 +1,25 @@
-import { buildForkMessages, getLogger } from "@getpochi/common";
+import { getLogger } from "@getpochi/common";
 import { type LiveKitStore, type Message, catalog } from "@getpochi/livekit";
 
 const logger = getLogger("CreateForkAgent");
+
+/**
+ * Build the init messages for a fork agent: all parent messages followed by
+ * a new user message containing the directive.
+ */
+function buildForkMessages(
+  parentMessages: Message[],
+  directive: string,
+): Message[] {
+  return [
+    ...parentMessages,
+    {
+      id: crypto.randomUUID(),
+      role: "user",
+      parts: [{ type: "text", text: directive }],
+    } as Message,
+  ];
+}
 
 export interface ForkAgentConfig {
   taskId: string;

--- a/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
+++ b/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
@@ -7,12 +7,15 @@ const logger = getLogger("CreateForkAgent");
  * Build the init messages for a fork agent: all parent messages followed by
  * a new user message containing the directive.
  */
-function buildForkMessages(
+export function buildForkMessages(
   parentMessages: Message[],
   directive: string,
 ): Message[] {
   return [
-    ...parentMessages,
+    ...parentMessages.map((message) => ({
+      ...structuredClone(message),
+      id: crypto.randomUUID(),
+    })),
     {
       id: crypto.randomUUID(),
       role: "user",

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -3,6 +3,7 @@ import { ChatContextProvider, useHandleChatEvents } from "@/features/chat";
 import { usePendingModelAutoStart } from "@/features/retry";
 import { useAttachmentUpload } from "@/lib/hooks/use-attachment-upload";
 import { useCustomAgent } from "@/lib/hooks/use-custom-agents";
+import { useLatest } from "@/lib/hooks/use-latest";
 import { usePochiCredentials } from "@/lib/hooks/use-pochi-credentials";
 import { useTaskContextWindowUsage } from "@/lib/hooks/use-task-context-window-usage";
 import { useTaskMcpConfigOverride } from "@/lib/hooks/use-task-mcp-config-override";
@@ -28,6 +29,7 @@ import {
   useSelectedModels,
   useSettingsStore,
 } from "../settings";
+import { AsyncAgentRunner } from "./components/async-agent-runner";
 import { ChatArea } from "./components/chat-area";
 import { ChatSkeleton } from "./components/chat-skeleton";
 import { ChatToolbar } from "./components/chat-toolbar";
@@ -44,6 +46,7 @@ import { useScrollToBottom } from "./hooks/use-scroll-to-bottom";
 import { useSetSubtaskModel } from "./hooks/use-set-subtask-model";
 import { useAddSubtaskResult } from "./hooks/use-subtask-completed";
 import { useSubtaskInfo } from "./hooks/use-subtask-info";
+import { useTaskMemory } from "./hooks/use-task-memory";
 import { useAutoApproveGuard, useChatAbortController } from "./lib/chat-state";
 import { onOverrideMessages } from "./lib/on-override-messages";
 import { useLiveChatKitGetters } from "./lib/use-live-chat-kit-getters";
@@ -143,6 +146,13 @@ function Chat({ user, uid, info }: ChatProps) {
     autoApproveSettings,
   });
 
+  const { tryExtractTaskMemory } = useTaskMemory({
+    isSubTask,
+    taskId: uid,
+    parentCwd: task?.cwd ?? undefined,
+  });
+  const tryExtractTaskMemoryRef = useLatest(tryExtractTaskMemory);
+
   const chatKit = useLiveChatKit({
     store,
     blobStore,
@@ -181,6 +191,11 @@ function Chat({ user, uid, info }: ChatProps) {
       if (data.contextWindowUsage) {
         setContextWindowUsage.current(data.contextWindowUsage);
       }
+      console.log(
+        "Task memory extraction attempt on stream finish with data:",
+        data,
+      );
+      tryExtractTaskMemoryRef.current(data);
     },
   });
 
@@ -335,6 +350,7 @@ function Chat({ user, uid, info }: ChatProps) {
           mcpConfigOverride={mcpConfigOverride}
         />
       </div>
+      <AsyncAgentRunner />
     </div>
   );
 }

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -146,12 +146,15 @@ function Chat({ user, uid, info }: ChatProps) {
     autoApproveSettings,
   });
 
-  const { tryExtractTaskMemory } = useTaskMemory({
-    isSubTask,
-    taskId: uid,
-    parentCwd: task?.cwd ?? undefined,
-  });
+  const { tryExtractTaskMemory, taskMemoryState, setTaskMemoryState } =
+    useTaskMemory({
+      isSubTask,
+      taskId: uid,
+      parentCwd: task?.cwd ?? undefined,
+    });
   const tryExtractTaskMemoryRef = useLatest(tryExtractTaskMemory);
+  const taskMemoryStateRef = useLatest(taskMemoryState);
+  const setTaskMemoryStateRef = useLatest(setTaskMemoryState);
 
   const chatKit = useLiveChatKit({
     store,
@@ -161,8 +164,18 @@ function Chat({ user, uid, info }: ChatProps) {
     isSubTask,
     customAgent,
     abortSignal: chatAbortController.current.signal,
-    onCompact: () => vscodeHost.clearFileStateCache(uid),
+    onCompact: async () => {
+      await vscodeHost.clearFileStateCache(uid);
+      // Token usage drops at compact, so rebase the baseline against the
+      // post-compact view; tool-call count is monotonic and unaffected.
+      const setter = setTaskMemoryStateRef.current;
+      const current = taskMemoryStateRef.current;
+      if (setter && current) {
+        setter({ ...current, lastExtractionTokens: 0 });
+      }
+    },
     getRecentFilesForCompact: () => vscodeHost.readRecentFilesForCompact(uid),
+    getTaskMemoryState: () => taskMemoryStateRef.current,
     sendAutomaticallyWhen: (x) => {
       if (chatAbortController.current.signal.aborted) {
         return false;
@@ -191,10 +204,6 @@ function Chat({ user, uid, info }: ChatProps) {
       if (data.contextWindowUsage) {
         setContextWindowUsage.current(data.contextWindowUsage);
       }
-      console.log(
-        "Task memory extraction attempt on stream finish with data:",
-        data,
-      );
       tryExtractTaskMemoryRef.current(data);
     },
   });

--- a/packages/vscode-webui/src/lib/hooks/use-async-agent-state.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-async-agent-state.ts
@@ -24,7 +24,7 @@ export const useAsyncAgentState = (taskId: string) => {
       {
         taskId,
         parentTaskId: state.parentTaskId,
-        allowedTools: state.allowedTools?.length,
+        tools: state.tools?.length,
       },
       "Setting async agent state",
     );
@@ -47,7 +47,7 @@ async function fetchAsyncAgentState(taskId: string) {
       taskId,
       hasAsyncAgentState: value.value !== undefined,
       parentTaskId: value.value?.parentTaskId,
-      allowedTools: value.value?.allowedTools?.length,
+      tools: value.value?.tools?.length,
     },
     "Fetched async agent state",
   );

--- a/packages/vscode-webui/src/lib/hooks/use-async-agent-state.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-async-agent-state.ts
@@ -1,0 +1,58 @@
+import { vscodeHost } from "@/lib/vscode";
+import { getLogger } from "@getpochi/common";
+import type { AsyncAgentState } from "@getpochi/common/vscode-webui-bridge";
+import { threadSignal } from "@quilted/threads/signals";
+import { useQuery } from "@tanstack/react-query";
+import { useLatest } from "./use-latest";
+
+const logger = getLogger("UseAsyncAgentState");
+
+/**
+ * Hook to read and manage AsyncAgentState for a task.
+ * Uses ThreadSignal for real-time updates.
+ * @useSignals this comment is needed to enable signals in this hook
+ */
+export const useAsyncAgentState = (taskId: string) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ["asyncAgentState", taskId],
+    queryFn: () => fetchAsyncAgentState(taskId),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  const setAsyncAgentState = useLatest((state: AsyncAgentState) => {
+    logger.debug(
+      {
+        taskId,
+        parentTaskId: state.parentTaskId,
+        allowedTools: state.allowedTools?.length,
+      },
+      "Setting async agent state",
+    );
+    return data?.setAsyncAgentState(state);
+  });
+
+  return {
+    asyncAgentState: data?.value.value,
+    setAsyncAgentState,
+    isLoading,
+  };
+};
+
+async function fetchAsyncAgentState(taskId: string) {
+  logger.debug({ taskId }, "Fetching async agent state");
+  const result = await vscodeHost.readAsyncAgentState(taskId);
+  const value = threadSignal(result.value);
+  logger.debug(
+    {
+      taskId,
+      hasAsyncAgentState: value.value !== undefined,
+      parentTaskId: value.value?.parentTaskId,
+      allowedTools: value.value?.allowedTools?.length,
+    },
+    "Fetched async agent state",
+  );
+  return {
+    value,
+    setAsyncAgentState: result.setAsyncAgentState,
+  };
+}

--- a/packages/vscode-webui/src/lib/hooks/use-task-memory-state.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-task-memory-state.ts
@@ -1,0 +1,42 @@
+import { vscodeHost } from "@/lib/vscode";
+import type { TaskMemoryState } from "@getpochi/common/vscode-webui-bridge";
+import { threadSignal } from "@quilted/threads/signals";
+import { useQuery } from "@tanstack/react-query";
+
+const defaultTaskMemoryState: TaskMemoryState = {
+  initialized: false,
+  lastExtractionTokens: 0,
+  lastExtractionToolCalls: 0,
+  isExtracting: false,
+  extractionCount: 0,
+};
+
+/**
+ * Hook to read and manage TaskMemoryState for a task.
+ * Uses ThreadSignal for real-time updates.
+ * @useSignals this comment is needed to enable signals in this hook
+ */
+export const useTaskMemoryState = (taskId: string) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ["taskMemoryState", taskId],
+    queryFn: () => fetchTaskMemoryState(taskId),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  const taskMemoryState = data?.value.value ?? defaultTaskMemoryState;
+  const setTaskMemoryState = data?.setTaskMemoryState;
+
+  return {
+    taskMemoryState,
+    setTaskMemoryState,
+    isLoading,
+  };
+};
+
+async function fetchTaskMemoryState(taskId: string) {
+  const result = await vscodeHost.readTaskMemoryState(taskId);
+  return {
+    value: threadSignal(result.value),
+    setTaskMemoryState: result.setTaskMemoryState,
+  };
+}

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -124,6 +124,8 @@ function createVSCodeHost(): VSCodeHostApi {
         "unregisterBrowserSession",
         "readMcpConfigOverride",
         "readContextWindowUsage",
+        "readTaskMemoryState",
+        "readAsyncAgentState",
         "readTaskArchived",
         "readLang",
         "readTaskChangedFiles",

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -72,6 +72,7 @@ import {
 } from "@getpochi/common/tool-utils";
 import { getVendor } from "@getpochi/common/vendor";
 import {
+  type AsyncAgentState,
   type BuiltinSubAgentInfo,
   type CaptureEvent,
   type ChangedFileContent,
@@ -94,6 +95,7 @@ import {
   type SkillFile,
   type TaskArchivedParams,
   type TaskChangedFile,
+  type TaskMemoryState,
   type TaskStates,
   type VSCodeHostApi,
   type VSCodeSettings,
@@ -467,6 +469,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       toolPolicies?: CompiledToolPolicies;
       storeId: string;
       taskId: string;
+      fileStateCacheSourceTaskId?: string;
     },
   ) => {
     let tool: ToolFunctionType<Tool> | undefined;
@@ -512,9 +515,15 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       options.builtinSubAgentInfo,
     );
     const taskId = options.taskId;
-    const fileStateCache = this.fileStateCacheRegistry.get(options.taskId);
+    if (options.fileStateCacheSourceTaskId) {
+      this.fileStateCacheRegistry.copyIfAbsent(
+        options.fileStateCacheSourceTaskId,
+        taskId,
+      );
+    }
+    const fileStateCache = this.fileStateCacheRegistry.get(taskId);
     logger.debug(
-      `executeToolCall: ${toolName} taskId=${options.taskId} fileStateCache=${fileStateCache ? "present" : "MISSING"}`,
+      `executeToolCall: ${toolName} taskId=${options.taskId} fileStateCacheSourceTaskId=${options.fileStateCacheSourceTaskId ?? "none"} fileStateCache=${fileStateCache ? "present" : "MISSING"}`,
     );
     const rawResult = await safeCall(
       tool(resolvedArgs, {
@@ -1233,6 +1242,46 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       ),
       setContextWindowUsage: (contextWindowUsage: ContextWindowUsage) =>
         this.taskStateStore.setContextWindowUsage(taskId, contextWindowUsage),
+    };
+  };
+
+  readTaskMemoryState = async (
+    taskId: string,
+  ): Promise<{
+    value: ThreadSignalSerialization<TaskMemoryState | undefined>;
+    setTaskMemoryState: (state: TaskMemoryState) => Promise<void>;
+  }> => {
+    return {
+      value: ThreadSignal.serialize(
+        this.taskStateStore.getTaskMemoryStateSignal(taskId),
+      ),
+      setTaskMemoryState: (state: TaskMemoryState) =>
+        this.taskStateStore.setTaskMemoryState(taskId, state),
+    };
+  };
+
+  readAsyncAgentState = async (
+    taskId: string,
+  ): Promise<{
+    value: ThreadSignalSerialization<AsyncAgentState | undefined>;
+    setAsyncAgentState: (state: AsyncAgentState) => Promise<void>;
+  }> => {
+    logger.debug({ taskId }, "readAsyncAgentState");
+    return {
+      value: ThreadSignal.serialize(
+        this.taskStateStore.getAsyncAgentStateSignal(taskId),
+      ),
+      setAsyncAgentState: (state: AsyncAgentState) => {
+        logger.debug(
+          {
+            taskId,
+            parentTaskId: state.parentTaskId,
+            allowedTools: state.allowedTools?.length,
+          },
+          "readAsyncAgentState.setAsyncAgentState",
+        );
+        return this.taskStateStore.setAsyncAgentState(taskId, state);
+      },
     };
   };
 

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1276,7 +1276,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
           {
             taskId,
             parentTaskId: state.parentTaskId,
-            allowedTools: state.allowedTools?.length,
+            tools: state.tools?.length,
           },
           "readAsyncAgentState.setAsyncAgentState",
         );

--- a/packages/vscode/src/lib/__test__/file-state-cache-registry.test.ts
+++ b/packages/vscode/src/lib/__test__/file-state-cache-registry.test.ts
@@ -22,6 +22,82 @@ describe("FileStateCacheRegistry", () => {
     assert.strictEqual(nextCache.size, 0);
   });
 
+  it("copies a source task cache without sharing cache state", () => {
+    const registry = new FileStateCacheRegistry();
+
+    const sourceCache = registry.get("parent-task");
+    sourceCache.set("/tmp/file.txt", {
+      content: "hello",
+      timestamp: 1,
+      startLine: 1,
+      endLine: 1,
+    });
+
+    registry.copyIfAbsent("parent-task", "fork-task");
+
+    const forkCache = registry.get("fork-task");
+    assert.notStrictEqual(forkCache, sourceCache);
+    assert.deepStrictEqual(forkCache.get("/tmp/file.txt"), {
+      content: "hello",
+      timestamp: 1,
+      startLine: 1,
+      endLine: 1,
+    });
+
+    forkCache.set("/tmp/file.txt", {
+      content: "fork",
+      timestamp: 2,
+      startLine: undefined,
+      endLine: undefined,
+      fromWrite: true,
+    });
+
+    assert.strictEqual(sourceCache.get("/tmp/file.txt")?.content, "hello");
+  });
+
+  it("does not overwrite an existing target cache when copying", () => {
+    const registry = new FileStateCacheRegistry();
+
+    registry.get("parent-task").set("/tmp/file.txt", {
+      content: "parent",
+      timestamp: 1,
+      startLine: 1,
+      endLine: 1,
+    });
+    registry.get("fork-task").set("/tmp/file.txt", {
+      content: "existing",
+      timestamp: 2,
+      startLine: 1,
+      endLine: 1,
+    });
+
+    registry.copyIfAbsent("parent-task", "fork-task");
+
+    assert.strictEqual(
+      registry.get("fork-task").get("/tmp/file.txt")?.content,
+      "existing",
+    );
+  });
+
+  it("copies into an empty target cache", () => {
+    const registry = new FileStateCacheRegistry();
+
+    registry.get("parent-task").set("/tmp/file.txt", {
+      content: "parent",
+      timestamp: 1,
+      startLine: 1,
+      endLine: 1,
+    });
+    registry.get("fork-task");
+
+    registry.copyIfAbsent("parent-task", "fork-task");
+
+    assert.strictEqual(
+      registry.get("fork-task").get("/tmp/file.txt")?.content,
+      "parent",
+    );
+  });
+
   it("disposes all retained caches", () => {
     const registry = new FileStateCacheRegistry();
 

--- a/packages/vscode/src/lib/file-state-cache-registry.ts
+++ b/packages/vscode/src/lib/file-state-cache-registry.ts
@@ -19,6 +19,22 @@ export class FileStateCacheRegistry implements vscode.Disposable {
     return cache;
   }
 
+  copyIfAbsent(sourceTaskId: string, targetTaskId: string): void {
+    const existingTarget = this.caches.get(targetTaskId);
+    if (existingTarget && existingTarget.size > 0) {
+      return;
+    }
+
+    const source = this.caches.get(sourceTaskId);
+    const target = new FileStateCache();
+    if (source) {
+      for (const [key, value] of source) {
+        target.set(key, { ...value });
+      }
+    }
+    this.caches.set(targetTaskId, target);
+  }
+
   clear(taskId: string): void {
     this.caches.get(taskId)?.clear();
   }

--- a/packages/vscode/src/lib/task-data-store.ts
+++ b/packages/vscode/src/lib/task-data-store.ts
@@ -1,8 +1,10 @@
 import { getLogger } from "@getpochi/common";
 import type {
+  AsyncAgentState,
   ContextWindowUsage,
   McpConfigOverride,
   TaskChangedFile,
+  TaskMemoryState,
 } from "@getpochi/common/vscode-webui-bridge";
 import { computed, signal } from "@preact/signals-core";
 import { inject, injectable, singleton } from "tsyringe";
@@ -13,6 +15,8 @@ type TaskStateData = {
   archived?: boolean;
   changedFiles?: TaskChangedFile[];
   contextWindowUsage?: ContextWindowUsage;
+  taskMemoryState?: TaskMemoryState;
+  asyncAgentState?: AsyncAgentState;
   // unix timestamp in milliseconds
   updatedAt: number;
 };
@@ -173,5 +177,56 @@ export class TaskDataStore {
    */
   getContextWindowUsageSignal(taskId: string) {
     return computed(() => this.state.value[taskId]?.contextWindowUsage);
+  }
+
+  getTaskMemoryState(taskId: string): TaskMemoryState | undefined {
+    return this.getTaskState(taskId)?.taskMemoryState;
+  }
+
+  async setTaskMemoryState(
+    taskId: string,
+    taskMemoryState: TaskMemoryState,
+  ): Promise<void> {
+    const existing = this.getTaskState(taskId) || {};
+    await this.saveTaskState(taskId, { ...existing, taskMemoryState });
+  }
+
+  getTaskMemoryStateSignal(taskId: string) {
+    return computed(() => this.state.value[taskId]?.taskMemoryState);
+  }
+
+  getAsyncAgentState(taskId: string): AsyncAgentState | undefined {
+    const asyncAgentState = this.getTaskState(taskId)?.asyncAgentState;
+    logger.debug(
+      {
+        taskId,
+        hasAsyncAgentState: asyncAgentState !== undefined,
+        parentTaskId: asyncAgentState?.parentTaskId,
+        allowedTools: asyncAgentState?.allowedTools?.length,
+      },
+      "getAsyncAgentState",
+    );
+    return asyncAgentState;
+  }
+
+  async setAsyncAgentState(
+    taskId: string,
+    asyncAgentState: AsyncAgentState,
+  ): Promise<void> {
+    const existing = this.getTaskState(taskId) || {};
+    logger.debug(
+      {
+        taskId,
+        parentTaskId: asyncAgentState.parentTaskId,
+        allowedTools: asyncAgentState.allowedTools?.length,
+      },
+      "setAsyncAgentState",
+    );
+    await this.saveTaskState(taskId, { ...existing, asyncAgentState });
+  }
+
+  getAsyncAgentStateSignal(taskId: string) {
+    logger.debug({ taskId }, "getAsyncAgentStateSignal");
+    return computed(() => this.state.value[taskId]?.asyncAgentState);
   }
 }

--- a/packages/vscode/src/lib/task-data-store.ts
+++ b/packages/vscode/src/lib/task-data-store.ts
@@ -202,7 +202,7 @@ export class TaskDataStore {
         taskId,
         hasAsyncAgentState: asyncAgentState !== undefined,
         parentTaskId: asyncAgentState?.parentTaskId,
-        allowedTools: asyncAgentState?.allowedTools?.length,
+        tools: asyncAgentState?.tools?.length,
       },
       "getAsyncAgentState",
     );
@@ -218,7 +218,7 @@ export class TaskDataStore {
       {
         taskId,
         parentTaskId: asyncAgentState.parentTaskId,
-        allowedTools: asyncAgentState.allowedTools?.length,
+        tools: asyncAgentState.tools?.length,
       },
       "setAsyncAgentState",
     );


### PR DESCRIPTION
## Summary

- Adds a background **task memory** system that periodically extracts structured session notes from the ongoing conversation into `pochi://-/memory.md` (stored in the task's virtual file system)
- Introduces `AsyncAgentRunner` / `AsyncAgentWorker` — headless React components that discover and drive `runAsync=true` fork-agent tasks, including the memory extraction agent
- On context compaction, the `compactTask` function now prefers the task memory file as the summary source, falling back to LLM-generated summaries when memory is absent
- Adds new VSCode host bridge methods: `readTaskMemoryState` and `readAsyncAgentState` for persisting lightweight runtime state across renders
- Registers `/memory.md` as a valid task file path in the pochi virtual file system and extends the LiveStore schema accordingly

## Key files

| File | Purpose |
|------|---------|
| `packages/common/src/base/prompts/task-memory.ts` | Memory template + extraction directive builder |
| `packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts` | Hook that triggers extraction when token/tool-call thresholds are met |
| `packages/vscode-webui/src/features/chat/components/async-agent-runner.tsx` | Headless runner that observes `runnableTasks$` and spawns workers |
| `packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx` | Per-task headless worker using `LiveChatKit` |
| `packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts` | Utility to commit a `taskInited` event for a fork agent |
| `packages/livekit/src/chat/llm/compact-task.ts` | Compaction updated to prefer memory file |

## Test plan

- [ ] Run `bun run test` and verify all existing tests pass including the new `task-memory.test.ts`
- [ ] Start a long session and confirm `memory.md` is created in the task's virtual FS after 10k tokens
- [ ] Trigger compaction and verify the memory file content is used as the summary
- [ ] Reload the extension mid-session and confirm `AsyncAgentRunner` resumes any interrupted async agents

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-6cfe855916b34d0e8e19ca1696d14fa3)