### PR TITLE
feat(compact): preserve recent file contents after task compaction

### DIFF
--- a/packages/cli/src/tools/read-file.ts
+++ b/packages/cli/src/tools/read-file.ts
@@ -52,7 +52,11 @@ export const readFile =
           addLineNumbers,
         });
 
-        return { result, fileCacheContent: fileContent };
+        return {
+          result,
+          fileCacheContent: result.content,
+          fileCacheIsTruncated: result.isTruncated,
+        };
       },
     });
 

--- a/packages/cli/src/tools/read-file.ts
+++ b/packages/cli/src/tools/read-file.ts
@@ -1,5 +1,5 @@
 import {
-  FILE_UNCHANGED_STUB,
+  FileUnchangedStub,
   getFileModificationTime,
   isPlainText,
   readMediaFile,
@@ -61,7 +61,7 @@ export const readFile =
     });
 
     if (cacheResult.deduplicated) {
-      return { content: FILE_UNCHANGED_STUB, isTruncated: false };
+      return { content: FileUnchangedStub, isTruncated: false };
     }
 
     return cacheResult.result;

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -35,6 +35,7 @@ export const PochiProviderOptions = z.object({
     z.literal("repair-tool-call"),
     z.literal("generate-task-title"),
     z.literal("compact-task"),
+    z.literal("repair-mermaid"),
   ]),
 });
 

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -58,11 +58,16 @@ function isCompact(content: string) {
   return content.startsWith("<compact>") && content.endsWith("</compact>");
 }
 
-function inlineCompact(summary: string, messageCount: number) {
+function inlineCompact(
+  summary: string,
+  messageCount: number,
+  appendix?: string,
+) {
+  const appendixText = appendix ? `\n\n${appendix}` : "";
   return `<compact>
 Previous conversation summary (${messageCount} messages):
 ${summary}
-This section contains a summary of the conversation up to this point to save context. The full conversation history has been preserved but condensed for efficiency.
+This section contains a summary of the conversation up to this point to save context. The full conversation history has been preserved but condensed for efficiency.${appendixText}
 </compact>`;
 }
 

--- a/packages/common/src/tool-utils/__tests__/file-state-cache.test.ts
+++ b/packages/common/src/tool-utils/__tests__/file-state-cache.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { checkStaleness, FileStateCache, withFileStateCacheGuard } from "../file-state-cache";
+import {
+  checkStaleness,
+  FileStateCache,
+  withFileStateCacheGuard,
+} from "../file-state-cache";
 
 describe("FileStateCache", () => {
   it("skips caching entries larger than the configured byte limit", () => {
@@ -98,6 +102,37 @@ describe("FileStateCache", () => {
       checkStaleness(cache, "/tmp/new-file.txt", async () => undefined, "writing"),
     ).resolves.toBeUndefined();
   });
+
+  it("returns recent files in LRU order", () => {
+    const cache = new FileStateCache();
+    cache.set("/tmp/a.txt", {
+      content: "a",
+      timestamp: 1,
+      startLine: 1,
+      endLine: 1,
+      isTruncated: true,
+    });
+    cache.set("/tmp/b.txt", {
+      content: "b",
+      timestamp: 2,
+      startLine: 1,
+      endLine: 1,
+    });
+    cache.set("/tmp/c.txt", {
+      content: "c",
+      timestamp: 3,
+      startLine: 1,
+      endLine: 1,
+    });
+
+    cache.get("/tmp/a.txt");
+
+    expect(cache.getRecentFiles(2).map((file) => file.path)).toEqual([
+      "/tmp/a.txt",
+      "/tmp/c.txt",
+    ]);
+    expect(cache.getRecentFiles(1)[0]?.isTruncated).toBe(true);
+  });
 });
 
 describe("withFileStateCacheGuard", () => {
@@ -112,7 +147,10 @@ describe("withFileStateCacheGuard", () => {
         cwd: "/tmp",
         getMtime,
         operation: "editing",
-        doWork: async () => ({ result: { success: true as const }, fileCacheContent: "new content" }),
+        doWork: async () => ({
+          result: { success: true as const },
+          fileCacheContent: "new content",
+        }),
       }),
     ).rejects.toThrow(
       "File has not been read yet. Please read the file before editing it.",
@@ -131,7 +169,10 @@ describe("withFileStateCacheGuard", () => {
         cwd: "/tmp",
         getMtime,
         operation: "writing",
-        doWork: async () => ({ result: { success: true as const }, fileCacheContent: "hello" }),
+        doWork: async () => ({
+          result: { success: true as const },
+          fileCacheContent: "hello",
+        }),
       }),
     ).resolves.toEqual({ success: true });
   });

--- a/packages/common/src/tool-utils/file-state-cache.ts
+++ b/packages/common/src/tool-utils/file-state-cache.ts
@@ -10,8 +10,19 @@ export const FILE_UNCHANGED_STUB =
 
 type FileCacheCallbackResult<T> = {
   result: T;
-  /** Content to store in cache. Pass null to skip caching (e.g. actual binary content). */
+  /** Model-visible content to store in cache. Pass null to skip caching (e.g. actual binary content). */
   fileCacheContent: string | null;
+  /** Whether the result sent to the model was truncated. */
+  fileCacheIsTruncated?: boolean;
+};
+
+export type RecentFileState = {
+  path: string;
+  content: string;
+  timestamp: number;
+  startLine: number | undefined;
+  endLine: number | undefined;
+  isTruncated?: boolean;
 };
 
 /** Default maximum number of entries in the cache */
@@ -118,6 +129,25 @@ export class FileStateCache {
 
   *values(): IterableIterator<IFileState> {
     yield* this.entries.values();
+  }
+
+  getRecentFiles(maxFiles = 5): RecentFileState[] {
+    const entries: Array<[string, IFileState]> = [];
+    this.entries.forEach((state, path) => {
+      entries.push([path, state]);
+    });
+
+    return entries
+      .reverse()
+      .slice(0, maxFiles)
+      .map(([path, state]) => ({
+        path,
+        content: state.content,
+        timestamp: state.timestamp,
+        startLine: state.startLine,
+        endLine: state.endLine,
+        isTruncated: state.isTruncated,
+      }));
   }
 
   *[Symbol.iterator](): IterableIterator<[string, IFileState]> {
@@ -359,7 +389,8 @@ export async function withReadFileCache<T>(opts: {
     }
   }
 
-  const { result, fileCacheContent } = await doRead(resolvedPath);
+  const { result, fileCacheContent, fileCacheIsTruncated } =
+    await doRead(resolvedPath);
 
   // --- Populate cache ---
   // Store what the model has "seen" so that future reads can dedup,
@@ -377,6 +408,7 @@ export async function withReadFileCache<T>(opts: {
         timestamp: mtimeMs,
         startLine,
         endLine,
+        isTruncated: fileCacheIsTruncated,
       });
     }
   }

--- a/packages/common/src/tool-utils/file-state-cache.ts
+++ b/packages/common/src/tool-utils/file-state-cache.ts
@@ -5,7 +5,7 @@ import { resolvePath } from "./fs";
 
 const logger = getLogger("FileStateCache");
 
-export const FILE_UNCHANGED_STUB =
+export const FileUnchangedStub =
   "File unchanged since last read. The content from the earlier Read tool_result in this conversation is still current — refer to that instead of re-reading.";
 
 type FileCacheCallbackResult<T> = {
@@ -237,7 +237,7 @@ export async function checkStaleness(
  * @param content - The new file content after edit/write
  * @param getMtime - Platform-specific function to get current file mtime
  */
-export async function updateCacheAfterWrite(
+async function updateCacheAfterWrite(
   cache: IFileStateCache,
   resolvedPath: string,
   content: string,
@@ -365,7 +365,7 @@ export async function withReadFileCache<T>(opts: {
   // --- Read deduplication ---
   // If we've already read this exact file + range and it hasn't been
   // modified on disk, return a "deduplicated" sentinel so the caller
-  // can return a lightweight FILE_UNCHANGED_STUB instead of re-sending
+  // can return a lightweight FileUnchangedStub instead of re-sending
   // the full content (saves tokens).
   if (shouldCache) {
     const existingState = cache.get(resolvedPath);

--- a/packages/common/src/tool-utils/index.ts
+++ b/packages/common/src/tool-utils/index.ts
@@ -43,6 +43,7 @@ export { readMediaFile } from "./media";
 export { getWorkspaceExcludePatterns } from "./workspace-exclude-patterns";
 export {
   FileStateCache,
+  type RecentFileState,
   FILE_UNCHANGED_STUB,
   checkStaleness,
   updateCacheAfterWrite,

--- a/packages/common/src/tool-utils/index.ts
+++ b/packages/common/src/tool-utils/index.ts
@@ -44,9 +44,8 @@ export { getWorkspaceExcludePatterns } from "./workspace-exclude-patterns";
 export {
   FileStateCache,
   type RecentFileState,
-  FILE_UNCHANGED_STUB,
+  FileUnchangedStub,
   checkStaleness,
-  updateCacheAfterWrite,
   withFileStateCacheGuard,
   withReadFileCache,
   isVirtualPath,

--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -114,6 +114,9 @@ const VSCodeHostStub = {
   clearFileStateCache: (_taskId: string): Promise<void> => {
     return Promise.resolve();
   },
+  readRecentFilesForCompact: (_taskId: string) => {
+    return Promise.resolve([]);
+  },
   readActiveSelection: (): Promise<
     ThreadSignalSerialization<ActiveSelection | undefined>
   > => {

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -3,6 +3,7 @@ import type { ThreadSignalSerialization } from "@quilted/threads/signals";
 import type { Environment } from "../base";
 import type { BrowserSession } from "../browser/types";
 import type { UserInfo } from "../configuration";
+import type { RecentFileState } from "../tool-utils";
 import type {
   BuiltinSubAgentInfo,
   CaptureEvent,
@@ -134,6 +135,13 @@ export interface VSCodeHostApi {
    * from being returned for content that was compacted away.
    */
   clearFileStateCache(taskId: string): Promise<void>;
+
+  /**
+   * Read recent file state cache entries for the given task ID.
+   * Used by compaction to keep recently read file contents visible after
+   * the compacted conversation drops the original readFile tool results.
+   */
+  readRecentFilesForCompact(taskId: string): Promise<RecentFileState[]>;
 
   readActiveSelection(): Promise<
     ThreadSignalSerialization<ActiveSelection | undefined>

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "@getpochi/common";
+import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { type CustomAgent, ToolsByPermission } from "@getpochi/tools";
 import { Duration } from "@livestore/utils/effect";
 import {
@@ -33,6 +34,23 @@ import { ImageEstimatedTokens, estimateTokens } from "./token-utils";
 
 const logger = getLogger("LiveChatKit");
 const OverrideMessagesSideEffectTimeoutMs = 12_000;
+
+type GetRecentFilesForCompact = () =>
+  | RecentFileState[]
+  | Promise<RecentFileState[]>;
+
+async function readRecentFilesForCompact(
+  getRecentFilesForCompact: GetRecentFilesForCompact | undefined,
+): Promise<RecentFileState[] | undefined> {
+  try {
+    return await getRecentFilesForCompact?.();
+  } catch (error) {
+    logger.warn(
+      "Failed to read recent files for compaction. Continue compacting without file restoration.",
+      error,
+    );
+  }
+}
 
 async function runSideEffectSafely({
   sideEffectName,
@@ -137,7 +155,13 @@ export type LiveChatKitOptions<T> = {
    * Use this to clear caches (e.g. FileStateCache) that depend on
    * conversation context that was discarded during compaction.
    */
-  onCompact?: () => void;
+  onCompact?: () => void | Promise<void>;
+
+  /**
+   * Returns recent file contents the model saw before compaction.
+   * They are appended to the compact block before the cache is cleared.
+   */
+  getRecentFilesForCompact?: GetRecentFilesForCompact;
 
   customAgent?: CustomAgent;
   outputSchema?: z.ZodAny;
@@ -205,6 +229,7 @@ export class LiveChatKit<
     onStreamStart,
 
     onStreamFinish,
+    getRecentFilesForCompact,
     ...chatInit
   }: LiveChatKitOptions<T>) {
     this.taskId = taskId;
@@ -261,10 +286,13 @@ export class LiveChatKit<
             taskId: this.taskId,
             model,
             messages,
+            recentFiles: await readRecentFilesForCompact(
+              getRecentFilesForCompact,
+            ),
             abortSignal,
             inline: true,
           });
-          onCompact?.();
+          await onCompact?.();
         } catch (err) {
           logger.error("Failed to compact task", err);
           throw err;
@@ -295,12 +323,13 @@ export class LiveChatKit<
         taskId: this.taskId,
         model,
         messages,
+        recentFiles: await readRecentFilesForCompact(getRecentFilesForCompact),
       });
 
       if (!summary) {
         throw new Error("Failed to compact task");
       }
-      onCompact?.();
+      await onCompact?.();
       return summary;
     };
 

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -1,5 +1,10 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import { formatters, getLogger, prompts } from "@getpochi/common";
+import {
+  type PochiProviderOptions,
+  formatters,
+  getLogger,
+  prompts,
+} from "@getpochi/common";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { convertToModelMessages, generateText } from "ai";
 import type { BlobStore } from "../../blob-store";
@@ -55,6 +60,7 @@ export async function compactTask({
     return text;
   } catch (err) {
     logger.warn("Failed to create summary", err);
+    throw err;
   }
 }
 
@@ -83,9 +89,9 @@ async function createSummary(
     providerOptions: {
       pochi: {
         taskId,
-        version: globalThis.POCHI_CLIENT,
+        client: globalThis.POCHI_CLIENT,
         useCase: "compact-task",
-      },
+      } satisfies PochiProviderOptions,
     },
     model,
     prompt: await convertToModelMessages(

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -1,17 +1,22 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { formatters, getLogger, prompts } from "@getpochi/common";
+import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { convertToModelMessages, generateText } from "ai";
 import type { BlobStore } from "../../blob-store";
 import { makeDownloadFunction } from "../../store-blob";
 import type { Message } from "../../types";
 
 const logger = getLogger("compactTask");
+const PostCompactMaxFilesToRestore = 5;
+const PostCompactMaxCharsPerFile = 20_000;
+const PostCompactTotalCharBudget = 80_000;
 
 export async function compactTask({
   blobStore,
   taskId,
   model,
   messages,
+  recentFiles,
   abortSignal,
   inline,
 }: {
@@ -19,6 +24,7 @@ export async function compactTask({
   taskId: string;
   model: LanguageModelV3;
   messages: Message[];
+  recentFiles?: RecentFileState[];
   abortSignal?: AbortSignal;
   inline?: boolean;
 }): Promise<string | undefined> {
@@ -37,6 +43,7 @@ export async function compactTask({
         messages.slice(0, -1),
       ),
       messages.length - 1,
+      formatRecentFileContext(recentFiles),
     );
     if (inline) {
       lastMessage.parts.unshift({
@@ -93,4 +100,60 @@ async function createSummary(
   });
 
   return resp.text;
+}
+
+function formatRecentFileContext(
+  recentFiles: RecentFileState[] | undefined,
+): string | undefined {
+  const files = recentFiles?.slice(0, PostCompactMaxFilesToRestore) ?? [];
+  if (files.length === 0) {
+    return;
+  }
+
+  const parts: string[] = ["Recent files preserved after compaction:"];
+  let usedChars = 0;
+
+  for (const file of files) {
+    const content = file.content;
+    const remainingBudget = PostCompactTotalCharBudget - usedChars;
+    if (remainingBudget <= 0) {
+      break;
+    }
+
+    if (
+      file.isTruncated ||
+      content.length > PostCompactMaxCharsPerFile ||
+      content.length > remainingBudget
+    ) {
+      const reference = `File reference: ${file.path}${formatLineRange(file)} (content omitted because the file is too large or the read result was truncated)`;
+      usedChars += reference.length;
+      parts.push(reference);
+      continue;
+    }
+
+    usedChars += content.length;
+    parts.push(
+      [
+        `File: ${file.path}${formatLineRange(file)}`,
+        "```",
+        content,
+        "```",
+      ].join("\n"),
+    );
+  }
+
+  return parts.length > 1 ? parts.join("\n\n") : undefined;
+}
+
+function formatLineRange(file: RecentFileState): string {
+  if (file.startLine === undefined && file.endLine === undefined) {
+    return "";
+  }
+  if (file.startLine === undefined) {
+    return ` (through line ${file.endLine})`;
+  }
+  if (file.endLine === undefined) {
+    return ` (from line ${file.startLine})`;
+  }
+  return ` (lines ${file.startLine}-${file.endLine})`;
 }

--- a/packages/livekit/src/chat/llm/generate-task-title.ts
+++ b/packages/livekit/src/chat/llm/generate-task-title.ts
@@ -1,5 +1,10 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import { formatters, getLogger, prompts } from "@getpochi/common";
+import {
+  type PochiProviderOptions,
+  formatters,
+  getLogger,
+  prompts,
+} from "@getpochi/common";
 import { convertToModelMessages, generateText } from "ai";
 import type { BlobStore } from "../../blob-store";
 import { makeDownloadFunction } from "../../store-blob";
@@ -120,9 +125,9 @@ async function generateTitle(
     providerOptions: {
       pochi: {
         taskId,
-        version: globalThis.POCHI_CLIENT,
+        client: globalThis.POCHI_CLIENT,
         useCase: "generate-task-title",
-      },
+      } satisfies PochiProviderOptions,
     },
     model,
     prompt: await convertToModelMessages(

--- a/packages/livekit/src/chat/llm/repair-mermaid.ts
+++ b/packages/livekit/src/chat/llm/repair-mermaid.ts
@@ -1,5 +1,10 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import { formatters, getLogger, prompts } from "@getpochi/common";
+import {
+  type PochiProviderOptions,
+  formatters,
+  getLogger,
+  prompts,
+} from "@getpochi/common";
 import { convertToModelMessages, generateText } from "ai";
 import { events } from "../../livestore/default-schema";
 import type { LiveKitStore, Message } from "../../types";
@@ -172,9 +177,9 @@ async function generateFixedMermaid(
     providerOptions: {
       pochi: {
         taskId,
-        version: globalThis.POCHI_CLIENT,
+        client: globalThis.POCHI_CLIENT,
         useCase: "repair-mermaid",
-      },
+      } satisfies PochiProviderOptions,
     },
     model,
     prompt: await convertToModelMessages(

--- a/packages/livekit/src/chat/llm/repair-tool-call.ts
+++ b/packages/livekit/src/chat/llm/repair-tool-call.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { jsonSchema } from "@ai-sdk/provider-utils";
+import type { PochiProviderOptions } from "@getpochi/common";
 import {
   NoSuchToolError,
   Output,
@@ -26,9 +27,9 @@ export const makeRepairToolCall: (
       providerOptions: {
         pochi: {
           taskId,
-          version: globalThis.POCHI_CLIENT,
+          client: globalThis.POCHI_CLIENT,
           useCase: "repair-tool-call",
-        },
+        } satisfies PochiProviderOptions,
         anthropic: {
           thinking: { type: "disabled" },
         },

--- a/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
@@ -4,6 +4,7 @@ import type {
   LanguageModelV3StreamPart,
 } from "@ai-sdk/provider";
 import { safeParseJSON } from "@ai-sdk/provider-utils";
+import type { PochiProviderOptions } from "@getpochi/common";
 import { attemptCompletionSchema } from "@getpochi/tools";
 import { InvalidToolInputError, Output, generateText } from "ai";
 import z from "zod/v4";
@@ -99,9 +100,9 @@ async function ensureOutputSchema(
       providerOptions: {
         pochi: {
           taskId,
-          version: globalThis.POCHI_CLIENT,
+          client: globalThis.POCHI_CLIENT,
           useCase: "output-schema",
-        },
+        } satisfies PochiProviderOptions,
         anthropic: {
           thinking: { type: "disabled" },
         },

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -24,6 +24,8 @@ export interface IFileState {
   endLine: number | undefined;
   /** True for entries created by write/edit tools; absent or false for read entries */
   fromWrite?: boolean;
+  /** True when the readFile result sent to the model was truncated */
+  isTruncated?: boolean;
 }
 
 /**

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -151,9 +151,8 @@ function Chat({ user, uid, info }: ChatProps) {
     isSubTask,
     customAgent,
     abortSignal: chatAbortController.current.signal,
-    onCompact: () => {
-      vscodeHost.clearFileStateCache(uid);
-    },
+    onCompact: () => vscodeHost.clearFileStateCache(uid),
+    getRecentFilesForCompact: () => vscodeHost.readRecentFilesForCompact(uid),
     sendAutomaticallyWhen: (x) => {
       if (chatAbortController.current.signal.aborted) {
         return false;

--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -92,9 +92,7 @@ export function useLiveSubTask(
     getters,
     isSubTask: true,
     customAgent,
-    onCompact: () => {
-      vscodeHost.clearFileStateCache(uid);
-    },
+    onCompact: () => vscodeHost.clearFileStateCache(uid),
     sendAutomaticallyWhen: (x) => {
       const streamingResult = ensureNewTaskStreamingResult(
         lifecycle.streamingResult,

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -111,6 +111,7 @@ function createVSCodeHost(): VSCodeHostApi {
         "readPochiTabs",
         "closePochiTabs",
         "clearFileStateCache",
+        "readRecentFilesForCompact",
         "queryGithubIssues",
         "readGitBranches",
         "readReviews",

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -349,6 +349,10 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     this.fileStateCacheRegistry.clear(taskId);
   };
 
+  readRecentFilesForCompact = async (taskId: string) => {
+    return this.fileStateCacheRegistry.getRecentFiles(taskId);
+  };
+
   deleteFileStateCache(taskId: string): void {
     this.fileStateCacheRegistry.delete(taskId);
   }

--- a/packages/vscode/src/lib/file-state-cache-registry.ts
+++ b/packages/vscode/src/lib/file-state-cache-registry.ts
@@ -1,4 +1,7 @@
-import { FileStateCache } from "@getpochi/common/tool-utils";
+import {
+  FileStateCache,
+  type RecentFileState,
+} from "@getpochi/common/tool-utils";
 import { injectable, singleton } from "tsyringe";
 import type * as vscode from "vscode";
 
@@ -18,6 +21,10 @@ export class FileStateCacheRegistry implements vscode.Disposable {
 
   clear(taskId: string): void {
     this.caches.get(taskId)?.clear();
+  }
+
+  getRecentFiles(taskId: string): RecentFileState[] {
+    return this.caches.get(taskId)?.getRecentFiles() ?? [];
   }
 
   delete(taskId: string): void {

--- a/packages/vscode/src/tools/read-file.ts
+++ b/packages/vscode/src/tools/read-file.ts
@@ -64,7 +64,11 @@ export const readFile: ToolFunctionType<ClientTools["readFile"]> = async (
         addLineNumbers,
       });
 
-      return { result, fileCacheContent: fileContent };
+      return {
+        result,
+        fileCacheContent: result.content,
+        fileCacheIsTruncated: result.isTruncated,
+      };
     },
   });
 

--- a/packages/vscode/src/tools/read-file.ts
+++ b/packages/vscode/src/tools/read-file.ts
@@ -1,7 +1,7 @@
 import { getVscodeFileMtime } from "@/lib/fs";
 import { getLogger } from "@/lib/logger";
 import {
-  FILE_UNCHANGED_STUB,
+  FileUnchangedStub,
   isPlainText,
   isVirtualPath,
   readMediaFile,
@@ -73,8 +73,8 @@ export const readFile: ToolFunctionType<ClientTools["readFile"]> = async (
   });
 
   if (cacheResult.deduplicated) {
-    logger.debug(`readFile: returning FILE_UNCHANGED_STUB for "${path}"`);
-    return { content: FILE_UNCHANGED_STUB, isTruncated: false };
+    logger.debug(`readFile: returning FileUnchangedStub for "${path}"`);
+    return { content: FileUnchangedStub, isTruncated: false };
   }
 
   logger.debug(`readFile: returning fresh content for "${path}"`);


### PR DESCRIPTION
## Summary
- Expose `getRecentFiles()` on `FileStateCache` and a new `readRecentFilesForCompact` VSCode host API so the webview can fetch recently-read files by task ID.
- Thread a `getRecentFilesForCompact` hook through `LiveChatKit` into `compactTask`, appending a bounded snapshot of recent file contents to the inline compact block before the file state cache is cleared.
- Large or truncated reads are replaced with lightweight file references to stay within a total char budget, preserving model visibility without blowing up the prompt.

## Test plan
- [ ] `bun run test` in `packages/common` to cover `file-state-cache` additions
- [ ] Manual: trigger compaction in the VSCode extension and confirm recent file contents (or references) appear in the compact block
- [ ] Manual: verify `onCompact` still clears the file state cache after compaction completes

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fc9c3d95918941cf934155db975b9008)