### PR TITLE
feat(vscode-webui): move attachment preview inside chat input form

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -309,13 +309,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           />
         </div>
       )}
-      {files.length > 0 && (
-        <AttachmentPreviewList
-          files={files}
-          onRemove={removeFile}
-          isUploading={isUploadingAttachments}
-        />
-      )}
       <ChatInputForm
         input={input}
         setInput={setInput}
@@ -340,7 +333,17 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             todos.length > 0 ||
             useTaskChangedFilesHelpers.visibleChangedFiles.length > 0,
         })}
-      />
+      >
+        {files.length > 0 && (
+          <div className="px-3">
+            <AttachmentPreviewList
+              files={files}
+              onRemove={removeFile}
+              isUploading={isUploadingAttachments}
+            />
+          </div>
+        )}
+      </ChatInputForm>
 
       {/* Hidden file input for image uploads */}
       <input


### PR DESCRIPTION
## Summary

- Moves `AttachmentPreviewList` from above `ChatInputForm` to inside it as a child element
- Wraps it in a `px-3` div for consistent horizontal padding
- Attachment thumbnails now render within the input area (below the `+ Add Context` button and above the text input)

## Screenshot

![Attachment preview inside chat input](https://pochi-file-uploads.getpochi.com/blob-1776927217990.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260423%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260423T065338Z&X-Amz-Expires=561600&X-Amz-Signature=de5515f9168f3c5dc58b3973dd6c49baa1f3fa0ee18682b4dc649e7d411cf8c4&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan

- [ ] Attach an image/file via `+ Add Context` and verify the thumbnail appears inside the input area
- [ ] Verify the `×` remove button on thumbnails still works
- [ ] Verify upload loading state still displays correctly

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-4f158a96936442d1957801e422aa7ab4) | [Task](https://app.getpochi.com/share/p-4f158a96936442d1957801e422aa7ab4)