### PR TITLE
fix: pass abort reason to abort controller

### DIFF
--- a/packages/tools/src/utils/tool-call-queue.ts
+++ b/packages/tools/src/utils/tool-call-queue.ts
@@ -72,7 +72,7 @@ export class ToolCallQueue {
   }
 
   async abort(reason: BatchedToolCallCancelReason): Promise<void> {
-    this.abortController?.abort();
+    this.abortController?.abort(reason);
     await this.cancelItems(this.queue, reason);
     this.clearQueue();
   }

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -287,7 +287,7 @@ export class ManagedToolCallLifeCycle
       this.state.type === "execute" ||
       this.state.type === "execute:streaming"
     ) {
-      this.state.abort();
+      this.state.abort(reason);
       this.transitTo(["execute", "execute:streaming"], {
         type: "complete",
         result,


### PR DESCRIPTION
## Summary
- Pass the `BatchedToolCallCancelReason` to the `abort` method of `abortController` and `this.state.abort`.
- This provides more context when a tool call is cancelled, which can be useful for logging or further logic.

## Test plan
- Manually verified that cancellations still work as expected and the reason is correctly passed down.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-6c097d74e3ca4dc48aed497889621e1a)