### PR TITLE
fix(common): roll back invalid tool calls on retry

### DIFF
--- a/packages/common/src/message-utils/__tests__/message-utils.test.ts
+++ b/packages/common/src/message-utils/__tests__/message-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseTitle, prepareLastMessageForRetry } from "..";
+import {
+  isAssistantMessageWithInvalidToolCalls,
+  parseTitle,
+  prepareLastMessageForRetry,
+} from "..";
 import type { UIMessage } from "ai";
 
 describe("message-utils", () => {
@@ -66,5 +70,121 @@ describe("message-utils", () => {
       const after = message?.parts.filter((part) => part.type === "step-start").length || 0;
       expect(after).toBe(1);
     })
-  })
-})
+
+    it("should roll back the last step when it contains an invalid tool call", () => {
+      const lastMessage: UIMessage = {
+        id: "broken-1",
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          {
+            type: "text",
+            text: "Reading the file.",
+            // biome-ignore lint/suspicious/noExplicitAny: test fixture
+          } as any,
+          {
+            type: "tool-executeCommand",
+            toolCallId: "call_ok",
+            state: "output-available",
+            input: { command: "ls" },
+            output: { output: "ok", isTruncated: false },
+            // biome-ignore lint/suspicious/noExplicitAny: test fixture
+          } as any,
+          { type: "step-start" },
+          {
+            type: "text",
+            text: "Now let me add the abort handling for the batch manager:",
+            // biome-ignore lint/suspicious/noExplicitAny: test fixture
+          } as any,
+          {
+            type: "tool-readFile",
+            toolCallId: "call_bad",
+            state: "output-error",
+            input: undefined,
+            rawInput:
+              '{"path": "src/foo.tsx", "startLine": 100, 145}',
+            errorText: "Error repairing tool call: Unexpected token ...",
+            // biome-ignore lint/suspicious/noExplicitAny: test fixture
+          } as any,
+        ],
+      };
+
+      const before =
+        lastMessage.parts.filter((p) => p.type === "step-start").length;
+      expect(before).toBe(2);
+      const message = prepareLastMessageForRetry(lastMessage);
+      const after =
+        message?.parts.filter((p) => p.type === "step-start").length || 0;
+      // The step containing the invalid tool call is sliced off.
+      expect(after).toBe(1);
+      // The healthy preceding tool call is preserved.
+      expect(
+        message?.parts.some(
+          (p) => "toolCallId" in p && p.toolCallId === "call_ok",
+        ),
+      ).toBe(true);
+      expect(
+        message?.parts.some(
+          (p) => "toolCallId" in p && p.toolCallId === "call_bad",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("isAssistantMessageWithInvalidToolCalls", () => {
+    it("returns true for output-error tool calls with malformed rawInput", () => {
+      const message: UIMessage = {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-readFile",
+            toolCallId: "call_bad",
+            state: "output-error",
+            input: undefined,
+            rawInput: '{"path": "x", "startLine": 1, 2}',
+            errorText: "bad",
+            // biome-ignore lint/suspicious/noExplicitAny: test fixture
+          } as any,
+        ],
+      };
+      expect(isAssistantMessageWithInvalidToolCalls(message)).toBe(true);
+    });
+
+    it("returns false for output-error tool calls with valid object input", () => {
+      const message: UIMessage = {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-readFile",
+            toolCallId: "call_ok_err",
+            state: "output-error",
+            input: { path: "x" },
+            errorText: "tool execution failed",
+            // biome-ignore lint/suspicious/noExplicitAny: test fixture
+          } as any,
+        ],
+      };
+      expect(isAssistantMessageWithInvalidToolCalls(message)).toBe(false);
+    });
+
+    it("returns false for healthy output-available tool calls", () => {
+      const message: UIMessage = {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-readFile",
+            toolCallId: "call_ok",
+            state: "output-available",
+            input: { path: "x" },
+            output: { content: "" },
+            // biome-ignore lint/suspicious/noExplicitAny: test fixture
+          } as any,
+        ],
+      };
+      expect(isAssistantMessageWithInvalidToolCalls(message)).toBe(false);
+    });
+  });
+});

--- a/packages/common/src/message-utils/assistant-message.ts
+++ b/packages/common/src/message-utils/assistant-message.ts
@@ -1,4 +1,5 @@
 import {
+  type ToolUIPart,
   type UIMessage,
   isStaticToolUIPart,
   lastAssistantMessageIsCompleteWithToolCalls,
@@ -32,6 +33,34 @@ export function isAssistantMessageWithPartialToolCalls(lastMessage: UIMessage) {
   );
 }
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * A tool call is "invalid" when it ended in `output-error` state and neither
+ * `input` nor `rawInput` is a plain object. This typically happens when the
+ * model emitted malformed JSON tool arguments and the repair pass also failed:
+ * the AI SDK then leaves `input: undefined` and `rawInput` as the raw
+ * (non-JSON) string. Sending such a part to providers like Anthropic causes
+ * `tool_use.input: Input should be a valid dictionary` and the conversation
+ * gets stuck — every retry replays the same broken tool_use.
+ */
+function isInvalidToolCallPart(part: UIMessage["parts"][number]): boolean {
+  if (!isStaticToolUIPart(part)) return false;
+  if (part.state !== "output-error") return false;
+  if (isPlainObject(part.input)) return false;
+  const rawInput = (part as ToolUIPart & { rawInput?: unknown }).rawInput;
+  return !isPlainObject(rawInput);
+}
+
+export function isAssistantMessageWithInvalidToolCalls(
+  message: UIMessage,
+): boolean {
+  return (
+    message.role === "assistant" && message.parts.some(isInvalidToolCallPart)
+  );
+}
+
 export function prepareLastMessageForRetry<T extends UIMessage>(
   lastMessage: T,
 ): T | null {
@@ -41,12 +70,20 @@ export function prepareLastMessageForRetry<T extends UIMessage>(
   };
 
   do {
-    if (lastAssistantMessageIsCompleteWithToolCalls({ messages: [message] })) {
-      return message;
-    }
+    // Roll back the last step if it contains an invalid tool call. The AI SDK
+    // considers `output-error` parts "complete", so we have to detect the
+    // malformed-input case explicitly to avoid an infinite retry loop where
+    // the same broken `tool_use` is sent to the provider every time.
+    if (!isAssistantMessageWithInvalidToolCalls(message)) {
+      if (
+        lastAssistantMessageIsCompleteWithToolCalls({ messages: [message] })
+      ) {
+        return message;
+      }
 
-    if (isAssistantMessageWithNoToolCalls(message)) {
-      return message;
+      if (isAssistantMessageWithNoToolCalls(message)) {
+        return message;
+      }
     }
 
     const lastStepStartIndex = message.parts.findLastIndex(

--- a/packages/common/src/message-utils/index.ts
+++ b/packages/common/src/message-utils/index.ts
@@ -3,6 +3,7 @@ export {
   isAssistantMessageWithNoToolCalls,
   isAssistantMessageWithEmptyParts,
   isAssistantMessageWithPartialToolCalls,
+  isAssistantMessageWithInvalidToolCalls,
   prepareLastMessageForRetry,
   fixCodeGenerationOutput,
 } from "./assistant-message";

--- a/packages/vscode-webui/src/features/retry/hooks/use-ready-for-retry-error.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-ready-for-retry-error.ts
@@ -1,5 +1,6 @@
 import {
   isAssistantMessageWithEmptyParts,
+  isAssistantMessageWithInvalidToolCalls,
   isAssistantMessageWithNoToolCalls,
   isAssistantMessageWithPartialToolCalls,
 } from "@getpochi/common/message-utils";
@@ -38,6 +39,15 @@ export function getReadyForRetryError(messages: Message[]) {
   }
 
   if (isAssistantMessageWithPartialToolCalls(lastMessage)) {
+    return new ReadyForRetryError();
+  }
+
+  // Detect tool calls that ended in `output-error` with malformed input.
+  // These would otherwise be treated as "complete" by the AI SDK and replayed
+  // verbatim on every retry, causing the provider to keep rejecting the
+  // request. Returning a retry error here lets `prepareLastMessageForRetry`
+  // roll back the broken step before the next send.
+  if (isAssistantMessageWithInvalidToolCalls(lastMessage)) {
     return new ReadyForRetryError();
   }
 


### PR DESCRIPTION
## Summary
- When a model emits malformed JSON tool arguments and the AI SDK's repair pass also fails, the tool part ends up in `output-error` state with `input: undefined` and a non-dict `rawInput`. `convertToModelMessages` then falls back to that raw string, so providers like Anthropic reject the request with `messages.N.content.M.tool_use.input: Input should be a valid dictionary` — and every retry replays the same broken `tool_use`, leaving the conversation permanently stuck.
- Added `isAssistantMessageWithInvalidToolCalls` and taught `prepareLastMessageForRetry` to roll back the last step when it contains such a tool part. The AI SDK's `lastAssistantMessageIsCompleteWithToolCalls` treats `output-error` as "complete", so this case has to be detected explicitly.
- Surfaced the same condition from `getReadyForRetryError` (placed before the `tool-calls` branch) so the existing **Continue** button + auto-retry kicks in. The CLI's `task-runner` already calls `prepareLastMessageForRetry`, so it inherits the fix automatically.

## Test plan
- [x] `bun run test src/message-utils src/base/__tests__/formatters.test.ts` — 4 files, 40 tests passed (3 new tests for `isAssistantMessageWithInvalidToolCalls` + a new `prepareLastMessageForRetry` rollback test using a fixture that mirrors the failing `readFile` tool call from the report).
- [x] `bun tsc --noEmit` clean for `packages/common`, `packages/vscode-webui`, `packages/cli`.
- [x] `bun fix` no changes.
- [ ] Manual: trigger a malformed tool input (or load the affected task) and verify "Continue" no longer loops on the Anthropic 400.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8afea8c7a68a42a1b7b8fe0d5b89d7f4)