### PR TITLE
fix(livekit): harden tool-call auto-repair prompt

### DIFF
--- a/packages/livekit/src/chat/llm/repair-tool-call.ts
+++ b/packages/livekit/src/chat/llm/repair-tool-call.ts
@@ -6,8 +6,16 @@ import {
   Output,
   type Tool,
   type ToolCallRepairFunction,
+  extractJsonMiddleware,
   generateText,
+  wrapLanguageModel,
 } from "ai";
+
+const RepairSystemPrompt = [
+  "You are a JSON repair assistant.",
+  "Respond with ONLY a JSON object that matches the provided schema.",
+  "Do not include prose, explanations, comments, markdown, or code fences.",
+].join(" ");
 
 export const makeRepairToolCall: (
   taskId: string,
@@ -19,9 +27,17 @@ export const makeRepairToolCall: (
       return null; // do not attempt to fix invalid tool names
     }
 
-    const toolSchema = jsonSchema(
-      await inputSchema({ toolName: toolCall.toolName }),
-    );
+    const schema = await inputSchema({ toolName: toolCall.toolName });
+    const toolSchema = jsonSchema(schema);
+
+    // Wrap the model so that markdown code fences (```json ... ```) emitted by
+    // the repair model are stripped before JSON parsing. Without this, even a
+    // well-formed payload wrapped in fences fails with
+    // `Unexpected token '\`'` and the conversation gets stuck on retries.
+    const repairModel = wrapLanguageModel({
+      model,
+      middleware: [extractJsonMiddleware()],
+    });
 
     const { output: repairedArgs } = await generateText({
       providerOptions: {
@@ -34,16 +50,22 @@ export const makeRepairToolCall: (
           thinking: { type: "disabled" },
         },
       },
-      model,
+      model: repairModel,
       output: Output.object({
         schema: toolSchema,
       }),
+      system: RepairSystemPrompt,
       prompt: [
-        `The model tried to call the tool "${toolCall.toolName}" with the following inputs:`,
-        JSON.stringify(toolCall.input),
-        "The tool accepts the following schema:",
-        JSON.stringify(await inputSchema({ toolName: toolCall.toolName })),
-        "Please fix the inputs.",
+        `The model tried to call the tool "${toolCall.toolName}" with the following raw arguments:`,
+        // `toolCall.input` is already a stringified JSON payload (per
+        // LanguageModelV3ToolCall). Passing it through as-is avoids the
+        // double-stringification (`"\"…\""`) that previously confused the
+        // model.
+        toolCall.input,
+        "The tool accepts the following JSON schema:",
+        JSON.stringify(schema),
+        `Parse error: ${error.message}`,
+        "Return the corrected arguments as a single JSON object matching the schema.",
       ].join("\n"),
     });
 


### PR DESCRIPTION
## Summary
The `experimental_repairToolCall` pass was reliably failing with
```
Error repairing tool call: Unexpected token '`', "`temperatu"... is not valid JSON
```
when the repair model wrapped its response in markdown code fences (```` ```json … ``` ````) or prefixed it with prose. Once the repair fails, the broken `tool_use` is sent to the provider and Anthropic rejects the whole request. (Companion to #1491, which makes the retry pipeline roll back such broken tool calls.)

This PR makes the repair itself more robust:

- **Strip markdown fences before parsing.** Wrap the repair model with `extractJsonMiddleware` so ```` ```json … ``` ```` and similar wrappers are removed before `JSON.parse`.
- **Forbid prose / markdown explicitly.** New `system` prompt: *"Respond with ONLY a JSON object that matches the provided schema. Do not include prose, explanations, comments, markdown, or code fences."*
- **Stop double-stringifying `toolCall.input`.** Per `@ai-sdk/provider`:
  ```ts
  type LanguageModelV3ToolCall = { …; input: string /* stringified JSON */ }
  ```
  The previous code did `JSON.stringify(toolCall.input)`, turning `{"path":"…",…}` into `"{\"path\":\"…\",…}"`, which encouraged the model to "explain" rather than emit JSON. We now pass `toolCall.input` through as-is.
- **Surface the parse error** to the model so it has concrete context for the fix.

## Test plan
- [x] `bun run test` (livekit) — 4 files, 17 tests passed.
- [x] `bun tsc --noEmit` — clean.
- [x] `bun fix` — no changes.
- [ ] Manual: provoke a malformed-args response and confirm repair succeeds when the model emits ```` ```json … ``` ````.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8afea8c7a68a42a1b7b8fe0d5b89d7f4)