### PR TITLE
chore: sync bun.lock for @livestore/common-cf patch entry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -480,6 +480,7 @@
     "ai@6.0.146": "patches/ai@6.0.146.patch",
     "better-auth@1.2.9": "patches/better-auth@1.2.9.patch",
     "streamdown@1.6.10": "patches/streamdown@1.6.10.patch",
+    "@livestore/common-cf@0.4.0-dev.22": "patches/@livestore%2Fcommon-cf@0.4.0-dev.22.patch",
     "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch",
     "tslog@4.9.3": "patches/tslog@4.9.3.patch",
     "@ai-sdk/google-vertex@4.0.102": "patches/@ai-sdk%2Fgoogle-vertex@4.0.102.patch",


### PR DESCRIPTION
## Summary
- Adds the `@livestore/common-cf@0.4.0-dev.22` patch entry to `bun.lock` so the lockfile matches the `patchedDependencies` declared in `package.json`.

## Test plan
- [ ] `bun install` runs cleanly with no further lockfile changes.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d3dfb4501cf94e8c810cb4863e54a1bb)