### PR TITLE
chore: bump version to 0.45.0-dev and add minimatch dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -198,6 +198,7 @@
       "dependencies": {
         "ai": "catalog:",
         "json-schema": "^0.4.0",
+        "minimatch": "catalog:",
         "shell-quote": "^1.8.3",
         "zod": "catalog:",
       },
@@ -481,7 +482,6 @@
     "better-auth@1.2.9": "patches/better-auth@1.2.9.patch",
     "@ai-sdk/provider-utils@4.0.22": "patches/@ai-sdk%2Fprovider-utils@4.0.22.patch",
     "streamdown@1.6.10": "patches/streamdown@1.6.10.patch",
-    "@livestore/common-cf@0.4.0-dev.22": "patches/@livestore%2Fcommon-cf@0.4.0-dev.22.patch",
     "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch",
     "@livestore/common-cf@0.4.0-dev.22": "patches/@livestore%2Fcommon-cf@0.4.0-dev.22.patch",
     "tslog@4.9.3": "patches/tslog@4.9.3.patch",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.43.0-dev",
+  "version": "0.45.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump vscode package version from 0.43.0-dev to 0.45.0-dev
- Add minimatch as a dependency to the tools package
- Clean up duplicate @livestore/common-cf patch entry in bun.lock

## Test plan
- [ ] Verify version bump in packages/vscode/package.json
- [ ] Verify minimatch dependency is properly added
- [ ] Verify bun.lock is clean without duplicate entries

🤖 Generated with [Pochi](https://getpochi.com) | [Task](<Share URL>)