### PR TITLE
feat(tools): implement domain-based tool policies for webFetch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -198,6 +198,7 @@
       "dependencies": {
         "ai": "catalog:",
         "json-schema": "^0.4.0",
+        "minimatch": "catalog:",
         "shell-quote": "^1.8.3",
         "zod": "catalog:",
       },
@@ -481,7 +482,6 @@
     "better-auth@1.2.9": "patches/better-auth@1.2.9.patch",
     "@ai-sdk/provider-utils@4.0.22": "patches/@ai-sdk%2Fprovider-utils@4.0.22.patch",
     "streamdown@1.6.10": "patches/streamdown@1.6.10.patch",
-    "@livestore/common-cf@0.4.0-dev.22": "patches/@livestore%2Fcommon-cf@0.4.0-dev.22.patch",
     "jsonc-parser@3.3.1": "patches/jsonc-parser@3.3.1.patch",
     "@livestore/common-cf@0.4.0-dev.22": "patches/@livestore%2Fcommon-cf@0.4.0-dev.22.patch",
     "tslog@4.9.3": "patches/tslog@4.9.3.patch",

--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -233,3 +233,70 @@ describe("path pattern policies", () => {
     ).toThrow();
   });
 });
+
+describe("webFetch domain policies", () => {
+  it("should compile domain pattern rules for webFetch", () => {
+    const policies = compileToolPolicies([
+      "webFetch(domain:example.com)",
+      "webFetch(domain:*.tabbyml.com)",
+    ]);
+
+    expect(policies?.webFetch).toEqual({
+      kind: "domain-pattern",
+      patterns: ["example.com", "*.tabbyml.com"],
+    });
+  });
+
+  it("should reject invalid webFetch rule declarations", () => {
+    expect(() => compileToolPolicies(["webFetch(example.com)"])).toThrow(
+      'Invalid webFetch rule "example.com". Use webFetch(domain:example.com).',
+    );
+  });
+
+  it("should allow webFetch URLs matching configured domain rules", () => {
+    const policies = compileToolPolicies([
+      "webFetch(domain:example.com)",
+      "webFetch(domain:*.tabbyml.com)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "webFetch",
+        {
+          url: "https://example.com/docs",
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      validateToolPolicy(
+        "webFetch",
+        {
+          url: "https://api.tabbyml.com/v1/health",
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+  });
+
+  it("should reject webFetch URLs outside configured domain rules", () => {
+    const policies = compileToolPolicies([
+      "webFetch(domain:example.com)",
+      "webFetch(domain:*.tabbyml.com)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "webFetch",
+        {
+          url: "https://google.com",
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow("URL domain is not allowed by the configured webFetch domain rules.");
+  });
+});

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -45,12 +45,20 @@ export interface IFileStateCache {
 export type CompiledToolPolicy =
   | { kind: "command-pattern"; patterns: string[] }
   | {
+      kind: "domain-pattern";
+      patterns: string[];
+    }
+  | {
       kind: "path-pattern";
       patterns: string[];
     };
 
 export interface CompiledToolPolicies {
   executeCommand?: { kind: "command-pattern"; patterns: string[] };
+  webFetch?: {
+    kind: "domain-pattern";
+    patterns: string[];
+  };
   readFile?: {
     kind: "path-pattern";
     patterns: string[];

--- a/packages/tools/src/utils/index.ts
+++ b/packages/tools/src/utils/index.ts
@@ -144,6 +144,11 @@ export function compileToolPolicies(
     };
   }
 
+  const webFetchPolicy = compileWebFetchDomainPolicy(tools);
+  if (webFetchPolicy) {
+    policies.webFetch = webFetchPolicy;
+  }
+
   for (const toolName of [
     "readFile",
     "writeToFile",
@@ -157,6 +162,45 @@ export function compileToolPolicies(
   }
 
   return Object.keys(policies).length > 0 ? policies : undefined;
+}
+
+function compileWebFetchDomainPolicy(tools: ToolSpecInput[] | undefined) {
+  if (!tools?.some((tool) => parseToolSpec(tool).name === "webFetch")) {
+    return undefined;
+  }
+
+  const rules = getToolRules(tools, "webFetch");
+  if (!rules) {
+    return undefined;
+  }
+
+  return {
+    kind: "domain-pattern",
+    patterns: rules.map(parseWebFetchDomainRule),
+  } as const;
+}
+
+function parseWebFetchDomainRule(rule: string): string {
+  const trimmedRule = rule.trim();
+  const domainPrefix = "domain:";
+
+  if (!trimmedRule.toLowerCase().startsWith(domainPrefix)) {
+    throw new Error(
+      `Invalid webFetch rule "${rule}". Use webFetch(domain:example.com).`,
+    );
+  }
+
+  const domainPattern = normalizeDomainPattern(
+    trimmedRule.slice(domainPrefix.length),
+  );
+
+  if (!domainPattern) {
+    throw new Error(
+      `Invalid webFetch rule "${rule}". Use webFetch(domain:example.com).`,
+    );
+  }
+
+  return domainPattern;
 }
 
 function compilePathToolPolicy(
@@ -293,6 +337,20 @@ export function validateToolPolicy(
     return;
   }
 
+  if (toolName === "webFetch") {
+    const rawUrl =
+      typeof input === "object" && input !== null && "url" in input
+        ? (input as { url?: unknown }).url
+        : undefined;
+
+    if (typeof rawUrl !== "string") {
+      return;
+    }
+
+    validateDomainPatternPolicy(rawUrl, policies?.webFetch);
+    return;
+  }
+
   if (
     toolName === "readFile" ||
     toolName === "writeToFile" ||
@@ -341,6 +399,39 @@ function validatePathPatternPolicy(
   }
 }
 
+function validateDomainPatternPolicy(
+  inputUrl: string,
+  policy:
+    | {
+        kind: "domain-pattern";
+        patterns: string[];
+      }
+    | undefined,
+): void {
+  if (!policy) {
+    return;
+  }
+
+  let hostname: string;
+  try {
+    hostname = normalizeDomainPattern(new URL(inputUrl).hostname);
+  } catch {
+    return;
+  }
+
+  const matched = policy.patterns.some((pattern) =>
+    minimatch(hostname, normalizeDomainPattern(pattern), {
+      nocase: true,
+    }),
+  );
+
+  if (!matched) {
+    throw new Error(
+      `URL domain is not allowed by the configured webFetch domain rules. Allowed domain patterns: ${policy.patterns.join(", ")}`,
+    );
+  }
+}
+
 function normalizePathForRuleMatch(
   inputPath: string,
   options: { cwd: string },
@@ -371,4 +462,8 @@ function normalizeWorkspacePathForRuleMatch(
 
 function normalizePattern(input: string): string {
   return input.replace(/\\/g, "/");
+}
+
+function normalizeDomainPattern(input: string): string {
+  return input.trim().replace(/\.$/, "").toLowerCase();
 }


### PR DESCRIPTION
## Summary
- Introduces `domain-pattern` policy kind for the `webFetch` tool.
- Allows restricting `webFetch` requests to specific domains or glob patterns (e.g., `webFetch(domain:*.example.com)`).
- Added validation logic and comprehensive tests for the new policy type.

## Screenshot
<img width="1360" height="552" alt="image" src="https://github.com/user-attachments/assets/77a4f6f4-8e71-4364-814b-a6a45747b9d7" />


## Test plan
- Run `bun run test` in `packages/tools` to verify the new tests in `packages/tools/src/__test__/utils.test.ts`.
- Verified that invalid rules throw errors and valid rules correctly allow/reject URLs.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5341d11fab254b10bd3701e795107347)