### PR TITLE
feat(tools): allow batch execution for newTask tool

### DIFF
--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -591,9 +591,7 @@ export class TaskRunner {
       return "next" as const;
     }
 
-    const queue = new ToolCallQueue({
-      getCustomAgents: () => this.toolCallOptions.customAgents,
-    });
+    const queue = new ToolCallQueue();
 
     for (const toolCall of toolCalls) {
       queue.enqueue({

--- a/packages/tools/src/__test__/batch-utils.test.ts
+++ b/packages/tools/src/__test__/batch-utils.test.ts
@@ -36,9 +36,9 @@ describe("isSafeToBatchToolCall", () => {
     expect(isSafeToBatchToolCall("newTask", { runAsync: true })).toBe(true);
   });
 
-  it("returns false for newTask without runAsync", () => {
+  it("returns true for newTask without runAsync", () => {
     expect(isSafeToBatchToolCall("newTask", { agentType: "default" })).toBe(
-      false,
+      true,
     );
   });
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -72,7 +72,6 @@ export {
   partitionToolCalls,
 } from "./utils/batch-utils";
 export { ToolCallQueue } from "./utils/tool-call-queue";
-export type { ToolCallQueueOptions } from "./utils/tool-call-queue";
 export {
   checkReadOnlyConstraints,
   isReadonlyToolCall,

--- a/packages/tools/src/utils/batch-utils.ts
+++ b/packages/tools/src/utils/batch-utils.ts
@@ -1,5 +1,4 @@
 import { MaxToolCallConcurrency } from "../constants";
-import type { CustomAgent } from "../new-task";
 import { isReadonlyToolCall } from "./readonly-constraints-validation";
 
 export type BatchedToolCallCancelReason =
@@ -52,14 +51,6 @@ export class BatchExecutionError extends Error {
   }
 }
 
-function isSafeToBatchNewTask(
-  input: Record<string, unknown>,
-  customAgents: CustomAgent[] | undefined,
-): boolean {
-  if (input.runAsync === true) return true;
-  return isReadonlyToolCall("newTask", input, customAgents);
-}
-
 /**
  * Returns `true` if the tool call can share a concurrent microbatch without
  * becoming a barrier for subsequent batches.
@@ -67,22 +58,16 @@ function isSafeToBatchNewTask(
  * This is intentionally broader than `isReadonlyToolCall`:
  * - read-only tool calls are safe to batch;
  * - fire-and-forget tools like `startBackgroundJob` are also safe to batch;
- * - `newTask({ runAsync: true })` is safe to batch because completion only
- *   acknowledges task creation, not the background work itself.
+ * - `newTask` is safe to batch because completion acknowledges task creation,
+ *   while spawned work executes out-of-band.
  */
 export function isSafeToBatchToolCall(
   toolName: string,
   input: unknown,
-  customAgents?: CustomAgent[],
 ): boolean {
-  if (isReadonlyToolCall(toolName, input, customAgents)) return true;
+  if (toolName === "newTask") return true;
 
-  if (toolName === "newTask") {
-    return isSafeToBatchNewTask(
-      (input as Record<string, unknown>) ?? {},
-      customAgents,
-    );
-  }
+  if (isReadonlyToolCall(toolName, input)) return true;
 
   if (toolName === "startBackgroundJob") return true;
 
@@ -97,19 +82,12 @@ export function isSafeToBatchToolCall(
  *
  * Batches execute sequentially; batch N+1 only starts after N fully completes.
  */
-export function partitionToolCalls(
-  items: BatchedToolCall[],
-  customAgents?: CustomAgent[],
-): ToolCallBatch[] {
+export function partitionToolCalls(items: BatchedToolCall[]): ToolCallBatch[] {
   const batches: ToolCallBatch[] = [];
   let currentConcurrentBatch: BatchedToolCall[] = [];
 
   for (const item of items) {
-    const isConcurrencySafe = isSafeToBatchToolCall(
-      item.toolName,
-      item.input,
-      customAgents,
-    );
+    const isConcurrencySafe = isSafeToBatchToolCall(item.toolName, item.input);
 
     if (isConcurrencySafe) {
       currentConcurrentBatch.push(item);
@@ -173,14 +151,12 @@ export async function runConcurrentBatch(
  */
 export async function executeToolCalls({
   toolCalls,
-  customAgents,
   abortSignal,
 }: {
   toolCalls: BatchedToolCall[];
-  customAgents?: CustomAgent[];
   abortSignal?: AbortSignal;
 }): Promise<void> {
-  const batches = partitionToolCalls(toolCalls, customAgents);
+  const batches = partitionToolCalls(toolCalls);
 
   for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
     const batch = batches[batchIndex];

--- a/packages/tools/src/utils/tool-call-queue.ts
+++ b/packages/tools/src/utils/tool-call-queue.ts
@@ -1,4 +1,3 @@
-import type { CustomAgent } from "../new-task";
 import {
   BatchExecutionError,
   BatchExecutionErrorMessages,
@@ -6,11 +5,6 @@ import {
   type BatchedToolCallCancelReason,
   executeToolCalls,
 } from "./batch-utils";
-
-export type ToolCallQueueOptions = {
-  getCustomAgents?: () => CustomAgent[] | undefined;
-  concurrencyLimit?: number;
-};
 
 /**
  * Queue for executing BatchedToolCalls sequentially (with internal concurrency
@@ -21,8 +15,6 @@ export class ToolCallQueue {
   private queue: BatchedToolCall[] = [];
   private processing = false;
   private abortController: AbortController | null = null;
-
-  constructor(private readonly options: ToolCallQueueOptions = {}) {}
 
   enqueue(item: BatchedToolCall) {
     const removeFromQueue = () => {
@@ -84,7 +76,6 @@ export class ToolCallQueue {
       try {
         await executeToolCalls({
           toolCalls: queue,
-          customAgents: this.options.getCustomAgents?.(),
           abortSignal: this.abortController?.signal,
         });
       } catch (error) {

--- a/packages/vscode-webui/src/features/chat/lib/batch-execute-manager.ts
+++ b/packages/vscode-webui/src/features/chat/lib/batch-execute-manager.ts
@@ -1,10 +1,7 @@
 import {
   type BatchedToolCall,
-  type CustomAgent,
-  MaxToolCallConcurrency,
   type ToolCallCancelReason,
   ToolCallQueue,
-  type ToolCallQueueOptions,
 } from "@getpochi/tools";
 
 /**
@@ -20,14 +17,6 @@ import {
  */
 export class BatchExecuteManager {
   private readonly queues = new Map<string, ToolCallQueue>();
-  private readonly getDefaultCustomAgents: () => CustomAgent[] | undefined;
-
-  constructor(
-    customAgents?: CustomAgent[] | (() => CustomAgent[] | undefined),
-  ) {
-    this.getDefaultCustomAgents =
-      typeof customAgents === "function" ? customAgents : () => customAgents;
-  }
 
   /** Enqueue a tool call into the queue for `taskId`. */
   enqueue(taskId: string, item: BatchedToolCall) {
@@ -45,17 +34,10 @@ export class BatchExecuteManager {
     this.queues.get(taskId)?.abort(reason);
   }
 
-  private getOrCreateQueue(
-    taskId: string,
-    options?: ToolCallQueueOptions,
-  ): ToolCallQueue {
+  private getOrCreateQueue(taskId: string): ToolCallQueue {
     let queue = this.queues.get(taskId);
     if (!queue) {
-      queue = new ToolCallQueue({
-        getCustomAgents:
-          options?.getCustomAgents ?? this.getDefaultCustomAgents,
-        concurrencyLimit: options?.concurrencyLimit ?? MaxToolCallConcurrency,
-      });
+      queue = new ToolCallQueue();
       this.queues.set(taskId, queue);
     }
     return queue;

--- a/packages/vscode-webui/src/features/chat/lib/chat-state/chat.tsx
+++ b/packages/vscode-webui/src/features/chat/lib/chat-state/chat.tsx
@@ -1,5 +1,3 @@
-import { useCustomAgents } from "@/lib/hooks/use-custom-agents";
-import { useLatest } from "@/lib/hooks/use-latest";
 import { type ReactNode, useRef, useState } from "react";
 import { BatchExecuteManager } from "../batch-execute-manager";
 import { useToolCallLifeCycles } from "../use-tool-call-life-cycles";
@@ -17,11 +15,7 @@ export function ChatContextProvider({ children }: ChatContextProviderProps) {
   );
   const { executingToolCalls, getToolCallLifeCycle, completeToolCalls } =
     useToolCallLifeCycles(abortController.current.signal);
-  const { customAgents } = useCustomAgents(true);
-  const customAgentsRef = useLatest(customAgents);
-  const batchExecuteManager = useRef(
-    new BatchExecuteManager(() => customAgentsRef.current),
-  ).current;
+  const batchExecuteManager = useRef(new BatchExecuteManager()).current;
 
   const value: ChatState = {
     abortController,

--- a/packages/vscode-webui/src/features/chat/lib/chat-state/fixed-state.tsx
+++ b/packages/vscode-webui/src/features/chat/lib/chat-state/fixed-state.tsx
@@ -1,5 +1,3 @@
-import { useCustomAgents } from "@/lib/hooks/use-custom-agents";
-import { useLatest } from "@/lib/hooks/use-latest";
 import Emittery from "emittery";
 import {
   type ReactNode,
@@ -121,11 +119,7 @@ export function FixedStateChatContextProvider({
 
   const completeToolCalls: FixedStateToolCallLifeCycle[] = [];
 
-  const { customAgents } = useCustomAgents(true);
-  const customAgentsRef = useLatest(customAgents);
-  const batchExecuteManager = useRef(
-    new BatchExecuteManager(() => customAgentsRef.current),
-  ).current;
+  const batchExecuteManager = useRef(new BatchExecuteManager()).current;
 
   const value: ChatState = {
     autoApproveGuard,


### PR DESCRIPTION
## Summary
- Marks the `newTask` tool as safe for batch execution.
- Simplifies `ToolCallQueue` and related utilities by removing the `customAgents` dependency for batch safety checks.
- Cleans up unused `customAgents` references and imports in `vscode-webui`.

## Test plan
- Verified that `newTask` tool is now correctly identified as safe to batch in `isSafeToBatchToolCall`.
- Simplified the batch execution logic by removing unnecessary `customAgents` passing.
- Ensured all packages pass type checks (`turbo tsc`).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b195ae01485c4d149e65e52dc7e13b4d)