### PR TITLE
feat(tools): implement domain-based tool policies for webSearch

### DIFF
--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -300,3 +300,81 @@ describe("webFetch domain policies", () => {
     ).toThrow("URL domain is not allowed by the configured webFetch domain rules.");
   });
 });
+
+describe("webSearch domain policies", () => {
+  it("should compile domain pattern rules for webSearch", () => {
+    const policies = compileToolPolicies([
+      "webSearch(domain:example.com)",
+      "webSearch(domain:*.tabbyml.com)",
+    ]);
+
+    expect(policies?.webSearch).toEqual({
+      kind: "domain-pattern",
+      patterns: ["example.com", "*.tabbyml.com"],
+    });
+  });
+
+  it("should reject invalid webSearch rule declarations", () => {
+    expect(() => compileToolPolicies(["webSearch(example.com)"])).toThrow(
+      'Invalid webSearch rule "example.com". Use webSearch(domain:example.com).',
+    );
+  });
+
+  it("should allow webSearch searchDomainFilter entries matching configured domain rules", () => {
+    const policies = compileToolPolicies([
+      "webSearch(domain:example.com)",
+      "webSearch(domain:*.tabbyml.com)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "webSearch",
+        {
+          query: "latest release notes",
+          searchDomainFilter: ["example.com", "api.tabbyml.com"],
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+  });
+
+  it("should allow missing searchDomainFilter when webSearch domain rules are configured", () => {
+    const policies = compileToolPolicies([
+      "webSearch(domain:example.com)",
+      "webSearch(domain:*.tabbyml.com)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "webSearch",
+        {
+          query: "latest release notes",
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+  });
+
+  it("should reject webSearch searchDomainFilter entries outside configured domain rules", () => {
+    const policies = compileToolPolicies([
+      "webSearch(domain:example.com)",
+      "webSearch(domain:*.tabbyml.com)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "webSearch",
+        {
+          query: "latest release notes",
+          searchDomainFilter: ["google.com"],
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow(
+      'searchDomainFilter contains disallowed domain "google.com". Allowed domain patterns: example.com, *.tabbyml.com',
+    );
+  });
+});

--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -339,22 +339,102 @@ describe("webSearch domain policies", () => {
     ).not.toThrow();
   });
 
-  it("should allow missing searchDomainFilter when webSearch domain rules are configured", () => {
+  it("should not rewrite searchDomainFilter when rawDomainFilters is provided", () => {
     const policies = compileToolPolicies([
       "webSearch(domain:example.com)",
       "webSearch(domain:*.tabbyml.com)",
     ]);
 
+    const input: { query: string; searchDomainFilter?: unknown } = {
+      query: "latest release notes",
+      searchDomainFilter: ["example.com"],
+    };
+
     expect(() =>
       validateToolPolicy(
         "webSearch",
-        {
-          query: "latest release notes",
-        },
+        input,
         policies,
         { cwd: process.cwd() },
       ),
     ).not.toThrow();
+
+    expect(input.searchDomainFilter).toEqual(["example.com"]);
+  });
+
+  it("should inject agent-configured webSearch domains when searchDomainFilter is missing", () => {
+    const policies = compileToolPolicies([
+      "webSearch(domain:example.com)",
+      "webSearch(domain:*.tabbyml.com)",
+    ]);
+
+    const input: { query: string; searchDomainFilter?: unknown } = {
+      query: "latest release notes",
+    };
+
+    expect(() =>
+      validateToolPolicy(
+        "webSearch",
+        input,
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    expect(input.searchDomainFilter).toEqual([
+      "example.com",
+      "*.tabbyml.com",
+    ]);
+  });
+
+  it("should inject agent allowlist for deny-only searchDomainFilter", () => {
+    const policies = compileToolPolicies([
+      "webSearch(domain:example.com)",
+      "webSearch(domain:*.tabbyml.com)",
+    ]);
+
+    const input: { query: string; searchDomainFilter?: unknown } = {
+      query: "latest release notes",
+      searchDomainFilter: ["-google.com"],
+    };
+
+    expect(() =>
+      validateToolPolicy(
+        "webSearch",
+        input,
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    expect(input.searchDomainFilter).toEqual([
+      "example.com",
+      "*.tabbyml.com",
+      "-google.com",
+    ]);
+  });
+
+  it("should allow mixed allowlist and denylist entries", () => {
+    const policies = compileToolPolicies([
+      "webSearch(domain:example.com)",
+      "webSearch(domain:*.tabbyml.com)",
+    ]);
+
+    const input: { query: string; searchDomainFilter?: unknown } = {
+      query: "latest release notes",
+      searchDomainFilter: ["example.com", "-api.tabbyml.com"],
+    };
+
+    expect(() =>
+      validateToolPolicy(
+        "webSearch",
+        input,
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    expect(input.searchDomainFilter).toEqual(["example.com", "-api.tabbyml.com"]);
   });
 
   it("should reject webSearch searchDomainFilter entries outside configured domain rules", () => {

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -59,6 +59,10 @@ export interface CompiledToolPolicies {
     kind: "domain-pattern";
     patterns: string[];
   };
+  webSearch?: {
+    kind: "domain-pattern";
+    patterns: string[];
+  };
   readFile?: {
     kind: "path-pattern";
     patterns: string[];

--- a/packages/tools/src/utils/index.ts
+++ b/packages/tools/src/utils/index.ts
@@ -188,7 +188,10 @@ function compileDomainToolPolicy(
   } as const;
 }
 
-function parseDomainRule(toolName: "webFetch" | "webSearch", rule: string): string {
+function parseDomainRule(
+  toolName: "webFetch" | "webSearch",
+  rule: string,
+): string {
   const trimmedRule = rule.trim();
   const domainPrefix = "domain:";
 
@@ -360,12 +363,32 @@ export function validateToolPolicy(
   }
 
   if (toolName === "webSearch") {
-    const rawDomainFilters =
-      typeof input === "object" && input !== null && "searchDomainFilter" in input
-        ? (input as { searchDomainFilter?: unknown }).searchDomainFilter
+    const webSearchInput =
+      typeof input === "object" && input !== null
+        ? (input as { searchDomainFilter?: unknown })
         : undefined;
+    const rawDomainFilters = webSearchInput?.searchDomainFilter;
 
-    validateWebSearchDomainPatternPolicy(rawDomainFilters, policies?.webSearch);
+    const effectiveDomainFilters = validateWebSearchDomainPatternPolicy(
+      rawDomainFilters,
+      policies?.webSearch,
+    );
+
+    const hasAllowlistEntries =
+      Array.isArray(rawDomainFilters) &&
+      rawDomainFilters.some(
+        (entry) =>
+          typeof entry === "string" &&
+          entry.trim().length > 0 &&
+          !entry.trim().startsWith("-"),
+      );
+
+    if (effectiveDomainFilters && webSearchInput && !hasAllowlistEntries) {
+      // Intentionally mutate when searchDomainFilter is missing or deny-only,
+      // so downstream executeToolCall includes agent-configured allowlist.
+      webSearchInput.searchDomainFilter = effectiveDomainFilters;
+    }
+
     return;
   }
 
@@ -396,13 +419,13 @@ function validateWebSearchDomainPatternPolicy(
         patterns: string[];
       }
     | undefined,
-): void {
+): string[] | undefined {
   if (!policy) {
-    return;
+    return undefined;
   }
 
   if (rawDomainFilters == null) {
-    return;
+    return [...policy.patterns];
   }
 
   if (!Array.isArray(rawDomainFilters)) {
@@ -410,20 +433,28 @@ function validateWebSearchDomainPatternPolicy(
   }
 
   if (rawDomainFilters.length === 0) {
-    return;
+    return [...policy.patterns];
   }
 
-  for (const entry of rawDomainFilters) {
+  const entries = rawDomainFilters.map((entry) => {
     if (typeof entry !== "string") {
       throw new Error("searchDomainFilter must be an array of domain strings.");
     }
 
-    if (entry.trim().startsWith("-")) {
+    const normalizedEntry = entry.trim();
+    if (!normalizedEntry) {
       throw new Error(
-        "searchDomainFilter denylist entries are not allowed when webSearch domain rules are configured.",
+        "searchDomainFilter must contain non-empty domain patterns.",
       );
     }
 
+    return normalizedEntry;
+  });
+
+  const allowEntries = entries.filter((entry) => !entry.startsWith("-"));
+  const denyEntries = entries.filter((entry) => entry.startsWith("-"));
+
+  for (const entry of allowEntries) {
     const normalizedDomain = normalizeDomainPattern(entry);
     if (!normalizedDomain) {
       throw new Error(
@@ -443,6 +474,12 @@ function validateWebSearchDomainPatternPolicy(
       );
     }
   }
+
+  if (allowEntries.length === 0) {
+    return [...new Set([...policy.patterns, ...denyEntries])];
+  }
+
+  return entries;
 }
 
 function validatePathPatternPolicy(

--- a/packages/tools/src/utils/index.ts
+++ b/packages/tools/src/utils/index.ts
@@ -144,9 +144,14 @@ export function compileToolPolicies(
     };
   }
 
-  const webFetchPolicy = compileWebFetchDomainPolicy(tools);
+  const webFetchPolicy = compileDomainToolPolicy(tools, "webFetch");
   if (webFetchPolicy) {
     policies.webFetch = webFetchPolicy;
+  }
+
+  const webSearchPolicy = compileDomainToolPolicy(tools, "webSearch");
+  if (webSearchPolicy) {
+    policies.webSearch = webSearchPolicy;
   }
 
   for (const toolName of [
@@ -164,29 +169,32 @@ export function compileToolPolicies(
   return Object.keys(policies).length > 0 ? policies : undefined;
 }
 
-function compileWebFetchDomainPolicy(tools: ToolSpecInput[] | undefined) {
-  if (!tools?.some((tool) => parseToolSpec(tool).name === "webFetch")) {
+function compileDomainToolPolicy(
+  tools: ToolSpecInput[] | undefined,
+  toolName: "webFetch" | "webSearch",
+) {
+  if (!tools?.some((tool) => parseToolSpec(tool).name === toolName)) {
     return undefined;
   }
 
-  const rules = getToolRules(tools, "webFetch");
+  const rules = getToolRules(tools, toolName);
   if (!rules) {
     return undefined;
   }
 
   return {
     kind: "domain-pattern",
-    patterns: rules.map(parseWebFetchDomainRule),
+    patterns: rules.map((rule) => parseDomainRule(toolName, rule)),
   } as const;
 }
 
-function parseWebFetchDomainRule(rule: string): string {
+function parseDomainRule(toolName: "webFetch" | "webSearch", rule: string): string {
   const trimmedRule = rule.trim();
   const domainPrefix = "domain:";
 
   if (!trimmedRule.toLowerCase().startsWith(domainPrefix)) {
     throw new Error(
-      `Invalid webFetch rule "${rule}". Use webFetch(domain:example.com).`,
+      `Invalid ${toolName} rule "${rule}". Use ${toolName}(domain:example.com).`,
     );
   }
 
@@ -196,7 +204,7 @@ function parseWebFetchDomainRule(rule: string): string {
 
   if (!domainPattern) {
     throw new Error(
-      `Invalid webFetch rule "${rule}". Use webFetch(domain:example.com).`,
+      `Invalid ${toolName} rule "${rule}". Use ${toolName}(domain:example.com).`,
     );
   }
 
@@ -351,6 +359,16 @@ export function validateToolPolicy(
     return;
   }
 
+  if (toolName === "webSearch") {
+    const rawDomainFilters =
+      typeof input === "object" && input !== null && "searchDomainFilter" in input
+        ? (input as { searchDomainFilter?: unknown }).searchDomainFilter
+        : undefined;
+
+    validateWebSearchDomainPatternPolicy(rawDomainFilters, policies?.webSearch);
+    return;
+  }
+
   if (
     toolName === "readFile" ||
     toolName === "writeToFile" ||
@@ -367,6 +385,63 @@ export function validateToolPolicy(
     }
 
     validatePathPatternPolicy(rawPath, policies?.[toolName], options);
+  }
+}
+
+function validateWebSearchDomainPatternPolicy(
+  rawDomainFilters: unknown,
+  policy:
+    | {
+        kind: "domain-pattern";
+        patterns: string[];
+      }
+    | undefined,
+): void {
+  if (!policy) {
+    return;
+  }
+
+  if (rawDomainFilters == null) {
+    return;
+  }
+
+  if (!Array.isArray(rawDomainFilters)) {
+    throw new Error("searchDomainFilter must be an array of domain strings.");
+  }
+
+  if (rawDomainFilters.length === 0) {
+    return;
+  }
+
+  for (const entry of rawDomainFilters) {
+    if (typeof entry !== "string") {
+      throw new Error("searchDomainFilter must be an array of domain strings.");
+    }
+
+    if (entry.trim().startsWith("-")) {
+      throw new Error(
+        "searchDomainFilter denylist entries are not allowed when webSearch domain rules are configured.",
+      );
+    }
+
+    const normalizedDomain = normalizeDomainPattern(entry);
+    if (!normalizedDomain) {
+      throw new Error(
+        "searchDomainFilter must contain non-empty domain patterns.",
+      );
+    }
+
+    const matched = policy.patterns.some((pattern) =>
+      minimatch(normalizedDomain, normalizeDomainPattern(pattern), {
+        nocase: true,
+      }),
+    );
+
+    if (!matched) {
+      throw new Error(
+        `searchDomainFilter contains disallowed domain "${entry}". Allowed domain patterns: ${policy.patterns.join(", ")}`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Implemented domain-based tool policies for the `webSearch` tool, similar to `webFetch`.
- Refactored domain policy compilation and validation to be generic across `webFetch` and `webSearch`.
- Enhanced `webSearch` validation to automatically inject agent-configured allowed domains into `searchDomainFilter` if missing or only containing denylist entries.
- Added comprehensive tests for `webSearch` domain policy enforcement and automatic allowlist injection.

## Test plan
- Run `bun vitest packages/tools/src/__test__/utils.test.ts` to verify all domain policy tests pass.
- Verified that `searchDomainFilter` is correctly mutated when missing or deny-only to include agent-configured allowlist.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-361eab69307044f587baa6603b34f09e)