### PR TITLE
fix(livekit): sanitize JSON schema for structured output

### DIFF
--- a/packages/livekit/src/chat/llm/__tests__/sanitize-schema.test.ts
+++ b/packages/livekit/src/chat/llm/__tests__/sanitize-schema.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeSchemaForStructuredOutput } from "../sanitize-schema";
+
+describe("sanitizeSchemaForStructuredOutput", () => {
+  it("removes minItems and maxItems from arrays", () => {
+    const schema = {
+      type: "array",
+      items: { type: "string" },
+      minItems: 1,
+      maxItems: 4,
+    };
+
+    expect(sanitizeSchemaForStructuredOutput(schema)).toEqual({
+      type: "array",
+      items: { type: "string" },
+    });
+  });
+
+  it("removes maxLength on string properties", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        header: { type: "string", maxLength: 12 },
+      },
+      required: ["header"],
+    };
+
+    expect(sanitizeSchemaForStructuredOutput(schema)).toEqual({
+      type: "object",
+      properties: {
+        header: { type: "string" },
+      },
+      required: ["header"],
+    });
+  });
+
+  it("recursively cleans nested schemas", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        questions: {
+          type: "array",
+          minItems: 1,
+          maxItems: 4,
+          items: {
+            type: "object",
+            properties: {
+              header: { type: "string", maxLength: 12 },
+              options: {
+                type: "array",
+                minItems: 2,
+                maxItems: 4,
+                items: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(sanitizeSchemaForStructuredOutput(schema)).toEqual({
+      type: "object",
+      properties: {
+        questions: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              header: { type: "string" },
+              options: {
+                type: "array",
+                items: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("preserves non-validation keywords", () => {
+    const schema = {
+      type: "object",
+      description: "An object",
+      properties: {
+        name: { type: "string", description: "A name" },
+      },
+      required: ["name"],
+      additionalProperties: false,
+    };
+
+    expect(sanitizeSchemaForStructuredOutput(schema)).toEqual(schema);
+  });
+
+  it("returns primitives unchanged", () => {
+    expect(sanitizeSchemaForStructuredOutput("hello")).toBe("hello");
+    expect(sanitizeSchemaForStructuredOutput(42)).toBe(42);
+    expect(sanitizeSchemaForStructuredOutput(null)).toBe(null);
+    expect(sanitizeSchemaForStructuredOutput(undefined)).toBe(undefined);
+  });
+});

--- a/packages/livekit/src/chat/llm/repair-tool-call.ts
+++ b/packages/livekit/src/chat/llm/repair-tool-call.ts
@@ -8,6 +8,7 @@ import {
   type ToolCallRepairFunction,
   generateText,
 } from "ai";
+import { sanitizeSchemaForStructuredOutput } from "./sanitize-schema";
 
 export const makeRepairToolCall: (
   taskId: string,
@@ -19,9 +20,8 @@ export const makeRepairToolCall: (
       return null; // do not attempt to fix invalid tool names
     }
 
-    const toolSchema = jsonSchema(
-      await inputSchema({ toolName: toolCall.toolName }),
-    );
+    const rawSchema = await inputSchema({ toolName: toolCall.toolName });
+    const toolSchema = jsonSchema(sanitizeSchemaForStructuredOutput(rawSchema));
 
     const { output: repairedArgs } = await generateText({
       providerOptions: {
@@ -42,7 +42,7 @@ export const makeRepairToolCall: (
         `The model tried to call the tool "${toolCall.toolName}" with the following inputs:`,
         JSON.stringify(toolCall.input),
         "The tool accepts the following schema:",
-        JSON.stringify(await inputSchema({ toolName: toolCall.toolName })),
+        JSON.stringify(rawSchema),
         "Please fix the inputs.",
       ].join("\n"),
     });

--- a/packages/livekit/src/chat/llm/sanitize-schema.ts
+++ b/packages/livekit/src/chat/llm/sanitize-schema.ts
@@ -1,0 +1,54 @@
+/**
+ * Keywords that are not supported by some providers' structured output schemas.
+ * For example, OpenAI's structured outputs and a few others reject
+ * validation keywords such as `minItems`, `maxItems`, `minLength`,
+ * `maxLength`, `pattern`, `format`, etc.
+ *
+ * Stripping these keywords from the JSON schema lets us safely use the schema
+ * as a `responseFormat.schema` (e.g. in `Output.object({ schema })`) without
+ * triggering provider-side validation errors like:
+ *
+ *   output_config.format.schema: For 'array' type, property 'maxItems' is not supported
+ */
+const UnsupportedKeywords = new Set<string>([
+  // array
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  // string
+  "minLength",
+  "maxLength",
+  "pattern",
+  "format",
+  // number
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+]);
+
+/**
+ * Recursively removes keywords that are not supported by some providers'
+ * structured output schemas.
+ */
+export function sanitizeSchemaForStructuredOutput<T>(schema: T): T {
+  if (Array.isArray(schema)) {
+    return schema.map((item) => sanitizeSchemaForStructuredOutput(item)) as T;
+  }
+
+  if (schema && typeof schema === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(
+      schema as Record<string, unknown>,
+    )) {
+      if (UnsupportedKeywords.has(key)) {
+        continue;
+      }
+      result[key] = sanitizeSchemaForStructuredOutput(value);
+    }
+    return result as T;
+  }
+
+  return schema;
+}

--- a/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
@@ -1,13 +1,15 @@
 import type {
+  JSONSchema7,
   LanguageModelV3,
   LanguageModelV3Middleware,
   LanguageModelV3StreamPart,
 } from "@ai-sdk/provider";
-import { safeParseJSON } from "@ai-sdk/provider-utils";
+import { jsonSchema, safeParseJSON } from "@ai-sdk/provider-utils";
 import type { PochiProviderOptions } from "@getpochi/common";
 import { attemptCompletionSchema } from "@getpochi/tools";
 import { InvalidToolInputError, Output, generateText } from "ai";
 import z from "zod";
+import { sanitizeSchemaForStructuredOutput } from "../llm/sanitize-schema";
 
 export function createOutputSchemaMiddleware(
   taskId: string,
@@ -96,6 +98,12 @@ async function ensureOutputSchema(
   content: string,
 ) {
   try {
+    const rawJsonSchema = z.toJSONSchema(schema);
+    const sanitizedSchema = jsonSchema(
+      sanitizeSchemaForStructuredOutput(
+        rawJsonSchema as unknown as JSONSchema7,
+      ),
+    );
     const { output: object } = await generateText({
       providerOptions: {
         pochi: {
@@ -108,10 +116,10 @@ async function ensureOutputSchema(
         },
       },
       model,
-      output: Output.object({ schema }),
+      output: Output.object({ schema: sanitizedSchema }),
       prompt: [
         "The model is trying to generate an object that conforms to the following schema:",
-        JSON.stringify(z.toJSONSchema(schema)),
+        JSON.stringify(rawJsonSchema),
         "The current input is:",
         content,
         "Please correct the input to match the schema. Ensure that all information from the original input is preserved in the corrected output.",


### PR DESCRIPTION
## Summary
- Anthropic's structured-outputs API (`output_config.format.schema`) only accepts a subset of JSON Schema and rejects keywords like `minItems` / `maxItems` / `maxLength`. This was breaking the `repair-tool-call` flow whenever a tool with such constraints (e.g. `askFollowupQuestion`, whose `questions`/`options` arrays carry `minItems`/`maxItems` and whose `header` has `maxLength: 12`) needed repair, with: `output_config.format.schema: For 'array' type, property 'maxItems' is not supported`.
- Add a shared `sanitizeSchemaForStructuredOutput` helper that recursively strips unsupported validation keywords (mirrors the transformation Anthropic's official Python/TS/Ruby/PHP SDKs perform — see [Claude structured outputs · How SDK transformation works](https://platform.claude.com/docs/en/build-with-claude/structured-outputs#how-sdk-transformation-works)).
- Apply it to the schemas passed to `Output.object` in both `repair-tool-call.ts` and the `output-schema` middleware. The original (un-sanitized) schema is still embedded in the prompt so the model remains aware of the full constraints.

## Why not in `@ai-sdk/anthropic`
The `@ai-sdk/anthropic` provider passes `responseFormat.schema` straight to `output_config.format.schema` without sanitization, unlike Anthropic's own SDKs. We may want to file an upstream issue for that, but in the meantime we control the policy here.

## Test plan
- [x] `bun tsc --noEmit` (livekit) — clean
- [x] `bun run test src/chat/llm/__tests__/sanitize-schema.test.ts` — 5/5 passing
- [x] `bun check` — clean (biome + ast-grep + i18n)
- [x] Pre-push hook: `bun dep-check`, `bun gen:config-schema`, `bun fix`, `bun tsc`, `bun install --frozen-lockfile`, `bun run test` — all green
- [ ] Manual: trigger a malformed `askFollowupQuestion` tool call and verify the repair request now succeeds (no more `maxItems` 400 from the provider)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-309088fbccfe4811a9fdadc10843590c)