### PR TITLE
fix(webui): correct reasoning part UI display

### DIFF
--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -298,7 +298,7 @@ function Part({
       <MemoReasoningPartUI
         className={paddingClass}
         part={part}
-        isLoading={part.state === "streaming"}
+        isLoading={isLastPartInMessages}
       />
     );
   }
@@ -384,7 +384,7 @@ function ReasoningPartRenderer(props: Parameters<typeof ReasoningPartUI>[0]) {
 }
 
 const MemoReasoningPartUI = memo(ReasoningPartRenderer, (prev, next) => {
-  return prev.part.text === next.part.text;
+  return prev.part.text === next.part.text && prev.isLoading === next.isLoading;
 });
 MemoReasoningPartUI.displayName = "MemoReasoningPartUI";
 


### PR DESCRIPTION
## Summary
- Corrects the reasoning part UI display by updating the `isLoading` condition.
- Ensures `MemoReasoningPartUI` re-renders correctly when its loading state changes.

## Test plan
- Verified that the reasoning part shows the correct loading state during streaming and completion.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-306b7daef2db418381a57bb4bdd6054f)