### PR TITLE
feat(tools): support newTask agentType restriction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -277,7 +277,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.43.0-dev",
+      "version": "0.45.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/docs/content/docs/custom-agent.mdx
+++ b/packages/docs/content/docs/custom-agent.mdx
@@ -89,6 +89,14 @@ Restrict which domains the agent can fetch via `webFetch`. The specifier must st
 | `webFetch(domain:example.com)` | Exact domain match (e.g., allows only `example.com`) |
 | `webFetch(domain:*.example.com)` | Glob match against subdomains (e.g., allows `api.example.com`, `docs.example.com`) |
 
+#### New Task Restrictions
+
+Restrict which agent types a custom agent can launch using `newTask`.
+
+- `newTask(_)` allows launching only the default agent (when `agentType` is omitted).
+- `newTask(browser)` allows launching only the `browser` agent.
+- `newTask(explorer-*)` allows launching any agent whose name starts with `explorer-`.
+
 Example:
 
 ```markdown
@@ -102,6 +110,8 @@ tools:
   - writeToFile(.pochi/**)
   - webFetch(domain:docs.example.com)
   - webFetch(domain:*.getpochi.com)
+  - newTask(_)
+  - newTask(browser)
 ---
 ```
 

--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -360,3 +360,163 @@ describe("webFetch domain policies", () => {
     ).toThrow("URL domain is not allowed by the configured webFetch domain rules.");
   });
 });
+
+describe("newTask agent type policies", () => {
+  it("should compile agent type pattern rules for newTask", () => {
+    const policies = compileToolPolicies([
+      "newTask(browser)",
+      "newTask(explorer-*)",
+    ]);
+
+    expect(policies?.newTask).toEqual({
+      kind: "agent-type-pattern",
+      patterns: ["browser", "explorer-*"],
+    });
+  });
+
+  it("should allow agent types matching configured rules", () => {
+    const policies = compileToolPolicies([
+      "newTask(browser)",
+      "newTask(explorer-*)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        {
+          agentType: "browser",
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        {
+          agentType: "explorer-code",
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+  });
+
+  it("should reject agent types not matching configured rules", () => {
+    const policies = compileToolPolicies([
+      "newTask(browser)",
+      "newTask(explorer-*)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        {
+          agentType: "planner",
+        },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow('Agent type "planner" is not allowed by the configured agent type rules.');
+  });
+
+  it("should allow empty agent type when rule '_' exists", () => {
+    const policies = compileToolPolicies(["newTask(_)"]);
+
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        {},
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        { agentType: "browser" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow();
+  });
+
+  it("should allow empty agent type when rule '_' exists in object form", () => {
+    const policies = compileToolPolicies([{ name: "newTask", rules: ["_"] }]);
+
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        {},
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        { agentType: "browser" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow();
+  });
+
+  it("should treat newTask() as unrestricted (default behavior)", () => {
+    const policies = compileToolPolicies(["newTask()"]);
+    expect(policies?.newTask).toBeUndefined();
+  });
+
+  it("should allow multiple agent type rules (whitelist)", () => {
+    const policies = compileToolPolicies([
+      "newTask(_)",
+      "newTask(browser)",
+    ]);
+
+    // Allows default agent
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        {},
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    // Allows browser agent
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        { agentType: "browser" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    // Rejects others
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        { agentType: "planner" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow();
+  });
+
+  it("should reject empty agent type when only specific agent types are allowed", () => {
+    const policies = compileToolPolicies(["newTask(browser)"]);
+
+    expect(() =>
+      validateToolPolicy(
+        "newTask",
+        {},
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow('Agent type "" is not allowed by the configured agent type rules.');
+  });
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -59,6 +59,7 @@ export {
   normalizeToolSpecs,
   parseToolSpec,
   validateCommandPatternPolicy,
+  validateAgentTypePatternPolicy,
   validateToolPolicy,
   validateExecuteCommandRules,
 } from "./utils";

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -44,6 +44,7 @@ export interface IFileStateCache {
 
 export type CompiledToolPolicy =
   | { kind: "command-pattern"; patterns: string[] }
+  | { kind: "agent-type-pattern"; patterns: string[] }
   | {
       kind: "domain-pattern";
       patterns: string[];
@@ -55,6 +56,7 @@ export type CompiledToolPolicy =
 
 export interface CompiledToolPolicies {
   executeCommand?: { kind: "command-pattern"; patterns: string[] };
+  newTask?: { kind: "agent-type-pattern"; patterns: string[] };
   webFetch?: {
     kind: "domain-pattern";
     patterns: string[];

--- a/packages/tools/src/utils/index.ts
+++ b/packages/tools/src/utils/index.ts
@@ -135,12 +135,20 @@ export function compileToolPolicies(
   tools: ToolSpecInput[] | undefined,
 ): CompiledToolPolicies | undefined {
   const executeCommandRules = getToolRules(tools, "executeCommand");
+  const newTaskRules = getToolRules(tools, "newTask");
   const policies: CompiledToolPolicies = {};
 
   if (executeCommandRules) {
     policies.executeCommand = {
       kind: "command-pattern",
       patterns: executeCommandRules,
+    };
+  }
+
+  if (newTaskRules) {
+    policies.newTask = {
+      kind: "agent-type-pattern",
+      patterns: newTaskRules,
     };
   }
 
@@ -330,6 +338,37 @@ export function validateCommandPatternPolicy(
   validateExecuteCommandRules(command, policy.patterns);
 }
 
+export function validateAgentTypePatternPolicy(
+  agentType: string | undefined,
+  policy: { kind: "agent-type-pattern"; patterns: string[] } | undefined,
+): void {
+  if (!policy) {
+    return;
+  }
+
+  const normalizedAgentType = agentType ?? "";
+
+  const matched = policy.patterns.some((pattern) => {
+    const trimedPattern = pattern.trim();
+    // '_' is a special value that matches an empty agentType (default agent).
+    const targetAgentType = trimedPattern === "_" ? "" : trimedPattern;
+
+    if (targetAgentType.includes("*")) {
+      const regex = new RegExp(
+        `^${escapeRegex(targetAgentType).replace(/\\\*/g, ".*")}$`,
+      );
+      return regex.test(normalizedAgentType);
+    }
+    return normalizedAgentType === targetAgentType;
+  });
+
+  if (!matched) {
+    throw new Error(
+      `Agent type "${normalizedAgentType}" is not allowed by the configured agent type rules. Allowed agent type patterns: ${policy.patterns.join(", ")}`,
+    );
+  }
+}
+
 export function validateToolPolicy(
   toolName: string,
   input: unknown,
@@ -347,6 +386,19 @@ export function validateToolPolicy(
     }
 
     validateCommandPatternPolicy(command, policies?.executeCommand);
+    return;
+  }
+
+  if (toolName === "newTask") {
+    const agentType =
+      typeof input === "object" && input !== null && "agentType" in input
+        ? (input as { agentType?: unknown }).agentType
+        : undefined;
+
+    validateAgentTypePatternPolicy(
+      typeof agentType === "string" ? agentType : undefined,
+      policies?.newTask,
+    );
     return;
   }
 

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -13,7 +13,11 @@ import {
   processContentOutput,
 } from "@getpochi/livekit";
 
-import type { ClientTools, CompiledToolPolicies } from "@getpochi/tools";
+import {
+  type ClientTools,
+  type CompiledToolPolicies,
+  validateAgentTypePatternPolicy,
+} from "@getpochi/tools";
 import { ThreadAbortSignal } from "@quilted/threads";
 import {
   type ThreadSignalSerialization,
@@ -209,7 +213,9 @@ export class ManagedToolCallLifeCycle
     let executePromise: Promise<unknown>;
 
     if (this.toolName === "newTask") {
-      executePromise = this.runNewTask(args as NewTaskParameterType);
+      executePromise = this.runNewTask(args as NewTaskParameterType, {
+        toolPolicies: options?.toolPolicies,
+      });
     } else {
       executePromise = vscodeHost.executeToolCall(this.toolName, args, {
         toolCallId: this.toolCallId,
@@ -240,7 +246,18 @@ export class ManagedToolCallLifeCycle
     });
   }
 
-  private runNewTask(args: NewTaskParameterType): Promise<NewTaskReturnType> {
+  private runNewTask(
+    args: NewTaskParameterType,
+    options?: {
+      toolPolicies?: CompiledToolPolicies;
+    },
+  ): Promise<NewTaskReturnType> {
+    // Validate the agent type pattern policy, throw if failed
+    validateAgentTypePatternPolicy(
+      args.agentType,
+      options?.toolPolicies?.newTask,
+    );
+
     const uid = args._meta?.uid;
     if (!uid) {
       throw new Error("Missing uid in newTask arguments");


### PR DESCRIPTION
## Summary
This PR introduces a way to restrict which agent types a custom agent can launch using the `newTask` tool. This is useful for creating specialized agents that are limited to specific sub-workflows.

## Syntax Examples
The following syntax can be used in the `tools` section of a custom agent's frontmatter (e.g., in `README.pochi.md` or `.pochi/agents/*.md`):

- `newTask(_)`: **Restricted to Default Agent** - Allows launching a new task only if the `agentType` parameter is omitted or empty.
- `newTask(browser)`: **Restricted to Specific Agent** - Allows launching only the `browser` agent.
- `newTask(explorer-*)`: **Wildcard Matching** - Allows launching any agent whose name starts with `explorer-` (e.g., `explorer-code`, `explorer-docs`).
- **Whitelisting**: Multiple rules can be specified to allow several agent types:
  ```markdown
  tools:
    - newTask(_)
    - newTask(browser)
    - newTask(code-simplifier)
  ```
- `newTask` or `newTask()`: **Unrestricted** - Allows launching any agent type (backward compatible).

## Technical Details
- Implemented a specialized validation policy for `newTask` in `packages/tools/src/utils/index.ts`.
- Mapped the special character `-` to represent an empty `agentType` to avoid global side effects on other tools that use empty parentheses.
- Added comprehensive unit tests and updated user documentation.

## Test plan
- [x] Unit tests for `newTask` policy compilation and validation in `packages/tools/src/__test__/utils.test.ts`.
- [x] Verified that `newTask(_)` correctly matches calls with no `agentType`.
- [x] Verified that wildcard patterns work as expected.
- [x] Verified that multiple rules act as a whitelist.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-304548f81c3142d9a31cb6e686015dc0)