### PR TITLE
feat(agents): update browser agent tool definitions

### DIFF
--- a/packages/common/src/base/agents/browser.ts
+++ b/packages/common/src/base/agents/browser.ts
@@ -4,7 +4,10 @@ export const browser: CustomAgent = {
   name: "browser",
   description:
     "Web browser automation agent for navigating websites, interacting with pages, and extracting information. Uses agent-browser CLI for headless browser control.",
-  tools: ["executeCommand(agent-browser)", "executeCommand(npm)"],
+  tools: [
+    "executeCommand(agent-browser)",
+    "executeCommand(npm install -g agent-browser)",
+  ],
   systemPrompt: `
 You are a web browser automation agent. You control a headless browser using the agent-browser CLI.
 


### PR DESCRIPTION
## Summary
- Update the `browser` agent's tool definitions to be more specific.
- Explicitly include `npm install -g agent-browser` as a tool that the agent can use to set up its environment.

## Test plan
- Manual review of the agent definition.
- Verified that the system prompt already matches this instruction.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-53700795edd84422a06aa2c3ad41fbd4)