### PR TITLE
fix(webview): route worker assets through webview id and inline sqlite wasm

### DIFF
--- a/packages/vscode-webui/src/lib/__tests__/worker-url.test.ts
+++ b/packages/vscode-webui/src/lib/__tests__/worker-url.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isCrossOriginWorkerUrl,
   makeSharedWorkerBootstrapUrl,
+  makeWorkerBootstrapUrl,
   makeWorkerBootstrapSource,
 } from "../worker-url";
 
@@ -40,6 +41,20 @@ describe("makeSharedWorkerBootstrapUrl", () => {
     expect(first).toContain("data:text/javascript;charset=utf-8,");
     expect(decodeURIComponent(first.split(",")[1] ?? "")).toBe(
       'import "https://example.com/shared-worker.js"',
+    );
+  });
+
+  it("can carry the VS Code webview id in the data URL search", () => {
+    const url = makeWorkerBootstrapUrl(
+      "https://example.com/worker.js",
+      "module",
+      "webview-1",
+    );
+    const parsed = new URL(url);
+
+    expect(parsed.searchParams.get("id")).toBe("webview-1");
+    expect(decodeURIComponent(url.split(",")[1] ?? "")).toBe(
+      'import "https://example.com/worker.js"\n//# sourceURL=vscode-worker?id=webview-1',
     );
   });
 });

--- a/packages/vscode-webui/src/lib/worker-url.ts
+++ b/packages/vscode-webui/src/lib/worker-url.ts
@@ -21,9 +21,31 @@ export function makeWorkerBootstrapSource(
   return `importScripts=((i)=>(...a)=>i(...a.map((u)=>''+new URL(u,"${url}"))))(importScripts);importScripts("${url}")`;
 }
 
+export function getWebviewId(): string | undefined {
+  if (typeof location === "undefined") {
+    return;
+  }
+  return new URL(location.href).searchParams.get("id") ?? undefined;
+}
+
+export function makeWorkerBootstrapUrl(
+  url: string,
+  type: WorkerOptions["type"] | undefined,
+  webviewId = getWebviewId(),
+): string {
+  // VS Code's webview service worker uses the worker client URL's `id`
+  // query to route localhost and webview-resource requests back to the panel.
+  const source = webviewId
+    ? `${makeWorkerBootstrapSource(url, type)}\n//# sourceURL=vscode-worker`
+    : makeWorkerBootstrapSource(url, type);
+  const idSearch = webviewId ? `?id=${encodeURIComponent(webviewId)}` : "";
+  return `data:text/javascript;charset=utf-8,${encodeURIComponent(source)}${idSearch}`;
+}
+
 export function makeSharedWorkerBootstrapUrl(
   url: string,
   type: WorkerOptions["type"] | undefined,
+  webviewId = getWebviewId(),
 ): string {
-  return `data:text/javascript;charset=utf-8,${encodeURIComponent(makeWorkerBootstrapSource(url, type))}`;
+  return makeWorkerBootstrapUrl(url, type, webviewId);
 }

--- a/packages/vscode-webui/src/remote-web-worker.ts
+++ b/packages/vscode-webui/src/remote-web-worker.ts
@@ -1,7 +1,7 @@
 import {
   isCrossOriginWorkerUrl,
   makeSharedWorkerBootstrapUrl,
-  makeWorkerBootstrapSource,
+  makeWorkerBootstrapUrl,
   resolveWorkerUrl,
 } from "./lib/worker-url";
 
@@ -15,13 +15,7 @@ if (import.meta.env.DEV) {
           const url = resolveWorkerUrl(scriptURL);
           super(
             isCrossOriginWorkerUrl(url)
-              ? // Launch the worker with an inline script that will use `importScripts`
-                // to bootstrap the actual script to work around the same origin policy.
-                URL.createObjectURL(
-                  new Blob([makeWorkerBootstrapSource(url, options?.type)], {
-                    type: "text/javascript",
-                  }),
-                )
+              ? makeWorkerBootstrapUrl(url, options?.type)
               : scriptURL,
             options,
           );

--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -26,6 +26,7 @@ import type { VSCodeHostImpl } from "./vscode-host-impl";
 
 const logger = getLogger("WebviewBase");
 let liveStoreSharedWorkerDataUrl: string | undefined;
+let sqliteWasmDataUrl: string | undefined;
 
 function getLiveStoreSharedWorkerDataUrl(extensionUri: vscode.Uri): string {
   if (liveStoreSharedWorkerDataUrl) {
@@ -47,6 +48,26 @@ function getLiveStoreSharedWorkerDataUrl(extensionUri: vscode.Uri): string {
   )}`;
 
   return liveStoreSharedWorkerDataUrl;
+}
+
+function getSqliteWasmDataUrl(extensionUri: vscode.Uri): string {
+  if (sqliteWasmDataUrl) {
+    return sqliteWasmDataUrl;
+  }
+
+  const sqliteWasmPath = vscode.Uri.joinPath(
+    extensionUri,
+    "assets",
+    "webview-ui",
+    "dist",
+    "wa-sqlite.wasm",
+  );
+
+  sqliteWasmDataUrl = `data:application/wasm;base64,${readFileSync(
+    sqliteWasmPath.fsPath,
+  ).toString("base64")}`;
+
+  return sqliteWasmDataUrl;
 }
 
 /**
@@ -142,11 +163,20 @@ export abstract class WebviewBase implements vscode.Disposable {
         "dist",
         "wa-sqlite.wasm",
       ]);
+      const sqliteWasmWorkerDataUrl = getSqliteWasmDataUrl(
+        this.context.extensionUri,
+      );
       const webviewDistBaseUri = getUri(webview, this.context.extensionUri, [
         "assets",
         "webview-ui",
         "dist",
       ]).toString();
+      const workerAssetsPathScript = `self.__assetsPath = (path) => {
+        if (path === "wa-sqlite.wasm") {
+          return ${JSON.stringify(sqliteWasmWorkerDataUrl)};
+        }
+        return path;
+      };`;
 
       const assetLoaderScript = `<script nonce="${nonce}" type="module">
       window.__assetsPath = (path) => {
@@ -156,7 +186,7 @@ export abstract class WebviewBase implements vscode.Disposable {
         return path;
       }
       window.__liveStoreSharedWorkerUrl = ${JSON.stringify(sharedWorkerDataUrl)};
-      window.__workerAssetsPathScript = 'self.__assetsPath = (path) => { if (path === "wa-sqlite.wasm") { return "${sqliteWasmUri}"; }};';
+      window.__workerAssetsPathScript = ${JSON.stringify(workerAssetsPathScript)};
       </script>`;
 
       const scriptUri = getUri(webview, this.context.extensionUri, [


### PR DESCRIPTION
## Summary
- Pass the VS Code webview id through cross-origin worker bootstrap data URLs (`?id=...` + `//# sourceURL=vscode-worker`) so the webview service worker can route `vscode-resource` / localhost requests back to the originating panel.
- Replace the dev-mode `Blob`-based bootstrap with a unified `makeWorkerBootstrapUrl` helper shared between regular and shared workers.
- Inline `wa-sqlite.wasm` as a base64 data URL in the worker `__assetsPath` shim so workers can load it without a webview resource URI, with a small `getSqliteWasmDataUrl` cache on the extension side.

## Test plan
- [ ] `bun run test` in `packages/vscode-webui`
- [ ] Manually verify SQLite-backed features load inside the VS Code webview

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c40656b598de49aaa6e0052ea3a69857)