### PR TITLE
fix(webview): make async agent failWorker idempotent

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
@@ -296,6 +296,11 @@ function AsyncAgentWorkerInner({
 
   const failWorker = useCallback(
     (message: string) => {
+      // Idempotent: avoid re-aborting / re-committing taskFailed when callers
+      // (e.g. the max-step watcher) re-fire on subsequent renders.
+      if (completedRef.current) {
+        return;
+      }
       logger.warn({ taskId, message }, "Failing async agent worker");
       completedRef.current = true;
       if (!abortController.current.signal.aborted) {
@@ -411,6 +416,9 @@ function AsyncAgentWorkerInner({
   }, [stepCount, currentStepCount]);
 
   useEffect(() => {
+    if (completedRef.current) {
+      return;
+    }
     if (currentStepCount > AsyncAgentMaxStep) {
       failWorker("The async agent failed to complete, max step count reached.");
     }


### PR DESCRIPTION
## Summary
- Stops the async-agent worker from livelocking on hard failures (e.g. max step count reached). Once `failWorker` runs, subsequent calls are no-ops, so we don't keep re-aborting and re-committing `taskFailed` events on every render.
- Adds a defense-in-depth `completedRef.current` guard at the top of the max-step `useEffect` so the watcher itself stops re-evaluating the threshold once we've failed.

## Why
The max-step `useEffect` depends on `failWorker`, whose identity changes whenever `chatKit` is re-created during a render. Because `currentStepCount` only ever grows, every subsequent render re-fired the effect and:

1. logged another `Failing async agent worker` warn,
2. committed another `taskFailed` event,
3. fired another abort → another `LiveChatKit onError` → another `chatStreamFailed` event.

This surfaces in logs as the worker "endlessly retrying" the same failure (same `taskId` failing over and over within ~100ms windows).

## Test plan
- [ ] Trigger an async agent that exceeds `AsyncAgentMaxStep` and confirm only a single `Failing async agent worker` warn + single `LiveChatKit onError` are emitted.
- [ ] Verify the task transitions to `failed` exactly once and no further `taskFailed` / abort spam appears in logs.
- [ ] Confirm normal async agent flows (completion, retryable transient errors, user-abort) still behave correctly.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4a6b062c549c486bb11a546531285577)