### PR TITLE
fix(vendor-pochi): use z.xor instead of z.union for web-search query schema

### DIFF
--- a/packages/vendor-pochi/src/tools/web-search.ts
+++ b/packages/vendor-pochi/src/tools/web-search.ts
@@ -28,7 +28,7 @@ Usage notes:
     jsonSchema: z.toJSONSchema(
       z.object({
         query: z
-          .union([z.string().min(2), z.array(z.string().min(2)).min(1).max(5)])
+          .xor([z.string().min(2), z.array(z.string().min(2)).min(1).max(5)])
           .describe(
             "A single search query string, OR an array of up to 5 related query strings to batch in one request. Prefer a single string for focused lookups; use an array when you want to research several related facets in one call.",
           ),


### PR DESCRIPTION
## Summary
- Replace `z.union` with `z.xor` for the `query` parameter schema in the web-search tool
- `z.xor` enforces exclusive-or semantics: the query must be either a single string **or** an array of strings, but not a type that satisfies both simultaneously
- Aligns the runtime schema validation with the existing tool description which states "A single search query string, OR an array of up to 5 related query strings"

## Test plan
- [ ] Verify passing a single string query still works
- [ ] Verify passing an array of strings still works
- [ ] Verify the JSON schema output reflects the exclusive-or constraint

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-915247762998411593cd3fdeda901055)