### PR TITLE
fix(async-agent): stop wasted regenerate when resuming over-budget task

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
@@ -409,12 +409,8 @@ function AsyncAgentWorkerInner({
       .filter((part) => part.type === "step-start").length;
   }, [messages]);
 
-  // IMPORTANT: read `stepCount` directly here (instead of going through an
-  // intermediate `currentStepCount` state) so that the guard fires in the
-  // SAME render in which the worker mounts. This sets `completedRef.current`
-  // before the auto-start effect below has a chance to call `retry()`,
-  // preventing a wasted regenerate round-trip (and the spurious AbortError it
-  // produces) when we resume a task that already exceeded the step budget.
+  // Read `stepCount` directly so the guard fires on mount, before the
+  // auto-start effect below can call `retry()` on an over-budget task.
   useEffect(() => {
     if (completedRef.current) {
       return;
@@ -437,8 +433,7 @@ function AsyncAgentWorkerInner({
       messages.length > 0 &&
       !completedRef.current &&
       !abortController.current.signal.aborted &&
-      // Defensive guard: even if the max-step effect above hasn't yet flipped
-      // `completedRef`, refuse to resume a task that already blew the budget.
+      // Belt-and-suspenders: never resume an over-budget task.
       stepCount <= AsyncAgentMaxStep &&
       !(
         (task?.status === "failed" && task.error?.kind === "AbortError") ||

--- a/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
@@ -408,21 +408,21 @@ function AsyncAgentWorkerInner({
       .flatMap((message) => message.parts)
       .filter((part) => part.type === "step-start").length;
   }, [messages]);
-  const [currentStepCount, setCurrentStepCount] = useState(0);
-  useEffect(() => {
-    if (stepCount > currentStepCount) {
-      setCurrentStepCount(stepCount);
-    }
-  }, [stepCount, currentStepCount]);
 
+  // IMPORTANT: read `stepCount` directly here (instead of going through an
+  // intermediate `currentStepCount` state) so that the guard fires in the
+  // SAME render in which the worker mounts. This sets `completedRef.current`
+  // before the auto-start effect below has a chance to call `retry()`,
+  // preventing a wasted regenerate round-trip (and the spurious AbortError it
+  // produces) when we resume a task that already exceeded the step budget.
   useEffect(() => {
     if (completedRef.current) {
       return;
     }
-    if (currentStepCount > AsyncAgentMaxStep) {
+    if (stepCount > AsyncAgentMaxStep) {
       failWorker("The async agent failed to complete, max step count reached.");
     }
-  }, [currentStepCount, failWorker]);
+  }, [stepCount, failWorker]);
 
   // Auto-start / resume the agent from its current last message.
   // Only kicks in when the task already has at least one message, since async
@@ -437,6 +437,9 @@ function AsyncAgentWorkerInner({
       messages.length > 0 &&
       !completedRef.current &&
       !abortController.current.signal.aborted &&
+      // Defensive guard: even if the max-step effect above hasn't yet flipped
+      // `completedRef`, refuse to resume a task that already blew the budget.
+      stepCount <= AsyncAgentMaxStep &&
       !(
         (task?.status === "failed" && task.error?.kind === "AbortError") ||
         task?.status === "completed"
@@ -448,6 +451,7 @@ function AsyncAgentWorkerInner({
           taskId,
           modelId: selectedModel.id,
           messageCount: messages.length,
+          stepCount,
         },
         "▶ start async agent",
       );
@@ -458,6 +462,7 @@ function AsyncAgentWorkerInner({
     isModelsLoading,
     selectedModel,
     messages.length,
+    stepCount,
     retry,
     task?.status,
     task?.error,


### PR DESCRIPTION
## Summary
- Resuming an async agent task whose persisted history already exceeded `AsyncAgentMaxStep` (50) caused a wasted regenerate round trip on every mount: the max-step guard read an intermediate `currentStepCount` state that was still `0` on the first render, so the auto-start effect fired `retry()` *before* `failWorker` could flip `completedRef.current`. The kicked-off chat then immediately aborted, surfacing as `LiveChatKit onError: AbortError` every time the runner re-discovered the task.
- Read `stepCount` directly in the max-step guard so it fires synchronously on the same render the worker mounts. This sets `completedRef.current = true` before the auto-start effect runs, so the worker marks the task as failed once instead of issuing a doomed regenerate.
- Added a defensive `stepCount <= AsyncAgentMaxStep` check inside the auto-start effect, and included `stepCount` in the resume log line for easier debugging of budget headroom.

## Test plan
- [x] `bun tsc` (no errors)
- [x] `bun check` (biome + ast-grep + i18n + eslint clean)
- [ ] Manually verify in the webview: open a task whose stored history already has >50 step-start parts and confirm the agent fails immediately with "max step count reached" without an extra `AbortError` cycle.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b314e28d57a948e5b8c7f96f4e7cb7c4)