### PR TITLE
refactor(auto-memory): split prompt into static + dynamic parts

### DIFF
--- a/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
+++ b/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
@@ -1,9 +1,14 @@
+import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import {
   type AutoMemoryContext,
   buildAutoMemoryDreamDirective,
+  buildAutoMemoryDynamicPrompt,
   buildAutoMemoryPrompt,
+  buildAutoMemoryStaticPrompt,
   formatAutoMemoryManifest,
+  injectAutoMemory,
+  isAutoMemorySystemReminder,
   truncateAutoMemoryIndex,
 } from "../auto-memory";
 
@@ -20,15 +25,50 @@ const sampleContext: AutoMemoryContext = {
 
 describe("long-term memory prompt helpers", () => {
   it("does not render when memory is disabled", () => {
+    expect(buildAutoMemoryStaticPrompt(undefined)).toBe("");
+    expect(buildAutoMemoryDynamicPrompt(undefined)).toBe("");
     expect(buildAutoMemoryPrompt(undefined)).toBe("");
   });
 
-  it("renders memory location and truncated index content", () => {
-    const prompt = buildAutoMemoryPrompt(sampleContext);
+  it("static prompt carries rules and paths but never the live index", () => {
+    const staticPrompt = buildAutoMemoryStaticPrompt(sampleContext);
 
-    expect(prompt).toContain("LONG-TERM MEMORY");
-    expect(prompt).toContain("/home/user/.pochi/projects/repo-key/memory");
-    expect(prompt).toContain("- [project] conventions.md");
+    expect(staticPrompt).toContain("LONG-TERM MEMORY");
+    expect(staticPrompt).toContain(
+      "/home/user/.pochi/projects/repo-key/memory",
+    );
+    // Static prompt deliberately omits the live index content — it is
+    // delivered separately so the system prompt prefix can stay cached
+    // across sessions.
+    expect(staticPrompt).not.toContain("- [project] conventions.md");
+    expect(staticPrompt).toContain(
+      "delivered separately as its own system reminder",
+    );
+  });
+
+  it("dynamic prompt renders the live MEMORY.md index inline", () => {
+    const dynamicPrompt = buildAutoMemoryDynamicPrompt(sampleContext);
+
+    expect(dynamicPrompt).toContain("Long-term Memory Index (MEMORY.md)");
+    expect(dynamicPrompt).toContain("- [project] conventions.md");
+    expect(dynamicPrompt).toContain("snapshot of MEMORY.md was captured");
+  });
+
+  it("dynamic prompt falls back to a placeholder when the index is empty", () => {
+    const dynamicPrompt = buildAutoMemoryDynamicPrompt({
+      ...sampleContext,
+      indexContent: "   ",
+    });
+
+    expect(dynamicPrompt).toContain("(MEMORY.md is currently empty.)");
+  });
+
+  it("buildAutoMemoryPrompt composes static + dynamic for back-compat", () => {
+    const combined = buildAutoMemoryPrompt(sampleContext);
+
+    expect(combined).toContain("LONG-TERM MEMORY");
+    expect(combined).toContain("Long-term Memory Index (MEMORY.md)");
+    expect(combined).toContain("- [project] conventions.md");
   });
 
   it("dream directive references transcripts dir and lists session files only", () => {
@@ -82,5 +122,71 @@ describe("long-term memory prompt helpers", () => {
         },
       ]),
     ).toBe("- [feedback] feedback.md (Review feedback): Prefer compact plans.");
+  });
+
+  const makeUserMessage = (text: string): UIMessage => ({
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text }],
+  });
+
+  it("injectAutoMemory inserts a dedicated reminder before the user's text on the first turn", () => {
+    const messages = [makeUserMessage("hello")];
+    const result = injectAutoMemory(messages, sampleContext);
+
+    expect(result).toBe(messages);
+    const parts = result[0].parts;
+    expect(parts).toHaveLength(2);
+
+    const reminder = parts[0];
+    const userPart = parts[1];
+    expect(reminder.type).toBe("text");
+    expect(userPart.type).toBe("text");
+    if (reminder.type !== "text" || userPart.type !== "text") {
+      throw new Error("expected text parts");
+    }
+
+    expect(reminder.text.startsWith("<system-reminder>")).toBe(true);
+    expect(reminder.text.endsWith("</system-reminder>")).toBe(true);
+    expect(isAutoMemorySystemReminder(reminder.text)).toBe(true);
+    expect(reminder.text).toContain("Long-term Memory Index (MEMORY.md)");
+    expect(reminder.text).toContain("- [project] conventions.md");
+    expect(userPart.text).toBe("hello");
+  });
+
+  it("injectAutoMemory is a no-op without context or memory block", () => {
+    const messages = [makeUserMessage("hello")];
+    expect(injectAutoMemory(messages, undefined)).toBe(messages);
+    expect(messages[0].parts).toHaveLength(1);
+  });
+
+  it("injectAutoMemory only fires on the first user turn", () => {
+    const messages: UIMessage[] = [
+      makeUserMessage("first"),
+      { id: "asst-1", role: "assistant", parts: [{ type: "text", text: "ok" }] },
+      makeUserMessage("second"),
+    ];
+
+    injectAutoMemory(messages, sampleContext);
+    // No reminder appended on the latest user turn.
+    expect(messages[2].parts).toHaveLength(1);
+  });
+
+  it("injectAutoMemory replaces a stale reminder rather than duplicating", () => {
+    const messages = [makeUserMessage("hello")];
+    injectAutoMemory(messages, sampleContext);
+    injectAutoMemory(messages, {
+      ...sampleContext,
+      indexContent: "- [user] bio.md",
+    });
+
+    const reminders = messages[0].parts.filter(
+      (p) => p.type === "text" && isAutoMemorySystemReminder(p.text),
+    );
+    expect(reminders).toHaveLength(1);
+    if (reminders[0].type === "text") {
+      expect(reminders[0].text).toContain("- [user] bio.md");
+      expect(reminders[0].text).not.toContain("- [project] conventions.md");
+    }
   });
 });

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -1,6 +1,18 @@
-import type { UIMessage } from "ai";
+import type { TextUIPart, UIMessage } from "ai";
 
 export const AutoMemoryIndexName = "MEMORY.md";
+
+/**
+ * Distinctive marker used to tag the long-term memory system reminder so we
+ * can identify and replace prior injections without colliding with the
+ * environment system reminder. Kept as a literal string so call sites in
+ * other packages can match against it cheaply.
+ */
+const AutoMemoryReminderMarker = "<!-- pochi:auto-memory -->";
+
+export function isAutoMemorySystemReminder(content: string): boolean {
+  return content.includes(AutoMemoryReminderMarker);
+}
 export const AutoMemoryLockName = ".consolidate-lock";
 export const AutoMemoryMaxIndexLines = 200;
 export const AutoMemoryMaxIndexBytes = 25_000;
@@ -92,14 +104,21 @@ export function formatAutoMemoryManifest(
     .join("\n");
 }
 
-export function buildAutoMemoryPrompt(
+/**
+ * Static long-term memory guidance for the system prompt. Contains the
+ * behavioral rules and the per-workspace memory directory paths, but does
+ * NOT include the MEMORY.md index content — that is dynamic and must be
+ * injected separately via {@link buildAutoMemoryDynamicPrompt} so the system
+ * prompt prefix stays cacheable even when memory files change between tasks.
+ *
+ * Mirrors the split in claude-code's `memdir/memdir.ts`, where memory rules
+ * live in the system prompt and MEMORY.md content is delivered as a
+ * user-context attachment.
+ */
+export function buildAutoMemoryStaticPrompt(
   context: AutoMemoryContext | undefined,
 ): string {
   if (!context) return "";
-
-  const indexContent = context.indexContent.trim()
-    ? context.indexContent
-    : "(MEMORY.md is currently empty.)";
 
   return `====
 
@@ -123,8 +142,98 @@ When the user asks you to remember something, write or update the relevant topic
 
 The long-term memory directory is an explicit exception to the normal relative-path tool rule. You may use the absolute paths above when reading or writing memory files.
 
-Current MEMORY.md index:
+The current MEMORY.md index is delivered separately as its own system reminder on the first user turn. That snapshot is taken at the start of the task and is intentionally NOT refreshed mid-task — new memories you write here become visible only in the next task session.`;
+}
+
+/**
+ * Dynamic long-term memory block — just the MEMORY.md index snapshot wrapped
+ * in a labeled section. Injected by {@link injectAutoMemory} into the
+ * first-turn user message as a dedicated system reminder so it travels in the
+ * user-context portion of the request rather than the cached system prefix.
+ */
+export function buildAutoMemoryDynamicPrompt(
+  context: AutoMemoryContext | undefined,
+): string {
+  if (!context) return "";
+
+  const indexContent = context.indexContent.trim()
+    ? context.indexContent
+    : "(MEMORY.md is currently empty.)";
+
+  return `${AutoMemoryReminderMarker}
+# Long-term Memory Index (MEMORY.md)
+This snapshot of MEMORY.md was captured at the start of the task and will not be refreshed until the next task session. Topic files referenced here live under ${context.memoryDir}.
+
 ${indexContent}`;
+}
+
+/**
+ * Inject the dynamic MEMORY.md snapshot into the most recent user message as
+ * a dedicated system reminder, separate from the environment reminder.
+ *
+ * Behavior:
+ * - Only fires on the first user turn (`messages.length === 1`); subsequent
+ *   turns rely on conversation history to retain the snapshot.
+ * - Strips any prior auto-memory reminder from the target message before
+ *   inserting, keeping regenerations idempotent.
+ * - Inserts the new reminder immediately before the last text part so the
+ *   user's actual prompt remains the visible tail of the message — same
+ *   placement convention as `injectEnvironment`.
+ */
+export function injectAutoMemory(
+  messages: UIMessage[],
+  context: AutoMemoryContext | undefined,
+): UIMessage[] {
+  if (!context) return messages;
+  const memoryBlock = buildAutoMemoryDynamicPrompt(context);
+  if (!memoryBlock) return messages;
+
+  // Index in the conversation, not just the current request: avoids
+  // re-emitting on resume / regenerate where the same snapshot is already
+  // in history.
+  if (messages.length !== 1) return messages;
+
+  const messageToInject = messages.at(-1);
+  if (!messageToInject) return messages;
+  if (messageToInject.role !== "user") return messages;
+
+  const reminderText = `<system-reminder>${memoryBlock}</system-reminder>`;
+  const reminderPart: TextUIPart = {
+    type: "text",
+    text: reminderText,
+  };
+
+  const filteredParts = (messageToInject.parts ?? []).filter(
+    (part) =>
+      part.type !== "text" || !isAutoMemorySystemReminder(part.text ?? ""),
+  );
+  const lastTextPartIndex = filteredParts.findLastIndex(
+    (part) => part.type === "text",
+  );
+  const insertIndex = lastTextPartIndex >= 0 ? lastTextPartIndex : 0;
+
+  messageToInject.parts = [
+    ...filteredParts.slice(0, insertIndex),
+    reminderPart,
+    ...filteredParts.slice(insertIndex),
+  ];
+  return messages;
+}
+
+/**
+ * Backward-compatible composition of the static + dynamic memory prompts.
+ * New callers should prefer the split helpers; this remains for any
+ * consumer that still wants both blocks fused into a single string.
+ */
+export function buildAutoMemoryPrompt(
+  context: AutoMemoryContext | undefined,
+): string {
+  const staticPart = buildAutoMemoryStaticPrompt(context);
+  const dynamicPart = buildAutoMemoryDynamicPrompt(context);
+  if (!staticPart && !dynamicPart) return "";
+  if (!dynamicPart) return staticPart;
+  if (!staticPart) return dynamicPart;
+  return `${staticPart}\n\n${dynamicPart}`;
 }
 
 export function buildAutoMemoryExtractionDirective({

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -2,11 +2,11 @@ import type { TextUIPart, UIMessage } from "ai";
 
 export const AutoMemoryIndexName = "MEMORY.md";
 
-// Marker to identify auto-memory reminders for idempotent replacement.
-const AutoMemoryReminderMarker = "<!-- pochi:auto-memory -->";
+// Header doubles as the marker for identifying auto-memory reminders.
+const AutoMemoryHeader = "# Long-term Memory Index (MEMORY.md)";
 
 export function isAutoMemorySystemReminder(content: string): boolean {
-  return content.includes(AutoMemoryReminderMarker);
+  return content.includes(AutoMemoryHeader);
 }
 export const AutoMemoryLockName = ".consolidate-lock";
 export const AutoMemoryMaxIndexLines = 200;
@@ -144,8 +144,7 @@ export function buildAutoMemoryDynamicPrompt(
     ? context.indexContent
     : "(MEMORY.md is currently empty.)";
 
-  return `${AutoMemoryReminderMarker}
-# Long-term Memory Index (MEMORY.md)
+  return `${AutoMemoryHeader}
 This snapshot of MEMORY.md was captured at the start of the task and will not be refreshed until the next task session. Topic files referenced here live under ${context.memoryDir}.
 
 ${indexContent}`;

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -2,12 +2,7 @@ import type { TextUIPart, UIMessage } from "ai";
 
 export const AutoMemoryIndexName = "MEMORY.md";
 
-/**
- * Distinctive marker used to tag the long-term memory system reminder so we
- * can identify and replace prior injections without colliding with the
- * environment system reminder. Kept as a literal string so call sites in
- * other packages can match against it cheaply.
- */
+// Marker to identify auto-memory reminders for idempotent replacement.
 const AutoMemoryReminderMarker = "<!-- pochi:auto-memory -->";
 
 export function isAutoMemorySystemReminder(content: string): boolean {
@@ -105,15 +100,9 @@ export function formatAutoMemoryManifest(
 }
 
 /**
- * Static long-term memory guidance for the system prompt. Contains the
- * behavioral rules and the per-workspace memory directory paths, but does
- * NOT include the MEMORY.md index content — that is dynamic and must be
- * injected separately via {@link buildAutoMemoryDynamicPrompt} so the system
- * prompt prefix stays cacheable even when memory files change between tasks.
- *
- * Mirrors the split in claude-code's `memdir/memdir.ts`, where memory rules
- * live in the system prompt and MEMORY.md content is delivered as a
- * user-context attachment.
+ * Static memory guidance for the system prompt — rules + paths, no index.
+ * The index is injected separately so the system prefix stays cacheable
+ * across sessions. Mirrors claude-code's memdir split.
  */
 export function buildAutoMemoryStaticPrompt(
   context: AutoMemoryContext | undefined,
@@ -145,12 +134,7 @@ The long-term memory directory is an explicit exception to the normal relative-p
 The current MEMORY.md index is delivered separately as its own system reminder on the first user turn. That snapshot is taken at the start of the task and is intentionally NOT refreshed mid-task — new memories you write here become visible only in the next task session.`;
 }
 
-/**
- * Dynamic long-term memory block — just the MEMORY.md index snapshot wrapped
- * in a labeled section. Injected by {@link injectAutoMemory} into the
- * first-turn user message as a dedicated system reminder so it travels in the
- * user-context portion of the request rather than the cached system prefix.
- */
+/** MEMORY.md snapshot block, injected via {@link injectAutoMemory}. */
 export function buildAutoMemoryDynamicPrompt(
   context: AutoMemoryContext | undefined,
 ): string {
@@ -168,17 +152,8 @@ ${indexContent}`;
 }
 
 /**
- * Inject the dynamic MEMORY.md snapshot into the most recent user message as
- * a dedicated system reminder, separate from the environment reminder.
- *
- * Behavior:
- * - Only fires on the first user turn (`messages.length === 1`); subsequent
- *   turns rely on conversation history to retain the snapshot.
- * - Strips any prior auto-memory reminder from the target message before
- *   inserting, keeping regenerations idempotent.
- * - Inserts the new reminder immediately before the last text part so the
- *   user's actual prompt remains the visible tail of the message — same
- *   placement convention as `injectEnvironment`.
+ * Inject the MEMORY.md snapshot as a dedicated system reminder on the first
+ * user turn. Idempotent — replaces any prior auto-memory reminder.
  */
 export function injectAutoMemory(
   messages: UIMessage[],
@@ -187,26 +162,21 @@ export function injectAutoMemory(
   if (!context) return messages;
   const memoryBlock = buildAutoMemoryDynamicPrompt(context);
   if (!memoryBlock) return messages;
-
-  // Index in the conversation, not just the current request: avoids
-  // re-emitting on resume / regenerate where the same snapshot is already
-  // in history.
   if (messages.length !== 1) return messages;
 
   const messageToInject = messages.at(-1);
-  if (!messageToInject) return messages;
-  if (messageToInject.role !== "user") return messages;
+  if (!messageToInject || messageToInject.role !== "user") return messages;
 
-  const reminderText = `<system-reminder>${memoryBlock}</system-reminder>`;
   const reminderPart: TextUIPart = {
     type: "text",
-    text: reminderText,
+    text: `<system-reminder>${memoryBlock}</system-reminder>`,
   };
 
   const filteredParts = (messageToInject.parts ?? []).filter(
     (part) =>
       part.type !== "text" || !isAutoMemorySystemReminder(part.text ?? ""),
   );
+  // Place reminder before the user's text so the prompt remains the tail.
   const lastTextPartIndex = filteredParts.findLastIndex(
     (part) => part.type === "text",
   );
@@ -220,11 +190,7 @@ export function injectAutoMemory(
   return messages;
 }
 
-/**
- * Backward-compatible composition of the static + dynamic memory prompts.
- * New callers should prefer the split helpers; this remains for any
- * consumer that still wants both blocks fused into a single string.
- */
+/** Back-compat wrapper composing static + dynamic memory prompts. */
 export function buildAutoMemoryPrompt(
   context: AutoMemoryContext | undefined,
 ): string {

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -2,9 +2,13 @@ import { BuiltInAgentPath } from "../../vscode-webui-bridge/types/custom-agent";
 import { renderActiveSelection } from "./active-selection";
 import {
   buildAutoMemoryDreamDirective,
+  buildAutoMemoryDynamicPrompt,
   buildAutoMemoryExtractionDirective,
   buildAutoMemoryPrompt,
+  buildAutoMemoryStaticPrompt,
   formatAutoMemoryManifest,
+  injectAutoMemory,
+  isAutoMemorySystemReminder,
   serializeMemoryMessage,
   truncateAutoMemoryIndex,
 } from "./auto-memory";
@@ -25,10 +29,12 @@ import { renderUserEdits } from "./user-edits";
 export const prompts = {
   system: createSystemPrompt,
   injectEnvironment,
+  injectAutoMemory,
   environment: createEnvironmentPrompt,
   createSystemReminder,
   isSystemReminder,
   isEnvironmentSystemReminder,
+  isAutoMemorySystemReminder,
   isCompact,
   compact: createCompactPrompt,
   inlineCompact,
@@ -48,6 +54,8 @@ export const prompts = {
   },
   autoMemory: {
     buildPrompt: buildAutoMemoryPrompt,
+    buildStaticPrompt: buildAutoMemoryStaticPrompt,
+    buildDynamicPrompt: buildAutoMemoryDynamicPrompt,
     buildExtractionDirective: buildAutoMemoryExtractionDirective,
     buildDreamDirective: buildAutoMemoryDreamDirective,
     formatManifest: formatAutoMemoryManifest,

--- a/packages/common/src/base/prompts/system.ts
+++ b/packages/common/src/base/prompts/system.ts
@@ -18,10 +18,8 @@ export function createSystemPrompt(
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 
 `.trim();
-  // The system prompt only carries the static memory guidance. The
-  // MEMORY.md index snapshot itself is injected separately via the
-  // environment system reminder so it doesn't bust the cached system
-  // prefix when memory files change between sessions.
+  // Static guidance only — MEMORY.md index is injected separately to keep
+  // the system prefix cache stable across sessions.
   const autoMemoryPrompt = buildAutoMemoryStaticPrompt(autoMemory);
   const customRulesPrompt =
     customAgent?.omitAgentsMd === true ? "" : getCustomRulesPrompt(customRules);

--- a/packages/common/src/base/prompts/system.ts
+++ b/packages/common/src/base/prompts/system.ts
@@ -1,7 +1,7 @@
 import type { CustomAgent } from "@getpochi/tools";
 import type { Environment } from "../environment";
 import type { AutoMemoryContext } from "./auto-memory";
-import { buildAutoMemoryPrompt } from "./auto-memory";
+import { buildAutoMemoryStaticPrompt } from "./auto-memory";
 
 type CustomRules = Environment["info"]["customRules"];
 
@@ -18,7 +18,11 @@ export function createSystemPrompt(
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 
 `.trim();
-  const autoMemoryPrompt = buildAutoMemoryPrompt(autoMemory);
+  // The system prompt only carries the static memory guidance. The
+  // MEMORY.md index snapshot itself is injected separately via the
+  // environment system reminder so it doesn't bust the cached system
+  // prefix when memory files change between sessions.
+  const autoMemoryPrompt = buildAutoMemoryStaticPrompt(autoMemory);
   const customRulesPrompt =
     customAgent?.omitAgentsMd === true ? "" : getCustomRulesPrompt(customRules);
   const mcpInstructionsPrompt = getMcpInstructionsPrompt(mcpInstructions);

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -109,8 +109,9 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
   }) => {
     const llm = await this.getters.getLLM();
     const environment = await this.getters.getEnvironment?.();
-    messages = prompts.injectEnvironment(messages, environment) as Message[];
     const autoMemory = await this.getters.getAutoMemory?.();
+    messages = prompts.injectEnvironment(messages, environment) as Message[];
+    messages = prompts.injectAutoMemory(messages, autoMemory) as Message[];
     const mcpInfo = this.getters.getMcpInfo?.();
     const customAgents = this.getters.getCustomAgents?.();
     const skills = this.getters.getSkills?.();

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -68,10 +68,8 @@ export function useLiveChatKitGetters({
     } satisfies Environment;
   }, [todos, omitCustomRules, taskId]);
 
-  // Snapshot once per hook lifetime — i.e. once per task panel — so MEMORY.md
-  // rewrites by the extraction/dream agents during the task don't bust the
-  // cached system+tools prefix on subsequent turns. New memory becomes
-  // visible only when the panel is remounted (new task session).
+  // Snapshot once per task panel so mid-task MEMORY.md rewrites don't bust
+  // the cached system+tools prefix. New memory shows on next mount.
   const autoMemoryCacheRef = useRef<Promise<
     AutoMemoryContext | undefined
   > | null>(null);
@@ -79,8 +77,8 @@ export function useLiveChatKitGetters({
     if (autoMemoryCacheRef.current) return autoMemoryCacheRef.current;
     const pending = vscodeHost.readAutoMemory();
     autoMemoryCacheRef.current = pending;
-    // Allow retry on transient failure.
     pending.catch(() => {
+      // Allow retry on transient failure.
       if (autoMemoryCacheRef.current === pending) {
         autoMemoryCacheRef.current = null;
       }

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -13,6 +13,7 @@ import { useMcp } from "@/lib/hooks/use-mcp";
 import { useSkills } from "@/lib/hooks/use-skills";
 import { vscodeHost } from "@/lib/vscode";
 import { constants, type Environment } from "@getpochi/common";
+import type { AutoMemoryContext } from "@getpochi/common";
 import { createModel } from "@getpochi/common/vendor/edge";
 import {
   type DisplayModel,
@@ -21,7 +22,7 @@ import {
 } from "@getpochi/common/vscode-webui-bridge";
 import type { LLMRequestData } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 export function useLiveChatKitGetters({
   todos,
@@ -67,8 +68,24 @@ export function useLiveChatKitGetters({
     } satisfies Environment;
   }, [todos, omitCustomRules, taskId]);
 
-  const getAutoMemory = useCallback(async () => {
-    return vscodeHost.readAutoMemory();
+  // Snapshot once per hook lifetime — i.e. once per task panel — so MEMORY.md
+  // rewrites by the extraction/dream agents during the task don't bust the
+  // cached system+tools prefix on subsequent turns. New memory becomes
+  // visible only when the panel is remounted (new task session).
+  const autoMemoryCacheRef = useRef<Promise<
+    AutoMemoryContext | undefined
+  > | null>(null);
+  const getAutoMemory = useCallback(() => {
+    if (autoMemoryCacheRef.current) return autoMemoryCacheRef.current;
+    const pending = vscodeHost.readAutoMemory();
+    autoMemoryCacheRef.current = pending;
+    // Allow retry on transient failure.
+    pending.catch(() => {
+      if (autoMemoryCacheRef.current === pending) {
+        autoMemoryCacheRef.current = null;
+      }
+    });
+    return pending;
   }, []);
 
   return {


### PR DESCRIPTION
## Summary
- Split `buildAutoMemoryPrompt` into `buildAutoMemoryStaticPrompt` (rules + paths, lives in the cached system prompt) and `buildAutoMemoryDynamicPrompt` (MEMORY.md index snapshot). The system prefix now stays stable across tasks even when memory files change.
- Add a dedicated `injectAutoMemory` channel that delivers the MEMORY.md snapshot as its own `<system-reminder>` on the first user turn, separate from the environment reminder. Repeated calls are idempotent (marker-based replacement).
- Snapshot `AutoMemoryContext` once per task panel in `useLiveChatKitGetters` so mid-task rewrites by the extraction/dream agents don't bust the cached system+tools prefix on subsequent turns.

Reference: claude-code's `memdir/memdir.ts` keeps the memory rules in the system prompt and ships MEMORY.md content as user-context. This PR mirrors that split.

## Test plan
- [x] `bun run test src/base/prompts` (packages/common) — 29/29 pass, 12/12 in `auto-memory.test.ts` including 4 new `injectAutoMemory` cases (first-turn placement, no-op when context absent, only-first-turn, replaces stale reminder).
- [x] `bun tsc` workspace-wide — 12/12 packages pass.
- [x] `bun check` (biome + ast-grep + i18n) — clean.
- [ ] Manual: open a task with memory enabled, confirm system prompt shows the static guidance only and the first user message carries a dedicated `Long-term Memory Index (MEMORY.md)` reminder; subsequent turns no longer repeat it.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0d95563abe84466db036147d907e3987)