### PR TITLE
feat(fork-agent): typed use-case and configurable cache breakpoint

### DIFF
--- a/packages/common/src/base/__tests__/provider-options.test.ts
+++ b/packages/common/src/base/__tests__/provider-options.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { PochiProviderOptions } from "../index";
+
+describe("PochiProviderOptions", () => {
+  it("accepts fork agent labels as request use cases", () => {
+    const result = PochiProviderOptions.safeParse({
+      taskId: "task-1",
+      client: "vscode",
+      useCase: "task-memory",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown request use cases", () => {
+    const result = PochiProviderOptions.safeParse({
+      taskId: "task-1",
+      client: "vscode",
+      useCase: "custom-fork-label",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -1,3 +1,4 @@
+import type { ToolSpecInput } from "@getpochi/tools";
 import { z } from "zod";
 
 export { attachTransport, getLogger } from "./logger";
@@ -38,18 +39,50 @@ export { withTimeout } from "./async-utils";
 export { builtInAgents } from "./agents";
 
 export { builtInSkills, BuiltInSkillPath } from "./skills";
+export * from "./message-context";
+export type { AutoMemoryTaskState, TaskMemoryState } from "./memory";
+
+export const ForkAgentUseCase = z.enum([
+  "task-memory",
+  "auto-memory",
+  "auto-memory-dream",
+]);
+
+export type ForkAgentUseCase = z.infer<typeof ForkAgentUseCase>;
+
+export const PochiRequestUseCase = z.enum([
+  "agent",
+  "output-schema",
+  "repair-tool-call",
+  "generate-task-title",
+  "compact-task",
+  "repair-mermaid",
+  ...ForkAgentUseCase.options,
+]);
+
+export type PochiRequestUseCase = z.infer<typeof PochiRequestUseCase>;
 
 export const PochiProviderOptions = z.object({
   taskId: z.string(),
   client: z.string(),
-  useCase: z.union([
-    z.literal("agent"),
-    z.literal("output-schema"),
-    z.literal("repair-tool-call"),
-    z.literal("generate-task-title"),
-    z.literal("compact-task"),
-    z.literal("repair-mermaid"),
-  ]),
+  useCase: PochiRequestUseCase,
 });
 
 export type PochiProviderOptions = z.infer<typeof PochiProviderOptions>;
+
+export type MessageCacheBreakpoint = "last" | "secondLast";
+
+export type ContextWindowUsage = {
+  system: number;
+  tools: number;
+  messages: number;
+  files: number;
+  toolResults: number;
+};
+
+export interface AsyncAgentState {
+  tools?: readonly ToolSpecInput[];
+  parentTaskId?: string;
+  messageCacheBreakpoint?: MessageCacheBreakpoint;
+  useCase?: ForkAgentUseCase;
+}

--- a/packages/common/src/base/memory.ts
+++ b/packages/common/src/base/memory.ts
@@ -1,0 +1,38 @@
+export interface TaskMemoryState {
+  initialized: boolean;
+  lastExtractionTokens: number;
+  lastExtractionToolCalls: number;
+  /**
+   * UUID of the last message incorporated into memory.md by the most recent
+   * successful extraction. Compaction uses this as the boundary to know
+   * which messages are already covered by the curated session notes and
+   * which still need to be preserved verbatim. Stored as a UUID rather
+   * than a numeric index so it remains stable across any in-place
+   * mutations of the messages array (compact tag insertion, fork/restore,
+   * etc.).
+   */
+  lastExtractionMessageId?: string;
+  /**
+   * Snapshot of the trailing message UUID at the moment the in-flight
+   * extraction was started. Promoted to `lastExtractionMessageId` once the
+   * fork agent finishes successfully (and the snapshot was on a clean turn
+   * boundary at promotion time).
+   */
+  pendingExtractionMessageId?: string;
+  isExtracting: boolean;
+  extractionCount: number;
+  activeTaskId?: string;
+}
+
+export interface AutoMemoryTaskState {
+  lastExtractionMessageCount: number;
+  pendingExtractionMessageCount?: number;
+  isExtracting: boolean;
+  extractionCount: number;
+  activeExtractionTaskId?: string;
+  isDreaming: boolean;
+  activeDreamTaskId?: string;
+  activeDreamToken?: string;
+  activeDreamMemoryDir?: string;
+  activeDreamPreviousLastDreamAt?: number;
+}

--- a/packages/common/src/base/message-context.ts
+++ b/packages/common/src/base/message-context.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+
+export const ActiveSelection = z
+  .object({
+    filepath: z.string().describe("The path of the active file selection."),
+    range: z
+      .object({
+        start: z
+          .object({
+            line: z
+              .number()
+              .describe("The starting line number of the selection."),
+            character: z
+              .number()
+              .describe("The starting character number of the selection."),
+          })
+          .describe("The start position of the selection."),
+        end: z
+          .object({
+            line: z
+              .number()
+              .describe("The ending line number of the selection."),
+            character: z
+              .number()
+              .describe("The ending character number of the selection."),
+          })
+          .describe("The end position of the selection."),
+      })
+      .describe("The range of the active selection."),
+    content: z.string().describe("The content of the active selection."),
+    notebookCell: z
+      .object({
+        cellIndex: z
+          .number()
+          .describe("The zero-based index of the notebook cell."),
+        cellId: z
+          .string()
+          .describe(
+            "The ID of the notebook cell. This can be used with the editNotebook tool to edit the cell. Falls back to the cell index as a string if no ID is available.",
+          ),
+      })
+      .optional()
+      .describe(
+        "Notebook cell information if the selection is in a Jupyter notebook. The cellId can be used directly with the editNotebook tool.",
+      ),
+  })
+  .optional()
+  .describe("Active editor selection in the current workspace.");
+
+export type ActiveSelection = z.infer<typeof ActiveSelection>;
+
+export const UserEdits = z
+  .array(
+    z.object({
+      filepath: z.string().describe("Relative file path"),
+      diff: z.string().describe("Diff content with inline markers"),
+    }),
+  )
+  .optional()
+  .describe("User edits since last checkpoint in the current workspace.");
+
+export type UserEdits = z.infer<typeof UserEdits>;
+
+export const BashOutputs = z.array(
+  z.object({
+    command: z.string().describe("The command that was executed."),
+    output: z.string().describe("The output of the command."),
+    error: z.string().describe("The error of the command.").optional(),
+  }),
+);
+
+export type BashOutputs = z.infer<typeof BashOutputs>;
+
+export type ReviewComment = {
+  id: string;
+  body: string;
+};
+
+export type ReviewCodeSnippet = {
+  content: string;
+  startLine: number;
+  endLine: number;
+};
+
+export type Review = {
+  id: string;
+  uri: string;
+  range?: {
+    start: Position;
+    end: Position;
+  };
+  comments: ReviewComment[];
+  codeSnippet: ReviewCodeSnippet;
+};
+
+type Position = {
+  line: number;
+  character: number;
+};

--- a/packages/common/src/base/prompts/active-selection.ts
+++ b/packages/common/src/base/prompts/active-selection.ts
@@ -1,4 +1,4 @@
-import type { ActiveSelection } from "../../vscode-webui-bridge/types/message";
+import type { ActiveSelection } from "../message-context";
 
 export function renderActiveSelection(selection: ActiveSelection): string {
   if (!selection) {

--- a/packages/common/src/base/prompts/bash-outputs.ts
+++ b/packages/common/src/base/prompts/bash-outputs.ts
@@ -1,4 +1,4 @@
-import type { BashOutputs } from "../../vscode-webui-bridge/types/message";
+import type { BashOutputs } from "../message-context";
 
 export function renderBashOutputs(bashOutputs: BashOutputs): string {
   if (!bashOutputs?.length) {

--- a/packages/common/src/base/prompts/review-comments.ts
+++ b/packages/common/src/base/prompts/review-comments.ts
@@ -1,4 +1,4 @@
-import type { Review } from "../../vscode-webui-bridge/types/review";
+import type { Review } from "../message-context";
 
 export function renderReviewComments(reviews: Review[]): string {
   if (reviews.length === 0) {

--- a/packages/common/src/base/prompts/user-edits.ts
+++ b/packages/common/src/base/prompts/user-edits.ts
@@ -1,4 +1,4 @@
-import type { UserEdits } from "../../vscode-webui-bridge/types/message";
+import type { UserEdits } from "../message-context";
 
 export function renderUserEdits(userEdits: UserEdits): string {
   if (!userEdits || userEdits.length === 0) {

--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -24,10 +24,6 @@ export type {
   TaskStates,
   McpConfigOverride,
   TaskArchivedParams,
-  ContextWindowUsage,
-  TaskMemoryState,
-  AsyncAgentState,
-  AutoMemoryTaskState,
 } from "./types/task";
 export type {
   VSCodeLmModel,

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -1,4 +1,3 @@
-import type { ToolSpecInput } from "@getpochi/tools";
 import type { ActiveSelection } from "./message";
 
 export type FileUIPart = {
@@ -54,14 +53,6 @@ export type PochiTaskInfo = PochiTaskParams & {
   uid: string;
 };
 
-export type ContextWindowUsage = {
-  system: number;
-  tools: number;
-  messages: number;
-  files: number;
-  toolResults: number;
-};
-
 /**
  * only include fields that are used in the webview and node process
  */
@@ -109,47 +100,3 @@ export type TaskStates = Record<string, TaskState>;
 export type TaskArchivedParams =
   | { type: "single"; taskId: string; archived: boolean }
   | { type: "batch"; cwd?: string };
-
-export interface TaskMemoryState {
-  initialized: boolean;
-  lastExtractionTokens: number;
-  lastExtractionToolCalls: number;
-  /**
-   * UUID of the last message incorporated into memory.md by the most recent
-   * successful extraction. Compaction uses this as the boundary to know
-   * which messages are already covered by the curated session notes and
-   * which still need to be preserved verbatim. Stored as a UUID rather
-   * than a numeric index so it remains stable across any in-place
-   * mutations of the messages array (compact tag insertion, fork/restore,
-   * etc.).
-   */
-  lastExtractionMessageId?: string;
-  /**
-   * Snapshot of the trailing message UUID at the moment the in-flight
-   * extraction was started. Promoted to `lastExtractionMessageId` once the
-   * fork agent finishes successfully (and the snapshot was on a clean turn
-   * boundary at promotion time).
-   */
-  pendingExtractionMessageId?: string;
-  isExtracting: boolean;
-  extractionCount: number;
-  activeTaskId?: string;
-}
-
-export interface AsyncAgentState {
-  tools?: readonly ToolSpecInput[];
-  parentTaskId?: string;
-}
-
-export interface AutoMemoryTaskState {
-  lastExtractionMessageCount: number;
-  pendingExtractionMessageCount?: number;
-  isExtracting: boolean;
-  extractionCount: number;
-  activeExtractionTaskId?: string;
-  isDreaming: boolean;
-  activeDreamTaskId?: string;
-  activeDreamToken?: string;
-  activeDreamMemoryDir?: string;
-  activeDreamPreviousLastDreamAt?: number;
-}

--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -1,16 +1,20 @@
 import type { CompiledToolPolicies } from "@getpochi/tools";
 import type { ThreadAbortSignalSerialization } from "@quilted/threads";
 import type { ThreadSignalSerialization } from "@quilted/threads/signals";
-import type { AutoMemoryContext, Environment } from "../base";
+import type {
+  AsyncAgentState,
+  AutoMemoryContext,
+  AutoMemoryTaskState,
+  ContextWindowUsage,
+  Environment,
+  TaskMemoryState,
+} from "../base";
 import type { BrowserSession } from "../browser/types";
 import type { UserInfo } from "../configuration";
 import type {
-  AsyncAgentState,
-  AutoMemoryTaskState,
   BuiltinSubAgentInfo,
   CaptureEvent,
   ChangedFileContent,
-  ContextWindowUsage,
   CustomAgentFile,
   DisplayModel,
   FileDiff,
@@ -27,7 +31,6 @@ import type {
   SkillFile,
   TaskArchivedParams,
   TaskChangedFile,
-  TaskMemoryState,
   TaskStates,
   VSCodeHostApi,
   VSCodeSettings,

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -1,17 +1,21 @@
 import type { CompiledToolPolicies } from "@getpochi/tools";
 import type { ThreadAbortSignalSerialization } from "@quilted/threads";
 import type { ThreadSignalSerialization } from "@quilted/threads/signals";
-import type { AutoMemoryContext, Environment } from "../base";
+import type {
+  AsyncAgentState,
+  AutoMemoryContext,
+  AutoMemoryTaskState,
+  ContextWindowUsage,
+  Environment,
+  TaskMemoryState,
+} from "../base";
 import type { BrowserSession } from "../browser/types";
 import type { UserInfo } from "../configuration";
 import type { RecentFileState } from "../tool-utils";
 import type {
-  AsyncAgentState,
-  AutoMemoryTaskState,
   BuiltinSubAgentInfo,
   CaptureEvent,
   ChangedFileContent,
-  ContextWindowUsage,
   CustomAgentFile,
   ExecuteCommandResult,
   FileDiff,
@@ -27,7 +31,6 @@ import type {
   SkillFile,
   TaskArchivedParams,
   TaskChangedFile,
-  TaskMemoryState,
   TaskStates,
   WorkspaceState,
 } from "./index";

--- a/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
+++ b/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
@@ -1,0 +1,67 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { withMessageCacheBreakpoint } from "../flexible-chat-transport";
+
+const cacheControl = { anthropic: { cacheControl: { type: "ephemeral" } } };
+
+describe("withMessageCacheBreakpoint", () => {
+  it("marks the last message by default", () => {
+    const messages = [
+      modelMessage("first"),
+      modelMessage("second"),
+      modelMessage("third"),
+    ];
+
+    const result = withMessageCacheBreakpoint(messages, "last");
+
+    expect(result[0].providerOptions).toBeUndefined();
+    expect(result[1].providerOptions).toBeUndefined();
+    expect(result[2].providerOptions).toEqual(cacheControl);
+  });
+
+  it("marks the second-to-last message for fork agents", () => {
+    const messages = [
+      modelMessage("parent user"),
+      modelMessage("parent assistant"),
+      modelMessage("fork directive"),
+    ];
+
+    const result = withMessageCacheBreakpoint(messages, "secondLast");
+
+    expect(result[0].providerOptions).toBeUndefined();
+    expect(result[1].providerOptions).toEqual(cacheControl);
+    expect(result[2].providerOptions).toBeUndefined();
+  });
+
+  it("does not mark a single-message fork agent request", () => {
+    const messages = [modelMessage("fork directive")];
+
+    const result = withMessageCacheBreakpoint(messages, "secondLast");
+
+    expect(result[0].providerOptions).toBeUndefined();
+  });
+
+  it("preserves existing provider options on the selected message", () => {
+    const messages = [
+      modelMessage("parent"),
+      {
+        ...modelMessage("fork directive"),
+        providerOptions: { pochi: { taskId: "task-1" } },
+      },
+    ];
+
+    const result = withMessageCacheBreakpoint(messages, "last");
+
+    expect(result[1].providerOptions).toEqual({
+      pochi: { taskId: "task-1" },
+      ...cacheControl,
+    });
+  });
+});
+
+function modelMessage(content: string): ModelMessage {
+  return {
+    role: "user",
+    content,
+  };
+}

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -2,7 +2,9 @@ import { getErrorMessage } from "@ai-sdk/provider";
 import type {
   AutoMemoryContext,
   Environment,
+  MessageCacheBreakpoint,
   PochiProviderOptions,
+  PochiRequestUseCase,
 } from "@getpochi/common";
 import { formatters, prompts } from "@getpochi/common";
 import * as R from "remeda";
@@ -65,6 +67,8 @@ export type ChatTransportOptions = {
   onStart?: OnStartCallback;
   getters: PrepareRequestGetters;
   isSubTask?: boolean;
+  messageCacheBreakpoint?: MessageCacheBreakpoint;
+  requestUseCase?: PochiRequestUseCase;
   store: LiveKitStore;
   blobStore: BlobStore;
   customAgent?: CustomAgent;
@@ -76,6 +80,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
   private readonly onStart?: OnStartCallback;
   private readonly getters: PrepareRequestGetters;
   private readonly isSubTask?: boolean;
+  private readonly messageCacheBreakpoint: MessageCacheBreakpoint;
+  private readonly requestUseCase: PochiRequestUseCase;
   private readonly store: LiveKitStore;
   private readonly blobStore: BlobStore;
   private readonly customAgent?: CustomAgent;
@@ -87,6 +93,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
 
     this.getters = options.getters;
     this.isSubTask = options.isSubTask;
+    this.messageCacheBreakpoint = options.messageCacheBreakpoint ?? "last";
+    this.requestUseCase = options.requestUseCase ?? "agent";
     this.store = options.store;
     this.blobStore = options.blobStore;
     this.customAgent = options.customAgent;
@@ -204,14 +212,17 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       providerOptions: cacheControl,
     };
 
-    const cachedModelMessages = withCacheBreakpointOnLastMessage(modelMessages);
+    const cachedModelMessages = withMessageCacheBreakpoint(
+      modelMessages,
+      this.messageCacheBreakpoint,
+    );
 
     const stream = streamText({
       providerOptions: {
         pochi: {
           taskId: chatId,
           client: globalThis.POCHI_CLIENT,
-          useCase: "agent",
+          useCase: this.requestUseCase,
         } satisfies PochiProviderOptions,
       },
       system: systemMessage,
@@ -269,23 +280,26 @@ function prepareMessages(inputMessages: Message[]): Message[] {
 }
 
 /**
- * Attach an Anthropic ephemeral cache breakpoint to the last message of the
+ * Attach an Anthropic ephemeral cache breakpoint to a message in the
  * conversation. Combined with a breakpoint on the system block, this caches
- * the entire request prefix (tools + system + message history). On the next
- * request that adds new messages, the previous boundary becomes a cache hit.
+ * the request prefix (tools + system + message history) up to the selected
+ * boundary. On the next request that adds new messages, the previous boundary
+ * becomes a cache hit.
  *
- * For fork agents this is what makes the parent task's prefix reusable: the
- * fork's `[...parentMessages, newDirective]` will hit the cache up to the end
- * of `parentMessages` (the last message at the time of the parent's request),
- * even though the new directive itself is uncached.
+ * Fork agents select the second-to-last message because their final message is
+ * a fresh directive, while the reusable parent-task prefix ends immediately
+ * before it.
  */
-function withCacheBreakpointOnLastMessage(
+export function withMessageCacheBreakpoint(
   messages: ModelMessage[],
+  breakpoint: MessageCacheBreakpoint,
 ): ModelMessage[] {
   if (messages.length === 0) return messages;
-  const lastIndex = messages.length - 1;
+  const cacheIndex =
+    breakpoint === "secondLast" ? messages.length - 2 : messages.length - 1;
+  if (cacheIndex < 0) return messages;
   return messages.map((m, i) => {
-    if (i !== lastIndex) return m;
+    if (i !== cacheIndex) return m;
     return {
       ...m,
       providerOptions: {

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -1,3 +1,9 @@
+import type {
+  ContextWindowUsage,
+  MessageCacheBreakpoint,
+  PochiRequestUseCase,
+  TaskMemoryState,
+} from "@getpochi/common";
 import { getLogger } from "@getpochi/common";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { type CustomAgent, ToolsByPermission } from "@getpochi/tools";
@@ -18,10 +24,6 @@ import {
 import { events, tables } from "../livestore/default-schema";
 import { toTaskError, toTaskGitInfo, toTaskStatus } from "../task";
 
-import type {
-  ContextWindowUsage,
-  TaskMemoryState,
-} from "@getpochi/common/vscode-webui-bridge";
 import type { LiveKitStore, Message, Task } from "../types";
 import { scheduleGenerateTitleJob } from "./background-job";
 import { filterCompletionTools } from "./filter-completion-tools";
@@ -148,6 +150,8 @@ export type LiveChatKitOptions<T> = {
   getters: PrepareRequestGetters;
 
   isSubTask?: boolean;
+  messageCacheBreakpoint?: MessageCacheBreakpoint;
+  requestUseCase?: PochiRequestUseCase;
 
   store: LiveKitStore;
 
@@ -250,6 +254,8 @@ export class LiveChatKit<
     onCompact,
     getters,
     isSubTask,
+    messageCacheBreakpoint,
+    requestUseCase,
     customAgent,
     outputSchema,
     attemptCompletionSchema,
@@ -271,6 +277,8 @@ export class LiveChatKit<
       onStart: this.onStart,
       getters,
       isSubTask,
+      messageCacheBreakpoint,
+      requestUseCase,
       customAgent,
       outputSchema,
       attemptCompletionSchema,

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -1,12 +1,12 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import { Environment } from "@getpochi/common";
-import { GoogleVertexModel } from "@getpochi/common/configuration";
 import type {
   ActiveSelection,
   BashOutputs,
   Review,
   UserEdits,
-} from "@getpochi/common/vscode-webui-bridge";
+} from "@getpochi/common";
+import { Environment } from "@getpochi/common";
+import { GoogleVertexModel } from "@getpochi/common/configuration";
 import { type ClientTools, McpTool } from "@getpochi/tools";
 import type { Store } from "@livestore/livestore";
 import type { FinishReason, InferUITools, UIMessage } from "ai";

--- a/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/async-agent-worker.tsx
@@ -18,7 +18,11 @@ import { blobStore } from "@/lib/remote-blob-store";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { vscodeHost } from "@/lib/vscode";
 import { useChat } from "@ai-sdk/react";
-import { getLogger } from "@getpochi/common";
+import {
+  type ForkAgentUseCase,
+  type MessageCacheBreakpoint,
+  getLogger,
+} from "@getpochi/common";
 import { catalog } from "@getpochi/livekit";
 import { useLiveChatKit } from "@getpochi/livekit/react";
 import {
@@ -58,6 +62,8 @@ export function AsyncAgentWorker({
       taskId={taskId}
       tools={asyncAgentState?.tools}
       parentTaskId={asyncAgentState?.parentTaskId}
+      messageCacheBreakpoint={asyncAgentState?.messageCacheBreakpoint}
+      requestUseCase={asyncAgentState?.useCase}
       batchExecuteManager={batchExecuteManager}
     />
   );
@@ -67,10 +73,14 @@ function AsyncAgentWorkerInner({
   taskId,
   tools,
   parentTaskId,
+  messageCacheBreakpoint,
+  requestUseCase,
   batchExecuteManager,
 }: AsyncAgentWorkerProps & {
   tools?: readonly ToolSpecInput[];
   parentTaskId?: string;
+  messageCacheBreakpoint?: MessageCacheBreakpoint;
+  requestUseCase?: ForkAgentUseCase;
 }) {
   const store = useDefaultStore();
   const task = store.useQuery(catalog.queries.makeTaskQuery(taskId));
@@ -161,6 +171,8 @@ function AsyncAgentWorkerInner({
     abortSignal: abortController.current.signal,
     getters,
     isSubTask: false,
+    messageCacheBreakpoint: messageCacheBreakpoint ?? "last",
+    requestUseCase,
     sendAutomaticallyWhen: (x) => {
       if (
         abortController.current.signal.aborted ||

--- a/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
@@ -1,11 +1,8 @@
 import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { vscodeHost } from "@/lib/vscode";
+import type { ContextWindowUsage, TaskMemoryState } from "@getpochi/common";
 import { constants, getLogger, prompts } from "@getpochi/common";
-import type {
-  ContextWindowUsage,
-  TaskMemoryState,
-} from "@getpochi/common/vscode-webui-bridge";
 import { type Message, catalog } from "@getpochi/livekit";
 import type { ToolSpecInput } from "@getpochi/tools";
 import { useCallback, useEffect } from "react";

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/create-fork-agent.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/create-fork-agent.test.ts
@@ -46,7 +46,7 @@ describe("buildForkMessages", () => {
       store: {
         commit: (event: unknown) => commits.push(event),
       } as never,
-      label: "memory",
+      label: "task-memory",
       parentTaskId: "parent-task",
       parentMessages: [],
       parentCwd: "/repo",
@@ -66,6 +66,8 @@ describe("buildForkMessages", () => {
           "writeToFile(/memory/**)",
           "attemptCompletion",
         ],
+        messageCacheBreakpoint: "secondLast",
+        useCase: "task-memory",
       },
     ]);
   });

--- a/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
+++ b/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
@@ -1,4 +1,8 @@
-import { getLogger } from "@getpochi/common";
+import {
+  type AsyncAgentState,
+  type ForkAgentUseCase,
+  getLogger,
+} from "@getpochi/common";
 import { type LiveKitStore, type Message, catalog } from "@getpochi/livekit";
 import { type ToolSpecInput, parseToolSpec } from "@getpochi/tools";
 
@@ -28,20 +32,20 @@ export function buildForkMessages(
 export interface ForkAgentConfig {
   taskId: string;
   cwd: string | undefined;
-  label: string;
+  label: ForkAgentUseCase;
 }
 
 export interface CreateForkAgentOptions {
   store: LiveKitStore;
-  label: string;
+  label: ForkAgentUseCase;
   parentTaskId?: string;
   parentMessages: Message[];
   parentCwd: string | undefined;
   directive: string;
   tools?: readonly ToolSpecInput[];
-  setAsyncAgentState?: (
+  setAsyncAgentState: (
     taskId: string,
-    state: { tools?: readonly ToolSpecInput[]; parentTaskId?: string },
+    state: AsyncAgentState,
   ) => Promise<void> | void;
 }
 
@@ -53,10 +57,6 @@ export async function createForkAgent(
     options.parentMessages,
     options.directive,
   ) as Message[];
-
-  if ((options.tools || options.parentTaskId) && !options.setAsyncAgentState) {
-    throw new Error("setAsyncAgentState is required for async agent state");
-  }
 
   logger.debug(
     {
@@ -71,21 +71,23 @@ export async function createForkAgent(
     "Creating async fork agent",
   );
 
-  if (options.tools || options.parentTaskId) {
-    const asyncAgentState = {
-      parentTaskId: options.parentTaskId,
-      tools: options.tools ? ensureAttemptCompletion(options.tools) : undefined,
-    };
-    logger.debug(
-      {
-        taskId,
-        parentTaskId: asyncAgentState.parentTaskId,
-        tools: asyncAgentState.tools?.length,
-      },
-      "Persisting async fork agent state",
-    );
-    await options.setAsyncAgentState?.(taskId, asyncAgentState);
-  }
+  const asyncAgentState: AsyncAgentState = {
+    parentTaskId: options.parentTaskId,
+    tools: options.tools ? ensureAttemptCompletion(options.tools) : undefined,
+    messageCacheBreakpoint: "secondLast",
+    useCase: options.label,
+  };
+  logger.debug(
+    {
+      taskId,
+      parentTaskId: asyncAgentState.parentTaskId,
+      tools: asyncAgentState.tools?.length,
+      messageCacheBreakpoint: asyncAgentState.messageCacheBreakpoint,
+      useCase: asyncAgentState.useCase,
+    },
+    "Persisting async fork agent state",
+  );
+  await options.setAsyncAgentState(taskId, asyncAgentState);
 
   options.store.commit(
     catalog.events.taskInited({

--- a/packages/vscode-webui/src/lib/hooks/use-async-agent-state.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-async-agent-state.ts
@@ -1,6 +1,5 @@
 import { vscodeHost } from "@/lib/vscode";
-import { getLogger } from "@getpochi/common";
-import type { AsyncAgentState } from "@getpochi/common/vscode-webui-bridge";
+import { type AsyncAgentState, getLogger } from "@getpochi/common";
 import { threadSignal } from "@quilted/threads/signals";
 import { useQuery } from "@tanstack/react-query";
 import { useLatest } from "./use-latest";

--- a/packages/vscode-webui/src/lib/hooks/use-auto-memory-state.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-auto-memory-state.ts
@@ -1,5 +1,5 @@
 import { vscodeHost } from "@/lib/vscode";
-import type { AutoMemoryTaskState } from "@getpochi/common/vscode-webui-bridge";
+import type { AutoMemoryTaskState } from "@getpochi/common";
 import { threadSignal } from "@quilted/threads/signals";
 import { useQuery } from "@tanstack/react-query";
 

--- a/packages/vscode-webui/src/lib/hooks/use-task-context-window-usage.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-task-context-window-usage.ts
@@ -1,5 +1,5 @@
 import { vscodeHost } from "@/lib/vscode";
-import type { ContextWindowUsage } from "@getpochi/common/vscode-webui-bridge";
+import type { ContextWindowUsage } from "@getpochi/common";
 import { threadSignal } from "@quilted/threads/signals";
 import { useQuery } from "@tanstack/react-query";
 import { useLatest } from "./use-latest";

--- a/packages/vscode-webui/src/lib/hooks/use-task-memory-state.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-task-memory-state.ts
@@ -1,5 +1,5 @@
 import { vscodeHost } from "@/lib/vscode";
-import type { TaskMemoryState } from "@getpochi/common/vscode-webui-bridge";
+import type { TaskMemoryState } from "@getpochi/common";
 import { threadSignal } from "@quilted/threads/signals";
 import { useQuery } from "@tanstack/react-query";
 

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -55,8 +55,12 @@ import { todoWrite } from "@/tools/todo-write";
 import { useSkill } from "@/tools/use-skill";
 import { writeToFile } from "@/tools/write-to-file";
 import {
+  type AsyncAgentState,
+  type AutoMemoryTaskState,
+  type ContextWindowUsage,
   type Environment,
   type GitStatus,
+  type TaskMemoryState,
   toErrorMessage,
 } from "@getpochi/common";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -74,12 +78,9 @@ import {
 } from "@getpochi/common/tool-utils";
 import { getVendor } from "@getpochi/common/vendor";
 import {
-  type AsyncAgentState,
-  type AutoMemoryTaskState,
   type BuiltinSubAgentInfo,
   type CaptureEvent,
   type ChangedFileContent,
-  type ContextWindowUsage,
   type CreateWorktreeOptions,
   type CustomAgentFile,
   type DiffCheckpointOptions,
@@ -98,7 +99,6 @@ import {
   type SkillFile,
   type TaskArchivedParams,
   type TaskChangedFile,
-  type TaskMemoryState,
   type TaskStates,
   type VSCodeHostApi,
   type VSCodeSettings,

--- a/packages/vscode/src/lib/task-data-store.ts
+++ b/packages/vscode/src/lib/task-data-store.ts
@@ -3,9 +3,11 @@ import type {
   AsyncAgentState,
   AutoMemoryTaskState,
   ContextWindowUsage,
+  TaskMemoryState,
+} from "@getpochi/common";
+import type {
   McpConfigOverride,
   TaskChangedFile,
-  TaskMemoryState,
 } from "@getpochi/common/vscode-webui-bridge";
 import { computed, signal } from "@preact/signals-core";
 import { inject, injectable, singleton } from "tsyringe";


### PR DESCRIPTION
## Summary
- Promote shared task/memory/message-context types (`TaskMemoryState`, `AsyncAgentState`, `AutoMemoryTaskState`, `ContextWindowUsage`, `ActiveSelection`, `BashOutputs`, `UserEdits`, `Review`) from `vscode-webui-bridge` into `common/base` so non-bridge consumers (livekit, prompts, vscode-host) no longer cross layer boundaries to use them.
- Introduce typed `ForkAgentUseCase` (`task-memory` | `auto-memory` | `auto-memory-dream`) and `PochiRequestUseCase` enums, and validate them at the `PochiProviderOptions` schema level.
- Add a `MessageCacheBreakpoint` setting (`last` | `secondLast`) that fork agents thread through `AsyncAgentState` → `LiveChatKit` → `FlexibleChatTransport`, so the parent task's prefix stays cacheable while the fresh fork directive remains uncached.

## Test plan
- [ ] `bun run test` covers the new schema test (`packages/common/src/base/__tests__/provider-options.test.ts`) and cache-breakpoint test (`packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts`)
- [ ] `bun tsc` to verify type moves compile across the workspace
- [ ] Manual: trigger a memory/auto-memory fork agent and confirm the parent prefix produces a cache hit on subsequent requests

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-bd98113c4c09422796dd492c71f5656b)