### PR TITLE
feat(livekit): add client-only events for async tasks

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -466,8 +466,12 @@ export class LiveChatKit<
   };
 
   markAsFailed = (error: Error) => {
+    const taskFailed = this.task?.runAsync
+      ? events.asyncTaskFailed
+      : events.taskFailed;
+
     this.store.commit(
-      events.taskFailed({
+      taskFailed({
         id: this.taskId,
         error: toTaskError(error),
         updatedAt: new Date(),
@@ -530,19 +534,24 @@ export class LiveChatKit<
       if (!task) {
         throw new Error("Task not found");
       }
+      const chatStreamStarted = task.runAsync
+        ? events.asyncChatStreamStarted
+        : events.chatStreamStarted;
 
       const llm = getters.getLLM();
       const getModel = () => createModel({ llm });
-      scheduleGenerateTitleJob({
-        taskId: this.taskId,
-        store,
-        blobStore: this.blobStore,
-        messages,
-        getModel,
-      });
+      if (!task.runAsync) {
+        scheduleGenerateTitleJob({
+          taskId: this.taskId,
+          store,
+          blobStore: this.blobStore,
+          messages,
+          getModel,
+        });
+      }
 
       store.commit(
-        events.chatStreamStarted({
+        chatStreamStarted({
           id: this.taskId,
           data: lastMessage,
           todos: environment?.todos || [],
@@ -587,6 +596,9 @@ export class LiveChatKit<
 
     const finishReason = streamFinishReason ?? message.metadata?.finishReason;
     const status = toTaskStatus(message, finishReason);
+    const chatStreamFinished = this.task?.runAsync
+      ? events.asyncChatStreamFinished
+      : events.chatStreamFinished;
 
     let contextWindowUsage: ContextWindowUsage | undefined = undefined;
     if (message.metadata?.kind === "assistant") {
@@ -618,7 +630,7 @@ export class LiveChatKit<
     }
 
     store.commit(
-      events.chatStreamFinished({
+      chatStreamFinished({
         id: this.taskId,
         status,
         data: message,
@@ -649,9 +661,12 @@ export class LiveChatKit<
   private readonly onError: ChatOnErrorCallback = (error) => {
     logger.error("onError", error);
     const lastMessage = this.chat.messages.at(-1) || null;
+    const chatStreamFailed = this.task?.runAsync
+      ? events.asyncChatStreamFailed
+      : events.chatStreamFailed;
 
     this.store.commit(
-      events.chatStreamFailed({
+      chatStreamFailed({
         id: this.taskId,
         error: toTaskError(error),
         data: lastMessage,

--- a/packages/livekit/src/chat/middlewares/new-task-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/new-task-middleware.ts
@@ -100,7 +100,7 @@ export function createNewTaskMiddleware(
                 uid,
               };
               store.commit(
-                events.taskInited({
+                events[runAsync ? "asyncTaskInited" : "taskInited"]({
                   id: uid,
                   cwd,
                   parentId: parentTaskId,

--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -109,73 +109,103 @@ export const tables = {
   }),
 };
 
+const taskInitedSchema = Schema.Struct({
+  ...taskInitFields,
+  initMessages: Schema.optional(Schema.Array(DBMessage)),
+  initTitle: Schema.optional(Schema.String),
+  displayId: Schema.optional(Schema.Number).pipe(
+    deprecated("Concept of displayId is removed"),
+  ),
+  // @deprecated
+  // use initMessages instead
+  initMessage: Schema.optional(
+    Schema.Struct({
+      id: Schema.String,
+      parts: Schema.Array(DBUIPart),
+    }),
+  ).pipe(deprecated("use initMessages instead")),
+});
+
+const taskFailedSchema = Schema.Struct({
+  id: Schema.String,
+  error: TaskError,
+  updatedAt: Schema.Date,
+});
+
+const chatStreamStartedSchema = Schema.Struct({
+  id: Schema.String,
+  data: DBMessage,
+  todos: Todos,
+  title: Schema.optional(Schema.String).pipe(
+    deprecated("use updateTitle instead"),
+  ),
+  git: Schema.optional(Git),
+  updatedAt: Schema.Date,
+  modelId: Schema.optional(Schema.String),
+  displayId: Schema.optional(Schema.Number).pipe(
+    deprecated("Concept of displayId is removed"),
+  ),
+});
+
+const chatStreamFinishedSchema = Schema.Struct({
+  id: Schema.String,
+  data: DBMessage,
+  totalTokens: Schema.NullOr(Schema.Number),
+  status: TaskStatus,
+  updatedAt: Schema.Date,
+  duration: Schema.optional(Schema.DurationFromMillis),
+  lastCheckpointHash: Schema.optional(Schema.String),
+});
+
+const chatStreamFailedSchema = Schema.Struct({
+  id: Schema.String,
+  error: TaskError,
+  data: Schema.NullOr(DBMessage),
+  updatedAt: Schema.Date,
+  duration: Schema.optional(Schema.DurationFromMillis),
+  lastCheckpointHash: Schema.optional(Schema.String),
+});
+
 export const events = {
   taskInited: Events.synced({
     name: "v1.TaskInited",
-    schema: Schema.Struct({
-      ...taskInitFields,
-      initMessages: Schema.optional(Schema.Array(DBMessage)),
-      initTitle: Schema.optional(Schema.String),
-      displayId: Schema.optional(Schema.Number).pipe(
-        deprecated("Concept of displayId is removed"),
-      ),
-      // @deprecated
-      // use initMessages instead
-      initMessage: Schema.optional(
-        Schema.Struct({
-          id: Schema.String,
-          parts: Schema.Array(DBUIPart),
-        }),
-      ).pipe(deprecated("use initMessages instead")),
-    }),
+    schema: taskInitedSchema,
+  }),
+  asyncTaskInited: Events.clientOnly({
+    name: "client.AsyncTaskInited",
+    schema: taskInitedSchema,
   }),
   taskFailed: Events.synced({
     name: "v1.TaskFailed",
-    schema: Schema.Struct({
-      id: Schema.String,
-      error: TaskError,
-      updatedAt: Schema.Date,
-    }),
+    schema: taskFailedSchema,
+  }),
+  asyncTaskFailed: Events.clientOnly({
+    name: "client.AsyncTaskFailed",
+    schema: taskFailedSchema,
   }),
   chatStreamStarted: Events.synced({
     name: "v1.ChatStreamStarted",
-    schema: Schema.Struct({
-      id: Schema.String,
-      data: DBMessage,
-      todos: Todos,
-      title: Schema.optional(Schema.String).pipe(
-        deprecated("use updateTitle instead"),
-      ),
-      git: Schema.optional(Git),
-      updatedAt: Schema.Date,
-      modelId: Schema.optional(Schema.String),
-      displayId: Schema.optional(Schema.Number).pipe(
-        deprecated("Concept of displayId is removed"),
-      ),
-    }),
+    schema: chatStreamStartedSchema,
+  }),
+  asyncChatStreamStarted: Events.clientOnly({
+    name: "client.AsyncChatStreamStarted",
+    schema: chatStreamStartedSchema,
   }),
   chatStreamFinished: Events.synced({
     name: "v1.ChatStreamFinished",
-    schema: Schema.Struct({
-      id: Schema.String,
-      data: DBMessage,
-      totalTokens: Schema.NullOr(Schema.Number),
-      status: TaskStatus,
-      updatedAt: Schema.Date,
-      duration: Schema.optional(Schema.DurationFromMillis),
-      lastCheckpointHash: Schema.optional(Schema.String),
-    }),
+    schema: chatStreamFinishedSchema,
+  }),
+  asyncChatStreamFinished: Events.clientOnly({
+    name: "client.AsyncChatStreamFinished",
+    schema: chatStreamFinishedSchema,
   }),
   chatStreamFailed: Events.synced({
     name: "v1.ChatStreamFailed",
-    schema: Schema.Struct({
-      id: Schema.String,
-      error: TaskError,
-      data: Schema.NullOr(DBMessage),
-      updatedAt: Schema.Date,
-      duration: Schema.optional(Schema.DurationFromMillis),
-      lastCheckpointHash: Schema.optional(Schema.String),
-    }),
+    schema: chatStreamFailedSchema,
+  }),
+  asyncChatStreamFailed: Events.clientOnly({
+    name: "client.AsyncChatStreamFailed",
+    schema: chatStreamFailedSchema,
   }),
   updateShareId: Events.synced({
     name: "v1.UpdateShareId",
@@ -279,154 +309,173 @@ export const events = {
   }),
 };
 
-const materializers = State.SQLite.materializers(events, {
-  "v1.TaskInited": ({
+const materializeTaskInited = ({
+  id,
+  parentId,
+  runAsync,
+  createdAt,
+  cwd,
+  initMessage,
+  initMessages,
+  initTitle,
+  displayId,
+}: typeof taskInitedSchema.Type) => [
+  tables.tasks.insert({
     id,
+    shareId: parentId ? undefined : `p-${id.replaceAll("-", "")}`,
+    status: initMessages
+      ? initMessages.length > 0
+        ? "pending-model"
+        : "pending-input"
+      : initMessage
+        ? "pending-model"
+        : "pending-input",
     parentId,
-    runAsync,
+    runAsync: runAsync ?? false,
     createdAt,
     cwd,
-    initMessage,
-    initMessages,
-    initTitle,
+    title: initTitle,
     displayId,
-  }) => [
-    tables.tasks.insert({
-      id,
-      shareId: parentId ? undefined : `p-${id.replaceAll("-", "")}`,
-      status: initMessages
-        ? initMessages.length > 0
-          ? "pending-model"
-          : "pending-input"
-        : initMessage
-          ? "pending-model"
-          : "pending-input",
-      parentId,
-      runAsync: runAsync ?? false,
-      createdAt,
-      cwd,
-      title: initTitle,
-      displayId,
-      updatedAt: createdAt,
-      isPublicShared: true,
-    }),
-    ...(initMessages?.map((message) => {
-      return tables.messages.insert({
-        id: message.id,
-        taskId: id,
-        data: message,
-      });
-    }) ??
-      (initMessage
-        ? [
-            tables.messages.insert({
-              id: initMessage.id,
-              taskId: id,
-              data: {
-                id: initMessage.id,
-                role: "user",
-                parts: initMessage.parts,
-              },
-            }),
-          ]
-        : [])),
-  ],
-  "v1.TaskFailed": ({ id, error, updatedAt }) => [
-    tables.tasks
-      .update({
-        status: "failed",
-        error,
-        updatedAt,
-      })
-      .where({ id }),
-  ],
-  "v1.ChatStreamStarted": ({
-    id,
-    data,
-    todos,
-    git,
-    title,
-    updatedAt,
-    modelId,
-    displayId,
-  }) => [
-    tables.tasks
-      .update({
-        status: "pending-model",
-        todos,
-        git,
-        title,
-        updatedAt,
-        modelId,
-        displayId,
-        lastCheckpointHash: null, // set as null to disable user edit when streaming
-      })
-      .where({ id }),
-    tables.messages
-      .insert({
-        id: data.id,
-        taskId: id,
-        data,
-      })
-      .onConflict("id", "replace"),
-  ],
-  "v1.ChatStreamFinished": ({
-    id,
-    data,
-    totalTokens,
-    status,
-    updatedAt,
-    duration,
-    lastCheckpointHash,
-  }) => [
-    tables.tasks
-      .update({
-        totalTokens,
-        status,
-        updatedAt,
-        // Clear error if the stream is finished
-        error: null,
-        lastStepDuration: duration ?? undefined,
-        lastCheckpointHash: lastCheckpointHash,
-      })
-      .where({ id }),
-    tables.messages
-      .insert({
-        id: data.id,
-        data,
-        taskId: id,
-      })
-      .onConflict("id", "replace"),
-  ],
-  "v1.ChatStreamFailed": ({
-    id,
-    error,
-    updatedAt,
-    data,
-    duration,
-    lastCheckpointHash,
-  }) => [
-    tables.tasks
-      .update({
-        status: "failed",
-        error,
-        updatedAt,
-        lastStepDuration: duration ?? undefined,
-        lastCheckpointHash,
-      })
-      .where({ id }),
-    ...(data
+    updatedAt: createdAt,
+    isPublicShared: true,
+  }),
+  ...(initMessages?.map((message) => {
+    return tables.messages.insert({
+      id: message.id,
+      taskId: id,
+      data: message,
+    });
+  }) ??
+    (initMessage
       ? [
-          tables.messages
-            .insert({
-              id: data.id,
-              taskId: id,
-              data,
-            })
-            .onConflict("id", "replace"),
+          tables.messages.insert({
+            id: initMessage.id,
+            taskId: id,
+            data: {
+              id: initMessage.id,
+              role: "user",
+              parts: initMessage.parts,
+            },
+          }),
         ]
-      : []),
-  ],
+      : [])),
+];
+
+const materializeTaskFailed = ({
+  id,
+  error,
+  updatedAt,
+}: typeof taskFailedSchema.Type) => [
+  tables.tasks
+    .update({
+      status: "failed",
+      error,
+      updatedAt,
+    })
+    .where({ id }),
+];
+
+const materializeChatStreamStarted = ({
+  id,
+  data,
+  todos,
+  git,
+  title,
+  updatedAt,
+  modelId,
+  displayId,
+}: typeof chatStreamStartedSchema.Type) => [
+  tables.tasks
+    .update({
+      status: "pending-model",
+      todos,
+      git,
+      title,
+      updatedAt,
+      modelId,
+      displayId,
+      lastCheckpointHash: null, // set as null to disable user edit when streaming
+    })
+    .where({ id }),
+  tables.messages
+    .insert({
+      id: data.id,
+      taskId: id,
+      data,
+    })
+    .onConflict("id", "replace"),
+];
+
+const materializeChatStreamFinished = ({
+  id,
+  data,
+  totalTokens,
+  status,
+  updatedAt,
+  duration,
+  lastCheckpointHash,
+}: typeof chatStreamFinishedSchema.Type) => [
+  tables.tasks
+    .update({
+      totalTokens,
+      status,
+      updatedAt,
+      // Clear error if the stream is finished
+      error: null,
+      lastStepDuration: duration ?? undefined,
+      lastCheckpointHash: lastCheckpointHash,
+    })
+    .where({ id }),
+  tables.messages
+    .insert({
+      id: data.id,
+      data,
+      taskId: id,
+    })
+    .onConflict("id", "replace"),
+];
+
+const materializeChatStreamFailed = ({
+  id,
+  error,
+  updatedAt,
+  data,
+  duration,
+  lastCheckpointHash,
+}: typeof chatStreamFailedSchema.Type) => [
+  tables.tasks
+    .update({
+      status: "failed",
+      error,
+      updatedAt,
+      lastStepDuration: duration ?? undefined,
+      lastCheckpointHash,
+    })
+    .where({ id }),
+  ...(data
+    ? [
+        tables.messages
+          .insert({
+            id: data.id,
+            taskId: id,
+            data,
+          })
+          .onConflict("id", "replace"),
+      ]
+    : []),
+];
+
+const materializers = State.SQLite.materializers(events, {
+  "v1.TaskInited": materializeTaskInited,
+  "client.AsyncTaskInited": materializeTaskInited,
+  "v1.TaskFailed": materializeTaskFailed,
+  "client.AsyncTaskFailed": materializeTaskFailed,
+  "v1.ChatStreamStarted": materializeChatStreamStarted,
+  "client.AsyncChatStreamStarted": materializeChatStreamStarted,
+  "v1.ChatStreamFinished": materializeChatStreamFinished,
+  "client.AsyncChatStreamFinished": materializeChatStreamFinished,
+  "v1.ChatStreamFailed": materializeChatStreamFailed,
+  "client.AsyncChatStreamFailed": materializeChatStreamFailed,
   "v1.UpdateShareId": ({ id, shareId, updatedAt }) =>
     tables.tasks.update({ shareId, updatedAt }).where({ id, shareId: null }),
   "v1.UpdateTitle": ({ id, title, updatedAt }) =>

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/create-fork-agent.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/create-fork-agent.test.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@getpochi/livekit";
+import { type Message, catalog } from "@getpochi/livekit";
 import {
   type ToolSpecInput,
   compileToolPolicies,
@@ -58,6 +58,11 @@ describe("buildForkMessages", () => {
     });
 
     expect(commits).toHaveLength(1);
+    expect(commits[0]).toMatchObject({
+      name: catalog.events.asyncTaskInited.name,
+      args: { runAsync: true },
+    });
+    expect(catalog.events.asyncTaskInited.options.clientOnly).toBe(true);
     expect(states).toEqual([
       {
         parentTaskId: "parent-task",

--- a/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
+++ b/packages/vscode-webui/src/features/chat/lib/create-fork-agent.ts
@@ -90,7 +90,7 @@ export async function createForkAgent(
   await options.setAsyncAgentState(taskId, asyncAgentState);
 
   options.store.commit(
-    catalog.events.taskInited({
+    catalog.events.asyncTaskInited({
       id: taskId,
       cwd: options.parentCwd,
       runAsync: true,


### PR DESCRIPTION
## Summary
- Mirror the task and chat-stream lifecycle events (`taskInited`, `taskFailed`, `chatStreamStarted/Finished/Failed`) as client-only variants so async (background) tasks do not sync their full event stream to the server.
- Extract the event materializers into reusable functions and register them for both the synced and the new client-only event names.
- Route LiveChatKit, the new-task middleware, and the create-fork-agent helper to dispatch the async event variants when `task.runAsync` is true.

## Test plan
- [ ] `bun run test` for `packages/livekit`
- [ ] `bun run test` for `packages/vscode-webui` (covers `create-fork-agent` test that asserts the new `asyncTaskInited` client-only event)
- [ ] Manual smoke: trigger a normal task and an async/fork task, ensure both materialize correctly and async task events are not synced

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b2d542abae9c47ef87549dd653f3a3f7)