### PR TITLE
fix(async-agent): skip title generation for async-agent runners

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -532,14 +532,16 @@ export class LiveChatKit<
       }
 
       const llm = getters.getLLM();
-      const getModel = () => createModel({ llm });
-      scheduleGenerateTitleJob({
-        taskId: this.taskId,
-        store,
-        blobStore: this.blobStore,
-        messages,
-        getModel,
-      });
+      if (!task.runAsync) {
+        const getModel = () => createModel({ llm });
+        scheduleGenerateTitleJob({
+          taskId: this.taskId,
+          store,
+          blobStore: this.blobStore,
+          messages,
+          getModel,
+        });
+      }
 
       store.commit(
         events.chatStreamStarted({


### PR DESCRIPTION
## Summary
- Async-agent (`runAsync: true`) tasks no longer trigger the title-generation background job in `LiveChatKit.onStart`.
- Title generation remains untouched for regular user-initiated tasks.

## Why
Async agents run headlessly and inherit identity from their parent task / use-case label, so generating a title for them is wasted LLM work and can clobber the parent-derived label with a less meaningful summary.

## Test plan
- [x] `bunx tsc --noEmit` (livekit) passes
- [x] `bunx biome check` on the changed file passes
- [ ] Manual: spawn an async fork agent, confirm no `generate-title-<taskId>` job runs
- [ ] Manual: regular task still generates a title as before

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5869e1f2fb9b4cb982102c0325553e2e)