### PR TITLE
docs: update Weekly Update #29 (2026-05-08) 

### DIFF
--- a/packages/docs/content/docs/developer-updates/2026-05-08-weekly-update-29.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-05-08-weekly-update-29.mdx
@@ -1,6 +1,6 @@
 ---
 title: Weekly Update #29
---- 
+---
 
 # Weekly Update #29
 

--- a/packages/docs/content/docs/developer-updates/2026-05-08-weekly-update-29.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-05-08-weekly-update-29.mdx
@@ -1,6 +1,6 @@
 ---
 title: Weekly Update #29
----
+--- 
 
 # Weekly Update #29
 

--- a/packages/docs/content/docs/developer-updates/2026-05-08-weekly-update-29.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-05-08-weekly-update-29.mdx
@@ -1,8 +1,9 @@
 ---
-title: 'Weekly Update #29'
-slug: weekly-update-29
-date: '2026-05-08'
+title: Weekly Update #29
 ---
+
+# Weekly Update #29
+
 ### TL;DR
 
 In this update, Pochi gets context-aware in two directions: tasks now maintain persistent memory that survives compaction, and custom agents that can precisely scope which files and domains they're allowed to touch.


### PR DESCRIPTION
Added # Weekly Update #29 header to the mdx file as it was missing when i clicked into the header link

Before:

<img width="1128" height="831" alt="image" src="https://github.com/user-attachments/assets/e34274ec-9328-4172-855d-14647291803e" />


After: (github preview)

<img width="740" height="722" alt="image" src="https://github.com/user-attachments/assets/0aff923b-6bde-40db-8c28-e3801408c302" />

