### PR TITLE
test(vscode): wait for model selection before submitting create-task

### DIFF
--- a/packages/vscode-webui/src/components/model-select.tsx
+++ b/packages/vscode-webui/src/components/model-select.tsx
@@ -82,6 +82,8 @@ export function ModelSelect({
             <Button
               variant="ghost"
               aria-label="model-select"
+              data-valid={isValid ? "true" : "false"}
+              data-model-id={value?.id ?? ""}
               className={cn(
                 "!gap-0.5 !px-1 button-focus h-6 max-w-full items-center py-0 font-normal",
                 triggerClassName,

--- a/packages/vscode/tests/pageobjects/pochi-panel.ts
+++ b/packages/vscode/tests/pageobjects/pochi-panel.ts
@@ -59,13 +59,34 @@ export class PochiPanel {
   /**
    * Wait for at least one user message to appear in the task panel.
    * This confirms the task panel is properly displaying the conversation.
+   *
+   * If `expectedText` is provided, also wait for the rendered message
+   * text to contain that substring. This avoids races where the message
+   * wrapper (with the avatar fallback) is rendered before the message
+   * body finishes hydrating.
    */
-  async waitForUserMessage(timeout = 30000) {
+  async waitForUserMessage(timeout = 30000, expectedText?: string) {
     const userMessage = $('[aria-label="chat-message-user"]');
     await userMessage.waitForExist({
       timeout,
       timeoutMsg: "User message did not appear in task panel",
     });
+
+    if (!expectedText) {
+      return;
+    }
+
+    await browser.waitUntil(
+      async () => {
+        const text = await userMessage.getText();
+        return text.includes(expectedText);
+      },
+      {
+        timeout,
+        timeoutMsg: `User message did not contain expected text: ${expectedText}`,
+        interval: 500,
+      },
+    );
   }
 
   /**

--- a/packages/vscode/tests/pageobjects/pochi-sidebar.ts
+++ b/packages/vscode/tests/pageobjects/pochi-sidebar.ts
@@ -90,8 +90,37 @@ export class PochiSidebar {
     throw new Error(`Model ${modelName} not found in selection menu`);
   }
 
+  /**
+   * Wait until the model select button reports a selected, valid model.
+   * The chat input form silently drops submissions when no model is
+   * selected, so callers must guarantee selection before pressing Enter.
+   */
+  async waitForModelReady(timeout = 30000) {
+    await browser.waitUntil(
+      async () => {
+        const valid = await this.modelSelect.getAttribute("data-valid");
+        const modelId = await this.modelSelect.getAttribute("data-model-id");
+        const ready = valid === "true" && !!modelId;
+        if (!ready) {
+          console.log(
+            `[Test Debug] Waiting for model: valid=${valid} modelId=${modelId}`,
+          );
+        }
+        return ready;
+      },
+      {
+        timeout,
+        timeoutMsg: "Model select did not become ready",
+        interval: 500,
+      },
+    );
+  }
+
   async sendMessage(text: string, waitMs = 1000) {
     await this.input.waitForDisplayed({ timeout: 1000 * 10 });
+    // Make sure a usable model is selected before submitting; otherwise the
+    // form silently rejects the Enter keypress and no task is created.
+    await this.waitForModelReady();
     await this.input.click();
     await browser.keys(text);
     await browser.pause(waitMs);

--- a/packages/vscode/tests/specs/git-workspace/create-task.test.ts
+++ b/packages/vscode/tests/specs/git-workspace/create-task.test.ts
@@ -64,7 +64,7 @@ describe("Create Task Tests", () => {
     );
 
     // Verify the user message is visible in the task panel
-    await panel.waitForUserMessage(30000);
+    await panel.waitForUserMessage(30000, TestMessage);
     const userMessageText = await panel.getUserMessageText();
     console.log("[Test Debug] User message text in panel:", userMessageText);
     expect(userMessageText).toContain(TestMessage);

--- a/packages/vscode/tests/specs/git-worktrees-workspace/create-task.test.ts
+++ b/packages/vscode/tests/specs/git-worktrees-workspace/create-task.test.ts
@@ -64,7 +64,7 @@ describe("Create Task Tests", () => {
     );
 
     // Verify the user message is visible in the task panel
-    await panel.waitForUserMessage(30000);
+    await panel.waitForUserMessage(30000, TestMessage);
     const userMessageText = await panel.getUserMessageText();
     console.log("[Test Debug] User message text in panel:", userMessageText);
     expect(userMessageText).toContain(TestMessage);

--- a/packages/vscode/tests/specs/plain-workspace/create-task.test.ts
+++ b/packages/vscode/tests/specs/plain-workspace/create-task.test.ts
@@ -64,7 +64,7 @@ describe("Create Task Tests", () => {
     );
 
     // Verify the user message is visible in the task panel
-    await panel.waitForUserMessage(30000);
+    await panel.waitForUserMessage(30000, TestMessage);
     const userMessageText = await panel.getUserMessageText();
     console.log("[Test Debug] User message text in panel:", userMessageText);
     expect(userMessageText).toContain(TestMessage);


### PR DESCRIPTION
## Summary
- Fix flaky `Create Task Tests` integration spec on slow CI runs by waiting for the model select to report a usable model before pressing Enter.
- Avoid panel-side races where `chat-message-user` is queried before the message body finishes hydrating.
- Expose `data-valid` / `data-model-id` on the model-select trigger so tests can deterministically detect readiness.

## Details
The chat input form silently drops `Enter` submissions when no `selectedModel` is set. On slow CI the model list could finish loading after the test had already typed and submitted, leaving the sidebar with zero tasks until the 60s `waitForTaskToAppear` timeout.

- `PochiSidebar.sendMessage` now awaits a new `waitForModelReady()` helper (driven by the new attributes on the model-select trigger) before clicking and pressing Enter.
- `PochiPanel.waitForUserMessage` accepts an optional `expectedText` and polls until `getText()` actually contains it, eliminating the avatar-only race where the wrapper renders before the message body parts.
- All three `create-task.test.ts` specs (plain / git / git-worktrees) pass `TestMessage` into `waitForUserMessage` so the body has hydrated before reading it.

## Test plan
- [x] `bun turbo test:integration -- --spec ./tests/specs/plain-workspace/create-task.test.ts` — plain, git-repo and git-worktrees capabilities pass; only the no-workspace capability fails (expected when forcing the spec onto a workspace-less window via `--spec`).
- [x] `bunx tsc --noEmit` for `packages/vscode-webui` and `packages/vscode/tests`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0632f3f883b14f9281a0f1e9c48824a0)