### PR TITLE
fix(vscode-webui): restore left-pointing chevron for collapsed tool container

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/tool-container.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-container.tsx
@@ -43,7 +43,7 @@ export const ExpandIcon: React.FC<{
       <ChevronRight
         className={cn(
           "size-3 transition-transform",
-          isExpanded ? "rotate-90" : "rotate-0",
+          isExpanded ? "rotate-90" : "rotate-180",
         )}
       />
     </span>


### PR DESCRIPTION
## Summary
- Reverts the collapsed-state `ExpandIcon` orientation in `ExpandableToolContainer` from `rotate-0` (right-pointing) back to `rotate-180` (left-pointing), restoring the pre-#1432 behavior.
- The current right-pointing icon was inadvertently introduced in commit `9ab7495d5` (#1432) when the two `<ChevronRight>` branches were merged into a single element with conditional rotation.

### Before
- Collapsed: `rotate-0` → ▶ (right)
- Expanded:  `rotate-90` → ▼ (down)

### After
- Collapsed: `rotate-180` → ◀ (left)
- Expanded:  `rotate-90`  → ▼ (down)

## Test plan
- [ ] Visually verify chevron points left when any `ExpandableToolContainer` (e.g. `apply-diff`, `write-to-file`, `todo-write`, `mcp-tool-call`, `new-task`) is collapsed.
- [ ] Verify chevron rotates down on expand and animates smoothly via `transition-transform`.
- [ ] Hover behavior on collapsed state still fades the icon in (no regression to #1325).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-bea5c2921aed4359b1f23c17bb53e7de)