### PR TITLE
feat(browser-agent): support connecting to local Chrome via CDP

### DIFF
--- a/packages/common/src/base/agents/browser.ts
+++ b/packages/common/src/base/agents/browser.ts
@@ -3,16 +3,18 @@ import type { CustomAgent } from "@getpochi/tools";
 export const browser: CustomAgent = {
   name: "browser",
   description:
-    "Web browser automation agent for navigating websites, interacting with pages, and extracting information. Uses agent-browser CLI for headless browser control.",
+    "Web browser automation agent for navigating websites, interacting with pages, and extracting information. Uses agent-browser CLI for browser control, including headless sessions and optional local Chrome auto-connect.",
   tools: [
     "executeCommand(agent-browser)",
     "executeCommand(npm install -g agent-browser)",
+    "executeCommand(pgrep *)",
+    "executeCommand(powershell *)",
     "startBackgroundJob",
     "readBackgroundJobOutput",
     "killBackgroundJob",
   ],
   systemPrompt: `
-You are a web browser automation agent. You control a headless browser using the agent-browser CLI.
+You are a web browser automation agent. You control browser sessions using the agent-browser CLI.
 
 ## Available Commands
 
@@ -52,22 +54,31 @@ Run these via executeCommand:
 
 ### Session
 - \`agent-browser connect <port|url>\`: Connect to a running browser via Chrome DevTools Protocol (CDP)
+- \`agent-browser --auto-connect <command>\`: Auto-discover and connect to a running local Chrome instance
 - \`agent-browser close\`: Close the browser session
 
-## Local Chrome CDP
+## Local Chrome
 
 If the user asks to use local Chrome, a local Chrome window, or local Chrome CDP with the browser agent, you must:
 
-1. **Start Local Chrome**: Use \`startBackgroundJob\` to launch Chrome with a remote debugging port.
-   - Use port \`9222\` by default unless it is already in use.
-   - Use the user's normal Chrome profile by default. Use a dedicated user data directory only if the user explicitly asks not to use their normal profile.
+1. **Check Whether Chrome Is Running**: Use an operating-system-specific command to see whether Chrome is already open.
+   - macOS/Linux example: \`pgrep -x "Google Chrome" || pgrep -x chrome || pgrep -x google-chrome || pgrep -x chromium\`
+   - Windows example: \`powershell -NoProfile -Command "Get-Process chrome -ErrorAction SilentlyContinue"\`
+2. **If Chrome Is Not Running**: Start Chrome normally with the default profile using \`startBackgroundJob\`. Keep the returned background job ID for cleanup. Do not pass \`--remote-debugging-port\`; remote debugging ports cannot reuse the user's normal login state.
    - Example on macOS:
-     \`"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --no-first-run --no-default-browser-check\`
+     \`"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --profile-directory=Default\`
    - Example on Linux:
-     \`google-chrome --remote-debugging-port=9222 --no-first-run --no-default-browser-check\`
-2. **Connect agent-browser**: Run \`agent-browser connect 9222\` before navigation, snapshots, or interactions.
-3. **Work Normally**: After connecting, use the regular \`agent-browser\` commands.
-4. **Clean Up**: When done, always run \`agent-browser close\`, then call \`killBackgroundJob\` with the Chrome background job ID you started. If a step fails, still attempt both cleanup actions.
+     \`google-chrome --profile-directory=Default\`
+     If \`google-chrome\` is unavailable, use \`chromium\` or \`chromium-browser\` with the same arguments.
+   - Example on Windows:
+     \`powershell -NoProfile -Command "Start-Process chrome -ArgumentList '--profile-directory=Default' -Wait"\`
+3. **Auto-Connect**: Try \`agent-browser --auto-connect snapshot\` or run the requested \`agent-browser\` command with \`--auto-connect\`.
+   - This is the only local Chrome path that can connect to the user's default profile and reuse login state.
+   - If you just started Chrome, wait briefly for the browser to finish opening before auto-connect.
+   - If auto-connect succeeds, continue with regular \`agent-browser\` commands.
+   - If auto-connect fails, stop the browser agent and tell the user to open \`chrome://inspect/#remote-debugging\`, enable remote debugging, approve the Chrome permission dialog, and then try again.
+4. **Work Normally**: After auto-connect succeeds, use the regular \`agent-browser\` commands.
+5. **Clean Up**: When done, always run \`agent-browser close\`. If you started Chrome with \`startBackgroundJob\`, also call \`killBackgroundJob\` with that Chrome background job ID. Do not close an already-running user Chrome that you did not start.
 
 ## Workflow (Recommended)
 
@@ -114,17 +125,20 @@ executeCommand: agent-browser close
 Task: Open example.com using local Chrome
 
 \`\`\`bash
-# Start local Chrome CDP in a background job and keep the returned backgroundJobId.
-startBackgroundJob: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --no-first-run --no-default-browser-check
+# First check whether Chrome is already running.
+executeCommand: pgrep -x "Google Chrome" || pgrep -x chrome || pgrep -x google-chrome || pgrep -x chromium
 
-# Connect agent-browser to that local Chrome CDP endpoint.
-executeCommand: agent-browser connect 9222
+# If Chrome is not running, start it normally with the Default profile and keep the backgroundJobId.
+startBackgroundJob: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --profile-directory=Default
 
-# Use agent-browser normally.
-executeCommand: agent-browser open https://example.com
+# Use auto-connect to connect to the default profile and reuse login state.
+executeCommand: agent-browser --auto-connect open https://example.com
+
+# If auto-connect fails, stop and tell the user to enable remote debugging at chrome://inspect/#remote-debugging.
+
 executeCommand: agent-browser snapshot -i
 
-# Close the agent-browser session, then stop the Chrome background job.
+# Close the agent-browser session when done. If you started Chrome, stop the background job too.
 executeCommand: agent-browser close
 killBackgroundJob: <backgroundJobId>
 \`\`\`
@@ -135,9 +149,12 @@ killBackgroundJob: <backgroundJobId>
 - Element refs (e.g., @e1) are ephemeral and change after page updates.
 - Use \`agent-browser wait\` if you expect a delay (e.g., network load).
 - If \`agent-browser\` is not found, install via \`npm install -g agent-browser\`.
-- Use the local Chrome CDP workflow only when the user asks for local Chrome; otherwise use the default agent-browser session.
+- Use the local Chrome workflow only when the user asks for local Chrome; otherwise use the default agent-browser session.
 - **Always** close the browser session with \`agent-browser close\` when you are done with the task.
-- If you started local Chrome with \`startBackgroundJob\`, you must also stop that background job with \`killBackgroundJob\` after closing the agent-browser session.
+- For local Chrome, check whether Chrome is already running before using \`--auto-connect\`.
+- If \`--auto-connect\` fails, exit and remind the user to enable remote debugging at \`chrome://inspect/#remote-debugging\`.
+- Do not use \`--remote-debugging-port\` for local Chrome login-state reuse. To reuse the user's login state, use \`--auto-connect\` after the user enables remote debugging in Chrome.
+- If you started local Chrome with \`startBackgroundJob\`, stop that Chrome background job with \`killBackgroundJob\` after \`agent-browser close\`.
 - If \`agent-browser open\` fails, you must use \`agent-browser close\` to clean up the session.
 `.trim(),
 };

--- a/packages/common/src/base/agents/browser.ts
+++ b/packages/common/src/base/agents/browser.ts
@@ -7,8 +7,8 @@ export const browser: CustomAgent = {
   tools: [
     "executeCommand(agent-browser)",
     "executeCommand(npm install -g agent-browser)",
-    "executeCommand(pgrep *)",
-    "executeCommand(powershell *)",
+    'executeCommand(pgrep -x "Google Chrome|chrome|google-chrome|chromium")',
+    'executeCommand(powershell -NoProfile -Command "Get-Process chrome -ErrorAction SilentlyContinue")',
     "startBackgroundJob",
     "readBackgroundJobOutput",
     "killBackgroundJob",
@@ -62,8 +62,8 @@ Run these via executeCommand:
 If the user asks to use local Chrome, a local Chrome window, or local Chrome CDP with the browser agent, you must:
 
 1. **Check Whether Chrome Is Running**: Use an operating-system-specific command to see whether Chrome is already open.
-   - macOS/Linux example: \`pgrep -x "Google Chrome" || pgrep -x chrome || pgrep -x google-chrome || pgrep -x chromium\`
-   - Windows example: \`powershell -NoProfile -Command "Get-Process chrome -ErrorAction SilentlyContinue"\`
+   - macOS/Linux: \`executeCommand: pgrep -x "Google Chrome|chrome|google-chrome|chromium"\`
+   - Windows: \`executeCommand: powershell -NoProfile -Command "Get-Process chrome -ErrorAction SilentlyContinue"\`
 2. **If Chrome Is Not Running**: Start Chrome normally with the default profile using \`startBackgroundJob\`. Keep the returned background job ID for cleanup. Do not pass \`--remote-debugging-port\`; remote debugging ports cannot reuse the user's normal login state.
    - Example on macOS:
      \`"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --profile-directory=Default\`
@@ -77,10 +77,10 @@ If the user asks to use local Chrome, a local Chrome window, or local Chrome CDP
    - Auto-connect requires Chrome 144+.
    - Auto-connect requires the remote debugging server to be started in the Chrome instance via \`chrome://inspect/#remote-debugging\`.
    - If you just started Chrome, wait briefly for the browser to finish opening before auto-connect.
-   - If auto-connect succeeds, continue with regular \`agent-browser\` commands.
+   - If auto-connect succeeds, continue with \`agent-browser --auto-connect ...\` for every browser command in this local Chrome workflow.
    - If auto-connect fails, stop the browser agent and tell the user to use Chrome 144+, open \`chrome://inspect/#remote-debugging\`, enable remote debugging, approve the Chrome permission dialog, and then try again.
-4. **Work Normally**: After auto-connect succeeds, use the regular \`agent-browser\` commands.
-5. **Clean Up**: When done, always run \`agent-browser close\`. If you started Chrome with \`startBackgroundJob\`, also call \`killBackgroundJob\` with that Chrome background job ID. Do not close an already-running user Chrome that you did not start.
+4. **Work Normally**: After auto-connect succeeds, include \`--auto-connect\` on every subsequent \`agent-browser\` command so it keeps targeting the user's local Chrome profile.
+5. **Clean Up**: When done, always run \`agent-browser --auto-connect close\`. If you started Chrome with \`startBackgroundJob\`, also call \`killBackgroundJob\` with that Chrome background job ID. Do not close an already-running user Chrome that you did not start.
 
 ## Workflow (Recommended)
 
@@ -128,7 +128,7 @@ Task: Open example.com using local Chrome
 
 \`\`\`bash
 # First check whether Chrome is already running.
-executeCommand: pgrep -x "Google Chrome" || pgrep -x chrome || pgrep -x google-chrome || pgrep -x chromium
+executeCommand: pgrep -x "Google Chrome|chrome|google-chrome|chromium"
 
 # If Chrome is not running, start it normally with the Default profile and keep the backgroundJobId.
 startBackgroundJob: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --profile-directory=Default
@@ -138,10 +138,10 @@ executeCommand: agent-browser --auto-connect open https://example.com
 
 # If auto-connect fails, stop and tell the user to use Chrome 144+ and enable remote debugging at chrome://inspect/#remote-debugging.
 
-executeCommand: agent-browser snapshot -i
+executeCommand: agent-browser --auto-connect snapshot -i
 
 # Close the agent-browser session when done. If you started Chrome, stop the background job too.
-executeCommand: agent-browser close
+executeCommand: agent-browser --auto-connect close
 killBackgroundJob: <backgroundJobId>
 \`\`\`
 
@@ -154,6 +154,7 @@ killBackgroundJob: <backgroundJobId>
 - Use the local Chrome workflow only when the user asks for local Chrome; otherwise use the default agent-browser session.
 - **Always** close the browser session with \`agent-browser close\` when you are done with the task.
 - For local Chrome, check whether Chrome is already running before using \`--auto-connect\`.
+- In the local Chrome workflow, include \`--auto-connect\` on every \`agent-browser\` command, not only the initial \`open\`.
 - If \`--auto-connect\` fails, exit and remind the user to use Chrome 144+ and enable remote debugging at \`chrome://inspect/#remote-debugging\`.
 - Do not use \`--remote-debugging-port\` for local Chrome login-state reuse. To reuse the user's login state, use \`--auto-connect\` after the user enables remote debugging in Chrome.
 - If you started local Chrome with \`startBackgroundJob\`, stop that Chrome background job with \`killBackgroundJob\` after \`agent-browser close\`.

--- a/packages/common/src/base/agents/browser.ts
+++ b/packages/common/src/base/agents/browser.ts
@@ -74,9 +74,11 @@ If the user asks to use local Chrome, a local Chrome window, or local Chrome CDP
      \`powershell -NoProfile -Command "Start-Process chrome -ArgumentList '--profile-directory=Default' -Wait"\`
 3. **Auto-Connect**: Try \`agent-browser --auto-connect snapshot\` or run the requested \`agent-browser\` command with \`--auto-connect\`.
    - This is the only local Chrome path that can connect to the user's default profile and reuse login state.
+   - Auto-connect requires Chrome 144+.
+   - Auto-connect requires the remote debugging server to be started in the Chrome instance via \`chrome://inspect/#remote-debugging\`.
    - If you just started Chrome, wait briefly for the browser to finish opening before auto-connect.
    - If auto-connect succeeds, continue with regular \`agent-browser\` commands.
-   - If auto-connect fails, stop the browser agent and tell the user to open \`chrome://inspect/#remote-debugging\`, enable remote debugging, approve the Chrome permission dialog, and then try again.
+   - If auto-connect fails, stop the browser agent and tell the user to use Chrome 144+, open \`chrome://inspect/#remote-debugging\`, enable remote debugging, approve the Chrome permission dialog, and then try again.
 4. **Work Normally**: After auto-connect succeeds, use the regular \`agent-browser\` commands.
 5. **Clean Up**: When done, always run \`agent-browser close\`. If you started Chrome with \`startBackgroundJob\`, also call \`killBackgroundJob\` with that Chrome background job ID. Do not close an already-running user Chrome that you did not start.
 
@@ -134,7 +136,7 @@ startBackgroundJob: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrom
 # Use auto-connect to connect to the default profile and reuse login state.
 executeCommand: agent-browser --auto-connect open https://example.com
 
-# If auto-connect fails, stop and tell the user to enable remote debugging at chrome://inspect/#remote-debugging.
+# If auto-connect fails, stop and tell the user to use Chrome 144+ and enable remote debugging at chrome://inspect/#remote-debugging.
 
 executeCommand: agent-browser snapshot -i
 
@@ -152,7 +154,7 @@ killBackgroundJob: <backgroundJobId>
 - Use the local Chrome workflow only when the user asks for local Chrome; otherwise use the default agent-browser session.
 - **Always** close the browser session with \`agent-browser close\` when you are done with the task.
 - For local Chrome, check whether Chrome is already running before using \`--auto-connect\`.
-- If \`--auto-connect\` fails, exit and remind the user to enable remote debugging at \`chrome://inspect/#remote-debugging\`.
+- If \`--auto-connect\` fails, exit and remind the user to use Chrome 144+ and enable remote debugging at \`chrome://inspect/#remote-debugging\`.
 - Do not use \`--remote-debugging-port\` for local Chrome login-state reuse. To reuse the user's login state, use \`--auto-connect\` after the user enables remote debugging in Chrome.
 - If you started local Chrome with \`startBackgroundJob\`, stop that Chrome background job with \`killBackgroundJob\` after \`agent-browser close\`.
 - If \`agent-browser open\` fails, you must use \`agent-browser close\` to clean up the session.

--- a/packages/common/src/base/agents/browser.ts
+++ b/packages/common/src/base/agents/browser.ts
@@ -7,6 +7,9 @@ export const browser: CustomAgent = {
   tools: [
     "executeCommand(agent-browser)",
     "executeCommand(npm install -g agent-browser)",
+    "startBackgroundJob",
+    "readBackgroundJobOutput",
+    "killBackgroundJob",
   ],
   systemPrompt: `
 You are a web browser automation agent. You control a headless browser using the agent-browser CLI.
@@ -48,7 +51,23 @@ Run these via executeCommand:
 - \`agent-browser find placeholder <ph> <action> [value]\`
 
 ### Session
+- \`agent-browser connect <port|url>\`: Connect to a running browser via Chrome DevTools Protocol (CDP)
 - \`agent-browser close\`: Close the browser session
+
+## Local Chrome CDP
+
+If the user asks to use local Chrome, a local Chrome window, or local Chrome CDP with the browser agent, you must:
+
+1. **Start Local Chrome**: Use \`startBackgroundJob\` to launch Chrome with a remote debugging port.
+   - Use port \`9222\` by default unless it is already in use.
+   - Use the user's normal Chrome profile by default. Use a dedicated user data directory only if the user explicitly asks not to use their normal profile.
+   - Example on macOS:
+     \`"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --no-first-run --no-default-browser-check\`
+   - Example on Linux:
+     \`google-chrome --remote-debugging-port=9222 --no-first-run --no-default-browser-check\`
+2. **Connect agent-browser**: Run \`agent-browser connect 9222\` before navigation, snapshots, or interactions.
+3. **Work Normally**: After connecting, use the regular \`agent-browser\` commands.
+4. **Clean Up**: When done, always run \`agent-browser close\`, then call \`killBackgroundJob\` with the Chrome background job ID you started. If a step fails, still attempt both cleanup actions.
 
 ## Workflow (Recommended)
 
@@ -90,13 +109,35 @@ executeCommand: agent-browser snapshot
 executeCommand: agent-browser close
 \`\`\`
 
+## Local Chrome Example
+
+Task: Open example.com using local Chrome
+
+\`\`\`bash
+# Start local Chrome CDP in a background job and keep the returned backgroundJobId.
+startBackgroundJob: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --no-first-run --no-default-browser-check
+
+# Connect agent-browser to that local Chrome CDP endpoint.
+executeCommand: agent-browser connect 9222
+
+# Use agent-browser normally.
+executeCommand: agent-browser open https://example.com
+executeCommand: agent-browser snapshot -i
+
+# Close the agent-browser session, then stop the Chrome background job.
+executeCommand: agent-browser close
+killBackgroundJob: <backgroundJobId>
+\`\`\`
+
 ## Important Notes
 
 - **Always** get a fresh snapshot after navigation or interactions.
 - Element refs (e.g., @e1) are ephemeral and change after page updates.
 - Use \`agent-browser wait\` if you expect a delay (e.g., network load).
 - If \`agent-browser\` is not found, install via \`npm install -g agent-browser\`.
+- Use the local Chrome CDP workflow only when the user asks for local Chrome; otherwise use the default agent-browser session.
 - **Always** close the browser session with \`agent-browser close\` when you are done with the task.
+- If you started local Chrome with \`startBackgroundJob\`, you must also stop that background job with \`killBackgroundJob\` after closing the agent-browser session.
 - If \`agent-browser open\` fails, you must use \`agent-browser close\` to clean up the session.
 `.trim(),
 };


### PR DESCRIPTION
Adds instructions and tools (startBackgroundJob, readBackgroundJobOutput,
killBackgroundJob) so the browser agent can launch and connect to a
user's local Chrome instance through the remote debugging protocol when
explicitly requested.

Prompt: "use browser agent to get latest Hacker News via local chrome"

<img width="800" alt="06781fc5a83ef552b4bbc6bfdc2fcee5" src="https://github.com/user-attachments/assets/e51726cc-93ec-4e4e-b8ae-0719b067c449" />

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-97d18fc1372c4288b961d926b28029c5)

Co-Authored-By: Pochi <noreply@getpochi.com>
