### PR TITLE
feat(ui): auto-expand task panel input height for long content

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -659,7 +659,7 @@ export function FormEditor({
       }}
     >
       {children}
-      <ScrollArea viewportClassname="max-h-32">
+      <ScrollArea viewportClassname="max-h-[min(30vh,420px)]">
         <EditorContent
           editor={editor}
           className="prose !border-none min-h-25 w-full max-w-none overflow-hidden break-words text-[var(--vscode-input-foreground)] focus:outline-none"


### PR DESCRIPTION
## Summary
- Increases the maximum height of the task panel input area.
- Scaled up to 30% of the viewport height or 420px (from fixed 128px).
- Improves visibility for long prompts.

## Test plan
- Open the task panel.
- Enter a long prompt.
- Verify that the input area expands as expected up to the new limit.
- Verify that scrolling works when the limit is reached.

Closes #1514

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0aae8ba0be944177893570268c704282)