### PR TITLE
fix(task-memory): require parallel writeToFile + attemptCompletion calls

### DIFF
--- a/packages/common/src/base/prompts/__tests__/task-memory.test.ts
+++ b/packages/common/src/base/prompts/__tests__/task-memory.test.ts
@@ -1,18 +1,24 @@
 import { expect, test } from "vitest";
 import { buildMemoryExtractionDirective } from "../task-memory";
 
-test("task memory directive writes to the task file URI", () => {
+test("task memory directive targets the task memory file URI", () => {
   const directive = buildMemoryExtractionDirective();
 
-  expect(directive).toContain(
-    "Use writeToFile with path pochi://-/memory.md",
-  );
+  expect(directive).toContain("pochi://-/memory.md");
 });
 
-test("task memory update directive writes to the task file URI", () => {
+test("task memory update directive targets the task memory file URI", () => {
   const directive = buildMemoryExtractionDirective("# Session Title\nExisting");
 
-  expect(directive).toContain(
-    "Use writeToFile with path pochi://-/memory.md",
-  );
+  expect(directive).toContain("pochi://-/memory.md");
+});
+
+test("task memory directive requires parallel tool calls in one response", () => {
+  const directive = buildMemoryExtractionDirective();
+
+  expect(directive).toContain("parallel tool calls");
+  expect(directive).toContain("writeToFile");
+  expect(directive).toContain("attemptCompletion");
+  // The directive should explicitly forbid sequential turns.
+  expect(directive).toContain("Do NOT wait for the writeToFile result");
 });

--- a/packages/common/src/base/prompts/task-memory.ts
+++ b/packages/common/src/base/prompts/task-memory.ts
@@ -57,7 +57,10 @@ Based on the user conversation above (EXCLUDING this note-taking instruction mes
 
 ${currentNotesSection}
 
-Your ONLY task is to use the writeToFile tool to ${isUpdate ? "update" : "create"} ${TaskMemoryFileUri} with the session notes, then call attemptCompletion. Do not call any other tools except readFile if you need to check a file's content for accuracy.
+Your ONLY task is to ${isUpdate ? "update" : "create"} ${TaskMemoryFileUri} with the session notes in a SINGLE assistant response. You MUST emit BOTH tool calls below as parallel tool calls in the SAME assistant message so the extraction finishes in one turn:
+  1. writeToFile — write the full memory content to ${TaskMemoryFileUri}.
+  2. attemptCompletion — provide a brief summary of what was updated.
+Do NOT wait for the writeToFile result before calling attemptCompletion. Do NOT split the two calls across separate turns. Do NOT call any other tool.
 
 CRITICAL RULES:
 - The file must maintain its exact structure with all sections and headers intact
@@ -73,5 +76,5 @@ CRITICAL RULES:
 - IMPORTANT: Always update "Current State" to reflect the most recent work — this is critical for continuity after compaction
 - IMPORTANT: Always update "Worklog" with a terse log of what was done since the last extraction
 
-Use writeToFile with path ${TaskMemoryFileUri} and the full updated content, then call attemptCompletion with a brief summary of what was updated.`;
+Reminder: emit writeToFile (with path ${TaskMemoryFileUri} and the full updated content) and attemptCompletion (with a brief summary) as PARALLEL tool calls in this single assistant message — do not produce them across separate turns.`;
 }


### PR DESCRIPTION
## Summary
- The task-memory fork agent previously needed two LLM round-trips: one to call `writeToFile` and a second one to emit `attemptCompletion` after the tool result came back. The extraction prompt already knows the exact two tools to call, so that extra turn was wasted work.
- Rewrite the directive to require BOTH tool calls in the SAME assistant response (parallel tool calls). The extraction now finishes in a single turn, which also keeps the fork-agent server-side cache anchor (second-to-last on first turn) accurate.
- Add a regression test asserting the directive keeps the parallel-call phrasing and explicitly forbids waiting for the `writeToFile` result.

Pairs with the server-side change in https://github.com/TabbyML/ragdoll/pull/1712 that scopes the fork-agent cache anchor to the first turn only.

## Test plan
- [x] `bun tsc`
- [x] `cd packages/common && bun run test` (40 files / 492 tests, includes new task-memory directive assertions)
- [x] `bun check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e5883d359d4a42f3a777890bf43b5f81)