### PR TITLE
fix(vscode-webui): use blob bootstrap for dedicated workers

### DIFF
--- a/packages/vscode-webui/src/lib/__tests__/worker-url.test.ts
+++ b/packages/vscode-webui/src/lib/__tests__/worker-url.test.ts
@@ -1,10 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isCrossOriginWorkerUrl,
   makeSharedWorkerBootstrapUrl,
+  makeWorkerBootstrapBlobUrl,
   makeWorkerBootstrapUrl,
   makeWorkerBootstrapSource,
+  revokeWorkerBootstrapBlobUrl,
 } from "../worker-url";
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: originalCreateObjectURL,
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: originalRevokeObjectURL,
+  });
+  vi.restoreAllMocks();
+});
 
 describe("makeWorkerBootstrapSource", () => {
   it("creates a module bootstrap import", () => {
@@ -23,6 +41,83 @@ describe("makeWorkerBootstrapSource", () => {
         undefined,
       ),
     ).toContain('importScripts("https://example.com/shared-worker.js")');
+  });
+});
+
+describe("makeWorkerBootstrapBlobUrl", () => {
+  it("returns a same-origin blob URL with a debuggable source URL", () => {
+    let blobParts: BlobPart[] | undefined;
+    let blobOptions: BlobPropertyBag | undefined;
+    const BaseBlob = Blob;
+    class TestBlob extends BaseBlob {
+      constructor(parts?: BlobPart[], options?: BlobPropertyBag) {
+        blobParts = parts;
+        blobOptions = options;
+        super(parts, options);
+      }
+    }
+    const createObjectURL = vi.fn(() => "blob:vscode-webview://panel/worker");
+    vi.stubGlobal("Blob", TestBlob);
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+
+    const url = makeWorkerBootstrapBlobUrl(
+      "https://example.com/worker.js",
+      "module",
+      "webview-1",
+    );
+
+    expect(url).toBe("blob:vscode-webview://panel/worker");
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(createObjectURL).toHaveBeenCalledWith(expect.any(TestBlob));
+    expect(blobParts).toEqual([
+      'import "https://example.com/worker.js"\n//# sourceURL=vscode-worker?id=webview-1',
+    ]);
+    expect(blobOptions).toEqual({ type: "text/javascript" });
+  });
+
+  it("bypasses VS Code localhost routing for blob worker imports", () => {
+    let blobParts: BlobPart[] | undefined;
+    const BaseBlob = Blob;
+    class TestBlob extends BaseBlob {
+      constructor(parts?: BlobPart[], options?: BlobPropertyBag) {
+        blobParts = parts;
+        super(parts, options);
+      }
+    }
+    vi.stubGlobal("Blob", TestBlob);
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:vscode-webview://panel/worker"),
+    });
+
+    makeWorkerBootstrapBlobUrl(
+      "http://localhost:4112/src/livestore.default.worker.ts?worker_file&type=module",
+      "module",
+      "webview-1",
+    );
+
+    expect(blobParts).toEqual([
+      'import "http://localhost.:4112/src/livestore.default.worker.ts?worker_file&type=module"\n//# sourceURL=vscode-worker?id=webview-1',
+    ]);
+  });
+});
+
+describe("revokeWorkerBootstrapBlobUrl", () => {
+  it("revokes the underlying blob URL without routing search params", () => {
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    revokeWorkerBootstrapBlobUrl("blob:vscode-webview://panel/worker?id=webview-1");
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(
+      "blob:vscode-webview://panel/worker",
+    );
   });
 });
 

--- a/packages/vscode-webui/src/lib/worker-url.ts
+++ b/packages/vscode-webui/src/lib/worker-url.ts
@@ -21,6 +21,18 @@ export function makeWorkerBootstrapSource(
   return `importScripts=((i)=>(...a)=>i(...a.map((u)=>''+new URL(u,"${url}"))))(importScripts);importScripts("${url}")`;
 }
 
+function bypassVsCodeLocalhostWorkerRouting(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol === "http:" && parsed.hostname === "localhost") {
+    // `localhost.` still resolves to loopback, but it does not match VS Code's
+    // webview service-worker localhost routing regex. Blob workers have no
+    // `?id=` in their client URL, so that routing path can hang while trying to
+    // find the owning webview. Let Vite handle the CORS request directly.
+    parsed.hostname = "localhost.";
+  }
+  return parsed.toString();
+}
+
 export function getWebviewId(): string | undefined {
   if (typeof location === "undefined") {
     return;
@@ -40,6 +52,31 @@ export function makeWorkerBootstrapUrl(
     : makeWorkerBootstrapSource(url, type);
   const idSearch = webviewId ? `?id=${encodeURIComponent(webviewId)}` : "";
   return `data:text/javascript;charset=utf-8,${encodeURIComponent(source)}${idSearch}`;
+}
+
+export function makeWorkerBootstrapBlobUrl(
+  url: string,
+  type: WorkerOptions["type"] | undefined,
+  webviewId = getWebviewId(),
+): string {
+  const importUrl = bypassVsCodeLocalhostWorkerRouting(url);
+  const source = webviewId
+    ? `${makeWorkerBootstrapSource(
+        importUrl,
+        type,
+      )}\n//# sourceURL=vscode-worker?id=${encodeURIComponent(webviewId)}`
+    : makeWorkerBootstrapSource(importUrl, type);
+  const blobUrl = URL.createObjectURL(
+    new Blob([source], { type: "text/javascript" }),
+  );
+  return blobUrl;
+}
+
+export function revokeWorkerBootstrapBlobUrl(url: string): void {
+  const revokeUrl = new URL(url);
+  revokeUrl.search = "";
+  revokeUrl.hash = "";
+  URL.revokeObjectURL(revokeUrl.toString());
 }
 
 export function makeSharedWorkerBootstrapUrl(

--- a/packages/vscode-webui/src/remote-web-worker.ts
+++ b/packages/vscode-webui/src/remote-web-worker.ts
@@ -1,9 +1,9 @@
 import {
   isCrossOriginWorkerUrl,
-  makeWorkerBootstrapBlobUrl,
   makeSharedWorkerBootstrapUrl,
-  revokeWorkerBootstrapBlobUrl,
+  makeWorkerBootstrapBlobUrl,
   resolveWorkerUrl,
+  revokeWorkerBootstrapBlobUrl,
 } from "./lib/worker-url";
 
 if (import.meta.env.DEV) {
@@ -15,9 +15,9 @@ if (import.meta.env.DEV) {
         constructor(scriptURL: string | URL, options?: WorkerOptions) {
           const url = resolveWorkerUrl(scriptURL);
           const bootstrapUrl = isCrossOriginWorkerUrl(url)
-            // Dedicated workers need a blob: bootstrap so OPFS inherits the
-            // webview origin. SharedWorker keeps a deterministic data: URL below.
-            ? makeWorkerBootstrapBlobUrl(url, options?.type)
+            ? // Dedicated workers need a blob: bootstrap so OPFS inherits the
+              // webview origin. SharedWorker keeps a deterministic data: URL below.
+              makeWorkerBootstrapBlobUrl(url, options?.type)
             : undefined;
           try {
             super(bootstrapUrl ?? scriptURL, options);

--- a/packages/vscode-webui/src/remote-web-worker.ts
+++ b/packages/vscode-webui/src/remote-web-worker.ts
@@ -1,7 +1,8 @@
 import {
   isCrossOriginWorkerUrl,
+  makeWorkerBootstrapBlobUrl,
   makeSharedWorkerBootstrapUrl,
-  makeWorkerBootstrapUrl,
+  revokeWorkerBootstrapBlobUrl,
   resolveWorkerUrl,
 } from "./lib/worker-url";
 
@@ -13,12 +14,18 @@ if (import.meta.env.DEV) {
       class Worker extends BaseWorker {
         constructor(scriptURL: string | URL, options?: WorkerOptions) {
           const url = resolveWorkerUrl(scriptURL);
-          super(
-            isCrossOriginWorkerUrl(url)
-              ? makeWorkerBootstrapUrl(url, options?.type)
-              : scriptURL,
-            options,
-          );
+          const bootstrapUrl = isCrossOriginWorkerUrl(url)
+            // Dedicated workers need a blob: bootstrap so OPFS inherits the
+            // webview origin. SharedWorker keeps a deterministic data: URL below.
+            ? makeWorkerBootstrapBlobUrl(url, options?.type)
+            : undefined;
+          try {
+            super(bootstrapUrl ?? scriptURL, options);
+          } finally {
+            if (bootstrapUrl) {
+              setTimeout(() => revokeWorkerBootstrapBlobUrl(bootstrapUrl), 0);
+            }
+          }
         }
       })(Worker));
 

--- a/packages/vscode-webui/vite.config.js
+++ b/packages/vscode-webui/vite.config.js
@@ -141,6 +141,9 @@ export default defineConfig({
     environment: "jsdom",
   },
   server: {
+    // Blob-worker imports use `localhost.` to avoid VS Code webview localhost
+    // routing while still resolving to the local Vite dev server.
+    allowedHosts: ["localhost."],
     cors: true,
     hmr: {
       host: "localhost",

--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -254,8 +254,13 @@ export abstract class WebviewBase implements vscode.Disposable {
 
     const devWebUIPort = "4112";
     const devWebUIHttpBaseUrl = `http://localhost:${devWebUIPort}`;
+    // `localhost.` is the fully-qualified localhost name. We use it only for
+    // blob-worker imports so VS Code's webview service worker does not trap
+    // localhost requests that cannot be associated with a webview `id`.
+    const devWebUIHttpBaseUrlLocalhostDot = `http://localhost.:${devWebUIPort}`;
     const devWebUIHttpBaseUrlIp = `http://0.0.0.0:${devWebUIPort}`;
     const devWebUIWsBaseUrl = `ws://localhost:${devWebUIPort}`;
+    const devWebUIWsBaseUrlLocalhostDot = `ws://localhost.:${devWebUIPort}`;
     const devWebUIWsBaseUrlIp = `ws://0.0.0.0:${devWebUIPort}`;
 
     const scriptUri = vscode.Uri.parse(`${devWebUIHttpBaseUrl}/src/main.tsx`);
@@ -280,11 +285,11 @@ export abstract class WebviewBase implements vscode.Disposable {
       `default-src 'none';`,
       `img-src ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlIp} https://* blob: data:`,
       `media-src ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlIp} https://* blob: data:`,
-      `script-src 'nonce-${nonce}' ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlIp} '${reactRefreshHash}' 'unsafe-eval'`,
+      `script-src 'nonce-${nonce}' ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlLocalhostDot} ${devWebUIHttpBaseUrlIp} '${reactRefreshHash}' 'unsafe-eval'`,
       `style-src ${webview.cspSource} 'self' 'unsafe-inline'`,
       `font-src ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlIp} ${webview.cspSource} data:`,
-      `connect-src ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlIp} ${devWebUIWsBaseUrl} ${devWebUIWsBaseUrlIp} ${getServerBaseUrl()} ${getSyncBaseUrl()} ${getSyncBaseUrl().replace("http", "ws")} https://* http://*:* ws://localhost:* data: blob:`,
-      `worker-src ${webview.cspSource} ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlIp} data: blob:`,
+      `connect-src ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlLocalhostDot} ${devWebUIHttpBaseUrlIp} ${devWebUIWsBaseUrl} ${devWebUIWsBaseUrlLocalhostDot} ${devWebUIWsBaseUrlIp} ${getServerBaseUrl()} ${getSyncBaseUrl()} ${getSyncBaseUrl().replace("http", "ws")} https://* http://*:* ws://localhost:* data: blob:`,
+      `worker-src ${webview.cspSource} ${devWebUIHttpBaseUrl} ${devWebUIHttpBaseUrlLocalhostDot} ${devWebUIHttpBaseUrlIp} data: blob:`,
     ];
     const cspHeader = `<meta http-equiv="Content-Security-Policy" content="${csp.join("; ")}">`;
 


### PR DESCRIPTION
## Summary
- Switch the dedicated `Worker` dev bootstrap from a `data:` URL to a same-origin `blob:` URL so OPFS inherits the webview origin (data: workers get an opaque origin and cannot persist OPFS).
- Bypass VS Code's webview service-worker localhost routing for blob-worker imports by rewriting `localhost` → `localhost.` (still resolves to loopback, but isn't trapped by the webview routing regex that requires an `?id=` query).
- Extend CSP (`script-src`, `connect-src`, `worker-src`) and Vite `server.allowedHosts` to accept `localhost.` for HTTP/WS during dev.
- Keep `SharedWorker` on its deterministic `data:` URL.
- Add unit tests for the new `makeWorkerBootstrapBlobUrl` / `revokeWorkerBootstrapBlobUrl` helpers, including the `localhost.` rewrite.

## Test plan
- [ ] `bun run test` in `packages/vscode-webui` (covers `worker-url.test.ts`)
- [ ] Manual: launch the extension in dev mode, verify Livestore worker boots and OPFS persists data across reloads
- [ ] Manual: confirm no CSP violations in the webview devtools console

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-22e520a7692546799460ab94b4835ead)