### PR TITLE
fix(vscode-webui): detect supported codec for browser recording

### DIFF
--- a/packages/vscode-webui/src/lib/browser-recording-codecs.ts
+++ b/packages/vscode-webui/src/lib/browser-recording-codecs.ts
@@ -1,0 +1,37 @@
+export const RecordingVideoBitrate = 500_000;
+
+export const ChromeMp4RecordingCodecs = [
+  "avc1.42e01e",
+  "avc1.42e01f",
+  "avc1.42001f",
+  "avc1.4d401f",
+  "avc1.64001f",
+];
+
+export async function getSupportedRecordingVideoConfig(
+  width: number,
+  height: number,
+): Promise<VideoEncoderConfig | undefined> {
+  if (!VideoEncoder.isConfigSupported) {
+    return;
+  }
+
+  for (const candidate of ChromeMp4RecordingCodecs) {
+    const encoderConfig: VideoEncoderConfig = {
+      codec: candidate,
+      width,
+      height,
+      bitrate: RecordingVideoBitrate,
+      latencyMode: "quality",
+    };
+
+    try {
+      const support = await VideoEncoder.isConfigSupported(encoderConfig);
+      if (support.supported) {
+        return support.config ?? encoderConfig;
+      }
+    } catch {
+      // Try the next Chrome MP4-compatible codec.
+    }
+  }
+}

--- a/packages/vscode-webui/src/lib/browser-session-manager.ts
+++ b/packages/vscode-webui/src/lib/browser-session-manager.ts
@@ -3,6 +3,7 @@ import { getLogger } from "@getpochi/common";
 import { catalog } from "@getpochi/livekit";
 import { ArrayBufferTarget, Muxer } from "mp4-muxer";
 import * as runExclusive from "run-exclusive";
+import { getSupportedRecordingVideoConfig } from "./browser-recording-codecs";
 import type { useDefaultStore } from "./use-default-store";
 import { vscodeHost } from "./vscode";
 
@@ -53,6 +54,7 @@ export class BrowserRecordingSession {
   private videoEncoder: VideoEncoder | null = null;
   private startTime = 0;
   private lastWhiteScreenCheckTime = 0;
+  private recordingUnavailable = false;
 
   // WebSocket related
   private ws: WebSocket | null = null;
@@ -116,6 +118,10 @@ export class BrowserRecordingSession {
 
   private addFrame = runExclusive.buildMethod(async (frame: string) => {
     try {
+      if (this.recordingUnavailable) {
+        return;
+      }
+
       if (!this.muxer) {
         const now = Date.now();
         if (now - this.lastWhiteScreenCheckTime < WhiteScreenCheckInterval) {
@@ -132,7 +138,7 @@ export class BrowserRecordingSession {
       }
       const blob = new Blob([bytes], { type: "image/jpeg" });
       const imageBitmap = await createImageBitmap(blob, {
-        resizeHeight: 480,
+        resizeWidth: 720,
         resizeQuality: "high",
       });
 
@@ -144,6 +150,17 @@ export class BrowserRecordingSession {
 
         try {
           const { width, height } = imageBitmap;
+          const videoConfig = await getSupportedRecordingVideoConfig(
+            width,
+            height,
+          );
+          if (!videoConfig) {
+            this.recordingUnavailable = true;
+            logger.error("No supported browser recording codec");
+            imageBitmap.close();
+            return;
+          }
+
           const muxer = new Muxer({
             target: new ArrayBufferTarget(),
             video: {
@@ -158,18 +175,13 @@ export class BrowserRecordingSession {
             output: (chunk, meta) => muxer.addVideoChunk(chunk, meta),
             error: (e) => logger.error("VideoEncoder error", e),
           });
-          encoder.configure({
-            codec: "avc1.4d001f",
-            width,
-            height,
-            bitrate: 500_000,
-            latencyMode: "quality",
-          });
+          encoder.configure(videoConfig);
 
           this.muxer = muxer;
           this.videoEncoder = encoder;
           this.startTime = performance.now();
         } catch (e) {
+          this.recordingUnavailable = true;
           logger.error("Failed to initialize recording", e);
         }
       }


### PR DESCRIPTION
## Summary
- Probe available H.264 profiles via `VideoEncoder.isConfigSupported` and pick the first supported one, replacing the hard-coded `avc1.4d001f` that may not be available across platforms.
- Mark a `BrowserRecordingSession` as unavailable when no codec is supported (or initialization fails) to short-circuit further frame processing instead of repeatedly failing.
- Bump recording resolution from 480px tall to 720px wide for clearer captures.

<img width="976" height="526" alt="5b8bf280e909ec7cd62a4de1baafe9b4" src="https://github.com/user-attachments/assets/bcd279c0-d85b-4d72-b74b-0f0819edd0da" />

## Test plan
- [ ] Trigger a browser recording session in the webview and confirm the chosen codec is logged/used successfully.
- [ ] Simulate an environment where none of the candidate codecs are supported (e.g. via DevTools) and verify the session logs the unavailable state and stops processing frames without errors.
- [ ] Verify the recorded MP4 plays back at the new 720px width.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f4549b7a42ce41e9a9ed5d01ed5799da)