### PR TITLE
feat(tools): increase MaxToolCallConcurrency to 20

### DIFF
--- a/packages/tools/src/constants.ts
+++ b/packages/tools/src/constants.ts
@@ -84,4 +84,4 @@ export const ToolsByPermission = {
   default: ["todoWrite"] as string[],
 };
 
-export const MaxToolCallConcurrency = 10;
+export const MaxToolCallConcurrency = 20;

--- a/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
@@ -87,7 +87,7 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
     tool.output.result.trim().length > 0;
 
   const [showMessageList, setShowMessageList, setShowMessageListImmediately] =
-    useShowMessageList(completed);
+    useShowMessageList();
   const throttledTaskSource = useThrottle(taskSource, SubtaskPreviewThrottleMs);
   const previewSource = isExecuting ? throttledTaskSource : taskSource;
   const taskThreadSource = useMemo(() => {
@@ -181,8 +181,9 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
   );
 }
 
-function useShowMessageList(completed: boolean) {
-  return useDebounceState(!completed, 1_500, {
-    leading: !isVSCodeEnvironment(),
+function useShowMessageList() {
+  const isVSCode = isVSCodeEnvironment();
+  return useDebounceState(false, 1_500, {
+    leading: !isVSCode,
   });
 }


### PR DESCRIPTION
## Summary
- Increased `MaxToolCallConcurrency` from 10 to 20 in `packages/tools/src/constants.ts` to improve performance for parallel tool executions.
- Updated `NewTaskToolView` in `packages/vscode-webui/src/features/tools/components/new-task/index.tsx` to initialize message list visibility to `false`, improving the initial UI state.

## Test plan
- Verified that parallel tool calls can now scale up to 20.
- Verified that the task UI message list starts collapsed as expected.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-cd958901fdf446cf95680e1643700172)