### PR TITLE
fix(vscode-webui): robust browser recording codec & letterboxed canvas

### DIFF
--- a/packages/vscode-webui/src/lib/browser-recording-codecs.ts
+++ b/packages/vscode-webui/src/lib/browser-recording-codecs.ts
@@ -1,0 +1,37 @@
+export const RecordingVideoBitrate = 500_000;
+
+export const ChromeMp4RecordingCodecs = [
+  "avc1.42e01e",
+  "avc1.42e01f",
+  "avc1.42001f",
+  "avc1.4d401f",
+  "avc1.64001f",
+];
+
+export async function getSupportedRecordingVideoConfig(
+  width: number,
+  height: number,
+): Promise<VideoEncoderConfig | undefined> {
+  if (!VideoEncoder.isConfigSupported) {
+    return;
+  }
+
+  for (const candidate of ChromeMp4RecordingCodecs) {
+    const encoderConfig: VideoEncoderConfig = {
+      codec: candidate,
+      width,
+      height,
+      bitrate: RecordingVideoBitrate,
+      latencyMode: "quality",
+    };
+
+    try {
+      const support = await VideoEncoder.isConfigSupported(encoderConfig);
+      if (support.supported) {
+        return support.config ?? encoderConfig;
+      }
+    } catch {
+      // Try the next Chrome MP4-compatible codec.
+    }
+  }
+}

--- a/packages/vscode-webui/src/lib/browser-session-manager.ts
+++ b/packages/vscode-webui/src/lib/browser-session-manager.ts
@@ -188,16 +188,19 @@ export class BrowserRecordingSession {
       }
       const blob = new Blob([bytes], { type: "image/jpeg" });
       const imageBitmap = await createImageBitmap(blob);
-      const recordingImageBitmap =
-        await createRecordingImageBitmap(imageBitmap);
 
       if (!this.muxer) {
         if (isWhiteScreen(imageBitmap)) {
-          recordingImageBitmap.close();
           imageBitmap.close();
           return;
         }
+      }
 
+      const recordingImageBitmap =
+        await createRecordingImageBitmap(imageBitmap);
+      imageBitmap.close();
+
+      if (!this.muxer) {
         try {
           const { width, height } = recordingImageBitmap;
           const videoConfig = await getSupportedRecordingVideoConfig(
@@ -208,7 +211,6 @@ export class BrowserRecordingSession {
             this.recordingUnavailable = true;
             logger.error("No supported browser recording codec");
             recordingImageBitmap.close();
-            imageBitmap.close();
             return;
           }
 
@@ -244,7 +246,6 @@ export class BrowserRecordingSession {
         videoFrame.close();
       }
       recordingImageBitmap.close();
-      imageBitmap.close();
     } catch (err) {
       logger.error("Failed to process frame", err);
     }

--- a/packages/vscode-webui/src/lib/browser-session-manager.ts
+++ b/packages/vscode-webui/src/lib/browser-session-manager.ts
@@ -13,6 +13,8 @@ const frameSubscriptions = new Map<string, Set<(frame: string) => void>>();
 
 const WhiteScreenCheckInterval = 500;
 const WebsocketRetryInterval = 2500;
+const RecordingVideoWidth = 854;
+const RecordingVideoHeight = 480;
 
 function isWhiteScreen(imageBitmap: ImageBitmap): boolean {
   const width = 32;
@@ -47,6 +49,54 @@ function isWhiteScreen(imageBitmap: ImageBitmap): boolean {
   }
 
   return true;
+}
+
+async function createRecordingImageBitmap(
+  imageBitmap: ImageBitmap,
+): Promise<ImageBitmap> {
+  const width = RecordingVideoWidth;
+  const height = RecordingVideoHeight;
+  let canvas: OffscreenCanvas | HTMLCanvasElement;
+  let ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null =
+    null;
+
+  if (typeof OffscreenCanvas !== "undefined") {
+    canvas = new OffscreenCanvas(width, height);
+    ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D | null;
+  } else {
+    canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    ctx = canvas.getContext("2d");
+  }
+
+  if (!ctx) {
+    throw new Error("Failed to create browser recording canvas");
+  }
+
+  ctx.fillStyle = "black";
+  ctx.fillRect(0, 0, width, height);
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
+
+  const scale = Math.min(
+    width / imageBitmap.width,
+    height / imageBitmap.height,
+  );
+  const drawWidth = Math.round(imageBitmap.width * scale);
+  const drawHeight = Math.round(imageBitmap.height * scale);
+  const drawX = Math.floor((width - drawWidth) / 2);
+  const drawY = Math.floor((height - drawHeight) / 2);
+  ctx.drawImage(imageBitmap, drawX, drawY, drawWidth, drawHeight);
+
+  if (
+    typeof OffscreenCanvas !== "undefined" &&
+    canvas instanceof OffscreenCanvas
+  ) {
+    return canvas.transferToImageBitmap();
+  }
+
+  return createImageBitmap(canvas);
 }
 
 export class BrowserRecordingSession {
@@ -137,19 +187,19 @@ export class BrowserRecordingSession {
         bytes[i] = binaryString.charCodeAt(i);
       }
       const blob = new Blob([bytes], { type: "image/jpeg" });
-      const imageBitmap = await createImageBitmap(blob, {
-        resizeWidth: 720,
-        resizeQuality: "high",
-      });
+      const imageBitmap = await createImageBitmap(blob);
+      const recordingImageBitmap =
+        await createRecordingImageBitmap(imageBitmap);
 
       if (!this.muxer) {
         if (isWhiteScreen(imageBitmap)) {
+          recordingImageBitmap.close();
           imageBitmap.close();
           return;
         }
 
         try {
-          const { width, height } = imageBitmap;
+          const { width, height } = recordingImageBitmap;
           const videoConfig = await getSupportedRecordingVideoConfig(
             width,
             height,
@@ -157,6 +207,7 @@ export class BrowserRecordingSession {
           if (!videoConfig) {
             this.recordingUnavailable = true;
             logger.error("No supported browser recording codec");
+            recordingImageBitmap.close();
             imageBitmap.close();
             return;
           }
@@ -188,10 +239,11 @@ export class BrowserRecordingSession {
 
       if (this.videoEncoder?.state === "configured") {
         const timestamp = (performance.now() - this.startTime) * 1000;
-        const videoFrame = new VideoFrame(imageBitmap, { timestamp });
+        const videoFrame = new VideoFrame(recordingImageBitmap, { timestamp });
         this.videoEncoder.encode(videoFrame);
         videoFrame.close();
       }
+      recordingImageBitmap.close();
       imageBitmap.close();
     } catch (err) {
       logger.error("Failed to process frame", err);

--- a/packages/vscode-webui/src/lib/browser-session-manager.ts
+++ b/packages/vscode-webui/src/lib/browser-session-manager.ts
@@ -3,6 +3,7 @@ import { getLogger } from "@getpochi/common";
 import { catalog } from "@getpochi/livekit";
 import { ArrayBufferTarget, Muxer } from "mp4-muxer";
 import * as runExclusive from "run-exclusive";
+import { getSupportedRecordingVideoConfig } from "./browser-recording-codecs";
 import type { useDefaultStore } from "./use-default-store";
 import { vscodeHost } from "./vscode";
 
@@ -53,6 +54,7 @@ export class BrowserRecordingSession {
   private videoEncoder: VideoEncoder | null = null;
   private startTime = 0;
   private lastWhiteScreenCheckTime = 0;
+  private recordingUnavailable = false;
 
   // WebSocket related
   private ws: WebSocket | null = null;
@@ -116,6 +118,10 @@ export class BrowserRecordingSession {
 
   private addFrame = runExclusive.buildMethod(async (frame: string) => {
     try {
+      if (this.recordingUnavailable) {
+        return;
+      }
+
       if (!this.muxer) {
         const now = Date.now();
         if (now - this.lastWhiteScreenCheckTime < WhiteScreenCheckInterval) {
@@ -132,7 +138,7 @@ export class BrowserRecordingSession {
       }
       const blob = new Blob([bytes], { type: "image/jpeg" });
       const imageBitmap = await createImageBitmap(blob, {
-        resizeHeight: 480,
+        resizeWidth: 720,
         resizeQuality: "high",
       });
 
@@ -144,6 +150,17 @@ export class BrowserRecordingSession {
 
         try {
           const { width, height } = imageBitmap;
+          const videoConfig = await getSupportedRecordingVideoConfig(
+            width,
+            height,
+          );
+          if (!videoConfig) {
+            this.recordingUnavailable = true;
+            logger.error("No supported browser recording codec");
+            imageBitmap.close();
+            return;
+          }
+
           const muxer = new Muxer({
             target: new ArrayBufferTarget(),
             video: {
@@ -158,18 +175,13 @@ export class BrowserRecordingSession {
             output: (chunk, meta) => muxer.addVideoChunk(chunk, meta),
             error: (e) => logger.error("VideoEncoder error", e),
           });
-          encoder.configure({
-            codec: "avc1.4d001f",
-            width,
-            height,
-            bitrate: 500_000,
-            latencyMode: "quality",
-          });
+          encoder.configure(videoConfig);
 
           this.muxer = muxer;
           this.videoEncoder = encoder;
           this.startTime = performance.now();
         } catch (e) {
+          this.recordingUnavailable = true;
           logger.error("Failed to initialize recording", e);
         }
       }


### PR DESCRIPTION
## Summary
- Detect a supported `VideoEncoder` codec at runtime (with fallbacks) instead of assuming a fixed codec, avoiding recording failures on platforms without certain codec support.
- Render captured frames onto a fixed 854x480 canvas with aspect-preserving letterboxing so the encoder always receives consistent dimensions regardless of source frame size.

## Test plan
- [ ] Start a browser session and verify recording starts on a system where the previously hard-coded codec is unavailable.
- [ ] Confirm recordings produced from frames of varying source resolutions are 854x480 with black letterbox bars and no distortion.
- [ ] Verify white-screen detection still skips startup until real content arrives.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f6b9e165e43448fc8f6099c79c44ab1e)