### PR TITLE
feat(tools): enforce tool policy for startBackgroundJob

### DIFF
--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -50,6 +50,118 @@ def fibonacci(n):
   });
 });
 
+describe("startBackgroundJob command policies", () => {
+  it("should compile command pattern rules for startBackgroundJob", () => {
+    const policies = compileToolPolicies([
+      "startBackgroundJob(npm run dev)",
+      "startBackgroundJob(bun *)",
+    ]);
+
+    expect(policies?.startBackgroundJob).toEqual({
+      kind: "command-pattern",
+      patterns: ["npm run dev", "bun *"],
+    });
+  });
+
+  it("should preserve multiple startBackgroundJob patterns from object tool specs", () => {
+    const policies = compileToolPolicies([
+      {
+        name: "startBackgroundJob",
+        rules: ["npm run dev", "bun *"],
+      },
+    ]);
+
+    expect(policies?.startBackgroundJob).toEqual({
+      kind: "command-pattern",
+      patterns: ["npm run dev", "bun *"],
+    });
+  });
+
+  it("should allow startBackgroundJob commands matching configured patterns", () => {
+    const policies = compileToolPolicies([
+      "startBackgroundJob(npm run dev)",
+      "startBackgroundJob(bun *)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "startBackgroundJob",
+        { command: "npm run dev" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      validateToolPolicy(
+        "startBackgroundJob",
+        { command: "bun run watch" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+  });
+
+  it("should reject startBackgroundJob commands outside configured patterns", () => {
+    const policies = compileToolPolicies([
+      "startBackgroundJob(npm run dev)",
+    ]);
+
+    expect(() =>
+      validateToolPolicy(
+        "startBackgroundJob",
+        { command: "rm -rf /" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow("Command is not allowed by the configured command rules.");
+  });
+
+  it("should treat startBackgroundJob and executeCommand policies independently", () => {
+    const policies = compileToolPolicies([
+      "executeCommand(git status)",
+      "startBackgroundJob(npm run dev)",
+    ]);
+
+    // executeCommand rules should not authorize startBackgroundJob calls.
+    expect(() =>
+      validateToolPolicy(
+        "startBackgroundJob",
+        { command: "git status" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow("Command is not allowed by the configured command rules.");
+
+    // And startBackgroundJob rules should not authorize executeCommand calls.
+    expect(() =>
+      validateToolPolicy(
+        "executeCommand",
+        { command: "npm run dev" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).toThrow("Command is not allowed by the configured command rules.");
+  });
+
+  it("should leave startBackgroundJob unrestricted when no rules are configured", () => {
+    const policies = compileToolPolicies([
+      { name: "startBackgroundJob" },
+    ]);
+
+    expect(policies?.startBackgroundJob).toBeUndefined();
+
+    expect(() =>
+      validateToolPolicy(
+        "startBackgroundJob",
+        { command: "anything goes" },
+        policies,
+        { cwd: process.cwd() },
+      ),
+    ).not.toThrow();
+  });
+});
+
 describe("path pattern policies", () => {
   it("should reject string tool declarations with multiple rules", () => {
     expect(() => parseToolSpec("readFile(src/**, pochi://-/plan.md)")).toThrow(

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -56,6 +56,7 @@ export type CompiledToolPolicy =
 
 export interface CompiledToolPolicies {
   executeCommand?: { kind: "command-pattern"; patterns: string[] };
+  startBackgroundJob?: { kind: "command-pattern"; patterns: string[] };
   newTask?: { kind: "agent-type-pattern"; patterns: string[] };
   webFetch?: {
     kind: "domain-pattern";

--- a/packages/tools/src/utils/tool-policy.ts
+++ b/packages/tools/src/utils/tool-policy.ts
@@ -8,6 +8,19 @@ import { type ToolSpecInput, getToolRules, parseToolSpec } from "./tool-spec";
 // Policy compilation
 // ---------------------------------------------------------------------------
 
+const CommandPolicyToolNames = [
+  "executeCommand",
+  "startBackgroundJob",
+] as const;
+
+type CommandPolicyToolName = (typeof CommandPolicyToolNames)[number];
+
+function isCommandPolicyToolName(
+  toolName: string,
+): toolName is CommandPolicyToolName {
+  return (CommandPolicyToolNames as readonly string[]).includes(toolName);
+}
+
 const PathPolicyToolNames = [
   "readFile",
   "writeToFile",
@@ -29,15 +42,17 @@ function isPathPolicyToolName(
 export function compileToolPolicies(
   tools: ToolSpecInput[] | undefined,
 ): CompiledToolPolicies | undefined {
-  const executeCommandRules = getToolRules(tools, "executeCommand");
   const newTaskRules = getToolRules(tools, "newTask");
   const policies: CompiledToolPolicies = {};
 
-  if (executeCommandRules) {
-    policies.executeCommand = {
-      kind: "command-pattern",
-      patterns: executeCommandRules,
-    };
+  for (const toolName of CommandPolicyToolNames) {
+    const rules = getToolRules(tools, toolName);
+    if (rules) {
+      policies[toolName] = {
+        kind: "command-pattern",
+        patterns: rules,
+      };
+    }
   }
 
   if (newTaskRules) {
@@ -256,7 +271,7 @@ export function validateToolPolicy(
   policies: CompiledToolPolicies | undefined,
   options: { cwd: string },
 ): void {
-  if (toolName === "executeCommand") {
+  if (isCommandPolicyToolName(toolName)) {
     const command =
       typeof input === "object" && input !== null && "command" in input
         ? (input as { command?: unknown }).command
@@ -266,7 +281,7 @@ export function validateToolPolicy(
       return;
     }
 
-    validateCommandPatternPolicy(command, policies?.executeCommand);
+    validateCommandPatternPolicy(command, policies?.[toolName]);
     return;
   }
 


### PR DESCRIPTION
## Summary
- Close the gap where `startBackgroundJob` bypassed `executeCommand`'s command-pattern rules, letting agents run arbitrary shell commands via a background job even when `executeCommand` was policy-restricted.
- `compileToolPolicies` now compiles a dedicated command-pattern policy for `startBackgroundJob`, and `validateToolPolicy` validates it via the shared `validateCommandPatternPolicy`. The two tools are kept independent — `executeCommand(...)` rules do **not** authorize `startBackgroundJob` calls and vice versa.
- Refactored the validator to share a single `CommandPolicyToolNames` tuple + type guard (mirroring the existing `PathPolicyToolNames` pattern) so adding another command-pattern tool in the future is a two-line change.

## Implementation notes
- `packages/tools/src/types.ts` — added `startBackgroundJob?: { kind: "command-pattern"; patterns: string[] }` to `CompiledToolPolicies`.
- `packages/tools/src/utils/tool-policy.ts` — single loop compiles both `executeCommand` and `startBackgroundJob` policies; `validateToolPolicy` collapses the two near-identical branches into one `isCommandPolicyToolName` check.
- `tool-spec.ts`'s parser is already generic (`/^([a-zA-Z][\w-]*)\((.*)\)$/`), so `startBackgroundJob(npm run dev)` declarations work without parser changes.

`readonly-validation.ts` was intentionally **not** changed — that file still only inspects `executeCommand` for read-only classification. That gap is separate from policy enforcement and is documented as a follow-up.

## Test plan
- [x] `bun run test` in `packages/tools` → 93/93 tests pass (4 files), including 6 new cases under \`startBackgroundJob command policies\` covering:
  - string- and object-form rule compilation
  - allow/deny against configured patterns
  - independence of \`startBackgroundJob\` and \`executeCommand\` rules
  - default unrestricted behavior when no rules are configured
- [x] \`bun check\` at repo root → no biome / ast-grep / eslint findings
- [x] \`bun tsc\` shows no new TS errors in the \`tools\` package (remaining errors are pre-existing in unrelated packages)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-64947b700ce243aaaabe42f9d0273a91)