### PR TITLE
feat(compact): re-introduce automatic task compaction

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -551,6 +551,7 @@ async function createLLMConfigWithVendors(
     return {
       id: `${vendorId}/${modelId}`,
       type: "vendor",
+      contextWindow: options.contextWindow,
       useToolCallMiddleware: options.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {
@@ -573,6 +574,7 @@ async function createLLMConfigWithPochi(
     return {
       id: `${vendorId}/${model}`,
       type: "vendor",
+      contextWindow: pochiModelOptions.contextWindow,
       useToolCallMiddleware: pochiModelOptions.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -56,6 +56,7 @@ export const PochiRequestUseCase = z.enum([
   "repair-tool-call",
   "generate-task-title",
   "compact-task",
+  "auto-compact-task",
   "repair-mermaid",
   ...ForkAgentUseCase.options,
 ]);

--- a/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
+++ b/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
@@ -1,0 +1,160 @@
+import { constants } from "@getpochi/common";
+import { describe, expect, it } from "vitest";
+import type { Message, RequestData, Task } from "../../types";
+import {
+  AutoCompactContextWindowRatio,
+  shouldAutoCompact,
+} from "../auto-compact-policy";
+
+function userMessage(
+  text = "next question",
+  extra: Partial<Message> = {},
+): Message {
+  return {
+    id: "u-last",
+    role: "user",
+    parts: [{ type: "text", text }],
+    ...extra,
+  } as unknown as Message;
+}
+
+function assistantMessage(text = "previous answer"): Message {
+  return {
+    id: "a-prev",
+    role: "assistant",
+    parts: [{ type: "text", text }],
+  } as unknown as Message;
+}
+
+function task(totalTokens: number | undefined): Task {
+  return { totalTokens } as unknown as Task;
+}
+
+const openaiLlm = (contextWindow: number): RequestData["llm"] =>
+  ({
+    id: "test-model",
+    type: "openai",
+    modelId: "test",
+    contextWindow,
+    maxOutputTokens: 4096,
+  }) as RequestData["llm"];
+
+describe("shouldAutoCompact", () => {
+  const minTokens = constants.CompactTaskMinTokens;
+  const contextWindow = Math.ceil(minTokens / AutoCompactContextWindowRatio);
+
+  it("triggers when total tokens reach the threshold and last message is user", () => {
+    const messages = [assistantMessage(), userMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(Math.ceil(contextWindow * AutoCompactContextWindowRatio)),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not trigger when total tokens are below the floor", () => {
+    const messages = [assistantMessage(), userMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(minTokens - 1),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger when the last message is not from the user", () => {
+    const messages = [userMessage(), assistantMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(contextWindow),
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to DefaultContextWindow when the LLM has no contextWindow (e.g. vendor)", () => {
+    const messages = [assistantMessage(), userMessage()];
+    const vendorLlm = {
+      id: "vendor-cli",
+      type: "vendor",
+      getModel: () => ({}) as never,
+    } as RequestData["llm"];
+
+    // At DefaultContextWindow × ratio: should trigger.
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: vendorLlm,
+        task: task(
+          Math.ceil(
+            constants.DefaultContextWindow * AutoCompactContextWindowRatio,
+          ),
+        ),
+      }),
+    ).toBe(true);
+
+    // Below the fallback threshold still skips.
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: vendorLlm,
+        task: task(constants.CompactTaskMinTokens),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger below the ratio threshold", () => {
+    const messages = [assistantMessage(), userMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(1_000_000),
+        task: task(minTokens + 1),
+      }),
+    ).toBe(false);
+  });
+
+  it("skips the manual compact path (metadata.compact === true)", () => {
+    const messages = [
+      assistantMessage(),
+      userMessage("continue", {
+        metadata: { kind: "user", compact: true },
+      }) as Message,
+    ];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(contextWindow),
+      }),
+    ).toBe(false);
+  });
+
+  it("skips when the last user message already carries a <compact> block", () => {
+    const messages = [
+      assistantMessage(),
+      userMessage("<compact>previous summary</compact>"),
+    ];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(contextWindow),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when there are no messages", () => {
+    expect(
+      shouldAutoCompact({
+        messages: [],
+        llm: openaiLlm(contextWindow),
+        task: task(contextWindow),
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/livekit/src/chat/auto-compact-policy.ts
+++ b/packages/livekit/src/chat/auto-compact-policy.ts
@@ -1,0 +1,51 @@
+import { constants, prompts } from "@getpochi/common";
+import type { Message, RequestData, Task } from "../types";
+
+/** Threshold (fraction of context window) at which auto-compact triggers. */
+export const AutoCompactContextWindowRatio = 0.9;
+
+/** Decide whether the next request should be auto-compacted before sending. */
+export function shouldAutoCompact({
+  messages,
+  llm,
+  task,
+}: {
+  messages: Message[];
+  llm: RequestData["llm"] | undefined;
+  task: Task | null | undefined;
+}): boolean {
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role !== "user") return false;
+
+  // Skip the manual inline-compact path to avoid double-firing.
+  if (
+    lastMessage.metadata?.kind === "user" &&
+    lastMessage.metadata.compact === true
+  ) {
+    return false;
+  }
+
+  const totalTokens = task?.totalTokens ?? 0;
+  if (totalTokens < constants.CompactTaskMinTokens) return false;
+
+  // Same convention as token-usage.tsx: vendor LLMs don't carry a
+  // contextWindow on the request payload, so fall back to the default.
+  const contextWindow =
+    (llm && "contextWindow" in llm ? llm.contextWindow : undefined) ||
+    constants.DefaultContextWindow;
+
+  if (totalTokens < contextWindow * AutoCompactContextWindowRatio) {
+    return false;
+  }
+
+  // Avoid stacking compact blocks on top of each other.
+  if (
+    lastMessage.parts.some(
+      (part) => part.type === "text" && prompts.isCompact(part.text),
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -24,6 +24,7 @@ import { events, tables } from "../livestore/default-schema";
 import { toTaskError, toTaskGitInfo, toTaskStatus } from "../task";
 
 import type { LiveKitStore, Message, Task } from "../types";
+import { shouldAutoCompact } from "./auto-compact-policy";
 import { scheduleGenerateTitleJob } from "./background-job";
 import { filterCompletionTools } from "./filter-completion-tools";
 import {
@@ -306,11 +307,20 @@ export class LiveChatKit<
       // Mark status to make async behaivor blocked based on status (e.g isLoading )
       const { messages } = this.chat;
       const lastMessage = messages.at(-1);
-      if (
+      const isManualCompact =
         lastMessage?.role === "user" &&
         lastMessage.metadata?.kind === "user" &&
-        lastMessage.metadata.compact
-      ) {
+        lastMessage.metadata.compact === true;
+
+      const isAutoCompact =
+        !isManualCompact &&
+        shouldAutoCompact({
+          messages,
+          llm: getters.getLLM(),
+          task: this.task,
+        });
+
+      if (isManualCompact || isAutoCompact) {
         try {
           // Wait briefly so memory.md and boundary id are fresh.
           await settleTaskMemoryExtraction(
@@ -318,6 +328,13 @@ export class LiveChatKit<
             TaskMemorySettleTimeoutMs,
           );
           const model = createModel({ llm: getters.getLLM() });
+          if (isAutoCompact) {
+            logger.info(
+              `Auto-compact triggered (totalTokens=${
+                this.task?.totalTokens ?? 0
+              }).`,
+            );
+          }
           await compactTask({
             blobStore: this.blobStore,
             taskId: this.taskId,
@@ -331,6 +348,7 @@ export class LiveChatKit<
             abortSignal,
             inline: true,
             store: this.store,
+            useCase: isAutoCompact ? "auto-compact-task" : "compact-task",
           });
           await onCompact?.();
         } catch (err) {

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -1,6 +1,7 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import {
   type PochiProviderOptions,
+  type PochiRequestUseCase,
   formatters,
   getLogger,
   prompts,
@@ -27,6 +28,7 @@ export async function compactTask({
   abortSignal,
   inline,
   store,
+  useCase = "compact-task",
 }: {
   blobStore: BlobStore;
   taskId: string;
@@ -38,6 +40,7 @@ export async function compactTask({
   abortSignal?: AbortSignal;
   inline?: boolean;
   store?: LiveKitStore;
+  useCase?: Extract<PochiRequestUseCase, "compact-task" | "auto-compact-task">;
 }): Promise<string | undefined> {
   const lastMessage = messages.at(-1);
   if (!lastMessage) {
@@ -64,6 +67,7 @@ export async function compactTask({
         model,
         abortSignal,
         messages.slice(0, -1),
+        useCase,
       );
     }
 
@@ -152,6 +156,7 @@ async function createSummary(
   model: LanguageModelV3,
   abortSignal: AbortSignal | undefined,
   inputMessages: Message[],
+  useCase: Extract<PochiRequestUseCase, "compact-task" | "auto-compact-task">,
 ) {
   const messages: Message[] = [
     ...inputMessages,
@@ -172,7 +177,7 @@ async function createSummary(
       pochi: {
         taskId,
         client: globalThis.POCHI_CLIENT,
-        useCase: "compact-task",
+        useCase,
       } satisfies PochiProviderOptions,
     },
     model,

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -138,6 +138,10 @@ const RequestData = z.object({
     z.object({
       id: z.string(),
       type: z.literal("vendor"),
+      contextWindow: z
+        .number()
+        .optional()
+        .describe("Context window of the model."),
       useToolCallMiddleware: z
         .boolean()
         .optional()

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -131,6 +131,7 @@ function useLLM({
       return {
         id: model.id,
         type: "vendor",
+        contextWindow: model.options.contextWindow,
         useToolCallMiddleware: model.options.useToolCallMiddleware,
         getModel: () =>
           createModel(model.vendorId, {


### PR DESCRIPTION
## Summary

- Re-introduce **automatic** task compaction, which was removed in #1419 during the AI SDK v5 cleanup. The new policy runs entirely client-side in `LiveChatKit.onBeforeSnapshotInMakeRequest`, so when the previous turn pushes token usage past ~90% of the model's context window the next user message is summarised transparently before it is sent — no user-facing setting required.
- Fix a latent bug where `LLMRequestData`'s `vendor` variant did not carry `contextWindow`, even though `DisplayModel.options.contextWindow` is populated by `fetchModels()` (the Pochi `/api/models` response). Both call-sites that build vendor LLM payloads now pass it through, so the new policy can read it for Pochi-hosted models (and any vendor that reports a context window).
- New telemetry useCase `auto-compact-task` (alongside the existing `compact-task`) so usage analytics can distinguish automatic vs. manual compaction.

## How it works

1. `packages/livekit/src/chat/auto-compact-policy.ts` (new) — pure `shouldAutoCompact({ messages, llm, task })` with the same guards as the original server-side policy in PR #1215:
   - last message must be `role: \"user\"` (never interrupts a tool-result loop),
   - skip the manual inline-compact path (`metadata.compact === true`),
   - `task.totalTokens >= constants.CompactTaskMinTokens` (50 000),
   - `totalTokens >= contextWindow * 0.9` (uses `constants.DefaultContextWindow` as a fallback if the model doesn't expose one),
   - skip when the latest user message already carries a `<compact>` block.
2. `live-chat-kit.ts` — the existing manual-compact branch was generalised to fire on either `isManualCompact` or `isAutoCompact`, both reusing the same `compactTask({ inline: true, ... })` call, the `onCompact?.()` callback, and memory-aware verbatim-tail handling. Auto trips pass `useCase: \"auto-compact-task\"`.
3. `compact-task.ts` — `compactTask` now accepts an optional `useCase` (defaults to `\"compact-task\"`) and forwards it to the inner `generateText`'s `providerOptions.pochi.useCase`.
4. Vendor-LLM `contextWindow` plumbing — added to the zod schema in `packages/livekit/src/types.ts`, and pass-through fixes in `use-live-chat-kit-getters.ts` (webview) and `cli.ts` (both `createLLMConfigWithPochi` and the BYOK-vendor branch).

```mermaid
flowchart LR
  send[chat.sendMessage] --> hook[onBeforeSnapshotInMakeRequest]
  hook -- metadata.compact=true --> manual[compactTask useCase=compact-task]
  hook -- shouldAutoCompact --> auto[compactTask useCase=auto-compact-task]
  manual --> attach[prepend &lt;compact&gt; block]
  auto --> attach
  attach --> transport[FlexibleChatTransport.send]
```

## Test plan

- [x] `bun tsc` — 12/12 packages successful
- [x] `bun check` (biome + ast-grep + i18n + eslint) — clean
- [x] `bun vitest run` in `packages/livekit` — 35 passing (incl. the new 8-case `auto-compact-policy.test.ts` covering threshold edges, role guards, vendor-no-contextWindow fallback, `metadata.compact` skip, existing `<compact>` skip, empty-message edge case)
- [x] `bun vitest run` in `packages/common` — 492 passing
- [ ] Manual sanity check: with a Pochi-hosted model, watch a long conversation cross the 90% mark and confirm the next user message ships with a `<compact>` prefix and a logged `Auto-compact triggered (totalTokens=...)`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-48a72cf4223545a1af0e601d1cc8dfde)