### PR TITLE
fix(tools): allow exact command match to bypass segment validation

### DIFF
--- a/packages/tools/src/utils/tool-policy.ts
+++ b/packages/tools/src/utils/tool-policy.ts
@@ -208,6 +208,11 @@ export function validateExecuteCommandRules(
   command: string,
   allowedPatterns: string[],
 ): void {
+  const commandMatched = allowedPatterns.some((pattern) => pattern === command);
+  if (commandMatched) {
+    return;
+  }
+
   const segments = splitCommandSegments(command);
 
   for (const segment of segments) {


### PR DESCRIPTION
## Summary
- When the configured allowed pattern matches the full command string exactly, short-circuit `validateExecuteCommandRules` so commands containing operators (e.g. pipes, semicolons) can be allowlisted as a whole.
- Preserves existing per-segment validation behavior for patterns that are not exact matches.

## Test plan
- [ ] `bun run test` in `packages/tools`
- [ ] Manually verify configuring an exact command (e.g. `foo | bar`) in tool rules now permits execution.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-057598b506d945b2b359eb8221421aee)