### PR TITLE
fix(vscode-webui): robust tool call abortion and refactor useChatSubmit

### DIFF
--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -11,7 +11,11 @@ import type { Review } from "@getpochi/common/vscode-webui-bridge";
 import type React from "react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { useAutoApproveGuard, useToolCallLifeCycle } from "../lib/chat-state";
+import {
+  useAutoApproveGuard,
+  useBatchExecuteManager,
+  useToolCallLifeCycle,
+} from "../lib/chat-state";
 import type { BlockingState } from "./use-blocking-operations";
 import type { ChatInput } from "./use-chat-input-state";
 
@@ -51,14 +55,13 @@ export function useChatSubmit({
   taskId,
 }: UseChatSubmitProps) {
   const autoApproveGuard = useAutoApproveGuard();
-  const { executingToolCalls, isExecuting } = useToolCallLifeCycle();
+  const { isExecuting } = useToolCallLifeCycle();
+  const batchExecuteManager = useBatchExecuteManager();
   const { t } = useTranslation();
 
   const abortExecutingToolCalls = useCallback(() => {
-    for (const toolCall of executingToolCalls) {
-      toolCall.abort();
-    }
-  }, [executingToolCalls]);
+    batchExecuteManager.abort(taskId, "user-abort");
+  }, [batchExecuteManager, taskId]);
 
   const userEdits = useUserEdits(taskId);
   const activeSelection = useActiveSelection();

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { ManagedToolCallLifeCycle } from "../tool-call-life-cycle";
+
+vi.mock("@/lib/vscode", () => ({
+  vscodeHost: {},
+}));
+
+function makeStore() {
+  return {
+    storeId: "store-1",
+    subscribe: vi.fn(() => vi.fn()),
+  };
+}
+
+async function makeStreamingNewTaskLifecycle(
+  outerAbortSignal = new AbortController().signal,
+) {
+  const lifecycle = new ManagedToolCallLifeCycle(
+    makeStore() as never,
+    { toolName: "newTask", toolCallId: "tool-call-1" },
+    outerAbortSignal,
+  );
+
+  lifecycle.execute({ _meta: { uid: "subtask-1" } });
+  await vi.waitFor(() => expect(lifecycle.status).toBe("execute:streaming"));
+
+  return lifecycle;
+}
+
+describe("ManagedToolCallLifeCycle", () => {
+  it("aborts a streaming newTask without double-transitioning", async () => {
+    const lifecycle = await makeStreamingNewTaskLifecycle();
+
+    expect(() => lifecycle.abort("user-abort")).not.toThrow();
+    expect(lifecycle.status).toBe("complete");
+    expect(lifecycle.complete.reason).toBe("user-abort");
+  });
+
+  it("completes a streaming newTask when the outer abort signal fires", async () => {
+    const outerAbortController = new AbortController();
+    const lifecycle = await makeStreamingNewTaskLifecycle(
+      outerAbortController.signal,
+    );
+
+    outerAbortController.abort("user-abort");
+
+    await vi.waitFor(() => expect(lifecycle.status).toBe("complete"));
+    expect(lifecycle.complete.reason).toBe("user-abort");
+  });
+});

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -274,26 +274,14 @@ export class ManagedToolCallLifeCycle
   }
 
   abort(reason: AbortReason = "user-abort", result: unknown = {}) {
-    if (this.state.type === "init") {
-      this.transitTo("init", {
-        type: "complete",
-        result,
-        reason,
-      });
-      return;
-    }
-
     if (
       this.state.type === "execute" ||
       this.state.type === "execute:streaming"
     ) {
       this.state.abort(reason);
-      this.transitTo(["execute", "execute:streaming"], {
-        type: "complete",
-        result,
-        reason,
-      });
     }
+
+    this.settleAbort(reason, result);
   }
 
   reject() {
@@ -406,12 +394,8 @@ export class ManagedToolCallLifeCycle
     });
 
     const onAbort = () => {
-      this.transitTo("execute:streaming", {
-        type: "complete",
-        result: {
-          error: abortSignal.reason,
-        },
-        reason: "user-abort",
+      this.settleAbort("user-abort", {
+        error: abortSignal.reason,
       });
       cleanup();
     };
@@ -447,6 +431,20 @@ export class ManagedToolCallLifeCycle
       (task) => onTaskUpdate(task),
     );
     cleanupFns.push(unsubscribe);
+  }
+
+  private settleAbort(reason: AbortReason, result: unknown) {
+    if (
+      this.state.type === "init" ||
+      this.state.type === "execute" ||
+      this.state.type === "execute:streaming"
+    ) {
+      this.transitTo(this.state.type, {
+        type: "complete",
+        result,
+        reason,
+      });
+    }
   }
 
   private checkState<T extends ToolCallState["type"]>(


### PR DESCRIPTION
## Summary
- Refactored `ManagedToolCallLifeCycle` to use a centralized `settleAbort` method, ensuring consistent state transitions to `complete` when a tool call is aborted.
- Fixed potential double-transition errors when aborting streaming `newTask` tool calls.
- Updated `useChatSubmit` to use `batchExecuteManager.abort(taskId, \"user-abort\")` instead of manually iterating over and aborting `executingToolCalls`.
- Added unit tests for `ManagedToolCallLifeCycle` to verify abortion behavior.

## Test plan
- Run unit tests: `bun run test packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts`
- Manually verified that aborting a task in the UI correctly stops all associated tool calls without UI errors.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c534a56189e1491798f42355cefeddfd)