### PR TITLE
chore(vscode): bump version to 0.47.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.45.0-dev",
+  "version": "0.47.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bumps VS Code extension version from `0.45.0-dev` to `0.47.0-dev` in `packages/vscode/package.json`

## Test plan
- [ ] Verify the extension version is correctly reflected after build

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1976635c57b74f5884c5032326bc1893)