### PR TITLE
fix(vscode): robust worktree deletion with longer timeout and eager UI update

### DIFF
--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -28,3 +28,9 @@ export const TaskMemoryUpdateToolCallThreshold = 3;
  * to prevent hangs when git itself is broken or unresponsive.
  */
 export const GitOperationTimeoutMs = 10_000;
+
+/**
+ * Block timeout (ms) for `git worktree remove`, which is mostly filesystem
+ * IO and frequently exceeds the default 10s while git is still deleting.
+ */
+export const WorktreeRemoveTimeoutMs = 60_000;

--- a/packages/vscode/src/integrations/git/worktree.ts
+++ b/packages/vscode/src/integrations/git/worktree.ts
@@ -255,18 +255,35 @@ export class WorktreeManager implements vscode.Disposable {
       return false;
     }
 
+    // `git worktree remove --force` is mostly filesystem IO; the default 10s
+    // block timeout often fires while git is still deleting. Use a longer
+    // timeout and fall back to manual rm + prune on failure.
+    const git = simpleGit(this.workspacePath, {
+      timeout: { block: constants.WorktreeRemoveTimeoutMs },
+    });
+
     try {
-      await this.git.raw(["worktree", "remove", "--force", worktreePath]);
-      this.worktreeInfoProvider.delete(worktreePath);
-      return true;
+      await git.raw(["worktree", "remove", "--force", worktreePath]);
     } catch (error) {
-      logger.error(`Failed to delete worktree: ${toErrorMessage(error)}`);
-      vscode.window.showErrorMessage(
-        `Failed to delete worktree: ${toErrorMessage(error)}`,
-      );
+      logger.warn(`git worktree remove failed: ${toErrorMessage(error)}`);
+      try {
+        await fs.rm(worktreePath, { recursive: true, force: true });
+        await git.raw(["worktree", "prune"]);
+      } catch (cleanupError) {
+        const message = toErrorMessage(cleanupError);
+        logger.error(`Failed to delete worktree: ${message}`);
+        vscode.window.showErrorMessage(`Failed to delete worktree: ${message}`);
+        return false;
+      }
     }
 
-    return false;
+    // Update the signal eagerly so the UI doesn't flicker while waiting for
+    // the file-system watcher's onDidDelete to fire updateWorktrees().
+    this.worktrees.value = this.worktrees.value.filter(
+      (wt) => wt.path !== worktreePath,
+    );
+    this.worktreeInfoProvider.delete(worktreePath);
+    return true;
   }
 
   async showWorktreeDiff(cwd: string) {


### PR DESCRIPTION
## Summary
- `git worktree remove --force` is mostly filesystem IO and frequently exceeds the shared 10s simple-git block timeout while git is still deleting, surfacing **"Failed to delete worktree: block timeout reached"** notifications and leaving the worktree half-deleted. Use a dedicated 60s `WorktreeRemoveTimeoutMs` for the destructive op, and fall back to `fs.rm` + `git worktree prune` so partial state is reconciled instead of being left for the user to clean up.
- `deleteWorktree` never updated the `worktrees` signal directly, so the UI relied on a delayed file-system watcher event and would briefly re-show the just-deleted worktree before disappearing again. Update `this.worktrees` eagerly after a successful removal; the later watcher-driven `updateWorktrees()` is now a no-op for that path.

## Test plan
- [ ] Delete a worktree with a large `node_modules` directory and confirm no "block timeout reached" error.
- [ ] Delete a worktree whose directory is locked or partially gone and confirm the fs.rm + prune fallback finishes the cleanup.
- [ ] Delete a worktree and confirm it disappears immediately from the UI without re-appearing.
- [ ] `bun tsc` in `packages/vscode` passes.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-72462c4b146b4a2fbc5f9ab78ab2b3b8)