### PR TITLE
fix(livekit): skip completion-tool filter for fork agents

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -3,7 +3,7 @@ import type {
   PochiRequestUseCase,
   TaskMemoryState,
 } from "@getpochi/common";
-import { getLogger } from "@getpochi/common";
+import { getLogger, isForkAgentUseCase } from "@getpochi/common";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { type CustomAgent, ToolsByPermission } from "@getpochi/tools";
 import { Duration } from "@livestore/utils/effect";
@@ -225,6 +225,7 @@ export class LiveChatKit<
   protected readonly blobStore: BlobStore;
   readonly chat: T;
   private readonly transport: FlexibleChatTransport;
+  private readonly requestUseCase: PochiRequestUseCase | undefined;
 
   onStreamStart?: (
     data: Pick<Task, "id" | "cwd"> & {
@@ -266,6 +267,7 @@ export class LiveChatKit<
     this.taskId = taskId;
     this.store = store;
     this.blobStore = blobStore;
+    this.requestUseCase = requestUseCase;
     this.onStreamStart = onStreamStart;
     this.onStreamFinish = onStreamFinish;
     this.transport = new FlexibleChatTransport({
@@ -575,7 +577,12 @@ export class LiveChatKit<
 
     if (isError) return; // handled in onError already.
 
-    const message = filterCompletionTools(originalMessage);
+    // Fork-agent background tasks emit `writeToFile + attemptCompletion`
+    // as parallel tool calls; stripping `attemptCompletion` would lock the
+    // task at `pending-tool` forever, so skip the filter for them.
+    const message = isForkAgentUseCase(this.requestUseCase)
+      ? originalMessage
+      : filterCompletionTools(originalMessage);
     this.chat.messages = [...this.chat.messages.slice(0, -1), message];
 
     const { store } = this;


### PR DESCRIPTION
## Summary

- The first task-memory extraction often hangs in `pending-tool` indefinitely because `filterCompletionTools` strips the `attemptCompletion` part from the fork agent's final message — but the directive instructs the model to emit `writeToFile + attemptCompletion` as parallel tool calls, so removing `attemptCompletion` leaves the message stuck with an input-only `writeToFile`.
- Skip the filter when `requestUseCase` is a fork-agent use case (`task-memory`, `auto-memory`, `auto-memory-dream`) so the parallel pair survives, `toTaskStatus` resolves to `completed`, and the parent task's `use-task-memory` watcher correctly observes the extraction as finished.
- The original guard targets interactive user-facing chats and is preserved for them; background fork agents never surface step boundaries to a user, so the guard isn't needed for them.

## Root cause walkthrough

1. Fork agent streams `writeToFile + attemptCompletion` in one assistant step.
2. `LiveChatKit.onFinish` calls `filterCompletionTools(originalMessage)` → strips `attemptCompletion`.
3. The filtered message contains only `writeToFile`, whose result hasn't been added yet at this point.
4. `toTaskStatus` returns `pending-tool` (has tool call, no completion tool).
5. `chatStreamFinished` commits with status `pending-tool`.
6. `BackgroundTaskWorker` then runs `writeToFile` via `processQueue` and calls `addToolOutput`, but no further store event is committed.
7. `sendAutomaticallyWhen` returns `false` (the worker saw `attemptCompletion` during streaming and flipped `completedRef`), so no new stream fires.
8. Stored task status stays `pending-tool` forever → parent's `use-task-memory` watcher considers the extraction still running.

## Test plan

- [x] `bun tsc` — clean across the monorepo
- [x] `bun check` (biome + ast-grep + eslint + i18n) — clean
- [x] `cd packages/livekit && bun run test` — 27/27 passing
- [ ] Manual: trigger a first-time task-memory extraction in a fresh task and confirm the fork agent transitions to `completed` and `pochi://-/memory.md` is written.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d00f6119547f4bf5ad1c5763b1715d79)