### PR TITLE
refactor(browser-agent): simplify executeCommand tool permissions

### DIFF
--- a/packages/common/src/base/agents/browser.ts
+++ b/packages/common/src/base/agents/browser.ts
@@ -5,10 +5,7 @@ export const browser: CustomAgent = {
   description:
     "Web browser automation agent for navigating websites, interacting with pages, and extracting information. Uses agent-browser CLI for browser control, including headless sessions and optional local Chrome auto-connect.",
   tools: [
-    "executeCommand(agent-browser)",
-    "executeCommand(npm install -g agent-browser)",
-    'executeCommand(pgrep -x "Google Chrome|chrome|google-chrome|chromium")',
-    'executeCommand(powershell -NoProfile -Command "Get-Process chrome -ErrorAction SilentlyContinue")',
+    "executeCommand",
     "startBackgroundJob",
     "readBackgroundJobOutput",
     "killBackgroundJob",


### PR DESCRIPTION
## Summary
- Replace multiple specific `executeCommand(...)` entries with a single generic `executeCommand` permission for the browser agent
- Reduces brittleness around platform-specific commands (e.g. `pgrep`, `powershell`) and `npm install` of `agent-browser`

## Test plan
- [ ] Verify the browser agent can still launch and connect to local Chrome
- [ ] Verify `agent-browser` install/run flows succeed under the simplified permission

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-772a082845694136b62d93d931b39baa)