### PR TITLE
fix(vscode-webui): fix task memory trigger and persist final tool-call state in background tasks

### DIFF
--- a/packages/cli/src/renderers/output-renderer.ts
+++ b/packages/cli/src/renderers/output-renderer.ts
@@ -1,7 +1,7 @@
 import { formatters } from "@getpochi/common";
 import { parseMarkdown } from "@getpochi/common/message-utils";
 import type { Message, UITools } from "@getpochi/livekit";
-import { isAutoSuccessToolPart, isUserInputToolPart } from "@getpochi/tools";
+import { isAutoSuccessToolPart, isCompletionToolPart } from "@getpochi/tools";
 import { type ToolUIPart, getStaticToolName, isStaticToolUIPart } from "ai";
 import chalk from "chalk";
 import {
@@ -530,7 +530,7 @@ function renderSubtaskMessages(messages: Message[]): string {
   let output = "";
   for (const x of messages) {
     for (const p of x.parts) {
-      if (isStaticToolUIPart(p) && !isUserInputToolPart(p)) {
+      if (isStaticToolUIPart(p) && !isCompletionToolPart(p)) {
         const { text } = renderToolPart(p);
         const lines = text.split("\n");
         for (const line of lines) {

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -30,7 +30,7 @@ import {
   type Skill,
   type Todo,
   compileToolPolicies,
-  isUserInputToolPart,
+  isCompletionToolPart,
   validateToolPolicy,
 } from "@getpochi/tools";
 import {
@@ -752,7 +752,7 @@ ${asyncResults}`;
 function isResultMessage(message: Message): boolean {
   return (
     message.role === "assistant" &&
-    (message.parts?.some(isUserInputToolPart) ?? false)
+    (message.parts?.some(isCompletionToolPart) ?? false)
   );
 }
 

--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -8,7 +8,7 @@ vi.mock('@getpochi/tools', async (importOriginal) => {
   const original = await importOriginal<typeof import('@getpochi/tools')>();
   return {
     ...original,
-    isUserInputToolPart: vi.fn(),
+    isCompletionToolPart: vi.fn(),
   };
 });
 

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -1,4 +1,4 @@
-import { isAutoSuccessToolPart, isUserInputToolPart } from "@getpochi/tools";
+import { isAutoSuccessToolPart, isCompletionToolPart } from "@getpochi/tools";
 import {
   type ToolUIPart,
   type UIMessage,
@@ -360,7 +360,7 @@ function resolvePendingToolCallsForShareUI(messages: UIMessage[]) {
   const resolveLastMessage =
     lastMessage &&
     lastMessage.role === "assistant" &&
-    lastMessage.parts.some((x) => isUserInputToolPart(x));
+    lastMessage.parts.some((x) => isCompletionToolPart(x));
 
   return resolvePendingToolCalls(messages, resolveLastMessage);
 }

--- a/packages/livekit/src/chat/filter-completion-tools.ts
+++ b/packages/livekit/src/chat/filter-completion-tools.ts
@@ -1,3 +1,5 @@
+import { isCompletionToolPart } from "@getpochi/tools";
+import { getStaticToolName, isStaticToolUIPart } from "ai";
 import type { Message } from "../types";
 
 // Condition A: The last step contains completion tools (attemptCompletion or askFollowupQuestion).
@@ -14,25 +16,16 @@ export function filterCompletionTools(message: Message): Message {
       ? message.parts.slice(lastStepStartIndex)
       : message.parts;
 
-  const hasCompletionTools = parts.some(
-    (part) =>
-      part.type === "tool-attemptCompletion" ||
-      part.type === "tool-askFollowupQuestion",
-  );
+  const hasCompletionTools = parts.some(isCompletionToolPart);
   const hasOtherTools = parts.some(
     (part) =>
-      part.type.startsWith("tool-") &&
-      part.type !== "tool-todoWrite" &&
-      part.type !== "tool-attemptCompletion" &&
-      part.type !== "tool-askFollowupQuestion",
+      isStaticToolUIPart(part) &&
+      getStaticToolName(part) !== "todoWrite" &&
+      !isCompletionToolPart(part),
   );
 
   if (hasCompletionTools && hasOtherTools) {
-    const lastStepParts = parts.filter(
-      (part) =>
-        part.type !== "tool-attemptCompletion" &&
-        part.type !== "tool-askFollowupQuestion",
-    );
+    const lastStepParts = parts.filter((part) => !isCompletionToolPart(part));
     const prevStepsParts =
       lastStepStartIndex > 0 ? message.parts.slice(0, lastStepStartIndex) : [];
     return {

--- a/packages/livekit/src/task.ts
+++ b/packages/livekit/src/task.ts
@@ -1,5 +1,6 @@
 import { isAbortError } from "@ai-sdk/provider-utils";
 import type { GitStatus } from "@getpochi/common";
+import { isCompletionToolPart } from "@getpochi/tools";
 import {
   APICallError,
   type FinishReason,
@@ -27,10 +28,7 @@ export function toTaskStatus(
 
   let hasToolCall = false;
   for (const part of message.parts.slice(lastStepStart + 1)) {
-    if (
-      part.type === "tool-askFollowupQuestion" ||
-      part.type === "tool-attemptCompletion"
-    ) {
+    if (isCompletionToolPart(part)) {
       return "completed";
     }
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -85,18 +85,20 @@ export type {
   BatchedToolCall,
 } from "./utils/tool-batch";
 
-export function isUserInputToolName(name: string): boolean {
+export function isCompletionToolName(name: string): boolean {
   return name === "askFollowupQuestion" || name === "attemptCompletion";
 }
 
-export function isUserInputToolPart(part: UIMessagePart<UIDataTypes, UITools>) {
+export function isCompletionToolPart(
+  part: UIMessagePart<UIDataTypes, UITools>,
+) {
   if (!isStaticToolUIPart(part)) return false;
-  return isUserInputToolName(getStaticToolName(part));
+  return isCompletionToolName(getStaticToolName(part));
 }
 
 export function isAutoSuccessToolName(name: string): boolean {
   return (
-    isUserInputToolName(name) ||
+    isCompletionToolName(name) ||
     ToolsByPermission.default.some((tool) => name === tool)
   );
 }

--- a/packages/vscode-webui/src/features/approval/hooks/use-pending-tool-call-approval.ts
+++ b/packages/vscode-webui/src/features/approval/hooks/use-pending-tool-call-approval.ts
@@ -1,6 +1,6 @@
 import type { Message, UITools } from "@getpochi/livekit";
 import type { ToolName } from "@getpochi/tools";
-import { isUserInputToolPart } from "@getpochi/tools";
+import { isCompletionToolPart } from "@getpochi/tools";
 import { type ToolUIPart, getStaticToolName, isStaticToolUIPart } from "ai";
 import { useMemo } from "react";
 
@@ -33,7 +33,7 @@ export function usePendingToolCallApproval({
       if (
         isStaticToolUIPart(part) &&
         part.state === "input-available" &&
-        !isUserInputToolPart(part)
+        !isCompletionToolPart(part)
       ) {
         tools.push(part);
       }

--- a/packages/vscode-webui/src/features/chat/components/background-task-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-worker.tsx
@@ -19,15 +19,20 @@ import { useDefaultStore } from "@/lib/use-default-store";
 import { vscodeHost } from "@/lib/vscode";
 import { useChat } from "@ai-sdk/react";
 import { type ForkAgentUseCase, getLogger } from "@getpochi/common";
-import { catalog } from "@getpochi/livekit";
+import { type Message, catalog } from "@getpochi/livekit";
 import { useLiveChatKit } from "@getpochi/livekit/react";
 import {
   type Todo,
   type ToolSpecInput,
   compileToolPolicies,
   getAllowedToolNames,
+  isCompletionToolName,
 } from "@getpochi/tools";
-import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import {
+  getStaticToolName,
+  isStaticToolUIPart,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { BatchExecuteManager } from "../lib/batch-execute-manager";
 import { createBackgroundTaskBatchedToolCall } from "../lib/batched-tool-call-adapters";
@@ -83,13 +88,15 @@ function BackgroundTaskWorkerInner({
   const abortController = useRef(new AbortController());
   const todosRef = useRef<Todo[] | undefined>(undefined);
   const completedRef = useRef(false);
+  const terminalToolSeenRef = useRef(false);
   const toolRejectionCountRef = useRef(0);
+  const chatKitRef = useRef<ReturnType<typeof useLiveChatKit> | null>(null);
   // Refs that bridge values defined later in the component body into callbacks
   // passed to `useLiveChatKit` (which is created before those values exist).
   // This avoids accidental TDZ access if the callbacks ever ran synchronously.
-  const addToolOutputRef = useRef<((args: AddToolOutputArgs) => void) | null>(
-    null,
-  );
+  const addToolOutputRef = useRef<
+    ((args: AddToolOutputArgs) => void | Promise<void>) | null
+  >(null);
   const chatStatusRef = useRef<string | null>(null);
   const allowedToolsSet = useMemo(
     () => (tools ? getAllowedToolNames([...tools]) : undefined),
@@ -100,23 +107,34 @@ function BackgroundTaskWorkerInner({
     [tools],
   );
 
+  const persistLastMessage = useCallback(() => {
+    const lastMessage = chatKitRef.current?.chat.messages.at(-1);
+    if (!lastMessage) return;
+    // Final background turns may not make another request, so flush tool outputs now.
+    store.commit(catalog.events.updateMessages({ messages: [lastMessage] }));
+  }, [store]);
+
+  // Wrap the latest `addToolOutput` (delivered via ref) so adapters can invoke
+  // it even though they're constructed inside `onToolCall` before
+  // `useChat`-bound `addToolOutput` exists in the closure.
+  const adapterAddToolOutput = useCallback(
+    async (args: AddToolOutputArgs) => {
+      await addToolOutputRef.current?.(args);
+      persistLastMessage();
+    },
+    [persistLastMessage],
+  );
+
   const writeToolOutput = useCallback(
     (toolName: string, toolCallId: string, output: unknown) => {
-      addToolOutputRef.current?.({
+      void adapterAddToolOutput({
         tool: toolName,
         toolCallId,
         output,
       });
     },
-    [],
+    [adapterAddToolOutput],
   );
-
-  // Wrap the latest `addToolOutput` (delivered via ref) so adapters can invoke
-  // it even though they're constructed inside `onToolCall` before
-  // `useChat`-bound `addToolOutput` exists in the closure.
-  const adapterAddToolOutput = useCallback((args: AddToolOutputArgs) => {
-    addToolOutputRef.current?.(args);
-  }, []);
 
   useEffect(() => {
     const signal = abortController.current.signal;
@@ -178,6 +196,9 @@ function BackgroundTaskWorkerInner({
       return lastAssistantMessageIsCompleteWithToolCalls(x);
     },
     onStreamFinish: (data) => {
+      const terminalToolSeen = terminalToolSeenRef.current;
+      terminalToolSeenRef.current = false;
+
       if (data.status === "completed") {
         const conversation = summarizeMessages(data.messages);
         logger.debug(
@@ -191,17 +212,18 @@ function BackgroundTaskWorkerInner({
       if (!abortController.current.signal.aborted) {
         batchExecuteManager.processQueue(taskId);
       }
+
+      if (terminalToolSeen) {
+        completedRef.current = true;
+      }
     },
-    onToolCall: async ({ toolCall }) => {
+    onToolCall: ({ toolCall }) => {
       if (completedRef.current) {
         return;
       }
 
-      if (
-        toolCall.toolName === "attemptCompletion" ||
-        toolCall.toolName === "askFollowupQuestion"
-      ) {
-        completedRef.current = true;
+      if (isCompletionToolName(toolCall.toolName)) {
+        terminalToolSeenRef.current = true;
         logger.debug(
           { taskId, toolName: toolCall.toolName },
           `✔ terminal tool ${toolCall.toolName}`,
@@ -267,6 +289,7 @@ function BackgroundTaskWorkerInner({
       );
     },
   });
+  chatKitRef.current = chatKit;
 
   const {
     messages,
@@ -285,7 +308,7 @@ function BackgroundTaskWorkerInner({
   useEffect(() => {
     addToolOutputRef.current = addToolOutput as unknown as (
       args: AddToolOutputArgs,
-    ) => void;
+    ) => Promise<void>;
   }, [addToolOutput]);
 
   useEffect(() => {
@@ -557,17 +580,13 @@ function summarizeToolPayload(
  * readable block rather than a JS array literal with escape sequences.
  */
 function summarizeMessages(
-  messages: ReadonlyArray<{
-    role: string;
-    parts: ReadonlyArray<Record<string, unknown>>;
-  }>,
+  messages: ReadonlyArray<Pick<Message, "role" | "parts">>,
 ): string {
   const lines: string[] = [];
   let stepIndex = 0;
   for (const message of messages) {
     const role = message.role;
-    for (const rawPart of message.parts) {
-      const part = rawPart as Record<string, unknown> & { type: string };
+    for (const part of message.parts) {
       const type = part.type;
       if (type === "step-start") {
         stepIndex += 1;
@@ -590,23 +609,28 @@ function summarizeMessages(
         );
         continue;
       }
-      if (typeof type === "string" && type.startsWith("tool-")) {
-        const toolName = type.slice("tool-".length);
-        const state =
-          typeof part.state === "string" ? (part.state as string) : "unknown";
+      if (isStaticToolUIPart(part)) {
+        const toolName = getStaticToolName(part);
+        const state = typeof part.state === "string" ? part.state : "unknown";
         const callId =
-          typeof part.toolCallId === "string"
-            ? (part.toolCallId as string)
-            : "";
+          typeof part.toolCallId === "string" ? part.toolCallId : "";
         const shortId = callId ? callId.slice(-6) : "";
         const inputPreview = summarizeToolPayload(
           part.input,
           ToolInputPreviewMaxLen,
         );
+        const outputRecord = part as Record<string, unknown>;
         const outputKey =
-          "output" in part ? "output" : "result" in part ? "result" : undefined;
+          "output" in outputRecord
+            ? "output"
+            : "result" in outputRecord
+              ? "result"
+              : undefined;
         const outputPreview = outputKey
-          ? summarizeToolPayload(part[outputKey], ToolOutputPreviewMaxLen)
+          ? summarizeToolPayload(
+              outputRecord[outputKey],
+              ToolOutputPreviewMaxLen,
+            )
           : undefined;
         const header = `[${role}] ${toolName}${shortId ? `#${shortId}` : ""} (${state})`;
         const segments = [header];

--- a/packages/vscode-webui/src/features/chat/hooks/use-auto-memory.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-auto-memory.ts
@@ -9,6 +9,7 @@ import {
 } from "@getpochi/common";
 import { type Message, catalog } from "@getpochi/livekit";
 import type { ToolSpecInput } from "@getpochi/tools";
+import { getStaticToolName, isStaticToolUIPart } from "ai";
 import { useCallback, useEffect } from "react";
 import {
   buildForkAgentInitTitle,
@@ -394,9 +395,7 @@ function didConversationWriteMemory(
 }
 
 function getToolName(part: Message["parts"][number]): string | undefined {
-  return typeof part.type === "string" && part.type.startsWith("tool-")
-    ? part.type.slice("tool-".length)
-    : undefined;
+  return isStaticToolUIPart(part) ? getStaticToolName(part) : undefined;
 }
 
 function isSuccessfulToolOutput(part: Message["parts"][number]): boolean {
@@ -489,7 +488,7 @@ function serializeSessionTranscript(messages: readonly Message[]): string {
 function sanitizePart(part: Message["parts"][number]) {
   if (part.type === "text") return part;
   if (part.type.startsWith("data-")) return { type: part.type };
-  if (part.type.startsWith("tool-")) {
+  if (isStaticToolUIPart(part)) {
     return {
       type: part.type,
       state: "state" in part ? part.state : undefined,

--- a/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-task-memory.ts
@@ -1,15 +1,20 @@
 import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { vscodeHost } from "@/lib/vscode";
-import type { ContextWindowUsage, TaskMemoryState } from "@getpochi/common";
-import { constants, getLogger, prompts } from "@getpochi/common";
-import { type Message, catalog } from "@getpochi/livekit";
+import { getLogger, prompts } from "@getpochi/common";
+import { catalog } from "@getpochi/livekit";
 import type { ToolSpecInput } from "@getpochi/tools";
 import { useCallback, useEffect } from "react";
 import {
   buildForkAgentInitTitle,
   createForkAgent,
 } from "../lib/create-fork-agent";
+import {
+  type ExtractionData,
+  getExtractionMetrics,
+  shouldExtractTaskMemory,
+  toExtractingState,
+} from "../lib/task-memory-extraction";
 
 const logger = getLogger("useTaskMemory");
 
@@ -22,101 +27,6 @@ const TaskMemoryAllowedTools: readonly ToolSpecInput[] = [
 /** Fork-agent statuses that mean it is still running. */
 const ActiveStatuses = new Set(["pending-model", "pending-tool"]);
 const IdleTaskId = "__task_memory_idle__";
-
-type ExtractionData = {
-  messages: Message[];
-  contextWindowUsage?: ContextWindowUsage;
-};
-
-type ExtractionMetrics = {
-  tokens: number;
-  toolCalls: number;
-  trailingMessageId: string | undefined;
-  trailingMessageHasOpenToolCall: boolean;
-};
-
-function getExtractionMetrics(data: ExtractionData): ExtractionMetrics {
-  const last = data.messages.at(-1);
-  return {
-    tokens: computeTotalTokens(data.contextWindowUsage),
-    toolCalls: countToolCalls(data.messages),
-    trailingMessageId: last?.id,
-    trailingMessageHasOpenToolCall: lastMessageHasOpenToolCall(data.messages),
-  };
-}
-
-function computeTotalTokens(usage?: ContextWindowUsage) {
-  if (!usage) return 0;
-  return (
-    usage.system +
-    usage.tools +
-    usage.messages +
-    usage.files +
-    usage.toolResults
-  );
-}
-
-function countToolCalls(messages: Message[]): number {
-  let count = 0;
-  for (const message of messages) {
-    if (message.role !== "assistant") continue;
-    for (const part of message.parts) {
-      if (part.type.startsWith("tool-")) {
-        count++;
-      }
-    }
-  }
-  return count;
-}
-
-/** True if the trailing assistant turn has tool calls without output yet. */
-function lastMessageHasOpenToolCall(messages: Message[]): boolean {
-  const last = messages.at(-1);
-  if (!last || last.role !== "assistant") return false;
-  return last.parts.some((part) => {
-    if (!part.type.startsWith("tool-")) return false;
-    if (!("state" in part)) return false;
-    const state = (part as { state: string }).state;
-    return state !== "output-available" && state !== "output-error";
-  });
-}
-
-function shouldExtractTaskMemory(
-  state: TaskMemoryState,
-  metrics: ExtractionMetrics,
-): boolean {
-  if (state.isExtracting) return false;
-
-  if (!state.initialized) {
-    return metrics.tokens >= constants.TaskMemoryInitTokenThreshold;
-  }
-
-  const tokenDelta = metrics.tokens - state.lastExtractionTokens;
-  const toolCallDelta = metrics.toolCalls - state.lastExtractionToolCalls;
-
-  return (
-    tokenDelta >= constants.TaskMemoryUpdateTokenIncrement &&
-    toolCallDelta >= constants.TaskMemoryUpdateToolCallThreshold
-  );
-}
-
-function toExtractingState(
-  state: TaskMemoryState,
-  metrics: ExtractionMetrics,
-): TaskMemoryState {
-  // Skip the boundary when the snapshot is mid-tool-call to avoid
-  // slicing through a tool_use/tool_result pair on the next compaction.
-  return {
-    ...state,
-    initialized: true,
-    isExtracting: true,
-    lastExtractionTokens: metrics.tokens,
-    lastExtractionToolCalls: metrics.toolCalls,
-    pendingExtractionMessageId: metrics.trailingMessageHasOpenToolCall
-      ? undefined
-      : metrics.trailingMessageId,
-  };
-}
 
 export function useTaskMemory({
   isSubTask,

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/task-memory-extraction.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/task-memory-extraction.test.ts
@@ -1,0 +1,86 @@
+import type { TaskMemoryState } from "@getpochi/common";
+import type { Message } from "@getpochi/livekit";
+import { describe, expect, it } from "vitest";
+import {
+  getExtractionMetrics,
+  lastMessageHasOpenToolCall,
+  shouldExtractTaskMemory,
+  toExtractingState,
+} from "../task-memory-extraction";
+
+const baseState: TaskMemoryState = {
+  initialized: false,
+  lastExtractionTokens: 0,
+  lastExtractionToolCalls: 0,
+  isExtracting: false,
+  extractionCount: 0,
+};
+
+function assistantMessage(
+  id: string,
+  parts: Message["parts"],
+): Message {
+  return {
+    id,
+    role: "assistant",
+    parts,
+  } as Message;
+}
+
+function usage(tokens: number) {
+  return {
+    system: tokens,
+    tools: 0,
+    messages: 0,
+    files: 0,
+    toolResults: 0,
+  };
+}
+
+describe("task memory extraction metrics", () => {
+  it("treats unresolved non-terminal tool calls as an unsafe fork boundary", () => {
+    const messages = [
+      assistantMessage("read-turn", [
+        {
+          type: "tool-readFile",
+          toolCallId: "read-1",
+          state: "input-available",
+          input: { path: "src/file.ts" },
+        },
+      ]),
+    ];
+
+    const metrics = getExtractionMetrics({
+      messages,
+      contextWindowUsage: usage(20_000),
+    });
+
+    expect(lastMessageHasOpenToolCall(messages)).toBe(true);
+    expect(metrics.trailingMessageHasOpenToolCall).toBe(true);
+    expect(shouldExtractTaskMemory(baseState, metrics)).toBe(false);
+  });
+
+  it("allows terminal completion tools because they do not require tool output", () => {
+    const messages = [
+      assistantMessage("done-turn", [
+        {
+          type: "tool-attemptCompletion",
+          toolCallId: "done-1",
+          state: "input-available",
+          input: { result: "Done" },
+        },
+      ]),
+    ];
+
+    const metrics = getExtractionMetrics({
+      messages,
+      contextWindowUsage: usage(20_000),
+    });
+
+    expect(lastMessageHasOpenToolCall(messages)).toBe(false);
+    expect(shouldExtractTaskMemory(baseState, metrics)).toBe(true);
+    expect(toExtractingState(baseState, metrics).pendingExtractionMessageId).toBe(
+      "done-turn",
+    );
+  });
+});

--- a/packages/vscode-webui/src/features/chat/lib/batched-tool-call-adapters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/batched-tool-call-adapters.ts
@@ -62,7 +62,7 @@ type CreateBackgroundTaskToolCallAdapterOptions = {
     tool: string;
     toolCallId: string;
     output: unknown;
-  }) => void;
+  }) => void | Promise<void>;
 };
 
 /** Backed by a ToolCallLifeCycle; execution and cancellation delegate to the lifecycle. */
@@ -354,7 +354,7 @@ export function createBackgroundTaskBatchedToolCall({
 
               let resolved = false;
 
-              const finalize = (
+              const finalize = async (
                 output: ExecuteCommandResult,
                 reason: "completed" | "aborted",
               ) => {
@@ -373,27 +373,29 @@ export function createBackgroundTaskBatchedToolCall({
                   finalResult.error = "Aborted by background task worker";
                 }
 
-                addToolOutput({
-                  tool: toolCall.toolName,
-                  toolCallId: toolCall.toolCallId,
-                  output: finalResult,
-                });
-
-                streamResolve(finalResult.error as string | undefined);
+                try {
+                  await addToolOutput({
+                    tool: toolCall.toolName,
+                    toolCallId: toolCall.toolCallId,
+                    output: finalResult,
+                  });
+                } finally {
+                  streamResolve(finalResult.error as string | undefined);
+                }
               };
 
               const onAbort = () => {
-                finalize(signal.value, "aborted");
+                void finalize(signal.value, "aborted");
               };
 
               const unsubscribe = signal.subscribe((output) => {
                 if (output.status === "completed") {
-                  finalize(output, "completed");
+                  void finalize(output, "completed");
                 }
               });
 
               if (abortSignal.aborted) {
-                finalize(signal.value, "aborted");
+                void finalize(signal.value, "aborted");
               } else {
                 abortSignal.addEventListener("abort", onAbort);
               }
@@ -412,7 +414,7 @@ export function createBackgroundTaskBatchedToolCall({
           } satisfies BatchedToolCallResult;
         }
 
-        addToolOutput({
+        await addToolOutput({
           tool: toolCall.toolName,
           toolCallId: toolCall.toolCallId,
           output: result,
@@ -434,7 +436,7 @@ export function createBackgroundTaskBatchedToolCall({
           error instanceof Error
             ? error
             : new Error("Background task batch execution failed");
-        addToolOutput({
+        await addToolOutput({
           tool: toolCall.toolName,
           toolCallId: toolCall.toolCallId,
           output: { error: normalizedError.message },
@@ -442,8 +444,8 @@ export function createBackgroundTaskBatchedToolCall({
         throw normalizedError;
       }
     },
-    cancel: (reason: ToolCallCancelReason) => {
-      addToolOutput({
+    cancel: async (reason: ToolCallCancelReason) => {
+      await addToolOutput({
         tool: toolCall.toolName,
         toolCallId: toolCall.toolCallId,
         output: {

--- a/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
+++ b/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
@@ -1,0 +1,96 @@
+import type { ContextWindowUsage, TaskMemoryState } from "@getpochi/common";
+import { constants } from "@getpochi/common";
+import type { Message } from "@getpochi/livekit";
+import { isCompletionToolPart } from "@getpochi/tools";
+import { isStaticToolUIPart } from "ai";
+
+export type ExtractionData = {
+  messages: Message[];
+  contextWindowUsage?: ContextWindowUsage;
+};
+
+export type ExtractionMetrics = {
+  tokens: number;
+  toolCalls: number;
+  trailingMessageId: string | undefined;
+  trailingMessageHasOpenToolCall: boolean;
+};
+
+export function getExtractionMetrics(data: ExtractionData): ExtractionMetrics {
+  const last = data.messages.at(-1);
+  return {
+    tokens: computeTotalTokens(data.contextWindowUsage),
+    toolCalls: countToolCalls(data.messages),
+    trailingMessageId: last?.id,
+    trailingMessageHasOpenToolCall: lastMessageHasOpenToolCall(data.messages),
+  };
+}
+
+function computeTotalTokens(usage?: ContextWindowUsage) {
+  if (!usage) return 0;
+  return (
+    usage.system +
+    usage.tools +
+    usage.messages +
+    usage.files +
+    usage.toolResults
+  );
+}
+
+function countToolCalls(messages: Message[]): number {
+  let count = 0;
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const part of message.parts) {
+      if (isStaticToolUIPart(part)) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+/** True if the trailing assistant turn has non-terminal tool calls without output yet. */
+export function lastMessageHasOpenToolCall(messages: Message[]): boolean {
+  const last = messages.at(-1);
+  if (!last || last.role !== "assistant") return false;
+  return last.parts.some((part) => {
+    if (!isStaticToolUIPart(part) || isCompletionToolPart(part)) return false;
+    return part.state !== "output-available" && part.state !== "output-error";
+  });
+}
+
+export function shouldExtractTaskMemory(
+  state: TaskMemoryState,
+  metrics: ExtractionMetrics,
+): boolean {
+  if (state.isExtracting) return false;
+
+  if (metrics.trailingMessageHasOpenToolCall) return false;
+
+  if (!state.initialized) {
+    return metrics.tokens >= constants.TaskMemoryInitTokenThreshold;
+  }
+
+  const tokenDelta = metrics.tokens - state.lastExtractionTokens;
+  const toolCallDelta = metrics.toolCalls - state.lastExtractionToolCalls;
+
+  return (
+    tokenDelta >= constants.TaskMemoryUpdateTokenIncrement &&
+    toolCallDelta >= constants.TaskMemoryUpdateToolCallThreshold
+  );
+}
+
+export function toExtractingState(
+  state: TaskMemoryState,
+  metrics: ExtractionMetrics,
+): TaskMemoryState {
+  return {
+    ...state,
+    initialized: true,
+    isExtracting: true,
+    lastExtractionTokens: metrics.tokens,
+    lastExtractionToolCalls: metrics.toolCalls,
+    pendingExtractionMessageId: metrics.trailingMessageId,
+  };
+}

--- a/packages/vscode-webui/src/features/settings/hooks/use-tool-auto-approval.ts
+++ b/packages/vscode-webui/src/features/settings/hooks/use-tool-auto-approval.ts
@@ -5,7 +5,7 @@ import type { Message } from "@getpochi/livekit";
 import {
   type ToolName,
   ToolsByPermission,
-  isUserInputToolPart,
+  isCompletionToolPart,
 } from "@getpochi/tools";
 import {
   type ToolUIPart,
@@ -46,7 +46,7 @@ export const getPendingToolcallApproval = (
     if (
       isStaticToolUIPart(part) &&
       part.state === "input-available" &&
-      !isUserInputToolPart(part)
+      !isCompletionToolPart(part)
     ) {
       tools.push(part);
     }

--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -22,7 +22,11 @@ import { useChat } from "@ai-sdk/react";
 import type { BuiltinSubAgentInfo } from "@getpochi/common/vscode-webui-bridge";
 import { catalog } from "@getpochi/livekit";
 import { useLiveChatKit } from "@getpochi/livekit/react";
-import { type Todo, compileToolPolicies } from "@getpochi/tools";
+import {
+  type Todo,
+  compileToolPolicies,
+  isCompletionToolName,
+} from "@getpochi/tools";
 import {
   getStaticToolName,
   lastAssistantMessageIsCompleteWithToolCalls,
@@ -110,10 +114,7 @@ export function useLiveSubTask(
       }
 
       // completion tools
-      if (
-        toolCall.toolName === "attemptCompletion" ||
-        toolCall.toolName === "askFollowupQuestion"
-      ) {
+      if (isCompletionToolName(toolCall.toolName)) {
         // no-op
         return;
       }


### PR DESCRIPTION
## Summary

Two main improvements:

### 1. Fix task memory extraction trigger

Previously, `lastMessageHasOpenToolCall` incorrectly treated completion tools (`attemptCompletion`, `askFollowupQuestion`) as open/pending tool calls and would block extraction even when the task was done. Now:
- Completion tool parts are explicitly excluded from the open-tool-call check, so extraction can fire immediately after the agent calls `attemptCompletion`
- Extraction logic and metrics are extracted from `use-task-memory.ts` into a dedicated `task-memory-extraction.ts` module with unit tests covering both cases

### 2. Fix final tool-call state (writeToFile, etc.) not persisted in background tasks

Background task workers were not flushing the last message to the store after calling `addToolOutput`. Because completion tools (`attemptCompletion`) do not produce another LLM round-trip, the final tool-call states (e.g. `writeToFile` going from `input-available` → `output-available`) were never committed. Fix:
- `persistLastMessage` is called after every `adapterAddToolOutput` invocation, ensuring tool output state is written even when no subsequent model request is made
- `completedRef` is now set in `onStreamFinish` (after the stream closes) rather than inside `onToolCall`, preventing a race where the ref was flipped before the final outputs were flushed

### Refactoring (supporting the above)

- Rename `isUserInputToolName` / `isUserInputToolPart` → `isCompletionToolName` / `isCompletionToolPart` across all packages for semantic clarity
- Replace raw `type.startsWith("tool-")` string checks with typed AI SDK helpers (`isStaticToolUIPart`, `getStaticToolName`) in `filter-completion-tools.ts`, `background-task-worker.tsx`, and `use-auto-memory.ts`

## Test plan

- [ ] Run `bun run test` — new `task-memory-extraction.test.ts` covers open-tool-call detection and extraction trigger logic
- [ ] Verify that after a background task completes, the last `writeToFile` (or other write tool) shows `output-available` state in the UI rather than staying stuck at `input-available`
- [ ] Verify task memory extraction fires correctly at completion boundaries (not blocked by `attemptCompletion` pending state)

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-f2889fa8e07749e1b77e814668fb493d) | [Task](https://app.getpochi.com/share/p-f2889fa8e07749e1b77e814668fb493d)