### PR TITLE
chore(vscode): bump version to 0.49.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.47.0-dev",
+  "version": "0.49.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump `packages/vscode` version from `0.47.0-dev` to `0.49.0-dev` to align with the next development cycle.

## Test plan
- [ ] CI passes

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-343bdb8ff99a43b1a024adbd9da102e3)