### PR TITLE
fix: safely handle undefined CORS proxy prefix and Request objects in proxy fetchers

### DIFF
--- a/packages/livekit/src/chat/__tests__/anthropic.test.ts
+++ b/packages/livekit/src/chat/__tests__/anthropic.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { proxiedFetch } from "../models/anthropic";
+
+describe("Anthropic fetch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(globalThis, "POCHI_CORS_PROXY_URL_PREFIX");
+  });
+
+  it("uses direct fetch when the CORS proxy is not configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await proxiedFetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/messages",
+      { method: "POST" },
+    );
+  });
+
+  it("uses the CORS proxy when configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
+
+    await proxiedFetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL(
+        "https://proxy.example/?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+      ),
+      { method: "POST" },
+    );
+  });
+});

--- a/packages/livekit/src/chat/models/anthropic.ts
+++ b/packages/livekit/src/chat/models/anthropic.ts
@@ -8,7 +8,7 @@ export function createAnthropicModel(
   const anthropic = createAnthropic({
     baseURL: llm.baseURL,
     apiKey: llm.apiKey,
-    fetch: proxedFetch,
+    fetch: proxiedFetch,
   });
 
   return wrapLanguageModel({
@@ -23,11 +23,14 @@ export function createAnthropicModel(
   });
 }
 
-const proxedFetch: typeof fetch = async (input, init) => {
-  const originalUrl = input.toString();
-  const url = new URL(
-    globalThis.POCHI_CORS_PROXY_URL_PREFIX + encodeURIComponent(originalUrl),
-  );
+export const proxiedFetch: typeof fetch = async (input, init) => {
+  const proxyPrefix = globalThis.POCHI_CORS_PROXY_URL_PREFIX;
+  if (!proxyPrefix) {
+    return fetch(input, init);
+  }
+
+  const originalUrl = input instanceof Request ? input.url : input.toString();
+  const url = new URL(`${proxyPrefix}${encodeURIComponent(originalUrl)}`);
 
   return fetch(url, init);
 };

--- a/packages/vendor-codex/src/model.test.ts
+++ b/packages/vendor-codex/src/model.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createProxyFetch } from "./model";
+
+describe("Codex proxy fetch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(globalThis, "POCHI_CORS_PROXY_URL_PREFIX");
+  });
+
+  it("uses direct fetch when the CORS proxy is not configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxyFetch = createProxyFetch(async () => ({
+      accessToken: "token",
+      mode: "chatgpt",
+    }));
+
+    await proxyFetch("https://chatgpt.com/backend-api/codex/responses", {
+      body: JSON.stringify({ model: "gpt-5", input: [] }),
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://chatgpt.com/backend-api/codex/responses");
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
+  it("uses the CORS proxy when configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
+
+    const proxyFetch = createProxyFetch(async () => ({
+      accessToken: "token",
+      mode: "chatgpt",
+    }));
+
+    await proxyFetch("https://chatgpt.com/backend-api/codex/responses", {
+      body: JSON.stringify({ model: "gpt-5", input: [] }),
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toEqual(
+      new URL(
+        "https://proxy.example/?url=https%3A%2F%2Fchatgpt.com%2Fbackend-api%2Fcodex%2Fresponses",
+      ),
+    );
+  });
+});

--- a/packages/vendor-codex/src/model.ts
+++ b/packages/vendor-codex/src/model.ts
@@ -96,16 +96,16 @@ function createCodexResponsesModel(
   return openai.responses(modelId || "gpt-5");
 }
 
-function createProxyFetch(getCredentials: () => Promise<unknown>) {
+export function createProxyFetch(getCredentials: () => Promise<unknown>) {
   return async (
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    const originalUrl = input.toString();
-
-    const url = new URL(
-      globalThis.POCHI_CORS_PROXY_URL_PREFIX + encodeURIComponent(originalUrl),
-    );
+    const proxyPrefix = globalThis.POCHI_CORS_PROXY_URL_PREFIX;
+    const originalUrl = input instanceof Request ? input.url : input.toString();
+    const url = proxyPrefix
+      ? new URL(`${proxyPrefix}${encodeURIComponent(originalUrl)}`)
+      : input;
 
     const transformedBody = transformRequestBody(
       typeof init?.body === "string" ? init.body : undefined,

--- a/packages/vendor-gemini-cli/src/model.test.ts
+++ b/packages/vendor-gemini-cli/src/model.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFetcher } from "./model";
+
+describe("Gemini CLI fetcher", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(globalThis, "POCHI_CORS_PROXY_URL_PREFIX");
+  });
+
+  it("uses direct fetch when CORS is requested but the proxy is not configured", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("data: {}\r\n\r\n"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const fetcher = createFetcher(
+      "gemini-2.5-pro",
+      async () => ({
+        accessToken: "token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() + 60_000,
+        project: "project-id",
+      }),
+      true,
+    );
+
+    await fetcher("https://unused.example", {
+      body: JSON.stringify({ contents: [] }),
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toEqual(
+      new URL(
+        "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+      ),
+    );
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
+  it("uses the CORS proxy when configured", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("data: {}\r\n\r\n"));
+    vi.stubGlobal("fetch", fetchMock);
+    globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
+
+    const fetcher = createFetcher(
+      "gemini-2.5-pro",
+      async () => ({
+        accessToken: "token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() + 60_000,
+        project: "project-id",
+      }),
+      true,
+    );
+
+    await fetcher("https://unused.example", {
+      body: JSON.stringify({ contents: [] }),
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toEqual(
+      new URL(
+        "https://proxy.example/?url=https%3A%2F%2Fcloudcode-pa.googleapis.com%2Fv1internal%3AstreamGenerateContent%3Falt%3Dsse",
+      ),
+    );
+  });
+});

--- a/packages/vendor-gemini-cli/src/model.ts
+++ b/packages/vendor-gemini-cli/src/model.ts
@@ -44,7 +44,7 @@ export function createGeminiCliModel({
   });
 }
 
-function createFetcher(
+export function createFetcher(
   model: string,
   getCredentials: () => Promise<GeminiCredentials>,
   cors?: boolean,
@@ -66,12 +66,11 @@ function createFetcher(
 
     let urlToFetch: URL;
 
-    if (cors) {
-      const url = new URL(
-        globalThis.POCHI_CORS_PROXY_URL_PREFIX +
-          encodeURIComponent(originalUrl.toString()),
+    const proxyPrefix = globalThis.POCHI_CORS_PROXY_URL_PREFIX;
+    if (cors && proxyPrefix) {
+      urlToFetch = new URL(
+        `${proxyPrefix}${encodeURIComponent(originalUrl.toString())}`,
       );
-      urlToFetch = url;
     } else {
       urlToFetch = originalUrl;
     }


### PR DESCRIPTION
## Summary
- Check if `globalThis.POCHI_CORS_PROXY_URL_PREFIX` is defined before appending it.
- Correctly extract URL from `Request` objects in custom fetchers.
- Apply fixes to Anthropic, Codex, and Gemini models.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-34da01b12c71450a936c911acf69096c)