### PR TITLE
feat(vscode-webui): support pinning tasks in the task list

### DIFF
--- a/packages/common/src/vscode-webui-bridge/index.ts
+++ b/packages/common/src/vscode-webui-bridge/index.ts
@@ -24,6 +24,7 @@ export type {
   TaskStates,
   McpConfigOverride,
   TaskArchivedParams,
+  TaskPinnedParams,
 } from "./types/task";
 export type {
   VSCodeLmModel,

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -100,3 +100,8 @@ export type TaskStates = Record<string, TaskState>;
 export type TaskArchivedParams =
   | { type: "single"; taskId: string; archived: boolean }
   | { type: "batch"; cwd?: string };
+
+export type TaskPinnedParams = {
+  taskId: string;
+  pinned: boolean;
+};

--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -31,6 +31,7 @@ import type {
   SkillFile,
   TaskArchivedParams,
   TaskChangedFile,
+  TaskPinnedParams,
   TaskStates,
   VSCodeHostApi,
   VSCodeSettings,
@@ -465,6 +466,16 @@ const VSCodeHostStub = {
       value: {} as ThreadSignalSerialization<Record<string, boolean>>,
       hasArchivableTasks: {} as ThreadSignalSerialization<boolean>,
       setTaskArchived: (_params: TaskArchivedParams) => Promise.resolve(),
+    });
+  },
+
+  readTaskPinned(): Promise<{
+    value: ThreadSignalSerialization<Record<string, boolean>>;
+    setTaskPinned: (params: TaskPinnedParams) => Promise<void>;
+  }> {
+    return Promise.resolve({
+      value: {} as ThreadSignalSerialization<Record<string, boolean>>,
+      setTaskPinned: (_params: TaskPinnedParams) => Promise.resolve(),
     });
   },
 

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -31,6 +31,7 @@ import type {
   SkillFile,
   TaskArchivedParams,
   TaskChangedFile,
+  TaskPinnedParams,
   TaskStates,
   WorkspaceState,
 } from "./index";
@@ -498,6 +499,15 @@ export interface VSCodeHostApi {
     value: ThreadSignalSerialization<Record<string, boolean>>;
     hasArchivableTasks: ThreadSignalSerialization<boolean>;
     setTaskArchived: (params: TaskArchivedParams) => Promise<void>;
+  }>;
+
+  /**
+   * Read and manage pinned state for tasks.
+   * Returns a serialized signal for the pinned value map and a setter function.
+   */
+  readTaskPinned(): Promise<{
+    value: ThreadSignalSerialization<Record<string, boolean>>;
+    setTaskPinned: (params: TaskPinnedParams) => Promise<void>;
   }>;
 
   readLang(): Promise<{

--- a/packages/vscode-webui/src/components/task-row.tsx
+++ b/packages/vscode-webui/src/components/task-row.tsx
@@ -8,6 +8,7 @@ import { EditSummary } from "@/features/tools";
 import { ToolCallLite } from "@/features/tools";
 import { usePochiCredentials } from "@/lib/hooks/use-pochi-credentials";
 import { useTaskArchived } from "@/lib/hooks/use-task-archived";
+import { useTaskPinned } from "@/lib/hooks/use-task-pinned";
 import { cn } from "@/lib/utils";
 import { vscodeHost } from "@/lib/vscode";
 import { parseTitle } from "@getpochi/common/message-utils";
@@ -15,7 +16,7 @@ import { encodeStoreId } from "@getpochi/common/store-id-utils";
 import type { TaskState } from "@getpochi/common/vscode-webui-bridge";
 import type { Task, UITools } from "@getpochi/livekit";
 import type { ToolUIPart } from "ai";
-import { Archive, GitBranch, Loader2 } from "lucide-react";
+import { Archive, GitBranch, Loader2, Pin, PinOff } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -32,11 +33,14 @@ export function TaskRow({
   const { t } = useTranslation();
   const [isHovered, setIsHovered] = useState(false);
   const { isTaskArchived, setTaskArchived } = useTaskArchived();
+  const { isTaskPinned, setTaskPinned } = useTaskPinned();
 
   const archived = useMemo(
     () => isTaskArchived(task.id),
     [isTaskArchived, task.id],
   );
+
+  const pinned = useMemo(() => isTaskPinned(task.id), [isTaskPinned, task.id]);
 
   const title = useMemo(() => parseTitle(task.title), [task.title]);
 
@@ -68,6 +72,17 @@ export function TaskRow({
       });
     },
     [setTaskArchived, task.id, archived],
+  );
+
+  const handlePinClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setTaskPinned?.({
+        taskId: task.id,
+        pinned: !pinned,
+      });
+    },
+    [setTaskPinned, task.id, pinned],
   );
 
   return (
@@ -105,24 +120,48 @@ export function TaskRow({
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 {!isDeleted && isHovered ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 w-6 p-0 hover:bg-transparent"
-                        onClick={handleArchiveClick}
-                        aria-label="archive-task-button"
-                      >
-                        <Archive className="size-3.5" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {archived
-                        ? t("tasksPage.unarchiveTask")
-                        : t("tasksPage.archiveTask")}
-                    </TooltipContent>
-                  </Tooltip>
+                  <div className="flex items-center">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 p-0 hover:bg-transparent"
+                          onClick={handlePinClick}
+                          aria-label="pin-task-button"
+                        >
+                          {pinned ? (
+                            <PinOff className="size-3.5" />
+                          ) : (
+                            <Pin className="size-3.5" />
+                          )}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {pinned
+                          ? t("tasksPage.unpinTask")
+                          : t("tasksPage.pinTask")}
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 p-0 hover:bg-transparent"
+                          onClick={handleArchiveClick}
+                          aria-label="archive-task-button"
+                        >
+                          <Archive className="size-3.5" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {archived
+                          ? t("tasksPage.unarchiveTask")
+                          : t("tasksPage.archiveTask")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
                 ) : (
                   <div className="text-sm">{formatTimeAgo(task.createdAt)}</div>
                 )}

--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -31,6 +31,7 @@ import { useSelectedModels } from "@/features/settings";
 import { useArchivedTasks } from "@/lib/hooks/use-archived-tasks";
 import { useCurrentWorkspace } from "@/lib/hooks/use-current-workspace";
 import { usePaginatedTasks } from "@/lib/hooks/use-paginated-tasks";
+import { usePinnedTasks } from "@/lib/hooks/use-pinned-tasks";
 import { usePochiTabs } from "@/lib/hooks/use-pochi-tabs";
 import { useTaskArchived } from "@/lib/hooks/use-task-archived";
 import { useWorktrees } from "@/lib/hooks/use-worktrees";
@@ -49,6 +50,7 @@ import type { Task } from "@getpochi/livekit";
 import {
   Archive,
   Check,
+  ChevronDown,
   GitCompare,
   GitPullRequest,
   ListFilterIcon,
@@ -184,9 +186,11 @@ export function WorktreeList({
     optimisticGroups[0].path === (workspacePath || cwd);
 
   const archivedTasks = useArchivedTasks();
+  const pinnedTasks = usePinnedTasks();
 
   return (
     <div className="flex flex-col gap-1">
+      {pinnedTasks.length > 0 && <PinnedTasksSection tasks={pinnedTasks} />}
       {/* Tasks Header */}
       <div
         className="group flex items-center gap-2 px-1 pb-1"
@@ -586,6 +590,51 @@ function WorktreeSection({
               {t("tasksPage.emptyState.description")}
             </div>
           )}
+        </ScrollArea>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function PinnedTasksSection({ tasks }: { tasks: readonly Task[] }) {
+  const { t } = useTranslation();
+  const pochiTasks = usePochiTabs();
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <Collapsible
+      open={isExpanded}
+      onOpenChange={setIsExpanded}
+      className="mb-3"
+    >
+      <div
+        className="group/pinned-header px-1"
+        data-testid="pinned-tasks-section-header"
+      >
+        <div className="flex h-6 items-center gap-2">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full flex-1 cursor-pointer select-none items-center gap-1.5 font-bold font-sans text-sm uppercase leading-6"
+            >
+              <span className="truncate">{t("tasksPage.pinned")}</span>
+              <ChevronDown
+                className={cn(
+                  "size-3.5 text-muted-foreground opacity-0 transition-[opacity,transform] duration-150 group-hover/pinned-header:opacity-100",
+                  !isExpanded && "-rotate-90",
+                )}
+              />
+            </button>
+          </CollapsibleTrigger>
+        </div>
+      </div>
+      <CollapsibleContent>
+        <ScrollArea viewportClassname="px-1 py-1 max-h-[300px]">
+          {tasks.map((task) => (
+            <div key={task.id} className="py-0.5">
+              <TaskRow task={task} state={pochiTasks[task.id]} />
+            </div>
+          ))}
         </ScrollArea>
       </CollapsibleContent>
     </Collapsible>

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -227,6 +227,7 @@
   },
   "tasksPage": {
     "tasks": "Tasks",
+    "pinned": "Pinned",
     "filter": "Filter tasks",
     "archivedTasks": "Archived tasks",
     "deletedWorktrees": "Deleted worktrees",
@@ -272,6 +273,8 @@
     "loadMore": "Load more",
     "archiveTask": "Archive task",
     "unarchiveTask": "Unarchive task",
+    "pinTask": "Pin task",
+    "unpinTask": "Unpin task",
     "archiveOldTasks": "Archive old tasks",
     "archiveOldTasksTooltip": "Archive tasks older than one week",
     "showAnyTasks": "Show any tasks",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -228,6 +228,7 @@
   },
   "tasksPage": {
     "tasks": "タスク",
+    "pinned": "ピン留め",
     "filter": "タスクをフィルター",
     "archivedTasks": "アーカイブされたタスク",
     "deletedWorktrees": "削除されたワークツリー",
@@ -272,6 +273,8 @@
     "loadMore": "さらに読み込む",
     "archiveTask": "タスクをアーカイブ",
     "unarchiveTask": "タスクをアーカイブ解除",
+    "pinTask": "タスクをピン留め",
+    "unpinTask": "ピン留めを解除",
     "archiveOldTasks": "古いタスクをアーカイブ",
     "archiveOldTasksTooltip": "1週間以上前のタスクをアーカイブ",
     "showAnyTasks": "すべてのタスクを表示",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -227,6 +227,7 @@
   },
   "tasksPage": {
     "tasks": "작업",
+    "pinned": "고정됨",
     "filter": "작업 필터",
     "archivedTasks": "보관된 작업",
     "deletedWorktrees": "삭제된 워크트리",
@@ -271,6 +272,8 @@
     "loadMore": "더 보기",
     "archiveTask": "작업 보관",
     "unarchiveTask": "작업 보관 취소",
+    "pinTask": "작업 고정",
+    "unpinTask": "작업 고정 해제",
     "archiveOldTasks": "오래된 작업 보관",
     "archiveOldTasksTooltip": "1주일 이상 된 작업 보관",
     "showAnyTasks": "모든 작업 표시",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -226,6 +226,7 @@
   },
   "tasksPage": {
     "tasks": "任务",
+    "pinned": "已置顶",
     "filter": "筛选任务",
     "archivedTasks": "已归档任务",
     "deletedWorktrees": "已删除的工作树",
@@ -270,6 +271,8 @@
     "loadMore": "加载更多",
     "archiveTask": "归档任务",
     "unarchiveTask": "取消归档任务",
+    "pinTask": "置顶任务",
+    "unpinTask": "取消置顶",
     "archiveOldTasks": "归档旧任务",
     "archiveOldTasksTooltip": "归档一周前的任务",
     "showAnyTasks": "显示所有任务",

--- a/packages/vscode-webui/src/lib/hooks/use-paginated-tasks.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-paginated-tasks.ts
@@ -2,6 +2,7 @@ import type { Task } from "@getpochi/livekit";
 import { useCallback, useState } from "react";
 import { useTasks } from "../use-tasks";
 import { useTaskArchived } from "./use-task-archived";
+import { useTaskPinned } from "./use-task-pinned";
 
 interface UsePaginatedTasksOptions {
   cwd: string;
@@ -25,6 +26,7 @@ export function usePaginatedTasks({
   const [limit, setLimit] = useState(pageSize);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const { isTaskArchived } = useTaskArchived();
+  const { isTaskPinned } = useTaskPinned();
 
   const tasks = useTasks()
     .filter(
@@ -32,6 +34,8 @@ export function usePaginatedTasks({
         t.parentId === null &&
         t.cwd === cwd &&
         !!t.title?.trim() &&
+        // Pinned tasks live in their own top-level section.
+        !isTaskPinned(t.id) &&
         (showArchived || !isTaskArchived(t.id)),
     )
     .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());

--- a/packages/vscode-webui/src/lib/hooks/use-pinned-tasks.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-pinned-tasks.ts
@@ -1,0 +1,22 @@
+import { useTasks } from "../use-tasks";
+import { useTaskArchived } from "./use-task-archived";
+import { useTaskPinned } from "./use-task-pinned";
+
+/**
+ * Returns all pinned tasks across all cwds (excluding archived), sorted by
+ * updatedAt descending.
+ */
+export function usePinnedTasks() {
+  const { isTaskPinned } = useTaskPinned();
+  const { isTaskArchived } = useTaskArchived();
+
+  return useTasks()
+    .filter(
+      (t) =>
+        t.parentId === null &&
+        !!t.title?.trim() &&
+        isTaskPinned(t.id) &&
+        !isTaskArchived(t.id),
+    )
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}

--- a/packages/vscode-webui/src/lib/hooks/use-task-pinned.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-task-pinned.ts
@@ -1,0 +1,38 @@
+import { threadSignal } from "@quilted/threads/signals";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { vscodeHost } from "../vscode";
+
+/** @useSignals */
+export const useTaskPinned = () => {
+  const { data, isLoading } = useQuery({
+    queryKey: ["tasksPinned"],
+    queryFn: () => fetchTaskPinned(),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  const tasksPinned = data?.tasksPinned.value;
+  const isTaskPinned = useCallback(
+    (taskId: string) => {
+      return (
+        tasksPinned && taskId in tasksPinned && tasksPinned[taskId] === true
+      );
+    },
+    [tasksPinned],
+  );
+
+  return {
+    tasksPinned: data?.tasksPinned.value,
+    setTaskPinned: data?.setTaskPinned,
+    isLoading,
+    isTaskPinned,
+  };
+};
+
+async function fetchTaskPinned() {
+  const result = await vscodeHost.readTaskPinned();
+  return {
+    tasksPinned: threadSignal(result.value),
+    setTaskPinned: result.setTaskPinned,
+  };
+}

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -132,6 +132,7 @@ function createVSCodeHost(): VSCodeHostApi {
         "writeTaskTranscript",
         "readBackgroundTaskState",
         "readTaskArchived",
+        "readTaskPinned",
         "readLang",
         "readTaskChangedFiles",
       ],

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -99,6 +99,7 @@ import {
   type SkillFile,
   type TaskArchivedParams,
   type TaskChangedFile,
+  type TaskPinnedParams,
   type TaskStates,
   type VSCodeHostApi,
   type VSCodeSettings,
@@ -1421,9 +1422,11 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
         computed(() => {
           const tasks = this.taskHistoryStore.tasks.value;
           const archived = this.taskStateStore.getArchivedSignal().value;
+          const pinned = this.taskStateStore.getPinnedSignal().value;
           return Object.values(tasks).some((task) => {
             if (task.parentId !== null) return false;
             if (archived[task.id]) return false;
+            if (pinned[task.id]) return false;
             return task.updatedAt < oneWeekAgo;
           });
         }),
@@ -1434,15 +1437,23 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
             [params.taskId]: params.archived,
           });
           if (params.archived) {
+            // Archiving a task implicitly unpins it.
+            if (this.taskStateStore.getPinnedSignal().value[params.taskId]) {
+              await this.taskStateStore.setPinned({
+                [params.taskId]: false,
+              });
+            }
             this.deleteFileStateCache(params.taskId);
           }
         } else if (params.type === "batch") {
           const tasks = this.taskHistoryStore.tasks.value;
+          const pinned = this.taskStateStore.getPinnedSignal().value;
           const updates: Record<string, boolean> = {};
 
           for (const [taskId, task] of Object.entries(tasks)) {
             if (
               task.updatedAt < oneWeekAgo &&
+              !pinned[taskId] &&
               (!params.cwd || task.cwd === params.cwd)
             ) {
               updates[taskId] = true;
@@ -1456,6 +1467,17 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
             }
           }
         }
+      },
+    };
+  };
+
+  readTaskPinned = async () => {
+    return {
+      value: ThreadSignal.serialize(this.taskStateStore.getPinnedSignal()),
+      setTaskPinned: async (params: TaskPinnedParams) => {
+        await this.taskStateStore.setPinned({
+          [params.taskId]: params.pinned,
+        });
       },
     };
   };

--- a/packages/vscode/src/lib/task-data-store.ts
+++ b/packages/vscode/src/lib/task-data-store.ts
@@ -16,6 +16,7 @@ import type * as vscode from "vscode";
 type TaskStateData = {
   mcpConfigOverride?: McpConfigOverride;
   archived?: boolean;
+  pinned?: boolean;
   changedFiles?: TaskChangedFile[];
   contextWindowUsage?: ContextWindowUsage;
   taskMemoryState?: TaskMemoryState;
@@ -138,6 +139,35 @@ export class TaskDataStore {
       for (const [taskId, taskData] of Object.entries(this.state.value)) {
         if (taskData.archived !== undefined) {
           result[taskId] = taskData.archived;
+        }
+      }
+      return result;
+    });
+  }
+
+  async setPinned(updates: Record<string, boolean>): Promise<void> {
+    const newState = { ...this.state.value };
+    const now = Date.now();
+    for (const [taskId, pinned] of Object.entries(updates)) {
+      const existing = newState[taskId] || { updatedAt: now };
+      newState[taskId] = { ...existing, pinned, updatedAt: now };
+    }
+    await this.context.globalState.update(this.storageKey, newState);
+    this.state.value = newState;
+  }
+
+  /**
+   * Get a computed signal for all tasks' pinned states.
+   *
+   * Returns a Record<taskId, pinned> for all tasks.
+   * Used for ThreadSignal serialization.
+   */
+  getPinnedSignal() {
+    return computed(() => {
+      const result: Record<string, boolean> = {};
+      for (const [taskId, taskData] of Object.entries(this.state.value)) {
+        if (taskData.pinned !== undefined) {
+          result[taskId] = taskData.pinned;
         }
       }
       return result;


### PR DESCRIPTION
## Summary

- Adds per-task pin/unpin so important tasks stay at the top of the task list independent of recency. Pinned tasks render in a dedicated, collapsible **Pinned** section above the worktree groups (and no longer duplicate inside their worktree group).
- Pinned state is persisted workspace-wide via `TaskDataStore.setPinned` / `getPinnedSignal` and exposed through a new `readTaskPinned` host bridge method (`webview.ts` / `webview-stub.ts` / `vscode-host-impl.ts` / `vscode.ts` allowed methods).
- Archiving a task implicitly unpins it, pinned tasks are excluded from the "Archive old tasks" batch action and `hasArchivableTasks`, and `usePinnedTasks` filters out archived tasks as a client-side safety net.

## UI

- `TaskRow` exposes Pin / Unpin next to Archive on hover with tooltip + i18n (en/zh/jp/ko); spacing between the two icons is tightened.
- `PinnedTasksSection` shows a hover-revealed chevron that rotates with collapse state and triggers the section toggle; pinned rows otherwise look identical to normal rows in their default state.

Demo: https://jam.dev/c/77ca98f2-a729-48b6-b64d-b752feb148d4

Closes #1553

## Test plan

- [ ] Pin a task → it moves into the **Pinned** section at the top and out of its worktree group.
- [ ] Unpin a task → it returns to its worktree group, sorted by recency.
- [ ] Archive a pinned task → it is removed from the Pinned section and ends up under Archived tasks (no longer pinned).
- [ ] "Archive old tasks" never archives pinned tasks; `hasArchivableTasks` reflects this.
- [ ] Hover on the Pinned header reveals the chevron; hover on individual rows does not.
- [ ] Pinned state persists across VS Code reloads (workspace-wide).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d82896f38a124a2589c5d13b189b582e)