### PR TITLE
chore(github): add explicit permissions to update-cli-latest-version workflow

### DIFF
--- a/.github/workflows/update-cli-latest-version.yml
+++ b/.github/workflows/update-cli-latest-version.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "cli@*"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-fallback:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Added `contents: write` and `pull-requests: write` permissions to the `update-cli-latest-version.yml` workflow.
- This ensures the `peter-evans/create-pull-request` action has the necessary permissions to create branches and pull requests.

## Test plan
- Verified that the permissions match the requirements for the `create-pull-request` action.
- The workflow should now run successfully in environments with restricted default token permissions.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3b4205600ccb4cf3b3f8f8a0abad6bd2)