### PR TITLE
feat(github): use NPM Trusted Publisher for releases

### DIFF
--- a/.github/workflows/release-pochi-npm.yml
+++ b/.github/workflows/release-pochi-npm.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v5
@@ -42,7 +43,6 @@ jobs:
       - name: Release NPM
         if: startsWith(github.ref, 'refs/tags/cli@')
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           POCHI_CLI_NPM_NAME: ${{ vars.POCHI_CLI_NPM_NAME }}
         run: |
           cd packages/cli
@@ -60,4 +60,8 @@ jobs:
           # so we have to replace the bin path in package.json here
           sed -i.bak 's|"pochi": "src/cli.ts"|"pochi": "dist/cli.js"|' package.json
           rm -f package.json.bak
-          bun publish --access public ${IS_PRERELEASE:+"--tag beta"}
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            npm publish --access public --tag beta --provenance
+          else
+            npm publish --access public --provenance
+          fi


### PR DESCRIPTION
## Summary
- Migrated the NPM release workflow to use **NPM Trusted Publisher** (OIDC).
- Added `id-token: write` permission to the workflow.
- Replaced `bun publish` with `npm publish --provenance` to support OIDC authentication and supply chain verification.
- Removed the dependency on `NPM_TOKEN` secret.

## Test plan
- This change requires configuring the Trusted Publisher on the NPM registry side (pointing to this repo and workflow).
- Future tags matching `cli@*` will attempt to publish using OIDC.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ad9c39a51f7c42b7bf6238181924138e)