### PR TITLE
feat(github): upgrade Node.js to v24 for NPM release

### DIFF
--- a/.github/workflows/release-pochi-npm.yml
+++ b/.github/workflows/release-pochi-npm.yml
@@ -24,6 +24,12 @@ jobs:
           bun-version: 1.2.15
       - run: bun install
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
       - name: Extract version and determine release type
         id: release_info
         run: |


### PR DESCRIPTION
## Summary
- Upgraded `actions/setup-node` to `v6`.
- Set Node.js version to `24` to meet NPM Trusted Publishing requirements (Node 22.14.0+).
- Disabled automatic package manager caching in `setup-node` to avoid potential conflicts with Bun.

## Test plan
- Verify the workflow runs correctly on the next tag push.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ad9c39a51f7c42b7bf6238181924138e)