### PR TITLE
chore(cli): add repository field to package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@getpochi/cli",
   "version": "0.6.0-dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TabbyML/pochi.git",
+    "directory": "packages/cli"
+  },
   "devDependencies": {
     "@commander-js/extra-typings": "^14.0.0",
     "@getpochi/common": "workspace:*",


### PR DESCRIPTION
## Summary
- Added `repository` field to `packages/cli/package.json`.
- Pointed it to the `TabbyML/pochi` GitHub repository with the correct `directory` path.

## Test plan
- Verified `packages/cli/package.json` contains the correct repository information.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-cd9bdb2f1c7a45d6a45c766779657e9f)