### PR TITLE
fix(vscode): skip auto-layout for built-in webview tabs (#1551)

### DIFF
--- a/packages/vscode/src/integrations/layout/layout-manager.ts
+++ b/packages/vscode/src/integrations/layout/layout-manager.ts
@@ -16,6 +16,7 @@ import {
   findActivePochiTaskTab,
   getTabGroupType,
   getTabGroupsShape,
+  isFileBackedEditorTab,
   isPochiOutputTab,
   isPochiTaskTab,
   isSameTabGroupsShape,
@@ -222,9 +223,12 @@ export class LayoutManager implements vscode.Disposable {
                 }
               });
             } else if (
-              // Auto apply when first editor tab open and task tab exists
+              // Auto apply when first file-backed editor tab opens and a
+              // task tab exists. Skip webview tabs like Settings to avoid
+              // closing them via the subsequent re-layout (issue #1551).
               !isPochiTaskTab(tab) &&
               !isTerminalTab(tab) &&
+              isFileBackedEditorTab(tab) &&
               countOtherTabs(prevTabGroupsShape) === 0 &&
               countPochiTaskTabs(this.tabGroupsShape) > 0
             ) {

--- a/packages/vscode/src/integrations/layout/tab-utils.ts
+++ b/packages/vscode/src/integrations/layout/tab-utils.ts
@@ -34,16 +34,50 @@ export function isPochiOutputTab(tab: vscode.Tab) {
   );
 }
 
-// Returns true if this tab is a file-backed editor (text/diff/custom/notebook).
-// Webview tabs (Settings, Keyboard Shortcuts, Extensions, …) return false.
+// URI schemes that represent VS Code's own configuration / chrome editors
+// rather than real workspace files. These tabs survive layout shuffles
+// poorly (issue #1551), so they should not trigger the Pochi auto-apply.
+//   - `vscode-userdata`: Preferences: Open User Settings (JSON), keybindings.json
+//   - `vscode-settings`: legacy settings editor input
+//   - `vscode`: internal vscode:// resources (walkthroughs, etc.)
+const NonWorkspaceUriSchemes = new Set([
+  "vscode-userdata",
+  "vscode-settings",
+  "vscode",
+]);
+
+function isNonWorkspaceUri(uri: vscode.Uri): boolean {
+  return NonWorkspaceUriSchemes.has(uri.scheme);
+}
+
+// Returns true if this tab is a file-backed editor (text/diff/custom/notebook)
+// backed by a real workspace URI. Tabs that look like editors but actually
+// host VS Code chrome — webview tabs (Settings, Keyboard Shortcuts,
+// Extensions, …) and `vscode-userdata:`-backed JSON editors (User Settings
+// JSON, keybindings.json) — return false so they don't trigger auto-layout.
 export function isFileBackedEditorTab(tab: vscode.Tab): boolean {
-  return (
-    tab.input instanceof vscode.TabInputText ||
-    tab.input instanceof vscode.TabInputTextDiff ||
-    tab.input instanceof vscode.TabInputCustom ||
-    tab.input instanceof vscode.TabInputNotebook ||
-    tab.input instanceof vscode.TabInputNotebookDiff
-  );
+  if (tab.input instanceof vscode.TabInputText) {
+    return !isNonWorkspaceUri(tab.input.uri);
+  }
+  if (tab.input instanceof vscode.TabInputTextDiff) {
+    return (
+      !isNonWorkspaceUri(tab.input.original) &&
+      !isNonWorkspaceUri(tab.input.modified)
+    );
+  }
+  if (tab.input instanceof vscode.TabInputCustom) {
+    return !isNonWorkspaceUri(tab.input.uri);
+  }
+  if (tab.input instanceof vscode.TabInputNotebook) {
+    return !isNonWorkspaceUri(tab.input.uri);
+  }
+  if (tab.input instanceof vscode.TabInputNotebookDiff) {
+    return (
+      !isNonWorkspaceUri(tab.input.original) &&
+      !isNonWorkspaceUri(tab.input.modified)
+    );
+  }
+  return false;
 }
 
 export function getTabGroupType(tabs: readonly vscode.Tab[]) {

--- a/packages/vscode/src/integrations/layout/tab-utils.ts
+++ b/packages/vscode/src/integrations/layout/tab-utils.ts
@@ -34,6 +34,18 @@ export function isPochiOutputTab(tab: vscode.Tab) {
   );
 }
 
+// Returns true if this tab is a file-backed editor (text/diff/custom/notebook).
+// Webview tabs (Settings, Keyboard Shortcuts, Extensions, …) return false.
+export function isFileBackedEditorTab(tab: vscode.Tab): boolean {
+  return (
+    tab.input instanceof vscode.TabInputText ||
+    tab.input instanceof vscode.TabInputTextDiff ||
+    tab.input instanceof vscode.TabInputCustom ||
+    tab.input instanceof vscode.TabInputNotebook ||
+    tab.input instanceof vscode.TabInputNotebookDiff
+  );
+}
+
 export function getTabGroupType(tabs: readonly vscode.Tab[]) {
   if (tabs.length === 0) {
     return "empty";


### PR DESCRIPTION
## Summary
- Stop closing the VS Code Settings UI (and other built-in webview tabs such as Keyboard Shortcuts and the Extensions view) when only a Pochi task tab is visible.
- Add `isFileBackedEditorTab` to `tab-utils.ts` and gate the `onDidChangeTabs` auto-apply trigger on it, so only text/diff/custom/notebook tabs flip the FSM into `apply-in-progress`.

## Root cause
`LayoutManager.onDidChangeTabs` treated any tab that wasn't a Pochi task tab and wasn't a terminal as an editor tab, so opening Settings (a `TabInputWebview`) dispatched `start-apply` with `trigger: "open-editor"`. The subsequent `applyPochiLayoutImpl` re-groups tabs (move panel, new groups, `moveActiveEditor`, `joinTwoGroups`, `setEditorLayout`, …), which the native Settings webview tab does not survive — VS Code closed it.

## Test plan
- [x] `bun tsc` in `packages/vscode` — clean
- [x] `bun check` at repo root (biome + biome.test + ast-grep + i18n eslint) — clean
- [ ] Manual: with only a Pochi task tab visible, run **Preferences: Open Settings (UI)** and confirm the Settings tab stays open
- [ ] Manual: opening a normal text file with only a Pochi task tab visible still triggers the Pochi layout

Closes #1551

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-222b3fbccdee42ea84205d93c8b50af7)