### PR TITLE
fix(i18n): update browser agent name in translations

### DIFF
--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -551,7 +551,7 @@
     "runtimeSection": "Browser Runtime",
     "localChromeSection": "Local Chrome",
     "recordingSection": "Session Recording",
-    "localChromeHint": "Local chrome uses --auto-connect and can reuse the current user's logged-in browser session. Browser Agent may access sites and accounts already signed in to that Chrome profile, so use it only for trusted tasks.",
+    "localChromeHint": "Local chrome uses --auto-connect and can reuse the current user's logged-in browser session. browser agent may access sites and accounts already signed in to that Chrome profile, so use it only for trusted tasks.",
     "browserMode": "Browser mode",
     "managedBrowser": "Managed browser",
     "localChrome": "Local chrome",
@@ -564,6 +564,6 @@
   },
   "builtInAgentsSettings": {
     "title": "Built-in agents",
-    "browser": "Browser Agent"
+    "browser": "browser"
   }
 }

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -554,7 +554,7 @@
     "runtimeSection": "ブラウザー実行環境",
     "localChromeSection": "ローカル Chrome",
     "recordingSection": "セッション録画",
-    "localChromeHint": "ローカル Chrome は --auto-connect を使用し、現在のユーザーのログイン済みブラウザーセッションを再利用できます。Browser Agent はその Chrome プロファイルでログイン済みのサイトやアカウントにアクセスできる可能性があるため、信頼できるタスクでのみ使用してください。",
+    "localChromeHint": "ローカル Chrome は --auto-connect を使用し、現在のユーザーのログイン済みブラウザーセッションを再利用できます。ブラウザーエージェントはその Chrome プロファイルでログイン済みのサイトやアカウントにアクセスできる可能性があるため、信頼できるタスクでのみ使用してください。",
     "browserMode": "ブラウザーモード",
     "managedBrowser": "マネージドブラウザー",
     "localChrome": "ローカル Chrome",
@@ -567,6 +567,6 @@
   },
   "builtInAgentsSettings": {
     "title": "組み込みエージェント",
-    "browser": "ブラウザーエージェント"
+    "browser": "ブラウザー"
   }
 }

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -548,7 +548,7 @@
     "runtimeSection": "브라우저 런타임",
     "localChromeSection": "로컬 Chrome",
     "recordingSection": "세션 녹화",
-    "localChromeHint": "로컬 Chrome은 --auto-connect를 사용하며 현재 사용자의 로그인된 브라우저 세션을 재사용할 수 있습니다. Browser Agent가 해당 Chrome 프로필에 이미 로그인된 사이트와 계정에 접근할 수 있으므로 신뢰할 수 있는 작업에서만 사용하세요.",
+    "localChromeHint": "로컬 Chrome은 --auto-connect를 사용하며 현재 사용자의 로그인된 브라우저 세션을 재사용할 수 있습니다. 브라우저 에이전트가 해당 Chrome 프로필에 이미 로그인된 사이트와 계정에 접근할 수 있으므로 신뢰할 수 있는 작업에서만 사용하세요.",
     "browserMode": "브라우저 모드",
     "managedBrowser": "관리형 브라우저",
     "localChrome": "로컬 Chrome",
@@ -561,6 +561,6 @@
   },
   "builtInAgentsSettings": {
     "title": "내장 에이전트",
-    "browser": "브라우저 에이전트"
+    "browser": "브라우저"
   }
 }

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -552,7 +552,7 @@
     "runtimeSection": "浏览器运行环境",
     "localChromeSection": "本地 Chrome",
     "recordingSection": "会话录制",
-    "localChromeHint": "本地 Chrome 使用 --auto-connect，并可复用当前用户已登录的浏览器会话。Browser Agent 可能访问该 Chrome 个人资料中已登录的网站和账号，请仅在可信任务中使用。",
+    "localChromeHint": "本地 Chrome 使用 --auto-connect，并可复用当前用户已登录的浏览器会话。浏览器代理可能访问该 Chrome 个人资料中已登录的网站和账号，请仅在可信任务中使用。",
     "browserMode": "浏览器模式",
     "managedBrowser": "托管浏览器",
     "localChrome": "本地 Chrome",
@@ -565,6 +565,6 @@
   },
   "builtInAgentsSettings": {
     "title": "内置代理",
-    "browser": "浏览器代理"
+    "browser": "浏览器"
   }
 }


### PR DESCRIPTION
## Summary
- Updates the "Browser Agent" name to "browser" across all locales (en, jp, ko, zh).
- Updates the `localChromeHint` text to reflect the updated agent name.

## Test plan
- Check the settings UI in the browser extension to verify that the built-in agent name and the local chrome hint text are correctly translated.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f05149a5c8234e909184f0d754403564)