### PR TITLE
refactor: update widget guidelines and streamline rendering animation

### DIFF
--- a/packages/common/src/base/skills/widget-guidelines/SKILL.md
+++ b/packages/common/src/base/skills/widget-guidelines/SKILL.md
@@ -24,28 +24,55 @@ These rules apply to every `renderWidget` call:
 - Use font-weight 500 for most labels and headings, 600 only for strong emphasis or primary metrics. Avoid oversized 32px+ hero typography inside chat widgets.
 - Use sentence case labels. Keep text short inside visuals; put prose explanations in the chat response outside `renderWidget`.
 
+## Core Design Principles
+
+These rules apply to every widget kind:
+
+- Make the widget feel native to Pochi and VSCode. Use transparent outer containers, compact spacing, flat surfaces, and theme variables instead of decorative backgrounds.
+- Keep prose outside the widget. Use the chat response for explanations, summaries, introductions, and caveats; use `widgetCode` only for the visual or local control surface.
+- Build for streaming. Put a short `<style>` first only when needed, then visible HTML/SVG structure, and put scripts last. The user should see useful structure before JavaScript runs.
+- Avoid decorative gradients, shadows, blur, glow, noise, or oversized hero typography. Use visual weight for meaning, not ornament.
+- Do not hide primary content behind tabs, carousels, or `display: none` during streaming. Post-stream local steppers are fine when all controls and state are local.
+- Keep content in normal flow and auto-height. Avoid fixed overlays, nested scrolling, and layout that depends on a viewport outside the iframe.
+
 ## Visual Contract
 
-Pick colors from two sources only: the diagram color classes below, and VSCode CSS variables for UI surfaces.
+Pick colors from two sources by default: the diagram color classes below, and VSCode CSS variables for UI surfaces. The only exception is an illustrative physical scene where theme inversion would be misleading, such as heat, water, flame, or material color; keep those hardcoded colors local and consistent.
 
 ### Diagram Color Classes
 
 Available color classnames: `gray`, `purple`, `teal`, `coral`, `pink`, `blue`, `green`, `amber`, `red`.
 
-Apply the class to a `<g>`, `<rect>`, `<circle>`, or `<ellipse>` — not to `<path>`. Dark mode is handled automatically.
+Apply the class to a `<g>` that directly contains the colored `<rect>`, `<circle>`, or `<ellipse>` and the child `.t`, `.ts`, or `.th` text.
 
-Light mode: 50 fill + 600 stroke + 800 title + 600 subtitle.
-Dark mode: 800 fill + 200 stroke + 100 title + 200 subtitle.
+### Palette Stops
+
+Palette stop numbers describe tone inside one color family. Lower numbers are lighter; higher numbers are darker. They are design roles, not CSS class names or CSS variables. The widget host implements the canonical seven-stop palette table; do not copy that table into `widgetCode`, write `blue-600`, `fill="600"`, or hardcode stop numbers in SVG.
+
+When using built-in diagram color classes, choose only the color class. Pochi applies the stop roles automatically:
+
+| Theme | Shape fill | Shape stroke | `.th` / `.t` text | `.ts` text |
+|---|---|---|---|---|
+| Light | 50, the pale fill | 600, the strong border | 800, dark same-family title text | 600, medium same-family subtitle text |
+| Dark | 800, the dark fill | 200, the light border | 100, light same-family title text | 200, light same-family subtitle text |
+
+Stop roles are useful only when reasoning about diagram contrast or hand-picked physical colors. For HTML controls, panels, and UI surfaces, use VSCode CSS variables instead.
+
+- `50`: pale fill on light themes.
+- `100` / `200`: light text or stroke on dark fills.
+- `400`: mid accent, rarely needed in widgets.
+- `600`: strong border or secondary text on pale fills.
+- `800` / `900`: dark text on pale fills; use `900` only when extra contrast is needed.
 
 ### Assigning Colors
 
 Color encodes meaning, not order. Group same-category nodes under one color class, keep 2–3 colors per diagram, and use `gray` for neutral or structural nodes.
 
-Prefer `purple`, `teal`, `coral`, `pink` for general categories. Keep `blue`, `green`, `amber`, `red` for genuine info / success / warning / error meaning (illustrative diagrams may use them for physical properties like temperature).
+Prefer `purple`, `teal`, `coral`, `pink` for general categories. Use `gray` for neutral or structural content. Keep `blue`, `green`, `amber`, `red` for genuine info / success / warning / error meaning; illustrative diagrams may also use them for physical properties like cold, organic growth, heat, pressure, danger, or error.
 
 ### Text on Colored Fills
 
-Use the 800/900 stop of the same color family — never black or `--vscode-foreground` on a colored fill. When a card has both a title and a subtitle, pick two different stops (title 800, subtitle 600 in light; title 100, subtitle 200 in dark).
+Built-in diagram color classes already choose same-family text colors for `.t`, `.ts`, and `.th`. If an illustrative physical scene needs hardcoded colors, keep text in the same color family with strong contrast; never place black or generic `--vscode-foreground` text on a colored fill.
 
 ### VSCode CSS Variables
 

--- a/packages/common/src/base/skills/widget-guidelines/SKILL.md
+++ b/packages/common/src/base/skills/widget-guidelines/SKILL.md
@@ -45,18 +45,32 @@ Available color classnames: `gray`, `purple`, `teal`, `coral`, `pink`, `blue`, `
 
 Apply the class to a `<g>` that directly contains the colored `<rect>`, `<circle>`, or `<ellipse>` and the child `.t`, `.ts`, or `.th` text.
 
-### Palette Stops
+### Palette Levels
 
-Palette stop numbers describe tone inside one color family. Lower numbers are lighter; higher numbers are darker. They are design roles, not CSS class names or CSS variables. The widget host implements the canonical seven-stop palette table; do not copy that table into `widgetCode`, write `blue-600`, `fill="600"`, or hardcode stop numbers in SVG.
+Palette levels describe tone inside one color family. Lower numbers are lighter; higher numbers are darker. They explain the hex values that the widget host applies internally; they are not CSS class names, CSS variables, or SVG attribute values. Do not copy the palette table into `widgetCode` or write numbered palette names in generated SVG.
 
-When using built-in diagram color classes, choose only the color class. Pochi applies the stop roles automatically:
+| Color | 50 | 100 | 200 | 400 | 600 | 800 | 900 |
+|---|---|---|---|---|---|---|---|
+| `purple` | `#EEEDFE` | `#CECBF6` | `#AFA9EC` | `#7F77DD` | `#534AB7` | `#3C3489` | `#26215C` |
+| `teal` | `#E1F5EE` | `#9FE1CB` | `#5DCAA5` | `#1D9E75` | `#0F6E56` | `#085041` | `#04342C` |
+| `coral` | `#FAECE7` | `#F5C4B3` | `#F0997B` | `#D85A30` | `#993C1D` | `#712B13` | `#4A1B0C` |
+| `pink` | `#FBEAF0` | `#F4C0D1` | `#ED93B1` | `#D4537E` | `#993556` | `#72243E` | `#4B1528` |
+| `gray` | `#F1EFE8` | `#D3D1C7` | `#B4B2A9` | `#888780` | `#5F5E5A` | `#444441` | `#2C2C2A` |
+| `blue` | `#E6F1FB` | `#B5D4F4` | `#85B7EB` | `#378ADD` | `#185FA5` | `#0C447C` | `#042C53` |
+| `green` | `#EAF3DE` | `#C0DD97` | `#97C459` | `#639922` | `#3B6D11` | `#27500A` | `#173404` |
+| `amber` | `#FAEEDA` | `#FAC775` | `#EF9F27` | `#BA7517` | `#854F0B` | `#633806` | `#412402` |
+| `red` | `#FCEBEB` | `#F7C1C1` | `#F09595` | `#E24B4A` | `#A32D2D` | `#791F1F` | `#501313` |
+
+When using built-in diagram color classes, choose only the plain color class. Pochi maps palette levels to roles automatically:
 
 | Theme | Shape fill | Shape stroke | `.th` / `.t` text | `.ts` text |
 |---|---|---|---|---|
 | Light | 50, the pale fill | 600, the strong border | 800, dark same-family title text | 600, medium same-family subtitle text |
 | Dark | 800, the dark fill | 200, the light border | 100, light same-family title text | 200, light same-family subtitle text |
 
-Stop roles are useful only when reasoning about diagram contrast or hand-picked physical colors. For HTML controls, panels, and UI surfaces, use VSCode CSS variables instead.
+In generated SVG, write `class="blue"` or `class="teal"` on the owning group; do not write numbered palette names.
+
+Palette levels are useful only when reasoning about diagram contrast or hand-picked physical colors. For HTML controls, panels, and UI surfaces, use VSCode CSS variables instead.
 
 - `50`: pale fill on light themes.
 - `100` / `200`: light text or stroke on dark fills.

--- a/packages/common/src/base/skills/widget-guidelines/references/diagram.md
+++ b/packages/common/src/base/skills/widget-guidelines/references/diagram.md
@@ -118,7 +118,3 @@ Do not mix diagram families in one SVG. If a topic needs both intuition and refe
 - Simple indicators such as particles, bubbles, flames, heat waves, or vibration lines are allowed only when they explain state.
 - Avoid decorative gradients. A single `<linearGradient>` is acceptable only when it represents a continuous physical property such as temperature or pressure.
 - If a mechanism has meaningful controls, prefer an interactive widget with local sliders, toggles, buttons, and `addEventListener` bindings. Do not use inline `on*` attributes.
-
-## Mermaid and schemas
-
-Do not load Mermaid.js inside `renderWidget`; widget CSP and sanitization only allow the approved Chart.js script. If an ERD or class diagram is better represented by Mermaid, put a Markdown `mermaid` code block in the chat response instead of using `renderWidget`. For diagrams that must live inside a widget, use carefully planned inline SVG.

--- a/packages/common/src/base/skills/widget-guidelines/references/diagram.md
+++ b/packages/common/src/base/skills/widget-guidelines/references/diagram.md
@@ -2,26 +2,123 @@
 
 Use this module for SVG flowcharts, structural diagrams, and illustrative diagrams.
 
-## SVG rules
+## SVG setup
 
-- Prefer inline SVG. Use `<svg width="100%" viewBox="0 0 680 H" role="img" aria-label="...">`; compute `H` from the lowest visual element plus padding.
-- The 680px viewBox width is fixed. Keep content inside x=40..640 and never use negative x/y coordinates.
-- Put `<defs>` and markers first, then put every visual SVG element in the exact reading order it should appear while streaming.
-- For flowcharts, write DOM in logical reveal order: source node group, outgoing connector path, next node group, next connector, then the next node.
-- Do not put all arrow paths before all node groups, and do not put a whole row of nodes before the connectors that explain the flow.
-- Keep each diagram block self-contained in source order. For a node, emit the group and its visible children together before the connector that leaves it.
-- Example source order: `<g class="node c-blue">...step 1...</g>`, then `<path class="arr" .../>`, then `<g class="node c-teal">...step 2...</g>`.
-- Every text element needs one class: `t` for 14px primary, `ts` for 12px secondary, or `th` for 14px/500 node headings.
-- SVG text never auto-wraps. Keep node titles short and subtitles to five words or fewer.
-- Size boxes from the actual text. Leave at least 24-32px horizontal padding, keep labels centered, and widen nodes before text gets cramped.
-- Connectors must use `fill="none"` and should not cross unrelated boxes or labels. Use L-shaped paths to route around existing nodes.
-- Use `class="arr"` for arrows, `class="leader"` for callout lines, `class="node"` for clickable groups, and `c-blue/c-teal/c-amber/c-green/c-red/c-purple/c-coral/c-pink/c-gray` for themed colored groups.
-- Put color classes on the same group as `node`, for example `<g class="node c-blue" data-node-id="..."><rect ... /></g>`.
-- Prefer built-in SVG classes instead of redefining `.t`, `.ts`, `.th`, `.arr`, `.node`, or `.c-*`.
+- Prefer one raw inline `<svg width="100%" viewBox="0 0 680 H" role="img" aria-label="...">` for static diagrams. For interactive diagrams, put the SVG first, controls below it, and scripts last.
+- The viewBox width is fixed at 680. Do not shrink it for narrow content; center narrow diagrams inside x=40..640.
+- Compute `H` from the lowest visual element plus 20-40px padding. Do not guess, clip content, or leave large empty space.
+- Keep structural content inside x=40..640 and y>=40. Never use negative x/y coordinates.
+- Put `<defs>` first, then visual elements in the reading order they should stream. Do not emit all boxes first and all arrows later; the reveal should build the explanation step by step.
+- Include this marker when arrows are needed, then set `marker-end="url(#arrow)"` on connector lines or paths:
+
+```svg
+<defs>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+    <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </marker>
+</defs>
+```
+
+Tiny streaming-order example:
+
+```svg
+<g class="gray">
+  <rect x="80" y="40" width="160" height="44" rx="8"/>
+  <text class="th" x="160" y="62" text-anchor="middle" dominant-baseline="central">Raw input</text>
+</g>
+<line class="arr" x1="240" y1="62" x2="300" y2="62" marker-end="url(#arrow)"/>
+<g class="blue">
+  <rect x="300" y="40" width="160" height="44" rx="8"/>
+  <text class="th" x="380" y="62" text-anchor="middle" dominant-baseline="central">Process</text>
+</g>
+```
+
+## Pre-built SVG classes
+
+These classes are already loaded by the Pochi widget host. Prefer them instead of redefining SVG typography, arrows, and node colors.
+
+| Class | Meaning |
+|---|---|
+| `t` | 14px primary SVG text |
+| `ts` | 12px secondary SVG text |
+| `th` | 14px medium-weight SVG heading text |
+| `box` | Neutral rectangle fill and border |
+| `node` | Selectable/clickable group affordance with pointer cursor and hover dimming |
+| `arr` | Arrow/connector line: secondary stroke, 1.5px, `fill: none` |
+| `leader` | Dashed callout line: secondary stroke, 0.5px, dashed, `fill: none` |
+| `blue`, `teal`, `amber`, `green`, `red`, `purple`, `coral`, `pink`, `gray` | Theme-aware color groups for direct child shapes and text |
+
+Put color classes on the innermost `<g>` that directly contains the colored shape and its text. Add `node` only when the group has local selection or click behavior.
+
+```svg
+<g class="blue">
+  <rect x="80" y="40" width="180" height="56" rx="8" stroke-width="0.5"/>
+  <text class="th" x="170" y="58" text-anchor="middle" dominant-baseline="central">Parse input</text>
+  <text class="ts" x="170" y="76" text-anchor="middle" dominant-baseline="central">Validate shape</text>
+</g>
+```
+
+The color selectors use direct children. If a `<g class="blue">` contains another nested `<g>`, the nested rect/text will not receive the palette. Put the color class on the nested group that directly owns the shapes, or keep the shape and text as direct children.
+
+## Text and sizing
+
+- Every `<text>` element must use `class="t"`, `class="ts"`, or `class="th"`.
+- Use only 14px text for node/region labels (`t` or `th`) and 12px text for subtitles, descriptions, legends, and callouts (`ts`).
+- SVG text does not auto-wrap. Every line break needs an explicit `<tspan>`, but long subtitles should usually be shortened instead.
+- Size boxes from the longest label before drawing the rect: `width >= max(title_chars * 8, subtitle_chars * 7) + 24`.
+- Use 24-32px horizontal padding, 12px minimum between text and edges, and 22px between title and subtitle baselines.
+- Use `dominant-baseline="central"` for centered text. For a rect at `(x, y, w, h)`, center single-line text at `x + w / 2`, `y + h / 2`.
+- Be careful with `text-anchor="end"` near the left edge. Text extends left from its x coordinate and can clip out of the viewBox.
+- Use sentence case. Avoid decorative step numbers, oversized headings, icons inside boxes, and rotated text.
+
+## Geometry checks
+
+- Before drawing a connector, trace it against every box already placed. If it crosses an unrelated box or label, route around with an L-shaped `<path>`.
+- Connector `<line>`, `<path>`, and `<polyline>` elements must have `fill="none"` unless `class="arr"` or `class="leader"` already supplies it.
+- Stop connector endpoints at component edges. Do not draw through shapes and rely on fills to hide the line.
+- For rows, check total width before placing: sum node widths plus gaps must fit within x=40..640.
+- Use 60px minimum gaps between flowchart nodes when possible and leave about 10px between arrowheads and box edges.
+- Use `rx="4"` for subtle rect rounding and `rx="8"` for emphasized nodes. Pill shapes should be deliberate.
+- Use 0.5px strokes for box borders and structural edges unless a semantic emphasis needs more.
 
 ## Diagram choices
 
-- Flowcharts: show sequential steps, decision points, and transformations. Prefer one direction, 4-5 nodes, and generous spacing.
-- Structural diagrams: show containment and architecture. Use large container rectangles with smaller regions inside; keep nesting to 2-3 levels.
-- Illustrative diagrams: show mechanisms and intuition. Draw the thing or visual metaphor, not boxes about the thing.
-- For complex topics, split into multiple focused widgets instead of one dense diagram.
+Pick the diagram type by user intent, not by subject name.
+
+- Flowcharts show sequential steps, decisions, and transformations. Use them for "what are the steps", "walk me through the flow", and lifecycle questions.
+- Structural diagrams show containment, architecture, and where things live. Use them for "what is inside", "how is this organized", and system maps.
+- Illustrative diagrams show mechanism and intuition. Use them for "how does this actually work", "explain this", and "give me an intuition".
+
+Do not mix diagram families in one SVG. If a topic needs both intuition and reference detail, make separate focused widgets with prose between them. For complex topics, split into multiple diagrams instead of cramming 6+ components and many arrows into one canvas.
+
+## Flowcharts
+
+- Prefer one direction: left-to-right or top-to-bottom.
+- Keep most flowcharts to 4-5 nodes. If there are more components, make a simplified overview first and separate sub-flow diagrams later.
+- Use same-height nodes for the same content type: about 44px for a single-line node and 56px for title plus subtitle.
+- Avoid arrow labels unless there is clear empty space. Put meaning in the source/target labels or in the chat prose.
+- Do not draw cycles as rings. For rich cycles, use an interactive stepper from `references/interactive.md`; for simple feedback, use a short return marker or local note instead of a long arrow across the layout.
+
+## Structural diagrams
+
+- Use large rounded rectangles as containers and smaller rectangles as regions. Keep nesting to 2-3 levels.
+- Leave at least 20px padding inside every container and 16px gaps between inner regions.
+- Use distinct but restrained color ramps so nested regions remain visible. Reusing the same color for parent and child flattens the hierarchy.
+- Put only text inside structural regions: a short name and a short description. Avoid icons, miniature flowcharts, and decorative object drawings inside containers.
+- For schematic boundaries such as services, vessels, networks, or zones, prefer a dashed labeled rect over literal cloud/organelle/server illustrations.
+- Put external inputs/outputs outside the main container with short labels and arrows that stop at the container edge.
+
+## Illustrative diagrams
+
+- Draw the mechanism, not boxes about the mechanism. Physical subjects can use simplified cross-sections; abstract subjects should use a spatial metaphor that explains the behavior.
+- Layout should follow the subject geometry. A tall object can be tall; a wide system can be wide, while still keeping the 680px viewBox width.
+- Color encodes intensity or state in illustrative diagrams: warm colors for active/hot/high-pressure, cool or gray for inactive/cold/structural.
+- Shape overlap is allowed when it communicates the mechanism, but text must never be crossed by strokes. Move labels to quiet regions instead of masking lines with background fills.
+- Put labels outside the drawn object when possible and connect them with `leader` lines. Prefer one label side, usually the right side with `text-anchor="start"`.
+- Simple indicators such as particles, bubbles, flames, heat waves, or vibration lines are allowed only when they explain state.
+- Avoid decorative gradients. A single `<linearGradient>` is acceptable only when it represents a continuous physical property such as temperature or pressure.
+- If a mechanism has meaningful controls, prefer an interactive widget with local sliders, toggles, buttons, and `addEventListener` bindings. Do not use inline `on*` attributes.
+
+## Mermaid and schemas
+
+Do not load Mermaid.js inside `renderWidget`; widget CSP and sanitization only allow the approved Chart.js script. If an ERD or class diagram is better represented by Mermaid, put a Markdown `mermaid` code block in the chat response instead of using `renderWidget`. For diagrams that must live inside a widget, use carefully planned inline SVG.

--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/renderer-runtime.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/renderer-runtime.test.ts
@@ -1,0 +1,13 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { getWidgetRevealDelayMs } from "../renderer-runtime";
+
+describe("render widget renderer runtime", () => {
+  it("uses a compact reveal stagger while allowing long diagrams to keep revealing", () => {
+    expect(getWidgetRevealDelayMs(0)).toBe(0);
+    expect(getWidgetRevealDelayMs(1)).toBe(80);
+    expect(getWidgetRevealDelayMs(5)).toBe(400);
+    expect(getWidgetRevealDelayMs(75)).toBe(6000);
+    expect(getWidgetRevealDelayMs(99)).toBe(6000);
+  });
+});

--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts
@@ -243,7 +243,7 @@ describe("render widget utilities", () => {
     expect(iframeDocument).toContain("svg .__pochi_widget_appear");
     expect(iframeDocument).toContain("--pochi-widget-appear-delay");
     expect(iframeDocument).toContain("translateY(8px)");
-    expect(iframeDocument).toContain("1200ms ease-out");
+    expect(iframeDocument).toContain("450ms ease-out");
     expect(iframeDocument).toContain(
       '<script type="module" src="http://localhost:4112/src/features/tools/components/render-widget/renderer-entry.ts"></script>',
     );
@@ -360,8 +360,102 @@ describe("render widget utilities", () => {
     expect(iframeDocument).toContain(
       `<style id="${WidgetThemeStyleId}">\n${themeCss}\n</style>`,
     );
-    expect(iframeDocument).toContain(".light svg .blue > rect");
-    expect(iframeDocument).toContain(".dark svg .blue > rect");
+    expect(iframeDocument).toContain(".light svg .blue");
+    expect(iframeDocument).toContain(".dark svg .blue");
+  });
+
+  it("uses canonical diagram palette stops through shared SVG color rules", () => {
+    const iframeDocument = buildWidgetIframeDocument(
+      "http://localhost:4112/widget.js",
+    );
+    const palette = {
+      blue: {
+        50: "#E6F1FB",
+        100: "#B5D4F4",
+        200: "#85B7EB",
+        600: "#185FA5",
+        800: "#0C447C",
+      },
+      teal: {
+        50: "#E1F5EE",
+        100: "#9FE1CB",
+        200: "#5DCAA5",
+        600: "#0F6E56",
+        800: "#085041",
+      },
+      amber: {
+        50: "#FAEEDA",
+        100: "#FAC775",
+        200: "#EF9F27",
+        600: "#854F0B",
+        800: "#633806",
+      },
+      green: {
+        50: "#EAF3DE",
+        100: "#C0DD97",
+        200: "#97C459",
+        600: "#3B6D11",
+        800: "#27500A",
+      },
+      red: {
+        50: "#FCEBEB",
+        100: "#F7C1C1",
+        200: "#F09595",
+        600: "#A32D2D",
+        800: "#791F1F",
+      },
+      purple: {
+        50: "#EEEDFE",
+        100: "#CECBF6",
+        200: "#AFA9EC",
+        600: "#534AB7",
+        800: "#3C3489",
+      },
+      coral: {
+        50: "#FAECE7",
+        100: "#F5C4B3",
+        200: "#F0997B",
+        600: "#993C1D",
+        800: "#712B13",
+      },
+      pink: {
+        50: "#FBEAF0",
+        100: "#F4C0D1",
+        200: "#ED93B1",
+        600: "#993556",
+        800: "#72243E",
+      },
+      gray: {
+        50: "#F1EFE8",
+        100: "#D3D1C7",
+        200: "#B4B2A9",
+        600: "#5F5E5A",
+        800: "#444441",
+      },
+    } as const;
+    const colorSelector = Object.keys(palette)
+      .map((name) => `svg .${name}`)
+      .join(", ");
+
+    for (const [name, stops] of Object.entries(palette)) {
+      expect(iframeDocument).toContain(
+        `.dark svg .${name} { --pochi-svg-fill: ${stops[800]}; --pochi-svg-stroke: ${stops[200]}; --pochi-svg-title: ${stops[100]}; --pochi-svg-subtitle: ${stops[200]}; }`,
+      );
+      expect(iframeDocument).toContain(
+        `.light svg .${name} { --pochi-svg-fill: ${stops[50]}; --pochi-svg-stroke: ${stops[600]}; --pochi-svg-title: ${stops[800]}; --pochi-svg-subtitle: ${stops[600]}; }`,
+      );
+    }
+    expect(iframeDocument).toContain(
+      `:where(${colorSelector}) > :where(rect, circle, ellipse) { fill: var(--pochi-svg-fill); stroke: var(--pochi-svg-stroke); }`,
+    );
+    expect(iframeDocument).toContain(
+      `:where(${colorSelector}) > :where(.th, .t) { fill: var(--pochi-svg-title); }`,
+    );
+    expect(iframeDocument).toContain(
+      `:where(${colorSelector}) > .ts { fill: var(--pochi-svg-subtitle); }`,
+    );
+    expect(iframeDocument).not.toContain(".light svg .blue > rect");
+    expect(iframeDocument).not.toContain(".dark svg .blue > rect");
   });
 
   it("defaults to the dark class when none is provided", () => {

--- a/packages/vscode-webui/src/features/tools/components/render-widget/renderer-runtime.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/renderer-runtime.ts
@@ -30,8 +30,12 @@ type WidgetEvent =
   | { type: "error"; message: string; stack?: string };
 type WidgetParentEndpoint = (event: WidgetEvent) => { ok: true };
 
-const RevealDelayStepMs = 220;
+const RevealDelayStepMs = 80;
 const MaxRevealDelayMs = 6000;
+
+export function getWidgetRevealDelayMs(index: number) {
+  return Math.min(index * RevealDelayStepMs, MaxRevealDelayMs);
+}
 
 export function startWidgetRenderer() {
   disableHostAndNetworkApis();
@@ -58,7 +62,7 @@ export function startWidgetRenderer() {
     const revealElements = collectWidgetRevealElements(elements);
 
     for (const [index, element] of revealElements.entries()) {
-      const delay = Math.min(index * RevealDelayStepMs, MaxRevealDelayMs);
+      const delay = getWidgetRevealDelayMs(index);
       element.classList.add("__pochi_widget_appear");
       (element as HTMLElement | SVGElement).style.setProperty(
         "--pochi-widget-appear-delay",

--- a/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
@@ -422,11 +422,11 @@ body {
   to { opacity: 1; }
 }
 .__pochi_widget_appear {
-  animation: __pochi_widget_fade_in 1200ms ease-out both;
+  animation: __pochi_widget_fade_in 450ms ease-out both;
   animation-delay: var(--pochi-widget-appear-delay, 0ms);
 }
 svg .__pochi_widget_appear {
-  animation: __pochi_widget_svg_fade_in 1200ms ease-out both;
+  animation: __pochi_widget_svg_fade_in 450ms ease-out both;
   animation-delay: var(--pochi-widget-appear-delay, 0ms);
 }
 svg {
@@ -444,61 +444,28 @@ svg {
 :where(svg .leader) { stroke: var(--vscode-descriptionForeground, #9d9d9d); stroke-width: 0.5; stroke-dasharray: 4 3; fill: none; }
 
 
-/* Dark palette */
-:where(.dark svg .blue > rect, .dark svg .blue > circle, .dark svg .blue > ellipse) { fill: #0C447C; stroke: #85B7EB; }
-:where(.dark svg .blue > .th, .dark svg .blue > .t) { fill: #B5D4F4; }
-:where(.dark svg .blue > .ts) { fill: #85B7EB; }
-:where(.dark svg .teal > rect, .dark svg .teal > circle, .dark svg .teal > ellipse) { fill: #085041; stroke: #5DCAA5; }
-:where(.dark svg .teal > .th, .dark svg .teal > .t) { fill: #9FE1CB; }
-:where(.dark svg .teal > .ts) { fill: #5DCAA5; }
-:where(.dark svg .amber > rect, .dark svg .amber > circle, .dark svg .amber > ellipse) { fill: #633806; stroke: #EF9F27; }
-:where(.dark svg .amber > .th, .dark svg .amber > .t) { fill: #FAC775; }
-:where(.dark svg .amber > .ts) { fill: #EF9F27; }
-:where(.dark svg .green > rect, .dark svg .green > circle, .dark svg .green > ellipse) { fill: #27500A; stroke: #97C459; }
-:where(.dark svg .green > .th, .dark svg .green > .t) { fill: #C0DD97; }
-:where(.dark svg .green > .ts) { fill: #97C459; }
-:where(.dark svg .red > rect, .dark svg .red > circle, .dark svg .red > ellipse) { fill: #791F1F; stroke: #F09595; }
-:where(.dark svg .red > .th, .dark svg .red > .t) { fill: #F7C1C1; }
-:where(.dark svg .red > .ts) { fill: #F09595; }
-:where(.dark svg .purple > rect, .dark svg .purple > circle, .dark svg .purple > ellipse) { fill: #3C3489; stroke: #AFA9EC; }
-:where(.dark svg .purple > .th, .dark svg .purple > .t) { fill: #CECBF6; }
-:where(.dark svg .purple > .ts) { fill: #AFA9EC; }
-:where(.dark svg .coral > rect, .dark svg .coral > circle, .dark svg .coral > ellipse) { fill: #712B13; stroke: #F0997B; }
-:where(.dark svg .coral > .th, .dark svg .coral > .t) { fill: #F5C4B3; }
-:where(.dark svg .coral > .ts) { fill: #F0997B; }
-:where(.dark svg .pink > rect, .dark svg .pink > circle, .dark svg .pink > ellipse) { fill: #72243E; stroke: #ED93B1; }
-:where(.dark svg .pink > .th, .dark svg .pink > .t) { fill: #F4C0D1; }
-:where(.dark svg .pink > .ts) { fill: #ED93B1; }
-:where(.dark svg .gray > rect, .dark svg .gray > circle, .dark svg .gray > ellipse) { fill: #444441; stroke: #B4B2A9; }
-:where(.dark svg .gray > .th, .dark svg .gray > .t) { fill: #D3D1C7; }
-:where(.dark svg .gray > .ts) { fill: #B4B2A9; }
+/* Diagram palette */
+.dark svg .blue { --pochi-svg-fill: #0C447C; --pochi-svg-stroke: #85B7EB; --pochi-svg-title: #B5D4F4; --pochi-svg-subtitle: #85B7EB; }
+.dark svg .teal { --pochi-svg-fill: #085041; --pochi-svg-stroke: #5DCAA5; --pochi-svg-title: #9FE1CB; --pochi-svg-subtitle: #5DCAA5; }
+.dark svg .amber { --pochi-svg-fill: #633806; --pochi-svg-stroke: #EF9F27; --pochi-svg-title: #FAC775; --pochi-svg-subtitle: #EF9F27; }
+.dark svg .green { --pochi-svg-fill: #27500A; --pochi-svg-stroke: #97C459; --pochi-svg-title: #C0DD97; --pochi-svg-subtitle: #97C459; }
+.dark svg .red { --pochi-svg-fill: #791F1F; --pochi-svg-stroke: #F09595; --pochi-svg-title: #F7C1C1; --pochi-svg-subtitle: #F09595; }
+.dark svg .purple { --pochi-svg-fill: #3C3489; --pochi-svg-stroke: #AFA9EC; --pochi-svg-title: #CECBF6; --pochi-svg-subtitle: #AFA9EC; }
+.dark svg .coral { --pochi-svg-fill: #712B13; --pochi-svg-stroke: #F0997B; --pochi-svg-title: #F5C4B3; --pochi-svg-subtitle: #F0997B; }
+.dark svg .pink { --pochi-svg-fill: #72243E; --pochi-svg-stroke: #ED93B1; --pochi-svg-title: #F4C0D1; --pochi-svg-subtitle: #ED93B1; }
+.dark svg .gray { --pochi-svg-fill: #444441; --pochi-svg-stroke: #B4B2A9; --pochi-svg-title: #D3D1C7; --pochi-svg-subtitle: #B4B2A9; }
 
-/* Light palette */
-:where(.light svg .blue > rect, .light svg .blue > circle, .light svg .blue > ellipse) { fill: #DBE7F4; stroke: #2B6CB0; }
-:where(.light svg .blue > .th, .light svg .blue > .t) { fill: #1B4480; }
-:where(.light svg .blue > .ts) { fill: #2B6CB0; }
-:where(.light svg .teal > rect, .light svg .teal > circle, .light svg .teal > ellipse) { fill: #D2EEDF; stroke: #0E8C6F; }
-:where(.light svg .teal > .th, .light svg .teal > .t) { fill: #084F3F; }
-:where(.light svg .teal > .ts) { fill: #0E8C6F; }
-:where(.light svg .amber > rect, .light svg .amber > circle, .light svg .amber > ellipse) { fill: #FBE6C2; stroke: #B47213; }
-:where(.light svg .amber > .th, .light svg .amber > .t) { fill: #5C3704; }
-:where(.light svg .amber > .ts) { fill: #B47213; }
-:where(.light svg .green > rect, .light svg .green > circle, .light svg .green > ellipse) { fill: #DDEFC7; stroke: #5E8A35; }
-:where(.light svg .green > .th, .light svg .green > .t) { fill: #294E0A; }
-:where(.light svg .green > .ts) { fill: #5E8A35; }
-:where(.light svg .red > rect, .light svg .red > circle, .light svg .red > ellipse) { fill: #F7D7D7; stroke: #BF3535; }
-:where(.light svg .red > .th, .light svg .red > .t) { fill: #791F1F; }
-:where(.light svg .red > .ts) { fill: #BF3535; }
-:where(.light svg .purple > rect, .light svg .purple > circle, .light svg .purple > ellipse) { fill: #E0DCF5; stroke: #5E4FBE; }
-:where(.light svg .purple > .th, .light svg .purple > .t) { fill: #393188; }
-:where(.light svg .purple > .ts) { fill: #5E4FBE; }
-:where(.light svg .coral > rect, .light svg .coral > circle, .light svg .coral > ellipse) { fill: #F8DDCF; stroke: #C25530; }
-:where(.light svg .coral > .th, .light svg .coral > .t) { fill: #6F2A12; }
-:where(.light svg .coral > .ts) { fill: #C25530; }
-:where(.light svg .pink > rect, .light svg .pink > circle, .light svg .pink > ellipse) { fill: #F8D8E2; stroke: #BD3F6D; }
-:where(.light svg .pink > .th, .light svg .pink > .t) { fill: #71243D; }
-:where(.light svg .pink > .ts) { fill: #BD3F6D; }
-:where(.light svg .gray > rect, .light svg .gray > circle, .light svg .gray > ellipse) { fill: #E5E3DD; stroke: #6F6E69; }
-:where(.light svg .gray > .th, .light svg .gray > .t) { fill: #404040; }
-:where(.light svg .gray > .ts) { fill: #6F6E69; }
+.light svg .blue { --pochi-svg-fill: #E6F1FB; --pochi-svg-stroke: #185FA5; --pochi-svg-title: #0C447C; --pochi-svg-subtitle: #185FA5; }
+.light svg .teal { --pochi-svg-fill: #E1F5EE; --pochi-svg-stroke: #0F6E56; --pochi-svg-title: #085041; --pochi-svg-subtitle: #0F6E56; }
+.light svg .amber { --pochi-svg-fill: #FAEEDA; --pochi-svg-stroke: #854F0B; --pochi-svg-title: #633806; --pochi-svg-subtitle: #854F0B; }
+.light svg .green { --pochi-svg-fill: #EAF3DE; --pochi-svg-stroke: #3B6D11; --pochi-svg-title: #27500A; --pochi-svg-subtitle: #3B6D11; }
+.light svg .red { --pochi-svg-fill: #FCEBEB; --pochi-svg-stroke: #A32D2D; --pochi-svg-title: #791F1F; --pochi-svg-subtitle: #A32D2D; }
+.light svg .purple { --pochi-svg-fill: #EEEDFE; --pochi-svg-stroke: #534AB7; --pochi-svg-title: #3C3489; --pochi-svg-subtitle: #534AB7; }
+.light svg .coral { --pochi-svg-fill: #FAECE7; --pochi-svg-stroke: #993C1D; --pochi-svg-title: #712B13; --pochi-svg-subtitle: #993C1D; }
+.light svg .pink { --pochi-svg-fill: #FBEAF0; --pochi-svg-stroke: #993556; --pochi-svg-title: #72243E; --pochi-svg-subtitle: #993556; }
+.light svg .gray { --pochi-svg-fill: #F1EFE8; --pochi-svg-stroke: #5F5E5A; --pochi-svg-title: #444441; --pochi-svg-subtitle: #5F5E5A; }
+
+:where(svg .blue, svg .teal, svg .amber, svg .green, svg .red, svg .purple, svg .coral, svg .pink, svg .gray) > :where(rect, circle, ellipse) { fill: var(--pochi-svg-fill); stroke: var(--pochi-svg-stroke); }
+:where(svg .blue, svg .teal, svg .amber, svg .green, svg .red, svg .purple, svg .coral, svg .pink, svg .gray) > :where(.th, .t) { fill: var(--pochi-svg-title); }
+:where(svg .blue, svg .teal, svg .amber, svg .green, svg .red, svg .purple, svg .coral, svg .pink, svg .gray) > .ts { fill: var(--pochi-svg-subtitle); }
 `;


### PR DESCRIPTION
## Summary
- Update widget design principles and SVG guidelines in SKILL.md and diagram.md
- Refactor diagram palette CSS to use CSS variables for better maintainability
- Reduce widget reveal delay and animation duration for faster rendering
- Add tests for new renderer runtime and SVG color rules

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0e0a050290db4caead9390b5eb2cc32b)