### PR TITLE
fix(generative-ui): inline packaged renderer script with nonce CSP

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts
@@ -284,6 +284,26 @@ describe("render widget utilities", () => {
     expect(iframeDocument).toContain("connect-src https://cdn.jsdelivr.net");
   });
 
+  it("can inline the packaged renderer script with the parent webview nonce", () => {
+    const scriptSrc =
+      "https://file+.vscode-resource.vscode-cdn.net/Users/me/.vscode/extensions/tabbyml.pochi/assets/webview-ui/dist/renderer-entry.js";
+    const iframeDocument = buildWidgetIframeDocument({
+      src: scriptSrc,
+      code: 'console.log("</script>")',
+      nonce: "abc123",
+    });
+
+    expect(iframeDocument).toContain(
+      `script-src 'nonce-abc123' ${ChartJsCdnScriptSrc} 'unsafe-eval'`,
+    );
+    expect(iframeDocument).toContain(
+      '<script nonce="abc123">console.log("<\\/script>")</script>',
+    );
+    expect(iframeDocument).not.toContain(`src="${scriptSrc}"`);
+    expect(iframeDocument).not.toContain("script-src https://file+");
+    expect(iframeDocument).not.toContain("data:text/javascript");
+  });
+
   it("uses one shared sanitizer policy for widget fragments", () => {
     expect(
       sanitizeWidgetFragment(

--- a/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
@@ -6,9 +6,9 @@ import { useTranslation } from "react-i18next";
 import { StatusIcon } from "../status-icon";
 import type { ToolProps } from "../types";
 // This intentionally borrows Vite's worker bundling pipeline only to get a
-// standalone module URL. No Web Worker is created; the URL is loaded as a
-// normal module script inside the sandboxed iframe, so it does not execute in
-// the parent WebUI window.
+// standalone module URL. No Web Worker is created; the renderer is loaded as a
+// normal script inside the sandboxed iframe, so it does not execute in the
+// parent WebUI window.
 import rendererScriptSrc from "./renderer-entry.ts?worker&url";
 import {
   type WidgetThemeClass,
@@ -80,22 +80,52 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   const [height, setHeight] = useState<number | undefined>();
   const [hasFirstHeight, setHasFirstHeight] = useState(false);
   const [rendererError, setRendererError] = useState<string | undefined>();
+  const [rendererScriptCode, setRendererScriptCode] = useState<
+    string | undefined
+  >();
   const channelId = useMemo(
     () => `pochi-widget-${tool.toolCallId}`,
     [tool.toolCallId],
   );
-  const iframeDocument = useMemo(
-    () =>
-      buildWidgetIframeDocument(
-        rendererScriptSrc,
-        collectWidgetThemeVariables(),
-        channelId,
-        getCurrentWidgetThemeClass(),
-      ),
-    [channelId],
-  );
+  useEffect(() => {
+    if (!import.meta.env.PROD) return;
+
+    let disposed = false;
+    loadPackagedRendererScriptCode()
+      .then((code) => {
+        if (!disposed) setRendererScriptCode(code);
+      })
+      .catch((error) => {
+        if (!disposed) {
+          setRendererError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      });
+
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  const iframeDocument = useMemo(() => {
+    if (import.meta.env.PROD && !rendererScriptCode) return undefined;
+
+    return buildWidgetIframeDocument(
+      import.meta.env.PROD
+        ? {
+            src: rendererScriptSrc,
+            code: rendererScriptCode,
+            nonce: getWebviewScriptNonce(),
+          }
+        : rendererScriptSrc,
+      collectWidgetThemeVariables(),
+      channelId,
+      getCurrentWidgetThemeClass(),
+    );
+  }, [channelId, rendererScriptCode]);
   const iframeSrc = useMemo(
-    () => buildWidgetIframeSrc(iframeDocument),
+    () => (iframeDocument ? buildWidgetIframeSrc(iframeDocument) : undefined),
     [iframeDocument],
   );
 
@@ -254,18 +284,20 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
         <span className="ml-2">{headerLabel}</span>
         <span className="ml-2 text-foreground">{title}</span>
       </div>
-      <iframe
-        ref={iframeRef}
-        title={title}
-        src={iframeSrc}
-        sandbox="allow-scripts"
-        onLoad={handleLoad}
-        className={cn(
-          "w-full bg-transparent",
-          hasFirstHeight && "transition-[height] duration-150 ease-out",
-        )}
-        style={{ height }}
-      />
+      {iframeSrc ? (
+        <iframe
+          ref={iframeRef}
+          title={title}
+          src={iframeSrc}
+          sandbox="allow-scripts"
+          onLoad={handleLoad}
+          className={cn(
+            "w-full bg-transparent",
+            hasFirstHeight && "transition-[height] duration-150 ease-out",
+          )}
+          style={{ height }}
+        />
+      ) : null}
       {rendererError ? (
         <div className="text-error text-xs">{rendererError}</div>
       ) : null}
@@ -276,4 +308,27 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
 function clampHeight(height: number | undefined) {
   if (!height || !Number.isFinite(height)) return 160;
   return Math.min(Math.max(Math.ceil(height), 120), 1200);
+}
+
+function getWebviewScriptNonce() {
+  if (typeof document === "undefined") return undefined;
+  for (const script of Array.from(document.scripts)) {
+    if (script.nonce) return script.nonce;
+  }
+}
+
+let packagedRendererScriptCodePromise: Promise<string> | undefined;
+
+function loadPackagedRendererScriptCode() {
+  packagedRendererScriptCodePromise ??= fetch(rendererScriptSrc).then(
+    async (response) => {
+      if (!response.ok) {
+        throw new Error(
+          `Failed to load widget renderer script: ${response.status}`,
+        );
+      }
+      return response.text();
+    },
+  );
+  return packagedRendererScriptCodePromise;
 }

--- a/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
@@ -18,6 +18,14 @@ export type WidgetScript =
   | { type: "external"; src: string }
   | { type: "inline"; code: string };
 
+export type WidgetRendererScript =
+  | string
+  | {
+      src: string;
+      code?: string;
+      nonce?: string;
+    };
+
 export function coalescePendingWidgetMessage<
   T extends PendingWidgetRenderMessage,
 >(current: T | undefined, next: T): T;
@@ -293,11 +301,17 @@ export function buildWidgetIframeSrc(html: string) {
 }
 
 export function buildWidgetIframeDocument(
-  rendererScriptSrc: string,
+  rendererScript: WidgetRendererScript,
   themeVariablesCss = "",
   channelId = "pochi-widget",
   themeClass: WidgetThemeClass = "dark",
 ) {
+  const rendererScriptSrc =
+    typeof rendererScript === "string" ? rendererScript : rendererScript.src;
+  const rendererScriptCode =
+    typeof rendererScript === "string" ? undefined : rendererScript.code;
+  const rendererScriptNonce =
+    typeof rendererScript === "string" ? undefined : rendererScript.nonce;
   const resolvedRendererScriptSrc = normalizeWidgetModuleScriptSrc(
     resolveWidgetModuleScriptSrc(rendererScriptSrc),
   );
@@ -311,8 +325,15 @@ export function buildWidgetIframeDocument(
   );
   const safeChannelId = escapeHtmlAttribute(channelId);
   const safeThemeClass = escapeHtmlAttribute(themeClass);
-  const scriptCspSource = getScriptCspSource(resolvedRendererScriptSrc);
+  const scriptCspSource =
+    rendererScriptCode && rendererScriptNonce
+      ? `'nonce-${rendererScriptNonce}'`
+      : getScriptCspSource(resolvedRendererScriptSrc);
   const connectCspSource = getWidgetConnectCspSource(resolvedRendererScriptSrc);
+  const rendererScriptElement =
+    rendererScriptCode && rendererScriptNonce
+      ? `<script nonce="${escapeHtmlAttribute(rendererScriptNonce)}">${escapeInlineScriptContent(rendererScriptCode)}</script>`
+      : `<script type="module" src="${safeRendererScriptSrc}"></script>`;
 
   return `<!doctype html>
 <html class="${safeThemeClass}">
@@ -329,7 +350,7 @@ ${WidgetBaseStyles}
 </head>
 <body>
 <div id="root" data-channel-id="${safeChannelId}" aria-label="sandboxed generative UI widget"></div>
-<script type="module" src="${safeRendererScriptSrc}"></script>
+${rendererScriptElement}
 </body>
 </html>`;
 }
@@ -339,6 +360,10 @@ function escapeHtmlAttribute(value: string) {
     .replace(/&/g, "&amp;")
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;");
+}
+
+function escapeInlineScriptContent(code: string) {
+  return code.replace(/<\/script/gi, "<\\/script").replace(/<!--/g, "<\\!--");
 }
 
 function resolveWidgetModuleScriptSrc(scriptSrc: string) {

--- a/packages/vscode/scripts/copy-webui-dist.js
+++ b/packages/vscode/scripts/copy-webui-dist.js
@@ -13,6 +13,7 @@ fs.mkdirSync(destBaseDir, { recursive: true });
 const filesToCopy = [
   "index.js",
   "index.css",
+  "renderer-entry.js",
   "wa-sqlite.wasm",
   "make-shared-worker.js",
 ];

--- a/packages/vscode/src/integrations/webview/__tests__/base-csp.test.ts
+++ b/packages/vscode/src/integrations/webview/__tests__/base-csp.test.ts
@@ -34,4 +34,18 @@ describe("webview CSP", () => {
     assert.strictEqual(matches?.length, 2);
     assert.ok(!source.includes("script-src 'unsafe-inline'"));
   });
+
+  it("resolves packaged webview assets through VS Code resource URIs", () => {
+    const source = readFileSync(
+      path.join(__dirname, "../base.ts"),
+      "utf8",
+    );
+    const copyScript = readFileSync(
+      path.join(__dirname, "../../../../scripts/copy-webui-dist.js"),
+      "utf8",
+    );
+
+    assert.ok(source.includes('return "${webviewDistBaseUri}/" + path;'));
+    assert.ok(copyScript.includes('"renderer-entry.js"'));
+  });
 });

--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -186,7 +186,7 @@ export abstract class WebviewBase implements vscode.Disposable {
         if (path === "wa-sqlite.wasm") {
           return "${sqliteWasmUri}";
         }
-        return path;
+        return "${webviewDistBaseUri}/" + path;
       }
       window.__liveStoreSharedWorkerUrl = ${JSON.stringify(sharedWorkerDataUrl)};
       window.__workerAssetsPathScript = ${JSON.stringify(workerAssetsPathScript)};


### PR DESCRIPTION
## Summary
- In production, fetch the packaged widget renderer script and inline it into the sandboxed iframe with a nonce-based CSP, avoiding reliance on the webview's external script-src host.
- Resolve packaged webview assets through proper VS Code resource URIs (`webviewDistBaseUri`) in `base.ts`.
- Copy `renderer-entry.js` as part of the extension's bundled webview dist so the renderer is available at runtime.
- Add unit tests covering the inlined-script CSP path and the packaged asset URI resolution.

## Test plan
- [ ] `bun run test` in `packages/vscode-webui`
- [ ] `bun run test` in `packages/vscode`
- [ ] Manual: open a generative-ui widget in a packaged extension build and verify the sandboxed iframe renders without CSP violations.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1a94dce49a60443b943113a6f434a752)