### PR TITLE
fix(vscode-webui): remove redundant tool header and polish widget rendering

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
@@ -37,8 +37,10 @@ vi.mock("../../status-icon", () => ({
   StatusIcon: () => <span data-testid="status-icon" />,
 }));
 
+let mockedTheme: "dark" | "light" = "dark";
+
 vi.mock("@/components/theme-provider", () => ({
-  useTheme: () => ({ theme: "dark", setTheme: () => {} }),
+  useTheme: () => ({ theme: mockedTheme, setTheme: () => {} }),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -56,6 +58,7 @@ describe("RenderWidgetTool", () => {
   beforeEach(() => {
     receiveHandler = undefined;
     sentMessages.length = 0;
+    mockedTheme = "dark";
     document.documentElement.className = "";
     document.documentElement.style.cssText = "";
     document.body.className = "";
@@ -219,6 +222,126 @@ describe("RenderWidgetTool", () => {
             )
           );
         }),
+      ).toBe(true);
+    });
+  });
+
+  it("keeps the iframe mounted across parent theme switches", () => {
+    const { rerender } = render(
+      <RenderWidgetTool
+        tool={
+          {
+            type: "tool-renderWidget",
+            toolCallId: "widget-stable-src",
+            state: "input-available",
+            input: {
+              title: "Stable widget",
+              kind: "diagram",
+              widgetCode: "<svg></svg>",
+              guidelinesRead: true,
+            },
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    const iframe = screen.getByTitle("Stable widget") as HTMLIFrameElement;
+    const originalSrc = iframe.src;
+    expect(originalSrc).toBeTruthy();
+
+    mockedTheme = "light";
+    rerender(
+      <RenderWidgetTool
+        tool={
+          {
+            type: "tool-renderWidget",
+            toolCallId: "widget-stable-src",
+            state: "input-available",
+            input: {
+              title: "Stable widget",
+              kind: "diagram",
+              widgetCode: "<svg></svg>",
+              guidelinesRead: true,
+            },
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    // The iframe src must NOT change when the parent webview theme switches —
+    // a new src would remount the iframe and clear the rendered widget body
+    // until the next render message arrives. Theme updates are pushed via the
+    // theme message channel instead.
+    expect(screen.getByTitle("Stable widget").getAttribute("src")).toBe(
+      originalSrc,
+    );
+  });
+
+  it("replays the last render message when the iframe reloads", async () => {
+    render(
+      <RenderWidgetTool
+        tool={
+          {
+            type: "tool-renderWidget",
+            toolCallId: "widget-replay",
+            state: "input-available",
+            input: {
+              title: "Replay widget",
+              kind: "diagram",
+              widgetCode: "<svg><rect/></svg>",
+              guidelinesRead: true,
+            },
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    const iframe = screen.getByTitle("Replay widget");
+    act(() => {
+      iframe.dispatchEvent(new Event("load"));
+    });
+    act(() => {
+      receiveHandler?.({ type: "ready" });
+    });
+
+    await waitFor(() => {
+      expect(
+        sentMessages.some(
+          (message) =>
+            message.type === "finalize" &&
+            typeof message.html === "string" &&
+            (message.html as string).includes("rect"),
+        ),
+      ).toBe(true);
+    });
+
+    sentMessages.length = 0;
+
+    // Simulate an iframe reload (which the bidc channel cleanup mimics).
+    act(() => {
+      iframe.dispatchEvent(new Event("load"));
+    });
+    act(() => {
+      receiveHandler?.({ type: "ready" });
+    });
+
+    await waitFor(() => {
+      expect(
+        sentMessages.some(
+          (message) =>
+            (message.type === "finalize" || message.type === "preview") &&
+            typeof message.html === "string" &&
+            (message.html as string).includes("rect"),
+        ),
       ).toBe(true);
     });
   });

--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
-import { act, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RenderWidgetTool } from "../index";
+
+const sentMessages: Record<string, unknown>[] = [];
 
 let receiveHandler:
   | ((event: {
@@ -18,7 +20,10 @@ vi.mock("bidc", () => ({
     receive: vi.fn((handler) => {
       receiveHandler = handler;
     }),
-    send: vi.fn(async () => ({ ok: true })),
+    send: vi.fn(async (message: Record<string, unknown>) => {
+      sentMessages.push(message);
+      return { ok: true };
+    }),
     cleanup: vi.fn(),
   })),
 }));
@@ -50,6 +55,18 @@ vi.mock("../renderer-entry.ts?worker&url", () => ({
 describe("RenderWidgetTool", () => {
   beforeEach(() => {
     receiveHandler = undefined;
+    sentMessages.length = 0;
+    document.documentElement.className = "";
+    document.documentElement.style.cssText = "";
+    document.body.className = "";
+    document.body.style.cssText = "";
+  });
+
+  afterEach(() => {
+    document.documentElement.className = "";
+    document.documentElement.style.cssText = "";
+    document.body.className = "";
+    document.body.style.cssText = "";
   });
 
   it("renders the widget iframe without VS Code tool header chrome", () => {
@@ -145,5 +162,64 @@ describe("RenderWidgetTool", () => {
     });
 
     expect(iframe.style.height).toBe("320px");
+  });
+
+  it("pushes theme updates when VS Code mutates body theme attributes", async () => {
+    render(
+      <RenderWidgetTool
+        tool={
+          {
+            type: "tool-renderWidget",
+            toolCallId: "widget-theme",
+            state: "input-available",
+            input: {
+              title: "Theme widget",
+              kind: "diagram",
+              widgetCode: "<svg></svg>",
+              guidelinesRead: true,
+            },
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    const iframe = screen.getByTitle("Theme widget");
+    act(() => {
+      iframe.dispatchEvent(new Event("load"));
+    });
+    act(() => {
+      receiveHandler?.({ type: "ready" });
+    });
+
+    await waitFor(() => {
+      expect(sentMessages.some((message) => message.type === "theme")).toBe(
+        true,
+      );
+    });
+    const initialMessageCount = sentMessages.length;
+
+    await act(async () => {
+      document.body.classList.add("vscode-light");
+      document.body.style.setProperty("--vscode-editor-foreground", "#123456");
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        sentMessages.slice(initialMessageCount).some((message) => {
+          return (
+            message.type === "theme" &&
+            message.themeClass === "light" &&
+            typeof message.variablesCss === "string" &&
+            message.variablesCss.includes(
+              "--vscode-editor-foreground: #123456;",
+            )
+          );
+        }),
+      ).toBe(true);
+    });
   });
 });

--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
@@ -52,6 +52,34 @@ describe("RenderWidgetTool", () => {
     receiveHandler = undefined;
   });
 
+  it("renders the widget iframe without VS Code tool header chrome", () => {
+    render(
+      <RenderWidgetTool
+        tool={
+          {
+            type: "tool-renderWidget",
+            toolCallId: "widget-no-header",
+            state: "input-available",
+            input: {
+              title: "Clean widget",
+              kind: "diagram",
+              widgetCode: "<svg></svg>",
+              guidelinesRead: true,
+            },
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByTestId("status-icon")).toBeNull();
+    expect(screen.queryByText("Rendering widget")).toBeNull();
+    expect(screen.queryByText("Clean widget")).toBeNull();
+    expect(screen.getByTitle("Clean widget")).toBeTruthy();
+  });
+
   it("shows renderer errors returned from the sandboxed iframe", () => {
     render(
       <RenderWidgetTool
@@ -84,7 +112,7 @@ describe("RenderWidgetTool", () => {
     expect(screen.getByText("boom")).toBeTruthy();
   });
 
-  it("waits for the sandboxed renderer to report widget height", () => {
+  it("starts at zero height and waits for the sandboxed renderer to report widget height", () => {
     render(
       <RenderWidgetTool
         tool={
@@ -107,7 +135,7 @@ describe("RenderWidgetTool", () => {
     );
 
     const iframe = screen.getByTitle("Measured widget");
-    expect(iframe.style.height).toBe("");
+    expect(iframe.style.height).toBe("0px");
 
     act(() => {
       iframe.dispatchEvent(new Event("load"));

--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts
@@ -210,8 +210,8 @@ describe("render widget utilities", () => {
   it("measures widget height from root content instead of viewport scroll height", () => {
     const root = document.createElement("div");
     const body = document.createElement("body");
-    body.style.paddingTop = "12px";
-    body.style.paddingBottom = "12px";
+    body.style.paddingTop = "4px";
+    body.style.paddingBottom = "4px";
     Object.defineProperty(document.documentElement, "scrollHeight", {
       configurable: true,
       value: 900,
@@ -221,7 +221,18 @@ describe("render widget utilities", () => {
         height: 180,
       }) as DOMRect;
 
-    expect(measureWidgetContentHeight(root, body)).toBe(204);
+    expect(measureWidgetContentHeight(root, body)).toBe(188);
+  });
+
+  it("allows an empty widget root to measure as zero before content renders", () => {
+    const root = document.createElement("div");
+    const body = document.createElement("body");
+    root.getBoundingClientRect = () =>
+      ({
+        height: 0,
+      }) as DOMRect;
+
+    expect(measureWidgetContentHeight(root, body)).toBe(0);
   });
 
   it("builds a renderer document with restrictive CSP and disabled network APIs", () => {
@@ -491,6 +502,17 @@ describe("render widget utilities", () => {
     );
     expect(iframeDocument).toContain(".light body { color-scheme: light; }");
     expect(iframeDocument).toContain(".dark body { color-scheme: dark; }");
+  });
+
+  it("starts the iframe body compact with no root minimum height", () => {
+    const iframeDocument = buildWidgetIframeDocument(
+      "http://localhost:4112/widget.js",
+    );
+
+    expect(iframeDocument).toContain("padding: 4px 0;");
+    expect(iframeDocument).toContain("min-height: 0;");
+    expect(iframeDocument).not.toContain("padding: 12px 0;");
+    expect(iframeDocument).not.toContain("min-height: 96px;");
   });
 
   it("does not leak `vscode-` prefixed selectors into the iframe stylesheet", () => {

--- a/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
@@ -76,6 +76,10 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   });
   // Tracks animation history only — intentionally separate from channel state.
   const hasPostedPreviewRef = useRef(false);
+  // Remember the most recently queued render so we can replay it after the
+  // iframe reloads (e.g. browser-initiated reloads). Theme changes alone must
+  // not remount the iframe — they propagate via the theme message channel.
+  const lastRenderRef = useRef<WidgetRenderMessage | undefined>(undefined);
   const [height, setHeight] = useState(0);
   const [hasFirstHeight, setHasFirstHeight] = useState(false);
   const [rendererError, setRendererError] = useState<string | undefined>();
@@ -88,6 +92,21 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   );
   const fallbackThemeClass: WidgetThemeClass =
     theme === "light" ? "light" : "dark";
+  // Capture the theme snapshot used to seed the initial iframe document. We
+  // keep this stable so the iframe src does not change when the parent webview
+  // theme switches; live theme updates are pushed through the theme message
+  // channel instead, which avoids remounting the iframe (which would clear the
+  // widget body until the next render message is queued).
+  const initialThemeRef = useRef<{
+    themeClass: WidgetThemeClass;
+    variablesCss: string;
+  } | null>(null);
+  if (!initialThemeRef.current) {
+    initialThemeRef.current = {
+      themeClass: getCurrentWidgetThemeClass(fallbackThemeClass),
+      variablesCss: collectWidgetThemeVariables(),
+    };
+  }
 
   useEffect(() => {
     if (!import.meta.env.PROD) return;
@@ -113,6 +132,7 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   const iframeDocument = useMemo(() => {
     if (import.meta.env.PROD && !rendererScriptCode) return undefined;
 
+    const initialTheme = initialThemeRef.current;
     return buildWidgetIframeDocument(
       import.meta.env.PROD
         ? {
@@ -121,11 +141,11 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
             nonce: getWebviewScriptNonce(),
           }
         : rendererScriptSrc,
-      collectWidgetThemeVariables(),
+      initialTheme?.variablesCss ?? "",
       channelId,
-      getCurrentWidgetThemeClass(fallbackThemeClass),
+      initialTheme?.themeClass ?? "dark",
     );
-  }, [channelId, fallbackThemeClass, rendererScriptCode]);
+  }, [channelId, rendererScriptCode]);
   const iframeSrc = useMemo(
     () => (iframeDocument ? buildWidgetIframeSrc(iframeDocument) : undefined),
     [iframeDocument],
@@ -182,6 +202,7 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   const queueRenderMessage = useCallback(
     (message: WidgetRenderMessage) => {
       const rt = runtimeRef.current;
+      lastRenderRef.current = message;
       const next = coalescePendingWidgetMessage(rt.pendingRender, message);
       if (next === rt.pendingRender) return;
       rt.pendingRender = next;
@@ -213,6 +234,17 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
 
     rt.channel?.cleanup();
     rt.ready = false;
+    // Seed the queue with the most recently rendered widget body and current
+    // theme so a fresh iframe (initial mount or an unexpected reload) catches
+    // up to the latest state as soon as it becomes ready.
+    rt.pendingTheme = {
+      type: "theme",
+      themeClass: getCurrentWidgetThemeClass(fallbackThemeClass),
+      variablesCss: collectWidgetThemeVariables(),
+    };
+    if (lastRenderRef.current) {
+      rt.pendingRender = lastRenderRef.current;
+    }
     const channel = createChannel(target, channelId);
     rt.channel = channel;
     channel.receive((event: WidgetRendererEvent) => {
@@ -227,7 +259,7 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
       }
       return { ok: true };
     });
-  }, [channelId, scheduleFlush]);
+  }, [channelId, fallbackThemeClass, scheduleFlush]);
 
   // Push theme updates whenever the parent webview theme changes so the
   // sandboxed iframe re-applies the new vscode-* variables and color palette

--- a/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
@@ -86,6 +86,9 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
     () => `pochi-widget-${tool.toolCallId}`,
     [tool.toolCallId],
   );
+  const fallbackThemeClass: WidgetThemeClass =
+    theme === "light" ? "light" : "dark";
+
   useEffect(() => {
     if (!import.meta.env.PROD) return;
 
@@ -120,9 +123,9 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
         : rendererScriptSrc,
       collectWidgetThemeVariables(),
       channelId,
-      getCurrentWidgetThemeClass(),
+      getCurrentWidgetThemeClass(fallbackThemeClass),
     );
-  }, [channelId, rendererScriptCode]);
+  }, [channelId, fallbackThemeClass, rendererScriptCode]);
   const iframeSrc = useMemo(
     () => (iframeDocument ? buildWidgetIframeSrc(iframeDocument) : undefined),
     [iframeDocument],
@@ -195,6 +198,14 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
     [scheduleFlush],
   );
 
+  const queueCurrentThemeMessage = useCallback(() => {
+    queueThemeMessage({
+      type: "theme",
+      themeClass: getCurrentWidgetThemeClass(fallbackThemeClass),
+      variablesCss: collectWidgetThemeVariables(),
+    });
+  }, [fallbackThemeClass, queueThemeMessage]);
+
   const handleLoad = useCallback(() => {
     const rt = runtimeRef.current;
     const target = iframeRef.current?.contentWindow;
@@ -222,13 +233,29 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   // sandboxed iframe re-applies the new vscode-* variables and color palette
   // without needing to be re-mounted.
   useEffect(() => {
-    const themeClass: WidgetThemeClass = theme === "light" ? "light" : "dark";
-    queueThemeMessage({
-      type: "theme",
-      themeClass,
-      variablesCss: collectWidgetThemeVariables(),
-    });
-  }, [theme, queueThemeMessage]);
+    queueCurrentThemeMessage();
+  }, [queueCurrentThemeMessage]);
+
+  useEffect(() => {
+    if (typeof MutationObserver === "undefined") return;
+
+    const targets = [document.body, document.documentElement].filter(
+      Boolean,
+    ) as Element[];
+    if (targets.length === 0) return;
+
+    const observer = new MutationObserver(queueCurrentThemeMessage);
+    for (const target of targets) {
+      observer.observe(target, {
+        attributes: true,
+        attributeFilter: ["class", "style"],
+      });
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [queueCurrentThemeMessage]);
 
   useEffect(() => {
     if (debounceRef.current) {

--- a/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
@@ -3,7 +3,6 @@ import { cn } from "@/lib/utils";
 import { createChannel } from "bidc";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { StatusIcon } from "../status-icon";
 import type { ToolProps } from "../types";
 // This intentionally borrows Vite's worker bundling pipeline only to get a
 // standalone module URL. No Web Worker is created; the renderer is loaded as a
@@ -77,7 +76,7 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   });
   // Tracks animation history only — intentionally separate from channel state.
   const hasPostedPreviewRef = useRef(false);
-  const [height, setHeight] = useState<number | undefined>();
+  const [height, setHeight] = useState(0);
   const [hasFirstHeight, setHasFirstHeight] = useState(false);
   const [rendererError, setRendererError] = useState<string | undefined>();
   const [rendererScriptCode, setRendererScriptCode] = useState<
@@ -275,15 +274,8 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
     };
   }, []);
 
-  const headerLabel = t("toolInvocation.renderingWidget");
-
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center text-muted-foreground text-sm">
-        <StatusIcon isExecuting={isExecuting} tool={tool} />
-        <span className="ml-2">{headerLabel}</span>
-        <span className="ml-2 text-foreground">{title}</span>
-      </div>
+    <div className="flex flex-col">
       {iframeSrc ? (
         <iframe
           ref={iframeRef}
@@ -306,8 +298,8 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
 };
 
 function clampHeight(height: number | undefined) {
-  if (!height || !Number.isFinite(height)) return 160;
-  return Math.min(Math.max(Math.ceil(height), 120), 1200);
+  if (height === undefined || !Number.isFinite(height)) return 0;
+  return Math.min(Math.max(Math.ceil(height), 0), 1200);
 }
 
 function getWebviewScriptNonce() {

--- a/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
@@ -245,7 +245,9 @@ export function sanitizeWidgetFragment(html: string) {
  * development environments that mirror the class on the root. Returns the
  * simplified `"dark"` / `"light"` token that we propagate into the iframe.
  */
-export function getCurrentWidgetThemeClass(): WidgetThemeClass {
+export function getCurrentWidgetThemeClass(
+  fallback: WidgetThemeClass = "dark",
+): WidgetThemeClass {
   const targets: Element[] = [];
   if (typeof document !== "undefined") {
     if (document.body) targets.push(document.body);
@@ -255,7 +257,7 @@ export function getCurrentWidgetThemeClass(): WidgetThemeClass {
     if (target.classList.contains("vscode-light")) return "light";
     if (target.classList.contains("vscode-dark")) return "dark";
   }
-  return "dark";
+  return fallback;
 }
 
 /**

--- a/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
@@ -87,11 +87,13 @@ export function measureWidgetContentHeight(
   body: HTMLElement = document.body,
 ) {
   const rootHeight = root.getBoundingClientRect().height;
+  if (rootHeight <= 0 && !root.hasChildNodes()) return 0;
+
   const bodyStyles = getComputedStyle(body);
   const paddingTop = Number.parseFloat(bodyStyles.paddingTop) || 0;
   const paddingBottom = Number.parseFloat(bodyStyles.paddingBottom) || 0;
 
-  return Math.max(120, Math.ceil(rootHeight + paddingTop + paddingBottom));
+  return Math.max(0, Math.ceil(rootHeight + paddingTop + paddingBottom));
 }
 
 function isWidgetRevealElement(element: Element, seen: Set<Element>) {
@@ -427,7 +429,7 @@ html { background: transparent !important; }
 .dark body { color-scheme: dark; }
 body {
   margin: 0;
-  padding: 12px 0;
+  padding: 4px 0;
   overflow: hidden;
   background: transparent !important;
   color: var(--vscode-editor-foreground, #cccccc);
@@ -436,7 +438,7 @@ body {
 #root {
   display: block;
   width: 100%;
-  min-height: 96px;
+  min-height: 0;
 }
 @keyframes __pochi_widget_fade_in {
   from { opacity: 0; transform: translateY(8px); }


### PR DESCRIPTION
## Summary
- Removed the redundant tool header for `renderWidget` to achieve a cleaner UI integrated into the chat flow.
- Polished the widget rendering lifecycle: widgets now start at zero height and expand as content loads.
- Reduced default padding and minimum height constraints for widgets to allow for more compact visualizations.
- Updated unit tests to verify the header removal and the new height measurement logic.

## Test plan
- [x] Verified that the tool header is no longer visible in the webview.
- [x] Confirmed that widgets still render correctly and resize dynamically.
- [x] Ran existing tests in `packages/vscode-webui/src/features/tools/components/render-widget/__tests__/` to ensure they pass with the new changes.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f93402bb1df54a0dbccf782fb3035c80)