### PR TITLE
feat(vscode-webui): improve searchFiles tool call UI for filePattern

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/search-files.tsx
+++ b/packages/vscode-webui/src/features/tools/components/search-files.tsx
@@ -31,7 +31,13 @@ export const searchFilesTool: React.FC<ToolProps<"searchFiles">> = ({
     <>
       <HighlightedText>{regex}</HighlightedText> {t("toolInvocation.in")}{" "}
       <HighlightedText>{path}</HighlightedText>
-      {filePattern && <HighlightedText>{filePattern}</HighlightedText>}
+      {filePattern && (
+        <>
+          {" "}
+          {t("toolInvocation.matching")}{" "}
+          <HighlightedText>{filePattern}</HighlightedText>
+        </>
+      )}
     </>
   );
 

--- a/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
@@ -245,7 +245,13 @@ const SearchFilesTool = ({ tool }: ToolCallLiteViewProps<"searchFiles">) => {
     <>
       <HighlightedText>{regex}</HighlightedText> {t("toolInvocation.in")}{" "}
       <HighlightedText>{path}</HighlightedText>
-      {filePattern && <HighlightedText>{filePattern}</HighlightedText>}
+      {filePattern && (
+        <>
+          {" "}
+          {t("toolInvocation.matching")}{" "}
+          <HighlightedText>{filePattern}</HighlightedText>
+        </>
+      )}
     </>
   );
 

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -318,6 +318,7 @@
     "executeCommand": "I will execute the following command",
     "executingCommand": "Executing command",
     "for": "for",
+    "matching": "matching",
     "searching": "Searching",
     "searchingFor": "Searching for:",
     "matchCount_one": "{{count}} match",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -319,6 +319,7 @@
     "executeCommand": "以下のコマンドを実行します",
     "executingCommand": "コマンドを実行中",
     "for": "で",
+    "matching": "一致する",
     "searching": "検索中",
     "searchingFor": "検索中：",
     "matchCount_one": "{{count}}件一致",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -318,6 +318,7 @@
     "executeCommand": "다음 명령을 실행합니다",
     "executingCommand": "명령 실행 중",
     "for": "대상",
+    "matching": "매칭",
     "searching": "검색 중",
     "searchingFor": "검색 중:",
     "matchCount_one": "{{count}}개 일치",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -317,6 +317,7 @@
     "executeCommand": "我将执行以下命令",
     "executingCommand": "正在执行命令",
     "for": "匹配",
+    "matching": "匹配",
     "searching": "搜索中",
     "searchingFor": "搜索：",
     "matchCount_one": "{{count}}个匹配",


### PR DESCRIPTION
## Summary
- Disambiguates the directory path and file pattern filter in `searchFiles` tool UI by adding a localized "matching" label.
- Added translation keys for `"matching"` in English (`matching`), Chinese (`匹配`), Korean (`매칭`), and Japanese (`一致する`).
- Updated both `searchFilesTool` in `search-files.tsx` and the `SearchFilesTool` lite view in `tool-call-lite.tsx` to conditionally render the localized label when `filePattern` is present.

### Screenshot
![Screenshot](https://pochi-file-uploads.getpochi.com/blob-1779938490962.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260528%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260528T032131Z&X-Amz-Expires=561600&X-Amz-Signature=ce6294f2b623abd595bfc97298d6c48ecb022d504c3876d982956403c20b5e07&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan
- Verified that `bun check` passes with no issues.
- Verified that types compile correctly with `bun tsc`.
- Verified UI rendering visually.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ac9b4086af894e26ada7276db170b14d)