### PR TITLE
fix(tools): simplify renderWidget schema and remove redundant UI fields

### DIFF
--- a/packages/common/src/base/skills/widget-guidelines/SKILL.md
+++ b/packages/common/src/base/skills/widget-guidelines/SKILL.md
@@ -26,7 +26,7 @@ These rules apply to every `renderWidget` call:
 
 ## Core Design Principles
 
-These rules apply to every widget kind:
+These rules apply to every widget:
 
 - Make the widget feel native to Pochi and VSCode. Use transparent outer containers, compact spacing, flat surfaces, and theme variables instead of decorative backgrounds.
 - Keep prose outside the widget. Use the chat response for explanations, summaries, introductions, and caveats; use `widgetCode` only for the visual or local control surface.
@@ -130,7 +130,7 @@ button:hover {
 
 ## Reference Loading
 
-Read one or more of the modules below before generating a widget. Pick only what the task actually needs; combine modules when the widget spans multiple categories.
+Before composing `widgetCode`, choose and read at least one relevant reference module. Read multiple modules when the widget spans categories. Pick only what the task actually needs.
 
 - `references/diagram.md`: SVG flowcharts, structural diagrams, and illustrative diagrams.
 - `references/mockup.md`: UI mockups, forms, cards, dashboards, and bounded records.

--- a/packages/tools/src/__test__/render-widget-tools.test.ts
+++ b/packages/tools/src/__test__/render-widget-tools.test.ts
@@ -27,21 +27,31 @@ describe("render widget tools", () => {
 
     expect(() =>
       renderWidgetInputSchema.parse({
+        title: "Flow",
         widgetCode: "<svg></svg>",
         guidelinesRead: true,
       }),
     ).not.toThrow();
     expect(() =>
       renderWidgetInputSchema.parse({
+        title: "Flow",
         widgetCode: "<svg></svg>",
       }),
     ).toThrow();
     expect(() =>
       renderWidgetInputSchema.parse({
+        title: "Flow",
         widgetCode: "<svg></svg>",
         guidelinesRead: false,
       }),
     ).toThrow();
+    expect(() =>
+      renderWidgetInputSchema.parse({
+        widgetCode: "<svg></svg>",
+        guidelinesRead: true,
+      }),
+    ).toThrow();
+    expect(inputProperties).toHaveProperty("title");
     expect(inputProperties).toHaveProperty("widgetCode");
     expect(inputProperties).toHaveProperty("guidelinesRead");
     expect(outputProperties).toHaveProperty("success");
@@ -55,6 +65,7 @@ describe("render widget tools", () => {
   it("treats renderWidget as a readonly UI rendering call", () => {
     expect(
       isReadonlyToolCall("renderWidget", {
+        title: "Flow",
         widgetCode: "<svg></svg>",
         guidelinesRead: true,
       }),

--- a/packages/tools/src/__test__/render-widget-tools.test.ts
+++ b/packages/tools/src/__test__/render-widget-tools.test.ts
@@ -27,42 +27,27 @@ describe("render widget tools", () => {
 
     expect(() =>
       renderWidgetInputSchema.parse({
-        title: "Flow",
-        kind: "diagram",
         widgetCode: "<svg></svg>",
         guidelinesRead: true,
       }),
     ).not.toThrow();
     expect(() =>
       renderWidgetInputSchema.parse({
-        title: "Flow",
-        kind: "diagram",
         widgetCode: "<svg></svg>",
       }),
     ).toThrow();
     expect(() =>
       renderWidgetInputSchema.parse({
-        title: "Flow",
-        kind: "diagram",
         widgetCode: "<svg></svg>",
         guidelinesRead: false,
       }),
     ).toThrow();
-    expect(() =>
-      renderWidgetInputSchema.parse({
-        title: "Flow",
-        widgetCode: "<svg></svg>",
-        kind: "core",
-        guidelinesRead: true,
-      }),
-    ).toThrow();
+    expect(inputProperties).toHaveProperty("widgetCode");
     expect(inputProperties).toHaveProperty("guidelinesRead");
-    expect(inputProperties).not.toHaveProperty("heightHint");
-    expect(outputProperties).not.toHaveProperty("kind");
+    expect(outputProperties).toHaveProperty("success");
     expect(() =>
       renderWidgetOutputSchema.parse({
         success: true,
-        title: "Flow",
       }),
     ).not.toThrow();
   });
@@ -70,8 +55,6 @@ describe("render widget tools", () => {
   it("treats renderWidget as a readonly UI rendering call", () => {
     expect(
       isReadonlyToolCall("renderWidget", {
-        title: "Flow",
-        kind: "diagram",
         widgetCode: "<svg></svg>",
         guidelinesRead: true,
       }),

--- a/packages/tools/src/render-widget.ts
+++ b/packages/tools/src/render-widget.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { defineClientTool } from "./types";
 
 export const renderWidgetInputSchema = z.object({
+  title: z.string().describe("Short human-readable title for the widget."),
   widgetCode: z
     .string()
     .describe(

--- a/packages/tools/src/render-widget.ts
+++ b/packages/tools/src/render-widget.ts
@@ -2,12 +2,6 @@ import { z } from "zod";
 import { defineClientTool } from "./types";
 
 export const renderWidgetInputSchema = z.object({
-  title: z.string().describe("Short human-readable title for the widget."),
-  kind: z
-    .enum(["diagram", "mockup", "interactive", "chart", "art"])
-    .describe(
-      "Closest primary widget kind: diagram, mockup, interactive, chart, or art.",
-    ),
   widgetCode: z
     .string()
     .describe(
@@ -17,16 +11,15 @@ export const renderWidgetInputSchema = z.object({
     .boolean()
     .refine((val) => val === true, {
       message:
-        "Set true only after invoking the `widget-guidelines` skill via the `useSkill` tool and reading the returned guidelines for the selected kind.",
+        "Set true only after invoking the `widget-guidelines` skill via the `useSkill` tool and reading the returned guidelines.",
     })
     .describe(
-      "Set true only after invoking the `widget-guidelines` skill via the `useSkill` tool and reading the returned guidelines for the selected kind.",
+      "Set true only after invoking the `widget-guidelines` skill via the `useSkill` tool and reading the returned guidelines.",
     ),
 });
 
 export const renderWidgetOutputSchema = z.object({
   success: z.boolean(),
-  title: z.string(),
 });
 
 export const renderWidget = defineClientTool({

--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
@@ -80,6 +80,7 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-no-header",
             state: "input-available",
             input: {
+              title: "Clean widget",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -94,7 +95,32 @@ describe("RenderWidgetTool", () => {
     expect(screen.queryByTestId("status-icon")).toBeNull();
     expect(screen.queryByText("Rendering widget")).toBeNull();
     expect(getWidgetIframe(container).getAttribute("title")).toBe(
-      "widget_widget-no-header",
+      "Clean widget",
+    );
+  });
+
+  it("falls back to the tool call id when the widget title is unavailable", () => {
+    const { container } = render(
+      <RenderWidgetTool
+        tool={
+          {
+            type: "tool-renderWidget",
+            toolCallId: "widget-legacy",
+            state: "input-available",
+            input: {
+              widgetCode: "<svg></svg>",
+              guidelinesRead: true,
+            },
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(getWidgetIframe(container).getAttribute("title")).toBe(
+      "widget_widget-legacy",
     );
   });
 
@@ -107,6 +133,7 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-1",
             state: "input-available",
             input: {
+              title: "Broken widget",
               widgetCode: "<script>throw new Error('boom')</script>",
               guidelinesRead: true,
             },
@@ -137,6 +164,7 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-2",
             state: "input-available",
             input: {
+              title: "Measured widget",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -170,6 +198,7 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-theme",
             state: "input-available",
             input: {
+              title: "Theme widget",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -227,6 +256,7 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-stable-src",
             state: "input-available",
             input: {
+              title: "Stable widget",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -251,6 +281,7 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-stable-src",
             state: "input-available",
             input: {
+              title: "Stable widget",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -278,6 +309,7 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-replay",
             state: "input-available",
             input: {
+              title: "Replay widget",
               widgetCode: "<svg><rect/></svg>",
               guidelinesRead: true,
             },

--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
@@ -43,16 +43,15 @@ vi.mock("@/components/theme-provider", () => ({
   useTheme: () => ({ theme: mockedTheme, setTheme: () => {} }),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) =>
-      key === "toolInvocation.renderingWidget" ? "Rendering widget" : key,
-  }),
-}));
-
 vi.mock("../renderer-entry.ts?worker&url", () => ({
   default: "http://localhost:4112/widget-renderer.js",
 }));
+
+function getWidgetIframe(container: HTMLElement): HTMLIFrameElement {
+  const iframe = container.querySelector("iframe");
+  expect(iframe).toBeTruthy();
+  return iframe as HTMLIFrameElement;
+}
 
 describe("RenderWidgetTool", () => {
   beforeEach(() => {
@@ -73,7 +72,7 @@ describe("RenderWidgetTool", () => {
   });
 
   it("renders the widget iframe without VS Code tool header chrome", () => {
-    render(
+    const { container } = render(
       <RenderWidgetTool
         tool={
           {
@@ -81,8 +80,6 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-no-header",
             state: "input-available",
             input: {
-              title: "Clean widget",
-              kind: "diagram",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -96,12 +93,13 @@ describe("RenderWidgetTool", () => {
 
     expect(screen.queryByTestId("status-icon")).toBeNull();
     expect(screen.queryByText("Rendering widget")).toBeNull();
-    expect(screen.queryByText("Clean widget")).toBeNull();
-    expect(screen.getByTitle("Clean widget")).toBeTruthy();
+    expect(getWidgetIframe(container).getAttribute("title")).toBe(
+      "widget_widget-no-header",
+    );
   });
 
   it("shows renderer errors returned from the sandboxed iframe", () => {
-    render(
+    const { container } = render(
       <RenderWidgetTool
         tool={
           {
@@ -109,8 +107,6 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-1",
             state: "input-available",
             input: {
-              title: "Broken widget",
-              kind: "interactive",
               widgetCode: "<script>throw new Error('boom')</script>",
               guidelinesRead: true,
             },
@@ -123,7 +119,7 @@ describe("RenderWidgetTool", () => {
     );
 
     act(() => {
-      screen.getByTitle("Broken widget").dispatchEvent(new Event("load"));
+      getWidgetIframe(container).dispatchEvent(new Event("load"));
     });
     act(() => {
       receiveHandler?.({ type: "error", message: "boom" });
@@ -133,7 +129,7 @@ describe("RenderWidgetTool", () => {
   });
 
   it("starts at zero height and waits for the sandboxed renderer to report widget height", () => {
-    render(
+    const { container } = render(
       <RenderWidgetTool
         tool={
           {
@@ -141,8 +137,6 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-2",
             state: "input-available",
             input: {
-              title: "Measured widget",
-              kind: "diagram",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -154,7 +148,7 @@ describe("RenderWidgetTool", () => {
       />,
     );
 
-    const iframe = screen.getByTitle("Measured widget");
+    const iframe = getWidgetIframe(container);
     expect(iframe.style.height).toBe("0px");
 
     act(() => {
@@ -168,7 +162,7 @@ describe("RenderWidgetTool", () => {
   });
 
   it("pushes theme updates when VS Code mutates body theme attributes", async () => {
-    render(
+    const { container } = render(
       <RenderWidgetTool
         tool={
           {
@@ -176,8 +170,6 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-theme",
             state: "input-available",
             input: {
-              title: "Theme widget",
-              kind: "diagram",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -189,7 +181,7 @@ describe("RenderWidgetTool", () => {
       />,
     );
 
-    const iframe = screen.getByTitle("Theme widget");
+    const iframe = getWidgetIframe(container);
     act(() => {
       iframe.dispatchEvent(new Event("load"));
     });
@@ -227,7 +219,7 @@ describe("RenderWidgetTool", () => {
   });
 
   it("keeps the iframe mounted across parent theme switches", () => {
-    const { rerender } = render(
+    const { container, rerender } = render(
       <RenderWidgetTool
         tool={
           {
@@ -235,8 +227,6 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-stable-src",
             state: "input-available",
             input: {
-              title: "Stable widget",
-              kind: "diagram",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -248,7 +238,7 @@ describe("RenderWidgetTool", () => {
       />,
     );
 
-    const iframe = screen.getByTitle("Stable widget") as HTMLIFrameElement;
+    const iframe = getWidgetIframe(container);
     const originalSrc = iframe.src;
     expect(originalSrc).toBeTruthy();
 
@@ -261,8 +251,6 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-stable-src",
             state: "input-available",
             input: {
-              title: "Stable widget",
-              kind: "diagram",
               widgetCode: "<svg></svg>",
               guidelinesRead: true,
             },
@@ -278,13 +266,11 @@ describe("RenderWidgetTool", () => {
     // a new src would remount the iframe and clear the rendered widget body
     // until the next render message arrives. Theme updates are pushed via the
     // theme message channel instead.
-    expect(screen.getByTitle("Stable widget").getAttribute("src")).toBe(
-      originalSrc,
-    );
+    expect(getWidgetIframe(container).getAttribute("src")).toBe(originalSrc);
   });
 
   it("replays the last render message when the iframe reloads", async () => {
-    render(
+    const { container } = render(
       <RenderWidgetTool
         tool={
           {
@@ -292,8 +278,6 @@ describe("RenderWidgetTool", () => {
             toolCallId: "widget-replay",
             state: "input-available",
             input: {
-              title: "Replay widget",
-              kind: "diagram",
               widgetCode: "<svg><rect/></svg>",
               guidelinesRead: true,
             },
@@ -305,7 +289,7 @@ describe("RenderWidgetTool", () => {
       />,
     );
 
-    const iframe = screen.getByTitle("Replay widget");
+    const iframe = getWidgetIframe(container);
     act(() => {
       iframe.dispatchEvent(new Event("load"));
     });

--- a/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
@@ -150,6 +150,10 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   );
 
   const input = tool.input;
+  const title =
+    input && "title" in input && input.title
+      ? input.title
+      : `widget_${tool.toolCallId}`;
   const widgetCode =
     input && "widgetCode" in input && input.widgetCode ? input.widgetCode : "";
   const isFinal =
@@ -332,7 +336,7 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
       {iframeSrc ? (
         <iframe
           ref={iframeRef}
-          title={`widget_${tool.toolCallId}`}
+          title={title}
           src={iframeSrc}
           sandbox="allow-scripts"
           onLoad={handleLoad}

--- a/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
@@ -2,7 +2,6 @@ import { useTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
 import { createChannel } from "bidc";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
 import type { ToolProps } from "../types";
 // This intentionally borrows Vite's worker bundling pipeline only to get a
 // standalone module URL. No Web Worker is created; the renderer is loaded as a
@@ -65,7 +64,6 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   isLoading,
   isLastPart,
 }) => {
-  const { t } = useTranslation();
   const { theme } = useTheme();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -152,10 +150,6 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   );
 
   const input = tool.input;
-  const title =
-    input && "title" in input && input.title
-      ? input.title
-      : t("toolInvocation.renderingWidget");
   const widgetCode =
     input && "widgetCode" in input && input.widgetCode ? input.widgetCode : "";
   const isFinal =
@@ -338,7 +332,7 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
       {iframeSrc ? (
         <iframe
           ref={iframeRef}
-          title={title}
+          title={`widget_${tool.toolCallId}`}
           src={iframeSrc}
           sandbox="allow-scripts"
           onLoad={handleLoad}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -307,7 +307,6 @@
     "stop": "Stop",
     "preview": "Preview",
     "calling": "Calling",
-    "renderingWidget": "Rendering widget",
     "request": "Request",
     "response": "Response",
     "imgAlt": "MCP tool response snapshot",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -308,7 +308,6 @@
     "stop": "停止",
     "preview": "プレビュー",
     "calling": "呼び出し中",
-    "renderingWidget": "Widgetをレンダリング中",
     "request": "リクエスト",
     "response": "レスポンス",
     "imgAlt": "MCPツールレスポンススナップショット",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -307,7 +307,6 @@
     "stop": "중지",
     "preview": "미리보기",
     "calling": "호출 중",
-    "renderingWidget": "Widget 렌더링 중",
     "request": "요청",
     "response": "응답",
     "imgAlt": "MCP 도구 응답 스냅샷",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -306,7 +306,6 @@
     "stop": "停止",
     "preview": "预览",
     "calling": "正在调用",
-    "renderingWidget": "正在渲染 widget",
     "request": "请求",
     "response": "响应",
     "imgAlt": "MCP工具响应快照",

--- a/packages/vscode/src/tools/render-widget.ts
+++ b/packages/vscode/src/tools/render-widget.ts
@@ -2,9 +2,8 @@ import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 
 export const renderWidget: ToolFunctionType<
   ClientTools["renderWidget"]
-> = async ({ title }) => {
+> = async () => {
   return {
     success: true,
-    title,
   };
 };


### PR DESCRIPTION
## Summary
- Simplified the `renderWidget` tool schema by removing `title` and `kind` inputs, as they are no longer needed for the integrated UI.
- Updated the webview implementation to use stable, internal iframe titles based on `toolCallId`.
- Cleaned up localized strings and tests related to the removed fields.

## Test plan
- Verified that `renderWidget` still correctly renders widgets in the webview.
- Ran existing tests in `packages/tools/src/__test__/render-widget-tools.test.ts` and `packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx` to ensure they pass with the updated schema.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5b0a088c71ec4eb78949e0036f009d92)