### PR TITLE
feat(vscode): record source repo path in project.json sidecar

### DIFF
--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -26,6 +26,7 @@ export {
   AutoMemoryIndexName,
   AutoMemoryLockName,
   AutoMemoryMaxManifestEntries,
+  AutoMemoryProjectInfoName,
   AutoMemoryTypeValues,
   truncateAutoMemoryIndex,
 } from "./prompts/auto-memory";

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -9,6 +9,13 @@ export function isAutoMemorySystemReminder(content: string): boolean {
   return content.includes(AutoMemoryHeader);
 }
 export const AutoMemoryLockName = ".consolidate-lock";
+/**
+ * Sidecar metadata file that maps an obfuscated project directory
+ * (`~/.pochi/projects/<repoKey>/`) back to its source repository. Lets users
+ * — and future tooling — identify which project a hashed directory belongs
+ * to without scanning every memory or transcript file.
+ */
+export const AutoMemoryProjectInfoName = "project.json";
 export const AutoMemoryMaxIndexLines = 200;
 export const AutoMemoryMaxIndexBytes = 25_000;
 export const AutoMemoryMaxManifestEntries = 200;

--- a/packages/vscode/src/lib/__test__/auto-memory.test.ts
+++ b/packages/vscode/src/lib/__test__/auto-memory.test.ts
@@ -1,6 +1,14 @@
 import * as assert from "node:assert";
-import { describe, it } from "mocha";
+import * as fs from "node:fs/promises";
+import * as nodeOs from "node:os";
+import * as path from "node:path";
+import "reflect-metadata";
+import { AutoMemoryProjectInfoName } from "@getpochi/common";
+import { afterEach, beforeEach, describe, it } from "mocha";
+import proxyquire from "proxyquire";
 import { sanitizeMemoryRepoKey } from "../auto-memory";
+
+type AutoMemoryModule = typeof import("../auto-memory");
 
 describe("long-term memory helpers", () => {
   it("creates stable filesystem-safe repo keys from the project basename", () => {
@@ -27,5 +35,73 @@ describe("long-term memory helpers", () => {
 
     const root = sanitizeMemoryRepoKey("/");
     assert.match(root, /^repo-[a-f0-9]{10}$/);
+  });
+});
+
+describe("AutoMemoryManager project info file", () => {
+  let tmpHome: string;
+  let cwd: string;
+  let proxiedModule: AutoMemoryModule;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(
+      path.join(nodeOs.tmpdir(), "pochi-auto-memory-"),
+    );
+    cwd = await fs.mkdtemp(
+      path.join(nodeOs.tmpdir(), "pochi-auto-memory-repo-"),
+    );
+    // VS Code's extension host marks `os.homedir` as non-configurable so we
+    // can't `sinon.stub` it directly — use proxyquire to swap the bound
+    // `node:os` import inside `../auto-memory`.
+    proxiedModule = proxyquire.noCallThru()("../auto-memory", {
+      "node:os": {
+        ...nodeOs,
+        homedir: () => tmpHome,
+      },
+    }) as AutoMemoryModule;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpHome, { recursive: true, force: true });
+    await fs.rm(cwd, { recursive: true, force: true });
+  });
+
+  it("writes project.json mapping the repoKey back to the source repo path", async () => {
+    const manager = new proxiedModule.AutoMemoryManager();
+    const context = await manager.readContext(cwd);
+    assert.ok(context, "expected context to be created");
+
+    const infoPath = path.join(
+      tmpHome,
+      ".pochi",
+      "projects",
+      context.repoKey,
+      AutoMemoryProjectInfoName,
+    );
+    const info = JSON.parse(await fs.readFile(infoPath, "utf8"));
+    assert.deepStrictEqual(info, {
+      repoKey: context.repoKey,
+      repoPath: path.resolve(cwd),
+    });
+  });
+
+  it("skips rewriting project.json when the mapping is unchanged", async () => {
+    const manager = new proxiedModule.AutoMemoryManager();
+    const first = await manager.readContext(cwd);
+    assert.ok(first);
+    const infoPath = path.join(
+      tmpHome,
+      ".pochi",
+      "projects",
+      first.repoKey,
+      AutoMemoryProjectInfoName,
+    );
+    const firstStat = await fs.stat(infoPath);
+
+    // Second readContext should be a no-op on disk since nothing changed.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await manager.readContext(cwd);
+    const secondStat = await fs.stat(infoPath);
+    assert.strictEqual(secondStat.mtimeMs, firstStat.mtimeMs);
   });
 });

--- a/packages/vscode/src/lib/auto-memory.ts
+++ b/packages/vscode/src/lib/auto-memory.ts
@@ -10,6 +10,7 @@ import {
   AutoMemoryLockName,
   type AutoMemoryManifestEntry,
   AutoMemoryMaxManifestEntries,
+  AutoMemoryProjectInfoName,
   AutoMemoryTypeValues,
   toErrorMessage,
   truncateAutoMemoryIndex,
@@ -72,6 +73,13 @@ export class AutoMemoryManager {
       await fs.mkdir(memoryDir, { recursive: true });
       await fs.mkdir(transcriptDir, { recursive: true });
       await ensureIndexFile(indexPath);
+      await writeProjectInfoFile({ projectRoot, repoKey, repoRoot }).catch(
+        (error) => {
+          logger.warn(
+            `Failed to update project info file: ${toErrorMessage(error)}`,
+          );
+        },
+      );
     }
 
     const rawIndexContent = await fs
@@ -333,6 +341,44 @@ async function ensureIndexFile(indexPath: string): Promise<void> {
       }
       throw error;
     });
+}
+
+type ProjectInfoFile = {
+  repoKey: string;
+  repoPath: string;
+};
+
+/**
+ * Persist a sidecar `project.json` at the root of the obfuscated project
+ * directory so users (and future tooling) can map `<repoKey>` back to its
+ * source repository. The file is rewritten only when the mapping actually
+ * changes — e.g. a relocated repository — so steady-state turns don't churn
+ * the disk. Timestamps are intentionally omitted; the directory's own ctime
+ * / mtime already records that information.
+ */
+async function writeProjectInfoFile({
+  projectRoot,
+  repoKey,
+  repoRoot,
+}: {
+  projectRoot: string;
+  repoKey: string;
+  repoRoot: string;
+}): Promise<void> {
+  const filePath = path.join(projectRoot, AutoMemoryProjectInfoName);
+  try {
+    const existing = await fs.readFile(filePath, "utf8");
+    const parsed: Partial<ProjectInfoFile> = JSON.parse(existing);
+    if (parsed.repoKey === repoKey && parsed.repoPath === repoRoot) {
+      return;
+    }
+  } catch {
+    // Missing or unreadable file — fall through to writing a fresh copy.
+  }
+
+  const info: ProjectInfoFile = { repoKey, repoPath: repoRoot };
+  await fs.mkdir(projectRoot, { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(info, null, 2)}\n`);
 }
 
 async function scanAutoMemoryManifest(


### PR DESCRIPTION
## Summary
- Writes a minimal `{ repoKey, repoPath }` sidecar at `~/.pochi/projects/<repoKey>/project.json` so an obfuscated project directory can be mapped back to its source repository without scanning memory or transcript contents.
- Added shared constant `AutoMemoryProjectInfoName = "project.json"` in `@getpochi/common` and re-exported it from the package's base barrel.
- `AutoMemoryManager.readContext` now writes the sidecar alongside the existing `memory/` and `transcripts/` setup, only rewriting when `repoKey` / `repoPath` actually change (e.g. a relocated repo) so steady-state turns don't churn the disk.

## Motivation
The on-disk project directory under `~/.pochi/projects/` is a `<basename>-<sha256[:10]>` slug that's intentionally not reversible. Users browsing the directory had no easy way to tell which entry belonged to which repo. A tiny JSON sidecar gives a stable, human-readable mapping for both manual inspection and future tooling.

## Test plan
- [x] `bun run test` in `packages/vscode` — 161 passing (added 2 new mocha tests under "AutoMemoryManager project info file" covering the happy path and the no-op-when-unchanged path; tests use `proxyquire.noCallThru()` to swap `node:os.homedir` because VS Code's extension host marks the descriptor as non-configurable).
- [x] `bun tsc` — 12/12 successful.
- [x] `bun fix` — no fixes needed.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8c6959244f0247a4abfe58d478786df4)