### PR TITLE
refactor(vscode-webui): simplify browser agent settings layout

### DIFF
--- a/packages/vscode-webui/src/routes/browser-agent-settings.tsx
+++ b/packages/vscode-webui/src/routes/browser-agent-settings.tsx
@@ -128,7 +128,7 @@ export const BrowserSettingsSection: React.FC = () => {
       </SettingsSection>
 
       <SettingsSection title={t("browserAgentSettings.recordingSection")}>
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-4">
           <label
             htmlFor="browser-agent-recording-enabled"
             className="flex min-h-9 items-center gap-3 font-medium text-muted-foreground text-sm"
@@ -146,7 +146,7 @@ export const BrowserSettingsSection: React.FC = () => {
             />
             <span>{t("browserAgentSettings.enableRecording")}</span>
           </label>
-          <SettingsRow label={t("browserAgentSettings.recordingSize")} stacked>
+          <SettingsRow label={t("browserAgentSettings.recordingSize")}>
             <RecordingSizeSelect
               value={settings.recording.recordingSize}
               onChange={(recordingSize) =>
@@ -182,19 +182,12 @@ function SettingsSection({
 function SettingsRow({
   label,
   children,
-  stacked,
 }: {
   label: string;
   children: React.ReactNode;
-  stacked?: boolean;
 }) {
   return (
-    <div
-      className={cn(
-        "grid gap-1.5",
-        !stacked && "md:grid-cols-[160px_minmax(0,1fr)] md:items-center",
-      )}
-    >
+    <div className="grid gap-1.5">
       <span className="font-medium text-muted-foreground text-sm">{label}</span>
       <div className="min-w-0">{children}</div>
     </div>


### PR DESCRIPTION
## Summary
- Simplify the layout of `BrowserSettingsSection` and `SettingsRow`.
- Remove the `stacked` property from `SettingsRow` and use a clean, consistent single-column grid layout for form inputs.

<img width="800" alt="d85a0ef4ae9c5bf1d10ffdadc11c2900" src="https://github.com/user-attachments/assets/07eec06b-4658-4dba-bf22-09f92859f887" />

## Test plan
- Verify that Browser Agent settings render correctly in the WebUI.
- Check that the recording options and size select are properly aligned and look clean.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5fe5844d96c1485d8ec7b14bbaf0e418)