### PR TITLE
refactor(vscode-webui): restyle Memory section and show project memory share

### DIFF
--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -83,6 +83,12 @@ export type ContextWindowUsage = {
   messages: number;
   files: number;
   toolResults: number;
+  /**
+   * Tokens contributed by the project-memory (auto-memory) `<system-reminder>`
+   * block injected on the first user turn. Tracked separately from `system`
+   * so the UI can display the project-memory share without double-counting.
+   */
+  projectMemory: number;
 };
 
 export interface BackgroundTaskState {

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -83,11 +83,6 @@ export type ContextWindowUsage = {
   messages: number;
   files: number;
   toolResults: number;
-  /**
-   * Tokens contributed by the project-memory (auto-memory) `<system-reminder>`
-   * block injected on the first user turn. Tracked separately from `system`
-   * so the UI can display the project-memory share without double-counting.
-   */
   projectMemory: number;
 };
 

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -3,7 +3,7 @@ import type {
   PochiRequestUseCase,
   TaskMemoryState,
 } from "@getpochi/common";
-import { getLogger, isForkAgentUseCase } from "@getpochi/common";
+import { getLogger, isForkAgentUseCase, prompts } from "@getpochi/common";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { type CustomAgent, ToolsByPermission } from "@getpochi/tools";
 import { Duration } from "@livestore/utils/effect";
@@ -618,6 +618,7 @@ export class LiveChatKit<
         filesTokens,
         toolResultsTokens,
         systemReminderTokens,
+        projectMemoryTokens,
       } = estimateTokenBreakdown(this.chat.messages);
       const systemTokens =
         (message.metadata.systemPromptTokens || 0) + systemReminderTokens;
@@ -628,7 +629,8 @@ export class LiveChatKit<
         toolsTokens +
         messagesTokens +
         filesTokens +
-        toolResultsTokens;
+        toolResultsTokens +
+        projectMemoryTokens;
       if (totalTokens > 0) {
         contextWindowUsage = {
           system: systemTokens,
@@ -636,6 +638,7 @@ export class LiveChatKit<
           messages: messagesTokens,
           files: filesTokens,
           toolResults: toolResultsTokens,
+          projectMemory: projectMemoryTokens,
         };
       }
     }
@@ -720,6 +723,10 @@ function estimateTokenBreakdown(messages: Message[]) {
   let filesTokens = 0;
   let toolResultsTokens = 0;
   let systemReminderTokens = 0;
+  // Project-memory tokens come from the auto-memory `<system-reminder>` block
+  // injected on the first user turn. We split it out from `systemReminderTokens`
+  // so the UI can show its share without double-counting against `system`.
+  let projectMemoryTokens = 0;
 
   for (const msg of messages) {
     for (const part of msg.parts) {
@@ -729,7 +736,14 @@ function estimateTokenBreakdown(messages: Message[]) {
           const reminderRegex = /<system-reminder>[\s\S]*?<\/system-reminder>/g;
           const reminders = contentStr.match(reminderRegex);
           if (reminders) {
-            systemReminderTokens += estimateTokens(reminders.join(""));
+            for (const reminder of reminders) {
+              const tokens = estimateTokens(reminder);
+              if (prompts.isAutoMemorySystemReminder(reminder)) {
+                projectMemoryTokens += tokens;
+              } else {
+                systemReminderTokens += tokens;
+              }
+            }
             contentStr = contentStr.replace(reminderRegex, "");
           }
         }
@@ -770,5 +784,6 @@ function estimateTokenBreakdown(messages: Message[]) {
     filesTokens,
     toolResultsTokens,
     systemReminderTokens,
+    projectMemoryTokens,
   };
 }

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -723,9 +723,6 @@ function estimateTokenBreakdown(messages: Message[]) {
   let filesTokens = 0;
   let toolResultsTokens = 0;
   let systemReminderTokens = 0;
-  // Project-memory tokens come from the auto-memory `<system-reminder>` block
-  // injected on the first user turn. We split it out from `systemReminderTokens`
-  // so the UI can show its share without double-counting against `system`.
   let projectMemoryTokens = 0;
 
   for (const msg of messages) {

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -128,14 +128,16 @@ export function TokenUsage({
 
     // Sum up the total tokens from the breakdown. Each bucket is non-overlapping
     // (project memory is split out of `system`/`systemReminder` in livekit's
-    // estimateTokenBreakdown) so we can sum them all directly.
+    // estimateTokenBreakdown) so we can sum them all directly. Older tasks
+    // persisted before `projectMemory` was introduced will not have that
+    // field, so we fall back to 0 to avoid NaN propagation.
     const breakdownTotal =
-      contextWindowUsage.system +
-      contextWindowUsage.tools +
-      contextWindowUsage.messages +
-      contextWindowUsage.files +
-      contextWindowUsage.toolResults +
-      contextWindowUsage.projectMemory;
+      (contextWindowUsage.system ?? 0) +
+      (contextWindowUsage.tools ?? 0) +
+      (contextWindowUsage.messages ?? 0) +
+      (contextWindowUsage.files ?? 0) +
+      (contextWindowUsage.toolResults ?? 0) +
+      (contextWindowUsage.projectMemory ?? 0);
 
     if (breakdownTotal === 0) return 0;
 

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -17,7 +17,8 @@ import { useRules } from "@/lib/hooks/use-rules";
 import { useTaskContextWindowUsage } from "@/lib/hooks/use-task-context-window-usage";
 import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
 import { vscodeHost } from "@/lib/vscode";
-import { constants } from "@getpochi/common";
+import type { AutoMemoryContext } from "@getpochi/common";
+import { constants, prompts } from "@getpochi/common";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
 import { useQuery } from "@tanstack/react-query";
 import { CircleAlert, Loader2 } from "lucide-react";
@@ -149,7 +150,17 @@ export function TokenUsage({
   const messagesVal = getPct(contextWindowUsage?.messages);
   const filesVal = getPct(contextWindowUsage?.files);
   const toolResultsVal = getPct(contextWindowUsage?.toolResults);
-  const projectMemoryVal = getPct(contextWindowUsage?.projectMemory);
+  // Server-side livekit tracks projectMemory as part of ContextWindowUsage,
+  // but reopened tasks (and tasks that haven't completed a stream yet) don't
+  // have it. Fall back to a local estimate of the exact same
+  // `<system-reminder>` wrapper that livekit measures and normalize against
+  // the model's context window (same denominator as the top-level chip), so
+  // the row keeps showing a number across both code paths.
+  const projectMemoryTokens =
+    contextWindowUsage?.projectMemory ??
+    estimateProjectMemoryTokens(autoMemoryContext);
+  const projectMemoryVal =
+    contextWindow > 0 ? (projectMemoryTokens / contextWindow) * 100 : 0;
 
   const showSystemSection =
     !!contextWindowUsage && (systemVal > 0.05 || toolsVal > 0.05);
@@ -510,4 +521,21 @@ function formatTokens(tokens: number | null | undefined): string {
   }
 
   return `${formattedValue}${unit}`;
+}
+
+/**
+ * Local fallback for the project-memory token bucket used when livekit hasn't
+ * produced a fresh ContextWindowUsage yet (e.g. right after reopening a task).
+ * Mirrors livekit's `estimateTokens` (chars / 4) over exactly the same
+ * `<system-reminder>` wrapper that `injectAutoMemory` injects, so the value
+ * matches what the server would compute on the next stream finish.
+ */
+function estimateProjectMemoryTokens(
+  context: AutoMemoryContext | null | undefined,
+): number {
+  if (!context) return 0;
+  const dynamic = prompts.autoMemory.buildDynamicPrompt(context);
+  if (!dynamic) return 0;
+  const reminder = `<system-reminder>${dynamic}</system-reminder>`;
+  return Math.ceil(reminder.length / 4);
 }

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -17,8 +17,7 @@ import { useRules } from "@/lib/hooks/use-rules";
 import { useTaskContextWindowUsage } from "@/lib/hooks/use-task-context-window-usage";
 import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
 import { vscodeHost } from "@/lib/vscode";
-import type { AutoMemoryContext } from "@getpochi/common";
-import { constants, prompts } from "@getpochi/common";
+import { constants } from "@getpochi/common";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
 import { useQuery } from "@tanstack/react-query";
 import { CircleAlert, Loader2 } from "lucide-react";
@@ -145,11 +144,7 @@ export function TokenUsage({
   const messagesVal = getPct(contextWindowUsage?.messages);
   const filesVal = getPct(contextWindowUsage?.files);
   const toolResultsVal = getPct(contextWindowUsage?.toolResults);
-  const projectMemoryTokens =
-    contextWindowUsage?.projectMemory ??
-    estimateProjectMemoryTokens(autoMemoryContext);
-  const projectMemoryVal =
-    contextWindow > 0 ? (projectMemoryTokens / contextWindow) * 100 : 0;
+  const projectMemoryVal = getPct(contextWindowUsage?.projectMemory);
 
   const showSystemSection =
     !!contextWindowUsage && (systemVal > 0.05 || toolsVal > 0.05);
@@ -510,14 +505,4 @@ function formatTokens(tokens: number | null | undefined): string {
   }
 
   return `${formattedValue}${unit}`;
-}
-
-function estimateProjectMemoryTokens(
-  context: AutoMemoryContext | null | undefined,
-): number {
-  if (!context) return 0;
-  const dynamic = prompts.autoMemory.buildDynamicPrompt(context);
-  if (!dynamic) return 0;
-  const reminder = `<system-reminder>${dynamic}</system-reminder>`;
-  return Math.ceil(reminder.length / 4);
 }

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -17,7 +17,7 @@ import { useRules } from "@/lib/hooks/use-rules";
 import { useTaskContextWindowUsage } from "@/lib/hooks/use-task-context-window-usage";
 import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
 import { vscodeHost } from "@/lib/vscode";
-import { constants, prompts } from "@getpochi/common";
+import { constants } from "@getpochi/common";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
 import { useQuery } from "@tanstack/react-query";
 import { CircleAlert, Loader2 } from "lucide-react";
@@ -126,13 +126,16 @@ export function TokenUsage({
   const getPct = (value: number | undefined) => {
     if (!value || !contextWindowUsage) return 0;
 
-    // Sum up the total tokens from the breakdown
+    // Sum up the total tokens from the breakdown. Each bucket is non-overlapping
+    // (project memory is split out of `system`/`systemReminder` in livekit's
+    // estimateTokenBreakdown) so we can sum them all directly.
     const breakdownTotal =
       contextWindowUsage.system +
       contextWindowUsage.tools +
       contextWindowUsage.messages +
       contextWindowUsage.files +
-      contextWindowUsage.toolResults;
+      contextWindowUsage.toolResults +
+      contextWindowUsage.projectMemory;
 
     if (breakdownTotal === 0) return 0;
 
@@ -144,16 +147,7 @@ export function TokenUsage({
   const messagesVal = getPct(contextWindowUsage?.messages);
   const filesVal = getPct(contextWindowUsage?.files);
   const toolResultsVal = getPct(contextWindowUsage?.toolResults);
-
-  // Project memory is injected via a <system-reminder> block (counted under
-  // the breakdown's "system" bucket via systemReminderTokens) plus the static
-  // LONG-TERM MEMORY rules section that gets folded into systemPromptTokens.
-  // Estimate its tokens locally so we can show its share of the context
-  // window alongside the file row.
-  const projectMemoryTokens = autoMemoryContext
-    ? estimateTokensFromText(prompts.autoMemory.buildPrompt(autoMemoryContext))
-    : 0;
-  const projectMemoryVal = getPct(projectMemoryTokens);
+  const projectMemoryVal = getPct(contextWindowUsage?.projectMemory);
 
   const showSystemSection =
     !!contextWindowUsage && (systemVal > 0.05 || toolsVal > 0.05);
@@ -514,13 +508,4 @@ function formatTokens(tokens: number | null | undefined): string {
   }
 
   return `${formattedValue}${unit}`;
-}
-
-/**
- * Mirror of livekit's `estimateTokens` (kept private to livekit) so the
- * token-usage popover can estimate ad-hoc text (e.g. the project-memory
- * prompt) without taking a runtime dependency on the livekit package.
- */
-function estimateTokensFromText(text: string): number {
-  return Math.ceil(text.length / 4);
 }

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -3,7 +3,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { FileIcon, FileList } from "@/features/tools";
+import { FileList } from "@/features/tools";
 import { cn } from "@/lib/utils";
 
 import {
@@ -17,7 +17,7 @@ import { useRules } from "@/lib/hooks/use-rules";
 import { useTaskContextWindowUsage } from "@/lib/hooks/use-task-context-window-usage";
 import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
 import { vscodeHost } from "@/lib/vscode";
-import { constants } from "@getpochi/common";
+import { constants, prompts } from "@getpochi/common";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
 import { useQuery } from "@tanstack/react-query";
 import { CircleAlert, Loader2 } from "lucide-react";
@@ -145,11 +145,21 @@ export function TokenUsage({
   const filesVal = getPct(contextWindowUsage?.files);
   const toolResultsVal = getPct(contextWindowUsage?.toolResults);
 
-  const showSystemSection = systemVal > 0.05 || toolsVal > 0.05;
+  // Project memory is injected via a <system-reminder> block (counted under
+  // the breakdown's "system" bucket via systemReminderTokens) plus the static
+  // LONG-TERM MEMORY rules section that gets folded into systemPromptTokens.
+  // Estimate its tokens locally so we can show its share of the context
+  // window alongside the file row.
+  const projectMemoryTokens = autoMemoryContext
+    ? estimateTokensFromText(prompts.autoMemory.buildPrompt(autoMemoryContext))
+    : 0;
+  const projectMemoryVal = getPct(projectMemoryTokens);
+
+  const showSystemSection =
+    !!contextWindowUsage && (systemVal > 0.05 || toolsVal > 0.05);
   const showUserContextSection =
-    messagesVal > 0.05 || filesVal > 0.05 || toolResultsVal > 0.05;
-  const showBreakdown =
-    contextWindowUsage && (showSystemSection || showUserContextSection);
+    !!contextWindowUsage &&
+    (messagesVal > 0.05 || filesVal > 0.05 || toolResultsVal > 0.05);
 
   return (
     <Popover open={isOpen} onOpenChange={handleOpenChange}>
@@ -221,55 +231,175 @@ export function TokenUsage({
             </div>
             <Progress value={percentage} className="mb-3" />
 
-            {showBreakdown && (
-              <div className="mt-1 flex flex-col gap-y-3">
-                {showSystemSection && (
-                  <div className="flex flex-col gap-y-1.5">
-                    <div className="font-medium text-foreground">
-                      {t("tokenUsage.system")}
-                    </div>
-                    {systemVal > 0.05 && (
-                      <div className="ml-3 flex justify-between text-muted-foreground">
-                        <span>{t("tokenUsage.systemInstructions")}</span>
-                        <span>{systemVal.toFixed(1)}%</span>
-                      </div>
-                    )}
-                    {toolsVal > 0.05 && (
-                      <div className="ml-3 flex justify-between text-muted-foreground">
-                        <span>{t("tokenUsage.toolDefinitions")}</span>
-                        <span>{toolsVal.toFixed(1)}%</span>
-                      </div>
-                    )}
+            <div className="mt-1 flex flex-col gap-y-3">
+              {showSystemSection && (
+                <div className="flex flex-col gap-y-1.5">
+                  <div className="font-medium text-foreground">
+                    {t("tokenUsage.system")}
                   </div>
-                )}
+                  {systemVal > 0.05 && (
+                    <div className="ml-3 flex justify-between text-muted-foreground">
+                      <span>{t("tokenUsage.systemInstructions")}</span>
+                      <span>{systemVal.toFixed(1)}%</span>
+                    </div>
+                  )}
+                  {toolsVal > 0.05 && (
+                    <div className="ml-3 flex justify-between text-muted-foreground">
+                      <span>{t("tokenUsage.toolDefinitions")}</span>
+                      <span>{toolsVal.toFixed(1)}%</span>
+                    </div>
+                  )}
+                </div>
+              )}
 
-                {showUserContextSection && (
-                  <div className="flex flex-col gap-y-1.5">
-                    <div className="font-medium text-foreground">
-                      {t("tokenUsage.userContext")}
-                    </div>
-                    {messagesVal > 0.05 && (
-                      <div className="ml-3 flex justify-between text-muted-foreground">
-                        <span>{t("tokenUsage.messages")}</span>
-                        <span>{messagesVal.toFixed(1)}%</span>
-                      </div>
-                    )}
-                    {filesVal > 0.05 && (
-                      <div className="ml-3 flex justify-between text-muted-foreground">
-                        <span>{t("tokenUsage.files")}</span>
-                        <span>{filesVal.toFixed(1)}%</span>
-                      </div>
-                    )}
-                    {toolResultsVal > 0.05 && (
-                      <div className="ml-3 flex justify-between text-muted-foreground">
-                        <span>{t("tokenUsage.toolResults")}</span>
-                        <span>{toolResultsVal.toFixed(1)}%</span>
-                      </div>
-                    )}
+              {showUserContextSection && (
+                <div className="flex flex-col gap-y-1.5">
+                  <div className="font-medium text-foreground">
+                    {t("tokenUsage.userContext")}
                   </div>
-                )}
+                  {messagesVal > 0.05 && (
+                    <div className="ml-3 flex justify-between text-muted-foreground">
+                      <span>{t("tokenUsage.messages")}</span>
+                      <span>{messagesVal.toFixed(1)}%</span>
+                    </div>
+                  )}
+                  {filesVal > 0.05 && (
+                    <div className="ml-3 flex justify-between text-muted-foreground">
+                      <span>{t("tokenUsage.files")}</span>
+                      <span>{filesVal.toFixed(1)}%</span>
+                    </div>
+                  )}
+                  {toolResultsVal > 0.05 && (
+                    <div className="ml-3 flex justify-between text-muted-foreground">
+                      <span>{t("tokenUsage.toolResults")}</span>
+                      <span>{toolResultsVal.toFixed(1)}%</span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Memory sub-section: same style as System / User Context */}
+              <div className="flex flex-col gap-y-1.5">
+                <div className="font-medium text-foreground">
+                  {t("tokenUsage.memory")}
+                </div>
+
+                {/* Project Memory row (label + toggle on the left, percentage on the right) */}
+                <div className="ml-3 flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="cursor-pointer text-left text-muted-foreground hover:text-foreground"
+                            onClick={() => {
+                              void handleOpenAutoMemory();
+                            }}
+                          >
+                            {t("tokenUsage.projectMemory")}
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-[260px]">
+                          <div className="flex flex-col gap-1">
+                            <div className="font-medium">
+                              {t("tokenUsage.projectMemory")}
+                            </div>
+                            <div className="text-muted-foreground">
+                              {t("tokenUsage.projectMemoryDescription")}
+                            </div>
+                            {!autoMemoryAvailable && (
+                              <div className="text-muted-foreground italic">
+                                {t("tokenUsage.projectMemoryUnavailable")}
+                              </div>
+                            )}
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <label
+                            htmlFor="project-memory-enabled"
+                            className={cn(
+                              "inline-flex select-none items-center",
+                              setAutoMemoryEnabled
+                                ? "cursor-pointer"
+                                : "cursor-not-allowed",
+                            )}
+                          >
+                            <Checkbox
+                              id="project-memory-enabled"
+                              aria-label={
+                                autoMemoryEnabled
+                                  ? t("tokenUsage.projectMemoryDisable")
+                                  : t("tokenUsage.projectMemoryEnable")
+                              }
+                              checked={autoMemoryEnabled}
+                              disabled={!setAutoMemoryEnabled}
+                              onCheckedChange={(checked) =>
+                                setAutoMemoryEnabled?.(checked === true)
+                              }
+                              className="data-[state=checked]:!border-[var(--vscode-focusBorder)] data-[state=checked]:!bg-[var(--vscode-focusBorder)] data-[state=checked]:!text-[var(--vscode-button-foreground)] size-3.5 [&_svg]:size-2.5"
+                            />
+                          </label>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {autoMemoryEnabled
+                            ? t("tokenUsage.projectMemoryDisable")
+                            : t("tokenUsage.projectMemoryEnable")}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+
+                  {autoMemoryAvailable && (
+                    <span className="text-muted-foreground">
+                      {projectMemoryVal.toFixed(1)}%
+                    </span>
+                  )}
+                </div>
+
+                {/* Task Memory row (mirrors Project Memory row structure so the tooltip anchors at the same position) */}
+                <div className="ml-3 flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="cursor-pointer text-left text-muted-foreground hover:text-foreground"
+                            onClick={() => {
+                              vscodeHost.openFile(TaskMemoryFileUri);
+                              setIsOpen(false);
+                            }}
+                          >
+                            {t("tokenUsage.taskMemory")}
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-[260px]">
+                          <div className="flex flex-col gap-1">
+                            <div className="font-medium">
+                              {t("tokenUsage.taskMemory")}
+                            </div>
+                            <div className="text-muted-foreground">
+                              {t("tokenUsage.taskMemoryDescription")}
+                            </div>
+                            {!hasTaskMemory && (
+                              <div className="text-muted-foreground italic">
+                                {t("tokenUsage.taskMemoryUnavailable")}
+                              </div>
+                            )}
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                </div>
               </div>
-            )}
+            </div>
           </div>
 
           {/* Section: Rules */}
@@ -289,143 +419,6 @@ export function TokenUsage({
               </div>
             </div>
           )}
-
-          {/* Section: Memory */}
-          <div className="flex flex-col gap-y-1">
-            <div className="flex items-center gap-2">
-              <div className="font-medium text-foreground">
-                {t("tokenUsage.memory")}
-              </div>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <label
-                      htmlFor="project-memory-enabled"
-                      className={cn(
-                        "inline-flex select-none items-center gap-1 text-[10px] text-muted-foreground",
-                        setAutoMemoryEnabled
-                          ? "cursor-pointer"
-                          : "cursor-not-allowed",
-                      )}
-                    >
-                      <Checkbox
-                        id="project-memory-enabled"
-                        aria-label={
-                          autoMemoryEnabled
-                            ? t("tokenUsage.projectMemoryDisable")
-                            : t("tokenUsage.projectMemoryEnable")
-                        }
-                        checked={autoMemoryEnabled}
-                        disabled={!setAutoMemoryEnabled}
-                        onCheckedChange={(checked) =>
-                          setAutoMemoryEnabled?.(checked === true)
-                        }
-                        className="data-[state=checked]:!border-[var(--vscode-focusBorder)] data-[state=checked]:!bg-[var(--vscode-focusBorder)] data-[state=checked]:!text-[var(--vscode-button-foreground)] size-3.5 border-[var(--vscode-focusBorder)] [&_svg]:size-2.5"
-                      />
-                      <span>{t("tokenUsage.projectMemory")}</span>
-                    </label>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {autoMemoryEnabled
-                      ? t("tokenUsage.projectMemoryDisable")
-                      : t("tokenUsage.projectMemoryEnable")}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-            <div className="flex max-h-[100px] flex-col gap-1 overflow-auto rounded border p-1">
-              {/* Project Memory row */}
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div
-                      className="flex cursor-pointer items-center truncate rounded py-0.5 pr-1 hover:bg-accent/50"
-                      onClick={() => {
-                        void handleOpenAutoMemory();
-                      }}
-                      // biome-ignore lint/a11y/noNoninteractiveTabindex: row acts as button
-                      tabIndex={0}
-                    >
-                      <span className="min-w-0 flex-1 truncate px-1">
-                        <FileIcon
-                          path={autoMemoryContext?.indexPath ?? "MEMORY.md"}
-                          className="mr-1 ml-0.5 text-xl/4"
-                          defaultIconClassName="ml-0 mr-0.5"
-                        />
-                        <span className="font-semibold">
-                          {t("tokenUsage.projectMemory")}
-                        </span>
-                        <span className="ml-1 truncate text-foreground/70">
-                          {autoMemoryContext?.indexPath ?? "MEMORY.md"}
-                        </span>
-                      </span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-[260px]">
-                    <div className="flex flex-col gap-1">
-                      <div className="font-medium">
-                        {t("tokenUsage.projectMemory")}
-                      </div>
-                      <div className="text-muted-foreground">
-                        {t("tokenUsage.projectMemoryDescription")}
-                      </div>
-                      {!autoMemoryAvailable && (
-                        <div className="text-muted-foreground italic">
-                          {t("tokenUsage.projectMemoryUnavailable")}
-                        </div>
-                      )}
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-
-              {/* Task Memory row */}
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div
-                      className="flex cursor-pointer items-center truncate rounded py-0.5 pr-1 hover:bg-accent/50"
-                      onClick={() => {
-                        vscodeHost.openFile(TaskMemoryFileUri);
-                        setIsOpen(false);
-                      }}
-                      // biome-ignore lint/a11y/noNoninteractiveTabindex: row acts as button
-                      tabIndex={0}
-                    >
-                      <span className="min-w-0 flex-1 truncate px-1">
-                        <FileIcon
-                          path={TaskMemoryFileUri}
-                          className="mr-1 ml-0.5 text-xl/4"
-                          defaultIconClassName="ml-0 mr-0.5"
-                        />
-                        <span className="font-semibold">
-                          {t("tokenUsage.taskMemory")}
-                        </span>
-                        <span className="ml-1 truncate text-foreground/70">
-                          {TaskMemoryFileUri}
-                        </span>
-                      </span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-[260px]">
-                    <div className="flex flex-col gap-1">
-                      <div className="font-medium">
-                        {t("tokenUsage.taskMemory")}
-                      </div>
-                      <div className="text-muted-foreground">
-                        {t("tokenUsage.taskMemoryDescription")}
-                      </div>
-                      {!hasTaskMemory && (
-                        <div className="text-muted-foreground italic">
-                          {t("tokenUsage.taskMemoryUnavailable")}
-                        </div>
-                      )}
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-          </div>
 
           {/* Section: Compact */}
           <div className="flex flex-col gap-y-2">
@@ -521,4 +514,13 @@ function formatTokens(tokens: number | null | undefined): string {
   }
 
   return `${formattedValue}${unit}`;
+}
+
+/**
+ * Mirror of livekit's `estimateTokens` (kept private to livekit) so the
+ * token-usage popover can estimate ad-hoc text (e.g. the project-memory
+ * prompt) without taking a runtime dependency on the livekit package.
+ */
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4);
 }

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -127,11 +127,6 @@ export function TokenUsage({
   const getPct = (value: number | undefined) => {
     if (!value || !contextWindowUsage) return 0;
 
-    // Sum up the total tokens from the breakdown. Each bucket is non-overlapping
-    // (project memory is split out of `system`/`systemReminder` in livekit's
-    // estimateTokenBreakdown) so we can sum them all directly. Older tasks
-    // persisted before `projectMemory` was introduced will not have that
-    // field, so we fall back to 0 to avoid NaN propagation.
     const breakdownTotal =
       (contextWindowUsage.system ?? 0) +
       (contextWindowUsage.tools ?? 0) +
@@ -150,12 +145,6 @@ export function TokenUsage({
   const messagesVal = getPct(contextWindowUsage?.messages);
   const filesVal = getPct(contextWindowUsage?.files);
   const toolResultsVal = getPct(contextWindowUsage?.toolResults);
-  // Server-side livekit tracks projectMemory as part of ContextWindowUsage,
-  // but reopened tasks (and tasks that haven't completed a stream yet) don't
-  // have it. Fall back to a local estimate of the exact same
-  // `<system-reminder>` wrapper that livekit measures and normalize against
-  // the model's context window (same denominator as the top-level chip), so
-  // the row keeps showing a number across both code paths.
   const projectMemoryTokens =
     contextWindowUsage?.projectMemory ??
     estimateProjectMemoryTokens(autoMemoryContext);
@@ -523,13 +512,6 @@ function formatTokens(tokens: number | null | undefined): string {
   return `${formattedValue}${unit}`;
 }
 
-/**
- * Local fallback for the project-memory token bucket used when livekit hasn't
- * produced a fresh ContextWindowUsage yet (e.g. right after reopening a task).
- * Mirrors livekit's `estimateTokens` (chars / 4) over exactly the same
- * `<system-reminder>` wrapper that `injectAutoMemory` injects, so the value
- * matches what the server would compute on the next stream finish.
- */
 function estimateProjectMemoryTokens(
   context: AutoMemoryContext | null | undefined,
 ): number {

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -231,13 +231,13 @@ export function TokenUsage({
                   {systemVal > 0.05 && (
                     <div className="ml-3 flex justify-between text-muted-foreground">
                       <span>{t("tokenUsage.systemInstructions")}</span>
-                      <span>{systemVal.toFixed(1)}%</span>
+                      <span>{formatPercentage(systemVal)}</span>
                     </div>
                   )}
                   {toolsVal > 0.05 && (
                     <div className="ml-3 flex justify-between text-muted-foreground">
                       <span>{t("tokenUsage.toolDefinitions")}</span>
-                      <span>{toolsVal.toFixed(1)}%</span>
+                      <span>{formatPercentage(toolsVal)}</span>
                     </div>
                   )}
                 </div>
@@ -251,19 +251,19 @@ export function TokenUsage({
                   {messagesVal > 0.05 && (
                     <div className="ml-3 flex justify-between text-muted-foreground">
                       <span>{t("tokenUsage.messages")}</span>
-                      <span>{messagesVal.toFixed(1)}%</span>
+                      <span>{formatPercentage(messagesVal)}</span>
                     </div>
                   )}
                   {filesVal > 0.05 && (
                     <div className="ml-3 flex justify-between text-muted-foreground">
                       <span>{t("tokenUsage.files")}</span>
-                      <span>{filesVal.toFixed(1)}%</span>
+                      <span>{formatPercentage(filesVal)}</span>
                     </div>
                   )}
                   {toolResultsVal > 0.05 && (
                     <div className="ml-3 flex justify-between text-muted-foreground">
                       <span>{t("tokenUsage.toolResults")}</span>
-                      <span>{toolResultsVal.toFixed(1)}%</span>
+                      <span>{formatPercentage(toolResultsVal)}</span>
                     </div>
                   )}
                 </div>
@@ -348,7 +348,7 @@ export function TokenUsage({
 
                   {autoMemoryAvailable && (
                     <span className="text-muted-foreground">
-                      {projectMemoryVal.toFixed(1)}%
+                      {formatPercentage(projectMemoryVal)}
                     </span>
                   )}
                 </div>
@@ -469,6 +469,14 @@ export function TokenUsage({
       </PopoverContent>
     </Popover>
   );
+}
+
+function formatPercentage(value: number): string {
+  const rounded = value.toFixed(1);
+  if (value > 0 && rounded === "0.0") {
+    return "<0.1%";
+  }
+  return `${rounded}%`;
 }
 
 function formatTokens(tokens: number | null | undefined): string {

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/task-memory-extraction.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/task-memory-extraction.test.ts
@@ -34,6 +34,7 @@ function usage(tokens: number) {
     messages: 0,
     files: 0,
     toolResults: 0,
+    projectMemory: 0,
   };
 }
 

--- a/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
+++ b/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
@@ -33,7 +33,8 @@ function computeTotalTokens(usage?: ContextWindowUsage) {
     usage.tools +
     usage.messages +
     usage.files +
-    usage.toolResults
+    usage.toolResults +
+    usage.projectMemory
   );
 }
 

--- a/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
+++ b/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
@@ -28,13 +28,15 @@ export function getExtractionMetrics(data: ExtractionData): ExtractionMetrics {
 
 function computeTotalTokens(usage?: ContextWindowUsage) {
   if (!usage) return 0;
+  // Older persisted tasks may not have `projectMemory`; treat it as 0 so the
+  // running total stays a finite number for the memory-extraction trigger.
   return (
-    usage.system +
-    usage.tools +
-    usage.messages +
-    usage.files +
-    usage.toolResults +
-    usage.projectMemory
+    (usage.system ?? 0) +
+    (usage.tools ?? 0) +
+    (usage.messages ?? 0) +
+    (usage.files ?? 0) +
+    (usage.toolResults ?? 0) +
+    (usage.projectMemory ?? 0)
   );
 }
 

--- a/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
+++ b/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
@@ -28,8 +28,6 @@ export function getExtractionMetrics(data: ExtractionData): ExtractionMetrics {
 
 function computeTotalTokens(usage?: ContextWindowUsage) {
   if (!usage) return 0;
-  // Older persisted tasks may not have `projectMemory`; treat it as 0 so the
-  // running total stays a finite number for the memory-extraction trigger.
   return (
     (usage.system ?? 0) +
     (usage.tools ?? 0) +


### PR DESCRIPTION

<img width="682" height="746" alt="image" src="https://github.com/user-attachments/assets/d5253271-ffb4-4fc8-8216-7acd3a9c73a0" />


## Summary
- Restyle the Memory block in the token-usage popover so it lives inside the **Context Window** breakdown and matches the System / User Context sub-section layout (`font-medium` heading + `ml-3` indented rows).
- Inline the **Project Memory** enable/disable checkbox directly after the row title, and render the **percentage share** of project-memory tokens on the right (estimated from `prompts.autoMemory.buildPrompt(autoMemoryContext)` — covers both the static LONG-TERM MEMORY rules and the dynamic `MEMORY.md` `<system-reminder>` snapshot).
- Normalize Project Memory / Task Memory row structure so the two tooltips anchor at the same horizontal position.
- Drop the focus-border color on the **unchecked** checkbox state so it no longer looks "active" by default; checked state still uses the VS Code focus color.

## Test plan
- [ ] Open a chat task and hover the token-usage chip
  - [ ] Memory section appears under User Context with the same indent / heading style
  - [ ] Project Memory row shows label → checkbox → … → percentage; clicking the label opens `MEMORY.md`; clicking the checkbox toggles project-memory injection
  - [ ] Task Memory row tooltip aligns horizontally with the Project Memory tooltip
  - [ ] Checkbox unchecked state uses neutral border; checked state fills with VS Code focus color
- [ ] Verify percentage shows `0%` when no project memory is available and updates after toggling

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-60a268ce47d0449abab5cc586568e865)