### PR TITLE
fix(vscode-webui): improve FileList virtualization and layout stability

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/__tests__/file-list.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/file-list.test.ts
@@ -1,5 +1,15 @@
+import { render } from "@testing-library/react";
+import { createElement } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { getVirtualFileListRange } from "../file-list";
+import { FileList, getVirtualFileListRange } from "../file-list";
+
+vi.mock("@/components/theme-provider", () => ({
+  useTheme: () => ({ theme: "dark" }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
 
 vi.mock("@/lib/vscode", () => ({
   vscodeHost: {
@@ -38,5 +48,94 @@ describe("getVirtualFileListRange", () => {
     expect(result.endIndex).toBe(209);
     expect(result.offsetTop).toBe(4704);
     expect(result.totalHeight).toBe(12000);
+  });
+});
+
+describe("FileList", () => {
+  const makeMatches = (count: number) =>
+    Array.from({ length: count }, (_, index) => ({
+      file: `packages/vscode-webui/src/example-${index}.tsx`,
+      line: index + 1,
+      context: `file list row ${index}`,
+    }));
+
+  it("keeps the pre-virtualization scroll area styling", () => {
+    const { container } = render(
+      createElement(FileList, {
+        matches: [
+          {
+            file: "packages/vscode-webui/src/features/tools/components/file-list.tsx",
+            line: 12,
+            context: "file list style contract",
+          },
+        ],
+      }),
+    );
+
+    const scrollArea = container.querySelector('[data-slot="scroll-area"]');
+    expect(scrollArea).not.toBeNull();
+    expect(scrollArea?.className.split(/\s+/)).toEqual(
+      expect.arrayContaining([
+        "flex",
+        "max-h-[100px]",
+        "flex-col",
+        "gap-1",
+        "rounded",
+        "border",
+        "p-1",
+      ]),
+    );
+  });
+
+  it("keeps rows at their pre-virtualization natural height", () => {
+    const { container } = render(
+      createElement(FileList, {
+        matches: [
+          {
+            file: "packages/vscode-webui/src/features/tools/components/file-list.tsx",
+            line: 12,
+            context: "file list row style contract",
+          },
+        ],
+      }),
+    );
+
+    const row = container.querySelector(
+      '[title="file list row style contract"]',
+    );
+    expect(row).not.toBeNull();
+    const rowClasses = row?.className.split(/\s+/);
+    expect(rowClasses).toEqual(
+      expect.arrayContaining([
+        "cursor-pointer",
+        "truncate",
+        "rounded",
+        "py-0.5",
+        "hover:bg-accent/50",
+      ]),
+    );
+    expect(rowClasses).not.toContain("h-6");
+  });
+
+  it("renders lists at the virtualization threshold without a virtual height spacer", () => {
+    const { container } = render(
+      createElement(FileList, {
+        matches: makeMatches(50),
+      }),
+    );
+
+    expect(container.querySelector('div.relative[style^="height:"]')).toBeNull();
+  });
+
+  it("virtualizes lists above the virtualization threshold", () => {
+    const { container } = render(
+      createElement(FileList, {
+        matches: makeMatches(51),
+      }),
+    );
+
+    expect(
+      container.querySelector('div.relative[style^="height:"]'),
+    ).not.toBeNull();
   });
 });

--- a/packages/vscode-webui/src/features/tools/components/file-list.tsx
+++ b/packages/vscode-webui/src/features/tools/components/file-list.tsx
@@ -2,7 +2,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { getBaseName, isFolder } from "@/lib/utils/file";
 import { vscodeHost } from "@/lib/vscode";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { FileIcon } from "./file-icon";
 
 export interface FileListMatch {
@@ -12,9 +12,10 @@ export interface FileListMatch {
   label?: string;
 }
 
-const FileListRowHeight = 24;
+const FileListDefaultRowHeight = 24;
 const FileListViewportHeight = 100;
 const FileListOverscan = 8;
+const FileListVirtualizationThreshold = 50;
 
 export function getVirtualFileListRange({
   itemCount,
@@ -57,6 +58,8 @@ export const FileList: React.FC<{
 }> = ({ matches, showBaseName = true }) => {
   const [activeIndex, setActiveIndex] = useState(-1);
   const viewportRef = useRef<HTMLDivElement | null>(null);
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const [rowHeight, setRowHeight] = useState(FileListDefaultRowHeight);
   const [scrollState, setScrollState] = useState({
     scrollTop: 0,
     viewportHeight: FileListViewportHeight,
@@ -88,31 +91,104 @@ export const FileList: React.FC<{
     };
   }, []);
 
+  useLayoutEffect(() => {
+    const row = rowRef.current;
+    if (!row) return;
+
+    const measuredRowHeight = row.getBoundingClientRect().height;
+    if (
+      measuredRowHeight > 0 &&
+      Math.abs(measuredRowHeight - rowHeight) > 0.5
+    ) {
+      setRowHeight(measuredRowHeight);
+    }
+  });
+
   const virtualRange = useMemo(
     () =>
       getVirtualFileListRange({
         itemCount: matches.length,
         scrollTop: scrollState.scrollTop,
         viewportHeight: scrollState.viewportHeight,
-        rowHeight: FileListRowHeight,
+        rowHeight,
         overscan: FileListOverscan,
       }),
-    [matches.length, scrollState],
+    [matches.length, scrollState, rowHeight],
   );
   const visibleMatches = matches.slice(
     virtualRange.startIndex,
     virtualRange.endIndex,
   );
+  const shouldVirtualize = matches.length > FileListVirtualizationThreshold;
 
   if (matches.length === 0) {
     return null;
   }
 
+  const renderMatch = (
+    match: FileListMatch,
+    index: number,
+    renderedIndex: number,
+  ) => (
+    <div
+      key={match.file + (match.line ?? "") + index}
+      ref={renderedIndex === 0 ? rowRef : undefined}
+      className={`cursor-pointer truncate rounded py-0.5 ${activeIndex === index ? "bg-accent" : "hover:bg-accent/50"}`}
+      title={match.context}
+      onClick={() => {
+        setActiveIndex(index);
+        vscodeHost.openFile(match.file, {
+          start: match.line,
+          preserveFocus: true,
+        });
+      }}
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: <explanation>
+      tabIndex={0}
+    >
+      <span
+        className={`truncate px-1 font-semibold ${activeIndex === index ? "text-accent-foreground" : "text-foreground"}`}
+      >
+        <FileIcon
+          path={match.file}
+          className="mr-1 ml-0.5 text-xl/4"
+          defaultIconClassName="ml-0 mr-0.5" // Default icon is larger than others
+          isDirectory={isFolder(match.file)}
+        />
+        {showBaseName && (
+          <>
+            {getBaseName(match.file)}
+            {match.line && (
+              <span
+                className={`truncate ${activeIndex === index ? "text-accent-foreground/70" : "text-foreground/70"}`}
+              >
+                :{match.line}
+              </span>
+            )}
+          </>
+        )}
+      </span>
+      <span
+        title={match.file}
+        className={cn(
+          activeIndex === index
+            ? showBaseName
+              ? "text-accent-foreground/70"
+              : "text-accent-foreground"
+            : showBaseName
+              ? "text-foreground/70"
+              : "text-foreground",
+        )}
+      >
+        {match.label ?? match.file}
+      </span>
+    </div>
+  );
+
   return (
     <ScrollArea
       ref={viewportRef}
-      className="rounded border"
-      viewportClassname="max-h-[100px] p-1"
+      className="flex max-h-[100px] flex-col gap-1 rounded border p-1"
+      viewportClassname={shouldVirtualize ? "max-h-[100px]" : undefined}
       onBlur={(e) => {
         if (e.currentTarget === e.relatedTarget) {
           return;
@@ -121,74 +197,26 @@ export const FileList: React.FC<{
       }}
       tabIndex={0}
     >
-      <div
-        className="relative"
-        style={{ height: `${virtualRange.totalHeight}px` }}
-      >
+      {!shouldVirtualize &&
+        matches.map((match, index) => renderMatch(match, index, index))}
+      {shouldVirtualize && (
         <div
-          style={{
-            transform: `translateY(${virtualRange.offsetTop}px)`,
-          }}
+          className="relative"
+          style={{ height: `${virtualRange.totalHeight}px` }}
         >
-          {visibleMatches.map((match, renderedIndex) => {
-            const index = virtualRange.startIndex + renderedIndex;
+          <div
+            style={{
+              transform: `translateY(${virtualRange.offsetTop}px)`,
+            }}
+          >
+            {visibleMatches.map((match, renderedIndex) => {
+              const index = virtualRange.startIndex + renderedIndex;
 
-            return (
-              <div
-                key={match.file + (match.line ?? "") + index}
-                className={`h-6 cursor-pointer truncate rounded py-0.5 ${activeIndex === index ? "bg-accent" : "hover:bg-accent/50"}`}
-                title={match.context}
-                onClick={() => {
-                  setActiveIndex(index);
-                  vscodeHost.openFile(match.file, {
-                    start: match.line,
-                    preserveFocus: true,
-                  });
-                }}
-                // biome-ignore lint/a11y/noNoninteractiveTabindex: <explanation>
-                tabIndex={0}
-              >
-                <span
-                  className={`truncate px-1 font-semibold ${activeIndex === index ? "text-accent-foreground" : "text-foreground"}`}
-                >
-                  <FileIcon
-                    path={match.file}
-                    className="mr-1 ml-0.5 text-xl/4"
-                    defaultIconClassName="ml-0 mr-0.5" // Default icon is larger than others
-                    isDirectory={isFolder(match.file)}
-                  />
-                  {showBaseName && (
-                    <>
-                      {getBaseName(match.file)}
-                      {match.line && (
-                        <span
-                          className={`truncate ${activeIndex === index ? "text-accent-foreground/70" : "text-foreground/70"}`}
-                        >
-                          :{match.line}
-                        </span>
-                      )}
-                    </>
-                  )}
-                </span>
-                <span
-                  title={match.file}
-                  className={cn(
-                    activeIndex === index
-                      ? showBaseName
-                        ? "text-accent-foreground/70"
-                        : "text-accent-foreground"
-                      : showBaseName
-                        ? "text-foreground/70"
-                        : "text-foreground",
-                  )}
-                >
-                  {match.label ?? match.file}
-                </span>
-              </div>
-            );
-          })}
+              return renderMatch(match, index, renderedIndex);
+            })}
+          </div>
         </div>
-      </div>
+      )}
     </ScrollArea>
   );
 };


### PR DESCRIPTION
- Only virtualize when item count > 50.
- Measure row height dynamically for accurate virtualization.
- Fix ScrollArea styling to maintain consistent layout.
- Add unit tests for FileList component.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e7ed3f28c8db40ec85a35257c9d4561e)