### PR TITLE
fix(vscode-webui): ensure renderWidget always has a CSP nonce for inline scripts

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts
@@ -315,6 +315,25 @@ describe("render widget utilities", () => {
     expect(iframeDocument).not.toContain("data:text/javascript");
   });
 
+  it("inlines the packaged renderer script with a local nonce when the parent page has none", () => {
+    const scriptSrc =
+      "https://livekit-cf.tabbyml.workers.dev/assets/renderer-entry-CmF2_IbD.js";
+    const iframeDocument = buildWidgetIframeDocument({
+      src: scriptSrc,
+      code: "console.log('share widget')",
+    });
+    const cspNonceMatch = iframeDocument.match(/script-src 'nonce-([^']+)'/);
+    const scriptNonceMatch = iframeDocument.match(/<script nonce="([^"]+)">/);
+
+    expect(cspNonceMatch?.[1]).toBeTruthy();
+    expect(scriptNonceMatch?.[1]).toBe(cspNonceMatch?.[1]);
+    expect(iframeDocument).toContain("console.log('share widget')</script>");
+    expect(iframeDocument).not.toContain(`src="${scriptSrc}"`);
+    expect(iframeDocument).not.toContain(
+      "script-src https://livekit-cf.tabbyml.workers.dev",
+    );
+  });
+
   it("uses one shared sanitizer policy for widget fragments", () => {
     expect(
       sanitizeWidgetFragment(

--- a/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/utils.ts
@@ -13,6 +13,7 @@ export const ChartJsCdnScriptSrc =
 export const ChartJsCdnOrigin = "https://cdn.jsdelivr.net";
 
 export const WidgetThemeStyleId = "pochi-widget-theme";
+const WidgetScriptNonceByteLength = 16;
 
 export type WidgetScript =
   | { type: "external"; src: string }
@@ -316,6 +317,9 @@ export function buildWidgetIframeDocument(
     typeof rendererScript === "string" ? undefined : rendererScript.code;
   const rendererScriptNonce =
     typeof rendererScript === "string" ? undefined : rendererScript.nonce;
+  const inlineRendererScriptNonce = rendererScriptCode
+    ? rendererScriptNonce || createWidgetScriptNonce()
+    : undefined;
   const resolvedRendererScriptSrc = normalizeWidgetModuleScriptSrc(
     resolveWidgetModuleScriptSrc(rendererScriptSrc),
   );
@@ -330,13 +334,13 @@ export function buildWidgetIframeDocument(
   const safeChannelId = escapeHtmlAttribute(channelId);
   const safeThemeClass = escapeHtmlAttribute(themeClass);
   const scriptCspSource =
-    rendererScriptCode && rendererScriptNonce
-      ? `'nonce-${rendererScriptNonce}'`
+    rendererScriptCode && inlineRendererScriptNonce
+      ? `'nonce-${inlineRendererScriptNonce}'`
       : getScriptCspSource(resolvedRendererScriptSrc);
   const connectCspSource = getWidgetConnectCspSource(resolvedRendererScriptSrc);
   const rendererScriptElement =
-    rendererScriptCode && rendererScriptNonce
-      ? `<script nonce="${escapeHtmlAttribute(rendererScriptNonce)}">${escapeInlineScriptContent(rendererScriptCode)}</script>`
+    rendererScriptCode && inlineRendererScriptNonce
+      ? `<script nonce="${escapeHtmlAttribute(inlineRendererScriptNonce)}">${escapeInlineScriptContent(rendererScriptCode)}</script>`
       : `<script type="module" src="${safeRendererScriptSrc}"></script>`;
 
   return `<!doctype html>
@@ -368,6 +372,20 @@ function escapeHtmlAttribute(value: string) {
 
 function escapeInlineScriptContent(code: string) {
   return code.replace(/<\/script/gi, "<\\/script").replace(/<!--/g, "<\\!--");
+}
+
+function createWidgetScriptNonce() {
+  if (globalThis.crypto?.getRandomValues) {
+    const bytes = new Uint8Array(WidgetScriptNonceByteLength);
+    globalThis.crypto.getRandomValues(bytes);
+    return Array.from(bytes, formatNonceByte).join("");
+  }
+
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
+}
+
+function formatNonceByte(byte: number) {
+  return byte.toString(16).padStart(2, "0");
 }
 
 function resolveWidgetModuleScriptSrc(scriptSrc: string) {


### PR DESCRIPTION
## Summary
- Implement a fallback nonce generator for `renderWidget` inline scripts when the parent page doesn't provide one.
- This ensures that inline scripts in the widget iframe are always allowed by the Content Security Policy (CSP), even in environments where the parent's nonce is missing (e.g., the share page).

## Test plan
- Added a unit test in `packages/vscode-webui/src/features/tools/components/render-widget/__tests__/utils.test.ts` to verify that a local nonce is generated and applied to both the CSP header and the script tag when no parent nonce is available.
- Verified that the generated nonce is unique and correctly formatted.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c37418c490d24853ba37001c09dd77c3)