### PR TITLE
style(vscode-webui): improve token usage UI layout in popover

### DIFF
--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -212,12 +212,16 @@ export function TokenUsage({
                   </TooltipProvider>
                 )}
             </div>
-            <div className="mb-2 text-muted-foreground">
-              {t("tokenUsage.tokensUsed", {
-                used: formatTokens(totalTokens),
-                total: formatTokens(contextWindow),
-                percentage,
-              })}
+            <div className="mb-2 flex items-center justify-between text-muted-foreground">
+              <span>
+                {t("tokenUsage.tokensUsed", {
+                  used: formatTokens(totalTokens),
+                  total: formatTokens(contextWindow),
+                })}
+              </span>
+              <span className="font-semibold text-foreground">
+                {percentage}%
+              </span>
             </div>
             <Progress value={percentage} className="mb-3" />
 

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -54,7 +54,7 @@
     "compactTask": "Compact Task",
     "minTokensRequired": "At least {{minTokens}} tokens are required to compact the conversation",
     "defaultContextWindowWarning": "The context window value is a default and may not be accurate for your custom model. For precise token management, please adjust it in the settings according to your model provider's documentation.",
-    "tokensUsed": "{{used}} / {{total}} tokens • {{percentage}}%",
+    "tokensUsed": "{{used}} / {{total}} tokens",
     "system": "System",
     "systemInstructions": "System Instructions",
     "toolDefinitions": "Tool Definitions",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -56,7 +56,7 @@
     "compactTask": "タスクを圧縮",
     "minTokensRequired": "会話を圧縮するには少なくとも {{minTokens}} tokens が必要です",
     "defaultContextWindowWarning": "コンテキストウィンドウの値はデフォルトであり、カスタムモデルには正確でない場合があります。正確な token 管理のために、モデルプロバイダーのドキュメントに従って設定で調整してください。",
-    "tokensUsed": "{{used}} / {{total}} tokens • {{percentage}}%",
+    "tokensUsed": "{{used}} / {{total}} tokens",
     "system": "システム",
     "systemInstructions": "システム指示",
     "toolDefinitions": "ツール定義",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -55,7 +55,7 @@
     "compactTask": "작업 압축",
     "minTokensRequired": "대화를 압축하려면 최소 {{minTokens}} tokens 이상 필요합니다",
     "defaultContextWindowWarning": "컨텍스트 창 값은 기본값이며 사용자 지정 모델에 대해 정확하지 않을 수 있습니다. 정확한 token 관리를 위해 모델 공급자의 설명서에 따라 설정에서 조정하십시오.",
-    "tokensUsed": "{{used}} / {{total}} tokens • {{percentage}}%",
+    "tokensUsed": "{{used}} / {{total}} tokens",
     "system": "시스템",
     "systemInstructions": "시스템 지침",
     "toolDefinitions": "도구 정의",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -55,7 +55,7 @@
     "compactTask": "压缩任务",
     "minTokensRequired": "至少需要 {{minTokens}} 个 token 才能压缩对话",
     "defaultContextWindowWarning": "上下文窗口值是默认值，对于您的自定义模型可能不准确。为了精确的 token 管理，请根据您的模型提供商的文档在设置中进行调整。",
-    "tokensUsed": "已使用 {{used}} / {{total}} tokens • {{percentage}}%",
+    "tokensUsed": "已使用 {{used}} / {{total}} tokens",
     "system": "系统",
     "systemInstructions": "系统指令",
     "toolDefinitions": "工具定义",


### PR DESCRIPTION
## Summary
- Improved the layout of the Token Usage panel in the Popover content to make it cleaner and more professional.
- Aligned the absolute token usage count (`used / total tokens`) to the left and the percentage to the right using a flexbox layout.
- Removed the redundant inline percentage indicator (`• {{percentage}}%`) from the translation keys in all locales (`en`, `jp`, `zh`, `ko`).

## Before & After
| Before | After |
| --- | --- |
| ![Before](https://pochi-file-uploads.getpochi.com/blob-1780015748741.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T004909Z&X-Amz-Expires=561600&X-Amz-Signature=da2ca665147358924ad291ef0033289e8cd9abb0bd8bbdb81658bb2d5388800f&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject) | ![After](https://pochi-file-uploads.getpochi.com/blob-1780016096311.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T005456Z&X-Amz-Expires=561600&X-Amz-Signature=3c4d89fecbf8aeb2ce63819662f2e1f6bcd903e5a3e2f7afe1956eb556011092&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject) |

## Test plan
- Verified that the layout renders correctly with the percentage aligned to the right.
- Ran `bun check` and `bun tsc` to verify linting, formatting, and typing.
- Ran `bun run test` to verify all unit tests pass.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-6633e58307e64b68a9374e6148a26b34)