### PR TITLE
refactor(vscode-webui): replace hide recommend settings checkbox with reset button

### DIFF
--- a/packages/vscode-webui/src/features/settings/components/sections/advanced-settings-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/advanced-settings-section.tsx
@@ -45,17 +45,19 @@ export const AdvancedSettingsSection: React.FC = () => {
                 updateEnablePochiModels(!!checked);
               }}
             />
-            {vscodeSettings && (
-              <SettingsCheckboxOption
-                id="hide-recommend-settings"
-                label={t("settings.advanced.hideRecommendSettings")}
-                checked={vscodeSettings.hideRecommendSettings}
-                onCheckedChange={async (checked) => {
-                  await vscodeHost.updateVSCodeSettings({
-                    hideRecommendSettings: !!checked,
-                  });
-                }}
-              />
+            {vscodeSettings?.hideRecommendSettings && (
+              <div>
+                <Button
+                  variant="outline"
+                  onClick={async () => {
+                    await vscodeHost.updateVSCodeSettings({
+                      hideRecommendSettings: false,
+                    });
+                  }}
+                >
+                  {t("settings.advanced.resetRecommendSettings")}
+                </Button>
+              </div>
             )}
             <div>
               <Button

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -153,7 +153,7 @@
       "language": "Language",
       "languageDescription": "Choose your preferred language",
       "openInTab": "Allows to open the task in a new tab",
-      "hideRecommendSettings": "Hide Recommended Settings"
+      "resetRecommendSettings": "Reset Setup Recommendations"
     },
     "rules": {
       "title": "Rules",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -154,7 +154,7 @@
       "resetReviewPlanTutorialCounter": "レビュー計画チュートリアルカウンターをリセット",
       "language": "言語",
       "languageDescription": "希望の言語を選択してください",
-      "hideRecommendSettings": "推奨設定を非表示にする"
+      "resetRecommendSettings": "推奨設定をリセット"
     },
     "rules": {
       "title": "ルール",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -153,7 +153,7 @@
       "resetReviewPlanTutorialCounter": "리뷰 계획 튜토리얼 카운터 재설정",
       "language": "언어",
       "languageDescription": "선호하는 언어를 선택하세요",
-      "hideRecommendSettings": "추천 설정 숨기기"
+      "resetRecommendSettings": "추천 설정 재설정"
     },
     "rules": {
       "title": "규칙",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -153,7 +153,7 @@
       "resetReviewPlanTutorialCounter": "重置评审计划教程计数器",
       "language": "语言",
       "languageDescription": "选择您的首选语言",
-      "hideRecommendSettings": "隐藏推荐设置"
+      "resetRecommendSettings": "重置推荐设置"
     },
     "rules": {
       "title": "规则",


### PR DESCRIPTION
## Summary
* Replace the "Hide Recommended Settings" negative-logic checkbox with a "Reset Setup Recommendations" button in the Advanced Settings panel.
* Conditionally render the reset button only when the recommended settings are hidden (`hideRecommendSettings === true`).
* Update i18n localization keys (`resetRecommendSettings`) for English, Chinese, Japanese, and Korean.

## Test plan
* Verified that formatting and linting pass via `bun check`.
* Verified that type checking passes via `bun tsc`.
* Verified visually that the button behaves correctly and updates VS Code settings to show/hide the recommended settings card.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3e201482625143cea18e2ee05f9e2537)