### PR TITLE
refactor(vscode-webui): conditionally show local Chrome settings section

### DIFF
--- a/packages/vscode-webui/src/routes/browser-agent-settings.tsx
+++ b/packages/vscode-webui/src/routes/browser-agent-settings.tsx
@@ -58,6 +58,8 @@ export const BrowserSettingsSection: React.FC = () => {
     return null;
   }
 
+  const isLocalChromeMode = settings.runtime.mode === "localChrome";
+
   return (
     <main className="grid gap-5">
       <SettingsSection title={t("browserAgentSettings.runtimeSection")}>
@@ -83,49 +85,51 @@ export const BrowserSettingsSection: React.FC = () => {
         </SettingsRow>
       </SettingsSection>
 
-      <SettingsSection title={t("browserAgentSettings.localChromeSection")}>
-        <p className="text-muted-foreground text-xs leading-5">
-          {t("browserAgentSettings.localChromeHint")}
-        </p>
-        <SettingsRow label={t("browserAgentSettings.chromePath")}>
-          <div className="grid gap-1.5">
-            <Input
-              className="h-9 border-border/80 bg-background shadow-sm placeholder:text-muted-foreground/80"
-              value={settings.localChrome.chromePath}
-              placeholder={DefaultChromePath}
-              onChange={(event) =>
-                setBrowserSettings({
-                  localChrome: {
-                    chromePath: event.target.value,
-                  },
-                })
-              }
-            />
-            <p className="text-muted-foreground text-xs">
-              {t("browserAgentSettings.chromePathHint")}
-            </p>
-          </div>
-        </SettingsRow>
-        <SettingsRow label={t("browserAgentSettings.startParams")}>
-          <div className="grid gap-1.5">
-            <Input
-              className="h-9 border-border/80 bg-background shadow-sm placeholder:text-muted-foreground/80"
-              value={settings.localChrome.startParams}
-              placeholder={DefaultStartParams}
-              onChange={(event) =>
-                setBrowserSettings({
-                  localChrome: {
-                    startParams: event.target.value,
-                  },
-                })
-              }
-            />
-            <p className="text-muted-foreground text-xs">
-              {t("browserAgentSettings.startParamsHint")}
-            </p>
-          </div>
-        </SettingsRow>
-      </SettingsSection>
+      {isLocalChromeMode && (
+        <SettingsSection title={t("browserAgentSettings.localChromeSection")}>
+          <p className="text-muted-foreground text-xs leading-5">
+            {t("browserAgentSettings.localChromeHint")}
+          </p>
+          <SettingsRow label={t("browserAgentSettings.chromePath")}>
+            <div className="grid gap-1.5">
+              <Input
+                className="h-9 border-border/80 bg-background shadow-sm placeholder:text-muted-foreground/80"
+                value={settings.localChrome.chromePath}
+                placeholder={DefaultChromePath}
+                onChange={(event) =>
+                  setBrowserSettings({
+                    localChrome: {
+                      chromePath: event.target.value,
+                    },
+                  })
+                }
+              />
+              <p className="text-muted-foreground text-xs">
+                {t("browserAgentSettings.chromePathHint")}
+              </p>
+            </div>
+          </SettingsRow>
+          <SettingsRow label={t("browserAgentSettings.startParams")}>
+            <div className="grid gap-1.5">
+              <Input
+                className="h-9 border-border/80 bg-background shadow-sm placeholder:text-muted-foreground/80"
+                value={settings.localChrome.startParams}
+                placeholder={DefaultStartParams}
+                onChange={(event) =>
+                  setBrowserSettings({
+                    localChrome: {
+                      startParams: event.target.value,
+                    },
+                  })
+                }
+              />
+              <p className="text-muted-foreground text-xs">
+                {t("browserAgentSettings.startParamsHint")}
+              </p>
+            </div>
+          </SettingsRow>
+        </SettingsSection>
+      )}
 
       <SettingsSection title={t("browserAgentSettings.recordingSection")}>
         <div className="grid gap-4">


### PR DESCRIPTION
## Summary
- Conditionally render the "Local Chrome" configuration section in browser agent settings based on the selected runtime mode.
- Only show the section when the runtime mode is set to "localChrome" to reduce UI clutter and improve settings page clarity.

<img width="600" alt="9c074edb5975841b93a98a0a5c530764" src="https://github.com/user-attachments/assets/4bf14839-8254-4560-a5f6-2201df0ddc5a" />

<img width="600" alt="cc215caf568e81b1c35126694651bffb" src="https://github.com/user-attachments/assets/d51301a8-15eb-4afd-ac7e-7a593cf5ea16" />


## Test plan
- Open browser agent settings.
- Select "Local Chrome" runtime mode and verify that the Local Chrome section (with chrome path and start params) is visible.
- Select a different runtime mode (e.g., Cloud / remote) and verify that the Local Chrome section is hidden.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-442f24fcba294907914ffc649397071d)