### PR TITLE
fix(vscode-webui): display subagent todo list regardless of toggle status

### DIFF
--- a/packages/vscode-webui/src/features/tools/__stories__/new-task-tool-gallery.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/new-task-tool-gallery.stories.tsx
@@ -231,3 +231,42 @@ export const Variants: Story = {
     ],
   },
 };
+
+export const CollapsedWithTodos: Story = {
+  args: {
+    tools: [
+      {
+        ...newTaskProps1,
+        toolCallId: `${newTaskProps1.toolCallId}-collapsed-with-todos`,
+        // @ts-expect-error - Adding custom prop for Storybook
+        taskThreadSource: {
+          messages: mockMessages,
+          todos: [
+            {
+              id: "todo-1",
+              content:
+                "Search for occurrences of enablePochiModels, useEnablePochiModels, and updateEnablePochiModels in the codebase",
+              status: "completed",
+              priority: "high",
+            },
+            {
+              id: "todo-2",
+              content:
+                "Analyze the search results and extract relevant code snippets and file paths",
+              status: "completed",
+              priority: "high",
+            },
+            {
+              id: "todo-3",
+              content:
+                "Present the final findings and code snippets to the user",
+              status: "pending",
+              priority: "medium",
+            },
+          ],
+          isLoading: false,
+        },
+      },
+    ],
+  },
+};

--- a/packages/vscode-webui/src/features/tools/__stories__/subtask-agent.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/subtask-agent.stories.tsx
@@ -89,7 +89,20 @@ const overviewMessage: Message = {
           task: {
             messages: subtaskMessages,
             clientTaskId: "task-inline-1",
-            todos: [],
+            todos: [
+              {
+                id: "todo-seq",
+                content: "Run seq 7 command to generate numbers",
+                status: "completed",
+                priority: "high",
+              },
+              {
+                id: "todo-verify",
+                content: "Verify that the numbers 1 to 7 are printed",
+                status: "completed",
+                priority: "medium",
+              },
+            ],
           },
         },
       },

--- a/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
@@ -113,11 +113,25 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
         <TaskThread
           source={taskThreadSource}
           showMessageList={showMessageList}
+          showTodos={false}
           assistant={{ name: agent ?? "Pochi" }}
         />
       </FixedStateChatContextProvider>
     ) : undefined;
   }, [agent, showMessageList, taskThreadSource, toolCallStatusRegistryRef]);
+
+  const detail = useMemo(() => {
+    if (!taskThreadSource) {
+      return undefined;
+    }
+    return (
+      <TaskThread
+        source={taskThreadSource}
+        showMessageList={false}
+        showTodos={true}
+      />
+    );
+  }, [taskThreadSource]);
 
   if (agentType === "browser") {
     return <BrowserView {...props} taskSource={previewSource} />;
@@ -175,6 +189,7 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
     <ExpandableToolContainer
       title={title}
       expandableDetail={expandableDetail}
+      detail={detail}
       expanded={showMessageList}
       onToggle={setShowMessageListImmediately}
     />

--- a/packages/vscode-webui/src/features/tools/components/tool-container.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-container.tsx
@@ -102,8 +102,8 @@ export const ExpandableToolContainer: React.FC<{
           />
         )}
       </ToolTitle>
-      {showDetails && expandableDetail}
       {detail}
+      {showDetails && expandableDetail}
     </ToolContainer>
   );
 };


### PR DESCRIPTION
## Summary
- Render the subagent's todo list using a separate `TaskThread` as the `detail` prop of `ExpandableToolContainer`.
- Position `{detail}` above `{showDetails && expandableDetail}` in `ExpandableToolContainer` to ensure that when expanded, the todo list is rendered immediately below the header block (and above the list of steps), matching the design specification.
- Set `showTodos={false}` in the main expandable detail's `TaskThread` to prevent duplicate todo list rendering when expanded.
- Added and updated storybooks (`new-task-tool-gallery.stories.tsx` and `subtask-agent.stories.tsx`) to showcase and verify this behavior.

## Screenshots

### Correct Behavior (Both Collapsed & Expanded)
- **Collapsed**: The todo list is displayed immediately below the header.
- **Expanded**: The todo list is displayed immediately below the header, and the list of steps is displayed below it.

## Test plan
- Open the Storybook and navigate to the `SubtaskAgent` or `NewTask` components.
- Verify that the todo list is displayed for collapsed subagent tool calls.
- Verify that expanding the subagent details renders the list of steps *below* the todo list, and does not duplicate the todo list.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7f53b13ecdc04990b2d35c9f8ebcd85e)