### PR TITLE
refactor(vscode-webui): decouple advanced and developer settings

### DIFF
--- a/packages/vscode-webui/src/features/settings/components/page.tsx
+++ b/packages/vscode-webui/src/features/settings/components/page.tsx
@@ -1,13 +1,17 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useSettingsStore } from "../store";
 import { AccountSection } from "./sections/account-section";
 import { AdvancedSettingsSection } from "./sections/advanced-settings-section";
 import { AgentSection } from "./sections/agent-section";
+import { DeveloperSettingsSection } from "./sections/developer-settings-section";
 import { ModelSection } from "./sections/model-section";
 import { SkillSection } from "./sections/skill-section";
 import { ToolsSection } from "./sections/tools-section";
 import { WorkspaceRulesSection } from "./sections/workspace-rules-section";
 
 export function SettingsPage() {
+  const { isDevMode } = useSettingsStore();
+
   return (
     <div className="container mx-auto h-screen max-w-6xl">
       <ScrollArea className="h-full p-4">
@@ -19,6 +23,7 @@ export function SettingsPage() {
           <ToolsSection />
           <ModelSection />
           <AdvancedSettingsSection />
+          {isDevMode && <DeveloperSettingsSection />}
         </div>
       </ScrollArea>
     </div>

--- a/packages/vscode-webui/src/features/settings/components/sections/advanced-settings-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/advanced-settings-section.tsx
@@ -1,17 +1,11 @@
-import { Button } from "@/components/ui/button";
-import { useReviewPlanTutorialCounter } from "@/lib/hooks/use-review-plan-tutorial-counter";
-import { useVSCodeSettings } from "@/lib/hooks/use-vscode-settings";
-import { vscodeHost } from "@/lib/vscode";
 import { useTranslation } from "react-i18next";
-import { useSettingsStore } from "../../store";
+import { useDevSettings } from "../../hooks/use-dev-settings";
 import { AccordionSection } from "../ui/accordion-section";
 import { SettingsCheckboxOption } from "../ui/settings-checkbox-option";
 
 export const AdvancedSettingsSection: React.FC = () => {
   const { t } = useTranslation();
-  const { isDevMode, updateIsDevMode } = useSettingsStore();
-  const vscodeSettings = useVSCodeSettings();
-  const { resetCount } = useReviewPlanTutorialCounter();
+  const { isDevMode, setDevMode } = useDevSettings();
 
   return (
     <AccordionSection
@@ -25,48 +19,9 @@ export const AdvancedSettingsSection: React.FC = () => {
             label={t("settings.advanced.developerMode")}
             checked={isDevMode}
             onCheckedChange={(checked) => {
-              updateIsDevMode(!!checked);
+              setDevMode(!!checked);
             }}
           />
-        )}
-        {isDevMode && (
-          <>
-            {vscodeSettings?.hideRecommendSettings && (
-              <div>
-                <Button
-                  variant="outline"
-                  onClick={async () => {
-                    await vscodeHost.updateVSCodeSettings({
-                      hideRecommendSettings: false,
-                    });
-                  }}
-                >
-                  {t("settings.advanced.resetRecommendSettings")}
-                </Button>
-              </div>
-            )}
-            <div>
-              <Button
-                variant="destructive"
-                onClick={async () => {
-                  const opfsRoot = await navigator.storage.getDirectory();
-                  if (
-                    "remove" in opfsRoot &&
-                    typeof opfsRoot.remove === "function"
-                  ) {
-                    await opfsRoot.remove();
-                  }
-                }}
-              >
-                {t("settings.advanced.clearStorage")}
-              </Button>
-            </div>
-            <div>
-              <Button variant="default" onClick={resetCount}>
-                {t("settings.advanced.resetReviewPlanTutorialCounter")}
-              </Button>
-            </div>
-          </>
         )}
       </div>
     </AccordionSection>

--- a/packages/vscode-webui/src/features/settings/components/sections/developer-settings-section.tsx
+++ b/packages/vscode-webui/src/features/settings/components/sections/developer-settings-section.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@/components/ui/button";
+import { useTranslation } from "react-i18next";
+import { useDevSettings } from "../../hooks/use-dev-settings";
+import { AccordionSection } from "../ui/accordion-section";
+
+export const DeveloperSettingsSection: React.FC = () => {
+  const { t } = useTranslation();
+  const {
+    showResetRecommendBtn,
+    resetRecommendSettings,
+    clearOPFSStorage,
+    resetTutorialCount,
+  } = useDevSettings();
+
+  return (
+    <AccordionSection
+      title={t("settings.advanced.developerSettings")}
+      localStorageKey="developer-settings-section"
+    >
+      <div className="flex flex-col gap-4 px-6 py-2">
+        {showResetRecommendBtn && (
+          <div className="flex items-center justify-between border-border border-b pb-4 last:border-0 last:pb-0">
+            <span className="font-semibold text-sm">
+              {t("settings.advanced.resetRecommendSettings")}
+            </span>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={resetRecommendSettings}
+            >
+              {t("common.reset")}
+            </Button>
+          </div>
+        )}
+        <div className="flex items-center justify-between border-border border-b pb-4 last:border-0 last:pb-0">
+          <span className="font-semibold text-sm">
+            {t("settings.advanced.clearStorage")}
+          </span>
+          <Button variant="default" size="sm" onClick={clearOPFSStorage}>
+            {t("common.clear")}
+          </Button>
+        </div>
+        <div className="flex items-center justify-between border-border border-b pb-4 last:border-0 last:pb-0">
+          <span className="font-semibold text-sm">
+            {t("settings.advanced.resetReviewPlanTutorialCounter")}
+          </span>
+          <Button variant="default" size="sm" onClick={resetTutorialCount}>
+            {t("common.reset")}
+          </Button>
+        </div>
+      </div>
+    </AccordionSection>
+  );
+};

--- a/packages/vscode-webui/src/features/settings/hooks/use-dev-settings.ts
+++ b/packages/vscode-webui/src/features/settings/hooks/use-dev-settings.ts
@@ -1,0 +1,37 @@
+import { useReviewPlanTutorialCounter } from "@/lib/hooks/use-review-plan-tutorial-counter";
+import { useVSCodeSettings } from "@/lib/hooks/use-vscode-settings";
+import { vscodeHost } from "@/lib/vscode";
+import { useSettingsStore } from "../store";
+
+export function useDevSettings() {
+  const { isDevMode, updateIsDevMode } = useSettingsStore();
+  const vscodeSettings = useVSCodeSettings();
+  const { resetCount: resetTutorialCount } = useReviewPlanTutorialCounter();
+
+  const resetRecommendSettings = async () => {
+    await vscodeHost.updateVSCodeSettings({
+      hideRecommendSettings: false,
+    });
+  };
+
+  const clearOPFSStorage = async () => {
+    const confirmed = window.confirm(
+      "Are you sure you want to clear Pochi's local OPFS storage? This action cannot be undone.",
+    );
+    if (!confirmed) return;
+
+    const opfsRoot = await navigator.storage.getDirectory();
+    if ("remove" in opfsRoot && typeof opfsRoot.remove === "function") {
+      await opfsRoot.remove();
+    }
+  };
+
+  return {
+    isDevMode,
+    setDevMode: updateIsDevMode,
+    showResetRecommendBtn: !!vscodeSettings?.hideRecommendSettings,
+    resetRecommendSettings,
+    clearOPFSStorage,
+    resetTutorialCount,
+  };
+}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -3,7 +3,9 @@
     "disable": "Disable",
     "openFolder": "Open Folder",
     "account": "Account",
-    "help": "Help"
+    "help": "Help",
+    "reset": "Reset",
+    "clear": "Clear"
   },
   "error": {
     "somethingWentWrong": "Something went wrong",
@@ -147,6 +149,7 @@
     "advanced": {
       "title": "Advanced Settings",
       "developerMode": "Developer Mode",
+      "developerSettings": "Developer Settings",
       "clearStorage": "Clear Storage",
       "resetReviewPlanTutorialCounter": "Reset Review Plan Tutorial Counter",
       "language": "Language",


### PR DESCRIPTION
## Summary
- Separated developer-only settings from the general advanced settings section.
- Created a dedicated `DeveloperSettingsSection` that is conditionally rendered only when Developer Mode is active.
- Introduced a `useDevSettings` hook to encapsulate developer action side-effects.
- Unified developer action button variants to `"default"` (primary) and redesigned the section to use a structured row layout (label on left, action button on right).
- Added safety confirmation dialogs for clearing local storage.

## Screenshot
![Developer Settings](https://pochi-file-uploads.getpochi.com/blob-1780021591791.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T022631Z&X-Amz-Expires=561600&X-Amz-Signature=77d07acaeebe7f5010a0761de3d8a8f6031e3c12083cad61e6dbed1dd2d3c716&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan
- Verify that "Developer Settings" is completely hidden when "Developer Mode" is unchecked.
- Verify that toggling "Developer Mode" on makes the "Developer Settings" section appear at the bottom of the page.
- Verify that the developer settings buttons are styled consistently as primary solid buttons.
- Confirm that clicking "Clear Storage" prompts the user with a confirmation dialog before clearing.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-91bcaf839459490c8a4444d822cdbfbe)