### PR TITLE
fix(vscode-webui): disable i18next literal string check for perf harness

### DIFF
--- a/packages/vscode-webui/src/__stories__/perf/perf-harness.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/perf-harness.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable i18next/no-literal-string */
+
 import {
   Profiler,
   type ProfilerOnRenderCallback,


### PR DESCRIPTION
## Summary
- Disables `i18next/no-literal-string` lint rule for `perf-harness.tsx` as it's a storybook fixture and doesn't need internationalization.

## Test plan
- Verified that linting passes for the file.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-89cc26e594434379a1897ec2d8bf1c6d)