### PR TITLE
docs: update demo videos and copy for weekly update #31

### DIFF
--- a/packages/docs/content/docs/developer-updates/2026-05-29-weekly-update-31.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-05-29-weekly-update-31.mdx
@@ -33,7 +33,7 @@ More below!
 
 
 
-- **Project Memory:** Project Memory is now enabled for all users out of the box. The Token Usage popover gains a new Memory section with two rows, Project Memory and Task Memory, each showing the file path and clickable to open the file directly in the editor. An inline checkbox next to the section heading toggles Project Memory on or off.
+- **Project Memory:** Project Memory is now enabled for all users out of the box. The Token Usage popover gains a new Memory section with two rows, Project and Task, each showing the file path and clickable to open the file directly in the editor. An inline checkbox next to the section heading toggles Project Memory on or off.
 
   Previously, Project Memory was opt-in via `pochi.advanced.memory.enabled: true` in VS Code settings, so persistent memory across tasks required deliberate setup.
 
@@ -47,13 +47,13 @@ More below!
     boxShadow: "0 4px 12px rgba(0, 0, 0, 0.15)",
   }}
 >
-  <source src="https://assets.docs.getpochi.com/docs/35/353344f073b633a3fa1dd3b7e77fe5341a9d70d87b47bdf8f78b7eddce03133a.mp4" type="video/mp4" />
+  <source src="https://assets.docs.getpochi.com/docs/project-memory-050.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 
 
 
-- **Browser Agent - Settings Panel:** The Browser Agent now has a dedicated settings panel for runtime and recording configuration. Switch between Managed browser and Local Chrome, set a custom Chrome executable path and start parameters, and configure recording resolution — all from the UI.
+- **Browser Agent - Settings Panel:** The Browser Agent now has a dedicated settings panel for runtime and recording configuration. Switch between Managed browser and Local Chrome, set a custom Chrome executable path and start parameters, and enable session recording — all from the UI.
 
   Previously, Browser Agent configuration required manually editing `~/.pochi/config.jsonc`. There was no UI, and switching to Local Chrome meant knowing the exact config key and editing it by hand.
 
@@ -67,7 +67,7 @@ More below!
     boxShadow: "0 4px 12px rgba(0, 0, 0, 0.15)",
   }}
 >
-  <source src="https://assets.docs.getpochi.com/docs/aa/aa8e099ea115e50a2f8e5d40204b6fd1a7faa1ff70734fc0068d9d7ad0d997b4.mp4" type="video/mp4" />
+  <source src="https://assets.docs.getpochi.com/docs/browser-agent-settings-050.mp4" type="video/mp4" />
   Your browser does not support the video tag.
 </video>
 


### PR DESCRIPTION
Replaces project memory and browser agent settings demo videos with updated recordings. Updates copy: 'Project Memory/Task Memory' → 'Project/Task' labels, removes mention of recording resolution (dropped in #1608).