### PR TITLE
fix(vscode-webui): simplify button outline variant by removing dark mode overrides

### DIFF
--- a/packages/vscode-webui/src/components/ui/button.tsx
+++ b/packages/vscode-webui/src/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost:


### PR DESCRIPTION
## Summary
- Simplify the button outline variant in `packages/vscode-webui/src/components/ui/button.tsx` by removing dark mode overrides (`dark:border-input`, `dark:bg-input/30`, and `dark:hover:bg-input/50`).
- This improves UI consistency and ensures the outline button variant behaves identically across light and dark themes.

## Test plan
- Verify outline button hover state and colors in both light and dark modes of the VS Code Webview.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f7b0e1fdc3eb4764bb5fccb6de0209da)