### PR TITLE
fix(vscode-webui): ensure git branch info is always visible and align status to right

### DIFF
--- a/packages/vscode-webui/src/components/task-row.tsx
+++ b/packages/vscode-webui/src/components/task-row.tsx
@@ -169,7 +169,7 @@ export function TaskRow({
             </div>
             <div className="h-6 text-muted-foreground text-sm">
               <div className="flex items-center justify-between gap-2 overflow-hidden">
-                <div className="flex flex-1 items-center gap-2 overflow-hidden">
+                <div className="flex min-w-0 max-w-[50%] items-center gap-2 overflow-hidden">
                   <GitBadge git={task.git} />
                   {task.lineChanges && (
                     <EditSummary
@@ -178,14 +178,19 @@ export function TaskRow({
                     />
                   )}
                 </div>
-                {state?.running && task.pendingToolCalls?.length ? (
-                  <ToolCallLite
-                    tools={task.pendingToolCalls as Array<ToolUIPart<UITools>>}
-                    requiresApproval={state.requiresApproval}
-                  />
-                ) : (
-                  <TaskStatusView task={task} state={state} />
-                )}
+                <div className="flex min-w-0 flex-1 justify-end overflow-hidden">
+                  {state?.running && task.pendingToolCalls?.length ? (
+                    <ToolCallLite
+                      tools={
+                        task.pendingToolCalls as Array<ToolUIPart<UITools>>
+                      }
+                      requiresApproval={state.requiresApproval}
+                      className="w-auto"
+                    />
+                  ) : (
+                    <TaskStatusView task={task} state={state} />
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
@@ -12,6 +12,7 @@ interface Props {
   requiresApproval?: boolean;
   showCommandDetails?: boolean;
   showStatusIcon?: boolean;
+  className?: string;
 }
 
 export function ToolCallLite({
@@ -19,6 +20,7 @@ export function ToolCallLite({
   requiresApproval,
   showCommandDetails,
   showStatusIcon = true,
+  className,
 }: Props) {
   const { t } = useTranslation();
 
@@ -97,7 +99,12 @@ export function ToolCallLite({
   }
 
   return detail ? (
-    <div className="flex w-full min-w-0 flex-nowrap items-center overflow-hidden whitespace-nowrap">
+    <div
+      className={cn(
+        "flex w-full min-w-0 flex-nowrap items-center overflow-hidden whitespace-nowrap",
+        className,
+      )}
+    >
       {!showStatusIcon ? null : requiresApproval ? (
         <Pause className="size-3.5 shrink-0" />
       ) : (


### PR DESCRIPTION
## Summary
- Prevents the git branch badge and edit summary from being squeezed out and hidden during command execution on task rows.
- Constrains the width of the executing status (`ToolCallLite`) to the remaining space on the right, allowing it to truncate cleanly if space is tight.
- Standardizes status alignment so that both running/executing and finished/paused statuses are consistently aligned to the right side of the card.

## Test plan
- Verified that the `TaskRow` component displays both the branch info on the left and the executing status on the right when running.
- Verified that the finished status correctly remains right-aligned.
- Ran all unit tests with `bun run test` and verified that they all pass perfectly.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-620664f09153454aa6f310941a461685)