### PR TITLE
refactor: extract and unify CORS proxy fetch utilities

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,6 +19,7 @@
     "./vscode-webui-bridge": "./src/vscode-webui-bridge/index.ts",
     "./store-id-utils": "./src/store-id-utils.ts",
     "./share-utils": "./src/share-utils.ts",
+    "./fetch-utils": "./src/fetch-utils.ts",
     "./google-vertex-utils": "./src/google-vertex-utils.ts",
     "./cors-proxy": "./src/cors-proxy/index.ts",
     "./pochi-file-system": "./src/pochi-file-system/index.ts",

--- a/packages/common/src/__tests__/fetch-utils.test.ts
+++ b/packages/common/src/__tests__/fetch-utils.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithCorsProxy, withCorsProxy } from "../fetch-utils";
+
+describe("fetch utils", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "POCHI_CORS_PROXY_URL_PREFIX");
+  });
+
+  it("returns the original input when the CORS proxy is not configured", () => {
+    const url = new URL("https://example.com/api");
+
+    expect(withCorsProxy(url)).toBe(url);
+  });
+
+  it("wraps URL input when the CORS proxy is configured", () => {
+    globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
+
+    expect(withCorsProxy(new URL("https://example.com/api"))).toEqual(
+      new URL("https://proxy.example/?url=https%3A%2F%2Fexample.com%2Fapi"),
+    );
+  });
+
+  it("uses the original URL for Request input", () => {
+    globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
+
+    expect(withCorsProxy(new Request("https://example.com/api"))).toEqual(
+      new URL("https://proxy.example/?url=https%3A%2F%2Fexample.com%2Fapi"),
+    );
+  });
+
+  it("fetches direct input when the CORS proxy is not configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWithCorsProxy("https://api.example.com/messages", {
+      method: "POST",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.example.com/messages", {
+      method: "POST",
+    });
+  });
+
+  it("fetches through the CORS proxy when configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
+
+    await fetchWithCorsProxy("https://api.example.com/messages", {
+      method: "POST",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL(
+        "https://proxy.example/?url=https%3A%2F%2Fapi.example.com%2Fmessages",
+      ),
+      { method: "POST" },
+    );
+  });
+});

--- a/packages/common/src/__tests__/google-vertex-utils.test.ts
+++ b/packages/common/src/__tests__/google-vertex-utils.test.ts
@@ -1,0 +1,62 @@
+import { createVertexWithoutCredentials } from "@ai-sdk/google-vertex/edge";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVertexModel } from "../google-vertex-utils";
+
+const mocks = vi.hoisted(() => ({
+  createVertexWithoutCredentials: vi.fn(),
+}));
+
+vi.mock("@ai-sdk/google-vertex/edge", () => ({
+  createVertex: vi.fn(),
+  createVertexWithoutCredentials: mocks.createVertexWithoutCredentials,
+}));
+
+describe("Google Vertex utils", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(globalThis, "POCHI_CORS_PROXY_URL_PREFIX");
+  });
+
+  it("uses the shared CORS proxy fetch for access-token models", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
+
+    let vertexFetch: typeof fetch | undefined;
+    vi.mocked(createVertexWithoutCredentials).mockImplementation((options) => {
+      if (!options?.fetch) {
+        throw new Error("Expected Vertex fetch option");
+      }
+      vertexFetch = options.fetch;
+      return ((modelId: string) => ({ modelId })) as ReturnType<
+        typeof createVertexWithoutCredentials
+      >;
+    });
+
+    createVertexModel(
+      {
+        type: "access-token",
+        accessToken: "token",
+        projectId: "project-id",
+        location: "us-central1",
+      },
+      "gemini-2.5-pro",
+    );
+
+    await vertexFetch?.(
+      "https://us-central1-aiplatform.googleapis.com/v1/projects/project-id/locations/us-central1/publishers/google/models/gemini-2.5-pro:streamGenerateContent",
+      { method: "POST" },
+    );
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toEqual(
+      new URL(
+        "https://proxy.example/?url=https%3A%2F%2Fus-central1-aiplatform.googleapis.com%2Fv1%2Fprojects%2Fproject-id%2Flocations%2Fus-central1%2Fpublishers%2Fgoogle%2Fmodels%2Fgemini-2.5-pro%3AstreamGenerateContent",
+      ),
+    );
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+});

--- a/packages/common/src/fetch-utils.ts
+++ b/packages/common/src/fetch-utils.ts
@@ -1,0 +1,26 @@
+type FetchInput = Request | URL | string;
+
+function getCorsProxyUrlPrefixFromGlobal() {
+  return (
+    globalThis as typeof globalThis & {
+      POCHI_CORS_PROXY_URL_PREFIX?: string;
+    }
+  ).POCHI_CORS_PROXY_URL_PREFIX;
+}
+
+function getUrlString(input: FetchInput) {
+  return input instanceof Request ? input.url : input.toString();
+}
+
+export function withCorsProxy(input: FetchInput): FetchInput {
+  const proxyPrefix = getCorsProxyUrlPrefixFromGlobal();
+  if (!proxyPrefix) {
+    return input;
+  }
+
+  return new URL(`${proxyPrefix}${encodeURIComponent(getUrlString(input))}`);
+}
+
+export const fetchWithCorsProxy: typeof fetch = (input, init) => {
+  return fetch(withCorsProxy(input), init);
+};

--- a/packages/common/src/google-vertex-utils.ts
+++ b/packages/common/src/google-vertex-utils.ts
@@ -3,11 +3,7 @@ import {
   createVertexWithoutCredentials,
 } from "@ai-sdk/google-vertex/edge";
 import type { GoogleVertexModel } from "./configuration";
-
-// Declare global variable for CORS proxy url prefix
-declare global {
-  var POCHI_CORS_PROXY_URL_PREFIX: string;
-}
+import { withCorsProxy } from "./fetch-utils";
 
 function createPatchedFetchForFinetune(accessToken?: string | undefined) {
   function patchString(str: string) {
@@ -44,15 +40,7 @@ function createPatchedFetchForFinetune(accessToken?: string | undefined) {
       throw new Error(`Unexpected requestInfo type: ${typeof requestInfo}`);
     }
 
-    // Use CORS proxy if configured
-    if (globalThis.POCHI_CORS_PROXY_URL_PREFIX) {
-      const proxyUrl = finalUrl.toString();
-      finalUrl = new URL(
-        globalThis.POCHI_CORS_PROXY_URL_PREFIX + encodeURIComponent(proxyUrl),
-      );
-    }
-
-    return fetch(finalUrl, patchedRequestInit);
+    return fetch(withCorsProxy(finalUrl), patchedRequestInit);
   };
 }
 

--- a/packages/livekit/src/chat/__tests__/anthropic.test.ts
+++ b/packages/livekit/src/chat/__tests__/anthropic.test.ts
@@ -1,32 +1,52 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { proxiedFetch } from "../models/anthropic";
+import { createAnthropicModel } from "../models/anthropic";
 
-describe("Anthropic fetch", () => {
+const mocks = vi.hoisted(() => ({
+  createAnthropic: vi.fn(),
+  wrapLanguageModel: vi.fn((value) => value),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: mocks.createAnthropic,
+}));
+
+vi.mock("ai", () => ({
+  wrapLanguageModel: mocks.wrapLanguageModel,
+}));
+
+describe("Anthropic model", () => {
   afterEach(() => {
+    vi.resetAllMocks();
     vi.unstubAllGlobals();
     Reflect.deleteProperty(globalThis, "POCHI_CORS_PROXY_URL_PREFIX");
   });
 
-  it("uses direct fetch when the CORS proxy is not configured", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
-    vi.stubGlobal("fetch", fetchMock);
-
-    await proxiedFetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-    });
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.anthropic.com/v1/messages",
-      { method: "POST" },
-    );
-  });
-
-  it("uses the CORS proxy when configured", async () => {
+  it("uses the shared CORS proxy fetch", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
     vi.stubGlobal("fetch", fetchMock);
     globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
 
-    await proxiedFetch("https://api.anthropic.com/v1/messages", {
+    let anthropicFetch: typeof fetch | undefined;
+    vi.mocked(createAnthropic).mockImplementation((options) => {
+      if (!options?.fetch) {
+        throw new Error("Expected Anthropic fetch option");
+      }
+      anthropicFetch = options.fetch;
+      return ((modelId: string) => ({ modelId })) as ReturnType<
+        typeof createAnthropic
+      >;
+    });
+
+    createAnthropicModel({
+      id: "anthropic",
+      type: "anthropic",
+      modelId: "claude-sonnet-4-5",
+      contextWindow: 200_000,
+      maxOutputTokens: 8192,
+    });
+
+    await anthropicFetch?.("https://api.anthropic.com/v1/messages", {
       method: "POST",
     });
 

--- a/packages/livekit/src/chat/models/anthropic.ts
+++ b/packages/livekit/src/chat/models/anthropic.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
+import { fetchWithCorsProxy } from "@getpochi/common/fetch-utils";
 import { wrapLanguageModel } from "ai";
 import type { RequestData } from "../../types";
 
@@ -8,7 +9,7 @@ export function createAnthropicModel(
   const anthropic = createAnthropic({
     baseURL: llm.baseURL,
     apiKey: llm.apiKey,
-    fetch: proxiedFetch,
+    fetch: fetchWithCorsProxy,
   });
 
   return wrapLanguageModel({
@@ -22,15 +23,3 @@ export function createAnthropicModel(
     },
   });
 }
-
-export const proxiedFetch: typeof fetch = async (input, init) => {
-  const proxyPrefix = globalThis.POCHI_CORS_PROXY_URL_PREFIX;
-  if (!proxyPrefix) {
-    return fetch(input, init);
-  }
-
-  const originalUrl = input instanceof Request ? input.url : input.toString();
-  const url = new URL(`${proxyPrefix}${encodeURIComponent(originalUrl)}`);
-
-  return fetch(url, init);
-};

--- a/packages/vendor-codex/src/model.ts
+++ b/packages/vendor-codex/src/model.ts
@@ -1,5 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { withCorsProxy } from "@getpochi/common/fetch-utils";
 import type { CreateModelOptions } from "@getpochi/common/vendor/edge";
 import { wrapLanguageModel } from "ai";
 import { transformToCodexFormat } from "./transformers";
@@ -101,12 +102,6 @@ export function createProxyFetch(getCredentials: () => Promise<unknown>) {
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    const proxyPrefix = globalThis.POCHI_CORS_PROXY_URL_PREFIX;
-    const originalUrl = input instanceof Request ? input.url : input.toString();
-    const url = proxyPrefix
-      ? new URL(`${proxyPrefix}${encodeURIComponent(originalUrl)}`)
-      : input;
-
     const transformedBody = transformRequestBody(
       typeof init?.body === "string" ? init.body : undefined,
     );
@@ -114,7 +109,7 @@ export function createProxyFetch(getCredentials: () => Promise<unknown>) {
     const credentials = await (getCredentials() as Promise<CodexCredentials>);
     const headers = createCodexHeaders(credentials, init);
 
-    return fetch(url, {
+    return fetch(withCorsProxy(input), {
       ...init,
       headers,
       body: transformedBody || undefined,

--- a/packages/vendor-gemini-cli/src/model.test.ts
+++ b/packages/vendor-gemini-cli/src/model.test.ts
@@ -7,7 +7,7 @@ describe("Gemini CLI fetcher", () => {
     Reflect.deleteProperty(globalThis, "POCHI_CORS_PROXY_URL_PREFIX");
   });
 
-  it("uses direct fetch when CORS is requested but the proxy is not configured", async () => {
+  it("uses direct fetch when the CORS proxy is not configured", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(new Response("data: {}\r\n\r\n"));
@@ -21,7 +21,6 @@ describe("Gemini CLI fetcher", () => {
         expiresAt: Date.now() + 60_000,
         project: "project-id",
       }),
-      true,
     );
 
     await fetcher("https://unused.example", {
@@ -54,7 +53,6 @@ describe("Gemini CLI fetcher", () => {
         expiresAt: Date.now() + 60_000,
         project: "project-id",
       }),
-      true,
     );
 
     await fetcher("https://unused.example", {

--- a/packages/vendor-gemini-cli/src/model.ts
+++ b/packages/vendor-gemini-cli/src/model.ts
@@ -2,6 +2,7 @@ import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
 import { createVertexWithoutCredentials } from "@ai-sdk/google-vertex/edge";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { EventSourceParserStream } from "@ai-sdk/provider-utils";
+import { withCorsProxy } from "@getpochi/common/fetch-utils";
 import type { CreateModelOptions } from "@getpochi/common/vendor/edge";
 import { APICallError, wrapLanguageModel } from "ai";
 import type { GeminiCredentials } from "./types";
@@ -17,8 +18,6 @@ export function createGeminiCliModel({
     fetch: createFetcher(
       modelId,
       getCredentials as () => Promise<GeminiCredentials>,
-      // Turn on cors if in browser env
-      "window" in globalThis,
     ),
   })(modelId);
 
@@ -47,7 +46,6 @@ export function createGeminiCliModel({
 export function createFetcher(
   model: string,
   getCredentials: () => Promise<GeminiCredentials>,
-  cors?: boolean,
 ) {
   return async (
     _requestInfo: Request | URL | string,
@@ -64,16 +62,7 @@ export function createFetcher(
       "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
     );
 
-    let urlToFetch: URL;
-
-    const proxyPrefix = globalThis.POCHI_CORS_PROXY_URL_PREFIX;
-    if (cors && proxyPrefix) {
-      urlToFetch = new URL(
-        `${proxyPrefix}${encodeURIComponent(originalUrl.toString())}`,
-      );
-    } else {
-      urlToFetch = originalUrl;
-    }
+    const urlToFetch = withCorsProxy(originalUrl);
 
     const patchedRequestInit = {
       ...requestInit,

--- a/packages/vendor-qwen-code/src/model.test.ts
+++ b/packages/vendor-qwen-code/src/model.test.ts
@@ -1,0 +1,64 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQwenModel } from "./model";
+
+const mocks = vi.hoisted(() => ({
+  createOpenAICompatible: vi.fn(),
+  wrapLanguageModel: vi.fn((value) => value),
+}));
+
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: mocks.createOpenAICompatible,
+}));
+
+vi.mock("ai", () => ({
+  APICallError: class APICallError extends Error {},
+  wrapLanguageModel: mocks.wrapLanguageModel,
+}));
+
+describe("Qwen Code model", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(globalThis, "POCHI_CORS_PROXY_URL_PREFIX");
+  });
+
+  it("uses the shared CORS proxy fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    globalThis.POCHI_CORS_PROXY_URL_PREFIX = "https://proxy.example/?url=";
+
+    let qwenFetch: typeof fetch | undefined;
+    vi.mocked(createOpenAICompatible).mockImplementation((options) => {
+      qwenFetch = options.fetch;
+      return ((modelId: string) => ({ modelId })) as ReturnType<
+        typeof createOpenAICompatible
+      >;
+    });
+
+    createQwenModel({
+      modelId: "qwen3-coder-plus",
+      getCredentials: async () => ({
+        access_token: "token",
+        refresh_token: "refresh-token",
+        token_type: "Bearer",
+        resource_url: "https://portal.qwen.ai",
+        expiry_date: Date.now() + 60_000,
+      }),
+    });
+
+    await qwenFetch?.("https://portal.qwen.ai/v1/chat/completions", {
+      method: "POST",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toEqual(
+      new URL(
+        "https://proxy.example/?url=https%3A%2F%2Fportal.qwen.ai%2Fv1%2Fchat%2Fcompletions",
+      ),
+    );
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+});

--- a/packages/vendor-qwen-code/src/model.ts
+++ b/packages/vendor-qwen-code/src/model.ts
@@ -1,5 +1,6 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { withCorsProxy } from "@getpochi/common/fetch-utils";
 import type { CreateModelOptions } from "@getpochi/common/vendor/edge";
 import { APICallError, wrapLanguageModel } from "ai";
 import type { QwenCoderCredentials } from "./types";
@@ -48,21 +49,7 @@ function createPatchedFetch(
     const headers = new Headers(requestInit?.headers);
     headers.set("Authorization", `Bearer ${access_token}`);
 
-    let finalUrl: string | URL | Request;
-
-    // Check if CORS proxy is available (VSCode environment)
-    if (globalThis.POCHI_CORS_PROXY_URL_PREFIX) {
-      const url = new URL(
-        globalThis.POCHI_CORS_PROXY_URL_PREFIX +
-          encodeURIComponent(requestInfo.toString()),
-      );
-      finalUrl = url;
-    } else {
-      // CLI environment - make direct request
-      finalUrl = requestInfo;
-    }
-
-    const resp = await fetch(finalUrl, {
+    const resp = await fetch(withCorsProxy(requestInfo), {
       ...requestInit,
       headers,
     });


### PR DESCRIPTION
## Summary
- Centralize CORS proxy URL patching logic into a shared `fetch-utils` module inside `@getpochi/common`.
- Refactor Anthropic, Codex, Gemini, Vertex, and Qwen-Code providers/vendors to import and use `withCorsProxy` or `fetchWithCorsProxy` instead of duplicating proxy URL logic.
- Add comprehensive unit tests for the new `fetch-utils` functions and update existing provider tests to match the new behavior.

## Test plan
- [x] Run `bun run test` to verify all unit tests pass, including the new `fetch-utils` and updated provider tests.
- [x] Run `bun tsc` to ensure there are no TypeScript compile/type-checking errors.
- [x] Run `bun check` to ensure code formatting and linting are clean.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ac9a2eb2a3af46efa502f69f572d5b83)