### PR TITLE
fix(vscode-webui): improve vertical centering of checkpoint button

### DIFF
--- a/packages/vscode-webui/src/components/checkpoint-ui.tsx
+++ b/packages/vscode-webui/src/components/checkpoint-ui.tsx
@@ -185,13 +185,13 @@ export const CheckpointUI: React.FC<{
   return (
     <div
       className={cn(
-        "relative w-full opacity-0 transition-opacity duration-200",
+        "relative min-h-5 w-full opacity-0 transition-opacity duration-200",
         showCheckpoint && "opacity-100",
       )}
     >
       <div
         className={cn(
-          "-translate-x-1/2 -top-1 group absolute left-1/2 mx-auto flex min-h-5 w-full max-w-[72px] select-none items-center hover:max-w-full",
+          "-translate-x-1/2 -translate-y-1/2 group absolute top-1/2 left-1/2 z-10 mx-auto flex min-h-5 w-full max-w-[72px] select-none items-center hover:max-w-full",
           isLoading && "pointer-events-none",
           className,
         )}


### PR DESCRIPTION
## Summary
- Add `min-h-5` to the outer container of `CheckpointUI` to reserve height.
- Reposition the checkpoint button using absolute positioning with `top-1/2` and `-translate-y-1/2` for perfect vertical centering.
- Add `z-10` to ensure the checkpoint button renders on top of overlapping contents.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/9ab9300d-e7d8-47f0-8ef7-601305e6db13" />

## Test plan
- Open the VS Code Webview panel and verify that the checkpoint UI is vertically centered properly and visible above its adjacent layout elements.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9d19a8bead1746ec853106147b38a77f)