### PR TITLE
refactor(vscode-webui): surface subtask todos in new-task tool detail

### DIFF
--- a/packages/vscode-webui/src/components/task-thread.tsx
+++ b/packages/vscode-webui/src/components/task-thread.tsx
@@ -23,19 +23,16 @@ export const TaskThread: React.FC<{
     image?: string | null;
   };
   showMessageList?: boolean;
-  showTodos?: boolean;
   scrollAreaClassName?: string;
 }> = ({
   source,
   user,
   assistant,
   showMessageList = true,
-  showTodos = true,
   scrollAreaClassName,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
-  const [todos, setTodos] = useState<Todo[]>([]);
 
   useEffect(() => {
     if (!source) {
@@ -44,7 +41,6 @@ export const TaskThread: React.FC<{
 
     setIsLoading(source.isLoading ?? false);
     setMessages(source.messages);
-    setTodos(source.todos);
   }, [source]);
 
   const renderMessages = useMemo(() => prepareForRender(messages), [messages]);
@@ -86,22 +82,6 @@ export const TaskThread: React.FC<{
 
   return (
     <div className="flex flex-col">
-      {showTodos && todos && todos.length > 0 && (
-        <div className="my-1 flex flex-col px-2 py-1">
-          {todos
-            .filter((x) => x.status !== "cancelled")
-            .map((todo) => (
-              <span
-                key={todo.id}
-                className={cn("text-sm", {
-                  "line-through": todo.status === "completed",
-                })}
-              >
-                • {todo.content}
-              </span>
-            ))}
-        </div>
-      )}
       {showMessageList && (
         <MessageList
           className={cn("px-1 py-0.5", {

--- a/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
@@ -55,7 +55,6 @@ export function BrowserView(props: NewTaskToolViewProps) {
               <TaskThread
                 source={taskSource}
                 showMessageList={true}
-                showTodos={false}
                 scrollAreaClassName="border-none h-full w-full my-0"
                 assistant={{ name: "Browser" }}
               />

--- a/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
@@ -18,6 +18,7 @@ import { ExpandableToolContainer } from "../tool-container";
 import type { ToolProps } from "../types";
 import { BrowserView } from "./browser-view";
 import { PlannerView } from "./planner-view";
+import { TodoDetail } from "./todo-detail";
 import { WalkthroughView } from "./walkthrough-view";
 
 const SubtaskPreviewThrottleMs = 300;
@@ -175,6 +176,7 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
     <ExpandableToolContainer
       title={title}
       expandableDetail={expandableDetail}
+      detail={<TodoDetail todos={taskSource?.todos ?? []} />}
       expanded={showMessageList}
       onToggle={setShowMessageListImmediately}
     />

--- a/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
@@ -158,7 +158,6 @@ export function PlannerView(props: NewTaskToolViewProps) {
           <TaskThread
             source={taskSource}
             showMessageList={true}
-            showTodos={false}
             scrollAreaClassName="border-none h-[300px] my-0"
             assistant={{ name: "Planner" }}
           />

--- a/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
@@ -12,7 +12,6 @@ import type { NewTaskToolViewProps } from ".";
 import { StatusIcon } from "../status-icon";
 import { ToolCallLite } from "../tool-call-lite";
 import { ExpandIcon } from "../tool-container";
-import { TodoDetail } from "./todo-detail";
 
 interface SubAgentViewProps {
   uid?: string;
@@ -26,6 +25,7 @@ interface SubAgentViewProps {
   assistantName?: string;
   showToolCall?: boolean;
   showTaskThread?: boolean;
+  showTodos?: boolean;
 }
 
 export function SubAgentView({
@@ -126,8 +126,6 @@ export function SubAgentView({
       </div>
 
       {children}
-
-      <TodoDetail todos={taskSource?.todos ?? []} />
 
       {showFooter && (
         <>

--- a/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
@@ -12,6 +12,7 @@ import type { NewTaskToolViewProps } from ".";
 import { StatusIcon } from "../status-icon";
 import { ToolCallLite } from "../tool-call-lite";
 import { ExpandIcon } from "../tool-container";
+import { TodoDetail } from "./todo-detail";
 
 interface SubAgentViewProps {
   uid?: string;
@@ -126,6 +127,8 @@ export function SubAgentView({
 
       {children}
 
+      <TodoDetail todos={taskSource?.todos ?? []} />
+
       {showFooter && (
         <>
           <div className="flex items-center gap-2 overflow-x-hidden border-t bg-muted/30 px-2 py-1.5 text-muted-foreground">
@@ -184,7 +187,6 @@ export function SubAgentView({
                 <TaskThread
                   source={{ ...taskSource, isLoading: false }}
                   showMessageList={true}
-                  showTodos={false}
                   scrollAreaClassName="border-none"
                   assistant={{ name: assistantName }}
                 />

--- a/packages/vscode-webui/src/features/tools/components/new-task/todo-detail.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/todo-detail.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+import type { Todo } from "@getpochi/tools";
+import { Circle, CircleCheckBig, CircleDot } from "lucide-react";
+
+interface TodoDetailProps {
+  todos: Todo[];
+}
+
+export function TodoDetail({ todos }: TodoDetailProps) {
+  const visibleTodos = todos.filter((todo) => todo.status !== "cancelled");
+
+  if (visibleTodos.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="my-1 flex flex-col gap-0.5 py-1 pr-2 pl-6">
+      {visibleTodos.map((todo) => (
+        <span
+          key={todo.id}
+          className={cn("flex items-center gap-1.5 text-sm", {
+            "text-muted-foreground line-through": todo.status === "completed",
+            "animated-gradient-text": todo.status === "in-progress",
+          })}
+        >
+          {todo.status === "completed" ? (
+            <CircleCheckBig className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : todo.status === "in-progress" ? (
+            <CircleDot className="size-3.5 shrink-0" />
+          ) : (
+            <Circle className="size-3.5 shrink-0 text-muted-foreground/70" />
+          )}
+          <span className="truncate">{todo.content}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/packages/vscode-webui/src/features/tools/components/new-task/walkthrough-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/walkthrough-view.tsx
@@ -54,7 +54,6 @@ export function WalkthroughView(props: NewTaskToolViewProps) {
           <TaskThread
             source={taskSource}
             showMessageList={true}
-            showTodos={false}
             scrollAreaClassName="border-none h-[300px] my-0"
             assistant={{ name: "Walkthrough" }}
           />

--- a/packages/vscode-webui/src/features/tools/components/tool-container.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-container.tsx
@@ -102,8 +102,8 @@ export const ExpandableToolContainer: React.FC<{
           />
         )}
       </ToolTitle>
-      {showDetails && expandableDetail}
       {detail}
+      {showDetails && expandableDetail}
     </ToolContainer>
   );
 };

--- a/packages/vscode-webui/src/main.tsx
+++ b/packages/vscode-webui/src/main.tsx
@@ -7,7 +7,7 @@ import {
   createHashHistory,
   createRouter,
 } from "@tanstack/react-router";
-import { StrictMode } from "react";
+import { Fragment, type ReactNode, StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 
 // Import the generated route tree
@@ -98,11 +98,7 @@ function InnerApp() {
     );
   }
 
-  return (
-    <StrictMode>
-      <RouterProvider router={router} context={{}} />
-    </StrictMode>
-  );
+  return <RouterProvider router={router} context={{}} />;
 }
 
 function App() {
@@ -113,14 +109,24 @@ function App() {
   );
 }
 
+function StrictModeBoundary({ children }: { children: ReactNode }) {
+  // React dev StrictMode replays effects. In the VS Code webview those effects
+  // can start host-backed streams, so dev should match the production runtime.
+  const Component =
+    import.meta.env.DEV && globalThis.POCHI_WEBVIEW_KIND
+      ? Fragment
+      : StrictMode;
+  return <Component>{children}</Component>;
+}
+
 // Render the app
 const rootElement = document.getElementById("app");
 if (rootElement && !rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
-    <StrictMode>
+    <StrictModeBoundary>
       <App />
-    </StrictMode>,
+    </StrictModeBoundary>,
   );
 }
 


### PR DESCRIPTION
## Summary

- Extract todo rendering out of `TaskThread` into a new `TodoDetail` component and show it as the collapsed detail of the `newTask` tool, so subtask progress is visible without expanding the message list.
- Render `detail` before `expandableDetail` in `ExpandableToolContainer` so the todos sit directly under the subtask title.
- Stop wrapping the VS Code webview in React `StrictMode` during dev (host-backed effects shouldn't replay), via a new `StrictModeBoundary`.

## Screenshot

![subtask todos in new-task detail](https://pochi-file-uploads.getpochi.com/blob-1780389907181.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260602%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260602T084507Z&X-Amz-Expires=561600&X-Amz-Signature=fac72ad6229bbfe2f60aaff21764ae29e7cd947cb56a5be7fd99ac60d6b7f53a&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan

- [ ] Run a task that spawns a subtask with multiple todos and confirm the todos render in the collapsed `newTask` tool detail with the expected icons (pending/in-progress/completed) and strikethrough for completed items.
- [ ] Expand the subtask and confirm `TaskThread` no longer renders a duplicate todo list.
- [ ] Verify Planner / Walkthrough / Browser sub-agent views still render correctly without their previous `showTodos={false}` prop.
- [ ] Launch the webview in dev mode and confirm host-backed streams (chat, tool runs) are not double-started.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ccc9e502cd994d659dac390db0467b6e)