### PR TITLE
docs: add issue title formatting guidelines to create-issue skill

### DIFF
--- a/.pochi/skills/create-issue/SKILL.md
+++ b/.pochi/skills/create-issue/SKILL.md
@@ -6,7 +6,8 @@ description: Help create a github issue given the request
 # Github Issue Creator
 
 1. Please conduct a thorough search of the codebase on relevant code snippets to help implement the feature / debug the issue.
-2. Create an issue in the TabbyML/pochi repository. Select the appropriate template from `.github/ISSUE_TEMPLATE`. and use `gh` cli to to create the issue.
+2. Create an issue in the TabbyML/pochi repository. Select the appropriate template from `.github/ISSUE_TEMPLATE` and use `gh` cli to create the issue.
+   - **Title Formatting:** Do NOT use PR or commit semantics for issue titles (e.g., avoid prefixes like `feat(cli):` or `fix(vscode-webui):`). Instead, use clear, descriptive sentence-case titles (e.g., `Support fork-agent in CLI`).
 3. When creating issue, attach following information in footer of issue.
     🤖 Generated with [Pochi](https://getpochi.com)
 4. Please include as much as possible information about the issues, especially link to existing code (make sure you make the link clickable by prefixing them with github link)


### PR DESCRIPTION
## Summary
- Update the `create-issue` skill instructions to avoid using PR/commit prefix semantics (e.g., `feat(cli):` or `fix(...)`) in GitHub issue titles.
- Recommend clear, descriptive sentence-case titles (e.g., `Support fork-agent in CLI`).

## Test plan
- Verify that `.pochi/skills/create-issue/SKILL.md` contains the updated guidelines.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d73cbdb5e1214c59aa18ddd2fcffda02)