### PR TITLE
fix(tools): persist raw text to .log files instead of serialized JSON

### DIFF
--- a/packages/common/src/tool-utils/__tests__/tool-result-persistence.test.ts
+++ b/packages/common/src/tool-utils/__tests__/tool-result-persistence.test.ts
@@ -59,16 +59,16 @@ describe("maybePersistToolResult", () => {
       // Field replaced with truncated message
       expect(typeof result.output).toBe("string");
       expect(result.output).toContain("[Output too large:");
-      expect(result.output).toContain(".json");
+      expect(result.output).toContain(".log");
       expect(result.output).toContain("Preview");
 
       // Other fields preserved
       expect(result.isTruncated).toBe(false);
 
-      // File written with full JSON-stringified output
-      const filePath = path.join(tmpDir, ".pochi", "tasks", TASK_ID, "tool-results", `executeCommand-${TOOL_CALL_ID}.json`);
+      // File written with full raw string output
+      const filePath = path.join(tmpDir, ".pochi", "tasks", TASK_ID, "tool-results", `executeCommand-${TOOL_CALL_ID}-output.log`);
       const fileContent = await fs.readFile(filePath, "utf-8");
-      expect(fileContent).toBe(JSON.stringify(output));
+      expect(fileContent).toBe(big);
     });
 
     it("preview contains first chars of the large field", async () => {
@@ -106,10 +106,10 @@ describe("maybePersistToolResult", () => {
       expect(result.content[0].type).toBe("text");
       expect(result.content[0].text).toContain("[Output too large:");
 
-      // File contains full original output
-      const filePath = path.join(tmpDir, ".pochi", "tasks", TASK_ID, "tool-results", `someMcpTool-${TOOL_CALL_ID}.json`);
+      // File contains full original output as combined text
+      const filePath = path.join(tmpDir, ".pochi", "tasks", TASK_ID, "tool-results", `someMcpTool-${TOOL_CALL_ID}-content.log`);
       const fileContent = await fs.readFile(filePath, "utf-8");
-      expect(fileContent).toBe(JSON.stringify(output));
+      expect(fileContent).toBe(`${big}\nmore text`);
     });
 
     it("skips content array containing non-text blocks", async () => {

--- a/packages/common/src/tool-utils/tool-result-persistence.ts
+++ b/packages/common/src/tool-utils/tool-result-persistence.ts
@@ -59,18 +59,7 @@ export async function maybePersistToolResult(
       ...(output as Record<string, unknown>),
     };
 
-    // Lazily write the full output once; both cases share the same file.
     const dir = getToolResultsDir(taskId);
-    const filePath = path.join(dir, `${toolName}-${toolCallId}.json`);
-    let fileWritten = false;
-    const ensureFile = async () => {
-      if (!fileWritten) {
-        await fs.mkdir(dir, { recursive: true });
-        await fs.writeFile(filePath, serialized, "utf-8");
-        fileWritten = true;
-      }
-    };
-
     let persisted = false;
 
     // Case 1: top-level string fields (execute-command, read-background-job)
@@ -78,7 +67,10 @@ export async function maybePersistToolResult(
       if (typeof value !== "string") continue;
       if (value.length <= PersistedToolResultPreviewSize) continue;
 
-      await ensureFile();
+      const filePath = path.join(dir, `${toolName}-${toolCallId}-${key}.log`);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(filePath, value, "utf-8");
+
       result[key] = buildTruncatedValue(value, filePath);
       persisted = true;
 
@@ -102,7 +94,14 @@ export async function maybePersistToolResult(
         const combined = (contentArray as { type: "text"; text: string }[])
           .map((b) => b.text)
           .join("\n");
-        await ensureFile();
+
+        const filePath = path.join(
+          dir,
+          `${toolName}-${toolCallId}-content.log`,
+        );
+        await fs.mkdir(dir, { recursive: true });
+        await fs.writeFile(filePath, combined, "utf-8");
+
         result.content = [
           { type: "text", text: buildTruncatedValue(combined, filePath) },
         ];


### PR DESCRIPTION
## Summary
- Modified `maybePersistToolResult` to save raw content of large string fields to `.log` files instead of JSON-serialized single-line `.json` files.
- This preserves actual literal newlines, enabling the `readFile` tool to split on `\n` and successfully support line-based navigation (`startLine` / `endLine`).
- Updated corresponding unit tests to match the new behavior.

## Test plan
- Run unit tests for tool result persistence: `bun vitest --run src/tool-utils/__tests__/tool-result-persistence.test.ts` inside `packages/common` directory.
- Verify formatting/linting and type checking are clean.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-6027c778dc5840bca5ea5ef173af0974)