### PR TITLE
feat(livekit): add auto-compact policy with buffer-based threshold

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -551,6 +551,7 @@ async function createLLMConfigWithVendors(
     return {
       id: `${vendorId}/${modelId}`,
       type: "vendor",
+      contextWindow: options.contextWindow,
       useToolCallMiddleware: options.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {
@@ -573,6 +574,7 @@ async function createLLMConfigWithPochi(
     return {
       id: `${vendorId}/${model}`,
       type: "vendor",
+      contextWindow: pochiModelOptions.contextWindow,
       useToolCallMiddleware: pochiModelOptions.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -236,8 +236,10 @@ export class TaskRunner {
 
       abortSignal: options.abortSignal,
 
-      onCompact: () => {
-        this.toolCallOptions.fileStateCache.clear();
+      onCompactFinish: (success: boolean) => {
+        if (success) {
+          this.toolCallOptions.fileStateCache.clear();
+        }
       },
 
       getters: {

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -84,7 +84,7 @@ function removeSystemReminder(messages: UIMessage[]): UIMessage[] {
     if (
       parts.some(
         (x) =>
-          x.type === "text" ||
+          (x.type === "text" && !prompts.isCompact(x.text)) ||
           x.type === "data-reviews" ||
           x.type === "data-bash-outputs" ||
           isStaticToolUIPart(x),

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -56,6 +56,7 @@ export const PochiRequestUseCase = z.enum([
   "repair-tool-call",
   "generate-task-title",
   "compact-task",
+  "auto-compact-task",
   "repair-mermaid",
   ...ForkAgentUseCase.options,
 ]);

--- a/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
+++ b/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
@@ -1,0 +1,202 @@
+import { constants } from "@getpochi/common";
+import { describe, expect, it } from "vitest";
+import type { Message, RequestData, Task } from "../../types";
+import {
+  AutoCompactBufferTokens,
+  MaxSummaryOutputTokens,
+  getAutoCompactThreshold,
+  shouldAutoCompact,
+} from "../auto-compact-policy";
+
+function userMessage(
+  text = "next question",
+  extra: Partial<Message> = {},
+): Message {
+  return {
+    id: "u-last",
+    role: "user",
+    parts: [{ type: "text", text }],
+    ...extra,
+  } as unknown as Message;
+}
+
+function assistantMessage(text = "previous answer"): Message {
+  return {
+    id: "a-prev",
+    role: "assistant",
+    parts: [{ type: "text", text }],
+  } as unknown as Message;
+}
+
+function task(totalTokens: number | undefined): Task {
+  return { totalTokens } as unknown as Task;
+}
+
+const openaiLlm = (contextWindow: number): RequestData["llm"] =>
+  ({
+    id: "test-model",
+    type: "openai",
+    modelId: "test",
+    contextWindow,
+    maxOutputTokens: 4096,
+  }) as RequestData["llm"];
+
+describe("getAutoCompactThreshold", () => {
+  it("subtracts summary reserve + buffer from the context window", () => {
+    expect(getAutoCompactThreshold(100_000)).toBe(
+      100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
+    );
+    expect(getAutoCompactThreshold(200_000)).toBe(
+      200_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
+    );
+  });
+
+  it("never returns a negative threshold for tiny windows", () => {
+    expect(getAutoCompactThreshold(5_000)).toBe(0);
+    expect(getAutoCompactThreshold(0)).toBe(0);
+  });
+});
+
+describe("shouldAutoCompact", () => {
+  const minTokens = constants.CompactTaskMinTokens;
+  const contextWindow =
+    minTokens + MaxSummaryOutputTokens + AutoCompactBufferTokens;
+
+  it("triggers once total tokens reach the buffer-based threshold", () => {
+    const messages = [assistantMessage(), userMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(getAutoCompactThreshold(contextWindow)),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not trigger when total tokens are below the floor", () => {
+    const messages = [assistantMessage(), userMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(minTokens - 1),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger when the last message is not from the user", () => {
+    const messages = [userMessage(), assistantMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(contextWindow),
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to DefaultContextWindow when the LLM has no contextWindow", () => {
+    const messages = [assistantMessage(), userMessage()];
+    const vendorLlm = {
+      id: "vendor-cli",
+      type: "vendor",
+      getModel: () => ({}) as never,
+    } as RequestData["llm"];
+
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: vendorLlm,
+        task: task(getAutoCompactThreshold(constants.DefaultContextWindow)),
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: vendorLlm,
+        task: task(constants.CompactTaskMinTokens - 1),
+      }),
+    ).toBe(false);
+  });
+
+  it("uses an explicit vendor contextWindow when one is provided", () => {
+    const messages = [assistantMessage(), userMessage()];
+    const vendorLlm = {
+      id: "vendor-cli",
+      type: "vendor",
+      contextWindow: 1_000_000,
+      getModel: () => ({}) as never,
+    } as RequestData["llm"];
+
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: vendorLlm,
+        task: task(constants.CompactTaskMinTokens * 2),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger when totalTokens is below the buffer-based threshold", () => {
+    const messages = [assistantMessage(), userMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(1_000_000),
+        task: task(minTokens + 1),
+      }),
+    ).toBe(false);
+  });
+
+  it("skips the manual compact path (metadata.compact === true)", () => {
+    const messages = [
+      assistantMessage(),
+      userMessage("continue", {
+        metadata: { kind: "user", compact: true },
+      }) as Message,
+    ];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(contextWindow),
+      }),
+    ).toBe(false);
+  });
+
+  it("skips when the last user message already carries a <compact> block", () => {
+    const messages = [
+      assistantMessage(),
+      userMessage("<compact>previous summary</compact>"),
+    ];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: task(contextWindow),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when there are no messages", () => {
+    expect(
+      shouldAutoCompact({
+        messages: [],
+        llm: openaiLlm(contextWindow),
+        task: task(contextWindow),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when task is missing", () => {
+    const messages = [assistantMessage(), userMessage()];
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: openaiLlm(contextWindow),
+        task: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/livekit/src/chat/auto-compact-policy.ts
+++ b/packages/livekit/src/chat/auto-compact-policy.ts
@@ -1,0 +1,57 @@
+import { constants, prompts } from "@getpochi/common";
+import type { Message, RequestData, Task } from "../types";
+
+export const MaxSummaryOutputTokens = 20_000;
+
+export const AutoCompactBufferTokens = 13_000;
+
+export const MaxConsecutiveAutoCompactFailures = 3;
+
+export function getAutoCompactThreshold(contextWindow: number): number {
+  const effective = Math.max(contextWindow - MaxSummaryOutputTokens, 0);
+  return Math.max(effective - AutoCompactBufferTokens, 0);
+}
+
+function resolveContextWindow(llm: RequestData["llm"] | undefined): number {
+  const declared =
+    llm && "contextWindow" in llm ? llm.contextWindow : undefined;
+  return declared || constants.DefaultContextWindow;
+}
+
+export function shouldAutoCompact({
+  messages,
+  llm,
+  task,
+}: {
+  messages: Message[];
+  llm: RequestData["llm"] | undefined;
+  task: Task | null | undefined;
+}): boolean {
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role !== "user") return false;
+
+  if (
+    lastMessage.metadata?.kind === "user" &&
+    lastMessage.metadata.compact === true
+  ) {
+    return false;
+  }
+
+  const totalTokens = task?.totalTokens ?? 0;
+  if (totalTokens < constants.CompactTaskMinTokens) return false;
+
+  const contextWindow = resolveContextWindow(llm);
+  if (totalTokens < getAutoCompactThreshold(contextWindow)) {
+    return false;
+  }
+
+  if (
+    lastMessage.parts.some(
+      (part) => part.type === "text" && prompts.isCompact(part.text),
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -24,6 +24,10 @@ import { events, tables } from "../livestore/default-schema";
 import { toTaskError, toTaskGitInfo, toTaskStatus } from "../task";
 
 import type { LiveKitStore, Message, Task } from "../types";
+import {
+  MaxConsecutiveAutoCompactFailures,
+  shouldAutoCompact,
+} from "./auto-compact-policy";
 import { scheduleGenerateTitleJob } from "./background-job";
 import { filterCompletionTools } from "./filter-completion-tools";
 import {
@@ -176,12 +180,9 @@ export type LiveChatKitOptions<T> = {
     },
   ) => void;
 
-  /**
-   * Called after a successful compaction (inline or explicit).
-   * Use this to clear caches (e.g. FileStateCache) that depend on
-   * conversation context that was discarded during compaction.
-   */
-  onCompact?: () => void | Promise<void>;
+  onCompactStart?: () => void;
+
+  onCompactFinish?: (success: boolean) => void | Promise<void>;
 
   /**
    * Returns recent file contents the model saw before compaction.
@@ -242,6 +243,7 @@ export class LiveChatKit<
   readonly compact: () => Promise<string>;
   readonly repairMermaid: (chart: string, error: string) => Promise<void>;
   private lastStepStartTimestamp: number | undefined;
+  private consecutiveAutoCompactFailures = 0;
 
   constructor({
     taskId,
@@ -250,7 +252,6 @@ export class LiveChatKit<
     blobStore,
     chatClass,
     onOverrideMessages,
-    onCompact,
     getters,
     isSubTask,
     requestUseCase,
@@ -258,8 +259,9 @@ export class LiveChatKit<
     outputSchema,
     attemptCompletionSchema,
     onStreamStart,
-
     onStreamFinish,
+    onCompactStart,
+    onCompactFinish,
     getRecentFilesForCompact,
     getTaskMemoryState,
     ...chatInit
@@ -308,11 +310,28 @@ export class LiveChatKit<
       // Mark status to make async behaivor blocked based on status (e.g isLoading )
       const { messages } = this.chat;
       const lastMessage = messages.at(-1);
-      if (
+      const isManualCompact =
         lastMessage?.role === "user" &&
         lastMessage.metadata?.kind === "user" &&
-        lastMessage.metadata.compact
-      ) {
+        lastMessage.metadata.compact === true;
+
+      const isAutoCompact =
+        !isManualCompact &&
+        this.consecutiveAutoCompactFailures <
+          MaxConsecutiveAutoCompactFailures &&
+        shouldAutoCompact({
+          messages,
+          llm: getters.getLLM(),
+          task: this.task,
+        });
+
+      if (isManualCompact || isAutoCompact) {
+        try {
+          onCompactStart?.();
+        } catch (notifyErr) {
+          logger.warn("onCompactStart callback threw", notifyErr);
+        }
+        let compactSucceeded = false;
         try {
           // Wait briefly so memory.md and boundary id are fresh.
           await settleTaskMemoryExtraction(
@@ -320,6 +339,13 @@ export class LiveChatKit<
             TaskMemorySettleTimeoutMs,
           );
           const model = createModel({ llm: getters.getLLM() });
+          if (isAutoCompact) {
+            logger.info(
+              `Auto-compact triggered (totalTokens=${
+                this.task?.totalTokens ?? 0
+              }).`,
+            );
+          }
           await compactTask({
             blobStore: this.blobStore,
             taskId: this.taskId,
@@ -333,11 +359,29 @@ export class LiveChatKit<
             abortSignal,
             inline: true,
             store: this.store,
+            useCase: isAutoCompact ? "auto-compact-task" : "compact-task",
           });
-          await onCompact?.();
+          if (isAutoCompact) {
+            this.consecutiveAutoCompactFailures = 0;
+          }
+          compactSucceeded = true;
         } catch (err) {
-          logger.error("Failed to compact task", err);
-          throw err;
+          if (isAutoCompact) {
+            this.consecutiveAutoCompactFailures += 1;
+            logger.warn(
+              `Auto-compact failed (${this.consecutiveAutoCompactFailures}/${MaxConsecutiveAutoCompactFailures}); request will proceed without compaction.`,
+              err,
+            );
+          } else {
+            logger.error("Failed to compact task", err);
+            throw err;
+          }
+        } finally {
+          try {
+            await onCompactFinish?.(compactSucceeded);
+          } catch (notifyErr) {
+            logger.warn("onCompactFinish callback threw", notifyErr);
+          }
         }
       }
       if (onOverrideMessages) {
@@ -358,29 +402,45 @@ export class LiveChatKit<
     };
 
     this.compact = async () => {
-      const { messages } = this.chat;
-      // Wait briefly so memory.md and boundary id are fresh.
-      await settleTaskMemoryExtraction(
-        getTaskMemoryState,
-        TaskMemorySettleTimeoutMs,
-      );
-      const model = createModel({ llm: getters.getLLM() });
-      const summary = await compactTask({
-        blobStore: this.blobStore,
-        taskId: this.taskId,
-        model,
-        messages,
-        recentFiles: await readRecentFilesForCompact(getRecentFilesForCompact),
-        taskMemoryBoundaryMessageId:
-          getTaskMemoryState?.()?.lastExtractionMessageId,
-        store: this.store,
-      });
-
-      if (!summary) {
-        throw new Error("Failed to compact task");
+      try {
+        onCompactStart?.();
+      } catch (notifyErr) {
+        logger.warn("onCompactStart callback threw", notifyErr);
       }
-      await onCompact?.();
-      return summary;
+      let compactSucceeded = false;
+      try {
+        const { messages } = this.chat;
+        // Wait briefly so memory.md and boundary id are fresh.
+        await settleTaskMemoryExtraction(
+          getTaskMemoryState,
+          TaskMemorySettleTimeoutMs,
+        );
+        const model = createModel({ llm: getters.getLLM() });
+        const summary = await compactTask({
+          blobStore: this.blobStore,
+          taskId: this.taskId,
+          model,
+          messages,
+          recentFiles: await readRecentFilesForCompact(
+            getRecentFilesForCompact,
+          ),
+          taskMemoryBoundaryMessageId:
+            getTaskMemoryState?.()?.lastExtractionMessageId,
+          store: this.store,
+        });
+
+        if (!summary) {
+          throw new Error("Failed to compact task");
+        }
+        compactSucceeded = true;
+        return summary;
+      } finally {
+        try {
+          await onCompactFinish?.(compactSucceeded);
+        } catch (notifyErr) {
+          logger.warn("onCompactFinish callback threw", notifyErr);
+        }
+      }
     };
 
     this.repairMermaid = async (chart: string, error: string) => {

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -1,6 +1,7 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import {
   type PochiProviderOptions,
+  type PochiRequestUseCase,
   formatters,
   getLogger,
   prompts,
@@ -27,6 +28,7 @@ export async function compactTask({
   abortSignal,
   inline,
   store,
+  useCase = "compact-task",
 }: {
   blobStore: BlobStore;
   taskId: string;
@@ -38,6 +40,7 @@ export async function compactTask({
   abortSignal?: AbortSignal;
   inline?: boolean;
   store?: LiveKitStore;
+  useCase?: Extract<PochiRequestUseCase, "compact-task" | "auto-compact-task">;
 }): Promise<string | undefined> {
   const lastMessage = messages.at(-1);
   if (!lastMessage) {
@@ -64,6 +67,7 @@ export async function compactTask({
         model,
         abortSignal,
         messages.slice(0, -1),
+        useCase,
       );
     }
 
@@ -152,6 +156,7 @@ async function createSummary(
   model: LanguageModelV3,
   abortSignal: AbortSignal | undefined,
   inputMessages: Message[],
+  useCase: Extract<PochiRequestUseCase, "compact-task" | "auto-compact-task">,
 ) {
   const messages: Message[] = [
     ...inputMessages,
@@ -172,7 +177,7 @@ async function createSummary(
       pochi: {
         taskId,
         client: globalThis.POCHI_CLIENT,
-        useCase: "compact-task",
+        useCase,
       } satisfies PochiProviderOptions,
     },
     model,

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -138,6 +138,10 @@ const RequestData = z.object({
     z.object({
       id: z.string(),
       type: z.literal("vendor"),
+      contextWindow: z
+        .number()
+        .optional()
+        .describe("Context window of the model."),
       useToolCallMiddleware: z
         .boolean()
         .optional()

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -46,6 +46,7 @@ export const MessageList: React.FC<{
     image?: string | null;
   };
   isLoading: boolean;
+  loadingLabel?: string;
   containerRef?: React.RefObject<HTMLDivElement | null>;
   showUserAvatar?: boolean;
   className?: string;
@@ -59,6 +60,7 @@ export const MessageList: React.FC<{
 }> = ({
   messages: renderMessages,
   isLoading,
+  loadingLabel,
   user = { name: "User" },
   assistant,
   containerRef,
@@ -204,12 +206,14 @@ export const MessageList: React.FC<{
           ))}
           {showLoader && (
             <div className="py-2">
-              <Loader2
-                className={cn(
-                  "mx-auto size-6",
-                  debouncedIsLoading ? "animate-spin" : "invisible",
-                )}
-              />
+              {debouncedIsLoading ? (
+                <div className="mx-auto flex items-center justify-center gap-2 text-muted-foreground text-sm">
+                  <Loader2 className="size-6 animate-spin" />
+                  {loadingLabel && <span>{loadingLabel}</span>}
+                </div>
+              ) : (
+                <Loader2 className="invisible mx-auto size-6" />
+              )}
             </div>
           )}
         </ScrollArea>

--- a/packages/vscode-webui/src/features/chat/components/chat-area.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.tsx
@@ -8,6 +8,7 @@ import type React from "react";
 interface ChatAreaProps {
   messages: Message[];
   isLoading: boolean;
+  loadingLabel?: string;
   user?: { name: string; image?: string | null };
   messagesContainerRef?: React.RefObject<HTMLDivElement | null>;
   className?: string;
@@ -21,6 +22,7 @@ interface ChatAreaProps {
 export function ChatArea({
   messages,
   isLoading,
+  loadingLabel,
   user,
   messagesContainerRef,
   className,
@@ -45,6 +47,7 @@ export function ChatArea({
           image: resourceUri?.logo128,
         }}
         isLoading={isLoading}
+        loadingLabel={loadingLabel}
         containerRef={messagesContainerRef}
         className={className}
         forkTask={forkTask}

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -131,6 +131,7 @@ function useLLM({
       return {
         id: model.id,
         type: "vendor",
+        contextWindow: model.options.contextWindow,
         useToolCallMiddleware: model.options.useToolCallMiddleware,
         getModel: () =>
           createModel(model.vendorId, {

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -22,7 +22,7 @@ import type { Todo } from "@getpochi/tools";
 import { useStoreRegistry } from "@livestore/react";
 import { Schema } from "@livestore/utils/effect";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useApprovalAndRetry } from "../approval";
 import {
@@ -165,15 +165,14 @@ function Chat({ user, uid, info }: ChatProps) {
   });
   const tryUpdateAutoMemoryRef = useLatest(tryUpdateAutoMemory);
 
-  const chatKit = useLiveChatKit({
-    store,
-    blobStore,
-    taskId: uid,
-    getters,
-    isSubTask,
-    customAgent,
-    abortSignal: chatAbortController.current.signal,
-    onCompact: async () => {
+  const [isCompacting, setIsCompacting] = useState(false);
+  const onCompactStart = useCallback(() => {
+    setIsCompacting(true);
+  }, []);
+  const onCompactFinish = useCallback(
+    async (success: boolean) => {
+      setIsCompacting(false);
+      if (!success) return;
       await vscodeHost.clearFileStateCache(uid);
       // Token usage drops at compact, so rebase the baseline against the
       // post-compact view; tool-call count is monotonic and unaffected.
@@ -183,6 +182,19 @@ function Chat({ user, uid, info }: ChatProps) {
         setter({ ...current, lastExtractionTokens: 0 });
       }
     },
+    [uid, setTaskMemoryStateRef, taskMemoryStateRef],
+  );
+
+  const chatKit = useLiveChatKit({
+    store,
+    blobStore,
+    taskId: uid,
+    getters,
+    isSubTask,
+    customAgent,
+    abortSignal: chatAbortController.current.signal,
+    onCompactStart,
+    onCompactFinish,
     getRecentFilesForCompact: () => vscodeHost.readRecentFilesForCompact(uid),
     getTaskMemoryState: () => taskMemoryStateRef.current,
     sendAutomaticallyWhen: (x) => {
@@ -339,7 +351,8 @@ function Chat({ user, uid, info }: ChatProps) {
       )}
       <ChatArea
         messages={renderMessages}
-        isLoading={isLoading}
+        isLoading={isLoading || isCompacting}
+        loadingLabel={isCompacting ? t("tokenUsage.compacting") : undefined}
         user={user || defaultUser}
         messagesContainerRef={messagesContainerRef}
         className={cn({

--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -91,7 +91,11 @@ export function useLiveSubTask(
     getters,
     isSubTask: true,
     customAgent,
-    onCompact: () => vscodeHost.clearFileStateCache(uid),
+    onCompactFinish: (success: boolean) => {
+      if (success) {
+        return vscodeHost.clearFileStateCache(uid);
+      }
+    },
     sendAutomaticallyWhen: (x) => {
       const streamingResult = ensureNewTaskStreamingResult(
         lifecycle.streamingResult,


### PR DESCRIPTION
## Summary
- Inline auto-compact before a user turn when token usage crosses a buffer-based threshold (`contextWindow - MaxSummaryOutputTokens(20k) - AutoCompactBufferTokens(13k)`), gated by a 3-strike `consecutiveAutoCompactFailures` circuit breaker so transient failures fall back to the normal request path
- New `auto-compact-task` `PochiRequestUseCase` so the auto path is distinguishable on the server cache layer from manual `compact-task`
- Unified compact lifecycle: replaces `onCompact` with generic `onCompactStart` / `onCompactFinish(success)` callbacks on `LiveChatKitOptions` that fire for all three compact paths (auto-inline, manual-inline, and the standalone `chatKit.compact()` method)
- UI feedback: `MessageList.loadingLabel?: string` plumbed through `ChatArea` so the trailing in-thread spinner can be captioned; `ChatPage` toggles `isCompacting` and shows the localized `tokenUsage.compacting` caption, keeping the `isLoading || isCompacting` OR so the standalone compact path (which leaves `chat.status === \"ready\"`) still renders the loader
- Plumbs `llm.contextWindow` through `RequestData` so the policy can use the per-model context window (CLI + vscode-webui both pass it now)
- Tightens `removeSystemReminder` so compact-text parts are still treated as content rather than dropped via the system-reminder filter
- 12 new unit tests in `auto-compact-policy.test.ts` (2 threshold + 10 `shouldAutoCompact`)

## Test plan
- [ ] `bun run test` in `packages/livekit` — auto-compact-policy suite green
- [ ] Manual: drive a chat past the threshold and confirm the auto path triggers once, shows the compacting caption, and that 3 consecutive failures trip the breaker
- [ ] Manual: standalone "New Task with Summary" still shows the compacting caption
- [ ] Manual: subtask compact (`useLiveSubTask`) still clears `fileStateCache` on success and is a no-op on failure

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3c346fe92031482a81effe5ea08e656d)