### PR TITLE
chore(vscode): bump version to 0.51.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.49.0-dev",
+  "version": "0.51.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bumps `packages/vscode/package.json` version from `0.49.0-dev` to `0.51.0-dev`

## Test plan
- [ ] No functional changes; version bump only

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-2b2623c256e6400299a2c5732e07711d) | [Task](https://app.getpochi.com/share/p-2b2623c256e6400299a2c5732e07711d)