### PR TITLE
test(tools): add executeToolCalls test for concurrent batch failure isolation

### DIFF
--- a/packages/tools/src/__test__/tool-batch.test.ts
+++ b/packages/tools/src/__test__/tool-batch.test.ts
@@ -282,6 +282,56 @@ describe("executeToolCalls", () => {
     expect(caught).toBeInstanceOf(BatchExecutionError);
   });
 
+  it("concurrent batch failure is isolated; subsequent serial items still execute", async () => {
+    const executed: string[] = [];
+
+    const items: BatchedToolCall[] = [
+      {
+        ...item("readFile"),
+        run: async () => {
+          throw new Error("first tool call failed");
+        },
+      },
+      {
+        ...item("listFiles"),
+        run: async () => {
+          executed.push("listFiles");
+          return { kind: "success" as const };
+        },
+      },
+      {
+        ...item("globFiles"),
+        run: async () => {
+          executed.push("globFiles");
+          return { kind: "success" as const };
+        },
+      },
+      {
+        ...item("writeToFile"),
+        run: async () => {
+          executed.push("writeToFile");
+          return { kind: "success" as const };
+        },
+      },
+      {
+        ...item("applyDiff"),
+        run: async () => {
+          executed.push("applyDiff");
+          return { kind: "success" as const };
+        },
+      },
+    ];
+
+    await executeToolCalls({ toolCalls: items });
+
+    // concurrent-batch failure is swallowed; the two serial items still run
+    expect(executed).toContain("listFiles");
+    expect(executed).toContain("globFiles");
+    expect(executed).toContain("writeToFile");
+    expect(executed).toContain("applyDiff");
+    expect(executed).not.toContain("readFile");
+  });
+
   it("runs all concurrent items and checks total execution count", async () => {
     let executeCount = 0;
 


### PR DESCRIPTION
## Summary

- Adds a new `executeToolCalls` test case where the first of three readonly (concurrent) tool calls throws, followed by two non-readonly (serial) tool calls
- Verifies that a failure inside a concurrent batch is isolated/swallowed and does not prevent subsequent serial batches from executing
- Covers the `runConcurrentBatch` error-swallow path and the full `readonly → readonly → readonly → serial → serial` partition shape in one end-to-end scenario

## Test plan

- [x] `bun run test` in `packages/tools` — 100 tests pass

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1f1429a12e66446690650369cb563a17)