### PR TITLE
fix(common): hide empty UI reasoning placeholders

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -80,6 +80,28 @@ describe('formatters', () => {
       expect(assistantMessages[0].parts).toHaveLength(4); // reasoning, text, tool1, tool2
     });
 
+    it('should remove empty reasoning parts with provider metadata', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: '',
+              providerMetadata: { openai: { itemId: 'rs_abc123' } },
+            },
+            createToolPart('webSearch', 'output-available', {}, { result: 'ok' }),
+          ],
+        },
+      ];
+
+      const formatted = formatters.ui(clone(messages));
+
+      expect(formatted[0].parts).toHaveLength(1);
+      expect(formatted[0].parts[0].type).toBe('tool-webSearch');
+    });
+
     it('should remove system reminder messages', () => {
       const formatted = formatters.ui(clone(baseMessages));
       expect(formatted.find((m) => m.id === 'user-2')).toBeUndefined();

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -264,6 +264,18 @@ function removeEmptyTextParts(messages: UIMessage[]) {
   });
 }
 
+function removeEmptyReasoningPartsForUI(messages: UIMessage[]) {
+  return messages.map((message) => {
+    message.parts = message.parts.filter((part) => {
+      if (part.type === "reasoning") {
+        return part.text.trim().length > 0;
+      }
+      return true;
+    });
+    return message;
+  });
+}
+
 function refineDetectedNewPromblems(messages: UIMessage[]) {
   const isWriteFileResultToolPart = (
     part: UIMessage["parts"][number],
@@ -381,6 +393,7 @@ const LLMFormatOps: FormatOp[] = [
 ];
 const UIFormatOps = [
   removeEmptyTextParts,
+  removeEmptyReasoningPartsForUI,
   removeEmptyMessages,
   refineDetectedNewPromblems,
   resolvePendingToolCalls,


### PR DESCRIPTION
## Summary
- Filter empty reasoning parts from UI-formatted messages even when provider metadata is present.
- Preserve LLM formatter behavior so provider metadata-only reasoning parts remain available for API item references.
- Add a regression test covering metadata-only reasoning before a tool call.

## Screenshot
![Thought for 0 characters UI artifact](https://pochi-file-uploads.getpochi.com/blob-1780679014212.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260605%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260605T170335Z&X-Amz-Expires=561600&X-Amz-Signature=f808bd3f2e9a6e325d25759f1816037572a5e50d2c9b4b2b9a9a556aaa7c349e&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan
- `bun run test src/base/__tests__/formatters.test.ts` from `packages/common`
- `bun check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-06d6e80595e34beea944483c9761a4b4)