### PR TITLE
feat(cli): add timestamp to trajectory stream renderer output

### DIFF
--- a/packages/cli/src/renderers/trajectory-stream-renderer.ts
+++ b/packages/cli/src/renderers/trajectory-stream-renderer.ts
@@ -47,6 +47,7 @@ export class TrajectoryStreamRenderer implements StreamRenderer {
           if (!R.isDeepEqual(cachedPart, resolvedPart)) {
             const outputData = {
               type: "message-part",
+              timestamp: new Date().toISOString(),
               messageId: message.id,
               role: message.role,
               index: i,


### PR DESCRIPTION
## Summary
- Add ISO timestamp field to each `message-part` output in `TrajectoryStreamRenderer`
- Enables time-based analysis and debugging of trajectory events in CLI output

## Test plan
- [ ] Run CLI with trajectory output and verify `timestamp` field appears in each `message-part` event
- [ ] Confirm timestamp is a valid ISO 8601 string

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e11cf6620dc842588f744959e77b9725)