### PR TITLE
fix(cli): fix build script to embed wasm and assets

### DIFF
--- a/packages/cli/scripts/build-cli.sh
+++ b/packages/cli/scripts/build-cli.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
 set -ex
 
-copy_builtin_skills() {
-        local dest="$1"
-        rm -rf "$dest/skills"
-        cp -R ../common/src/base/skills "$dest/skills"
-}
+#
+# build_js output:
+#
+# dist/
+# ├ cli.js
+# ├ wa-sqlite.node.wasm
+# ├ skills/*
+# └ agents/*
 
-copy_builtin_agents() {
+build_js_copy_assets() {
         local dest="$1"
+        cp "../../node_modules/@livestore/wa-sqlite/dist/wa-sqlite.node.wasm" "$dest/wa-sqlite.node.wasm"
+        rm -rf "$dest/skills"
+        cp -R "../common/src/base/skills" "$dest/skills"
         rm -rf "$dest/agents"
-        cp -R ../common/src/base/agents "$dest/agents"
+        cp -R "../common/src/base/agents" "$dest/agents"
 }
 
 build_js() {
@@ -24,25 +30,94 @@ build_js() {
         fi
 
         bun build src/cli.ts \
+                --asset-naming="[name].[ext]" \
                 --external lightningcss \
                 --target node \
                 --outdir ./dist \
-                --asset-naming="[name].[ext]" \
                 "$@"
 
         sed -i.bak '1s|^.*$|#!/usr/bin/env node|' ./dist/cli.js
         rm -f ./dist/cli.js.bak
 
-        copy_builtin_skills ./dist
-        copy_builtin_agents ./dist
+        build_js_copy_assets ./dist
+}
+
+#
+# build_exe output:
+#
+# dist/
+# └ pochi (binary -> Bun.embeddedFiles)
+#                    ├ assets/wa-sqlite.node.wasm
+#                    ├ assets/skills/*
+#                    └ assets/agents/*
+
+WASM_LOADER_FILE="../../node_modules/@livestore/wa-sqlite/dist/wa-sqlite.node.mjs"
+WASM_LOADER_BACKUP="${WASM_LOADER_FILE}.bak"
+
+# patch wasm loader to load `assets/wa-sqlite.node.wasm`
+patch_wasm_loader() {
+        cp "$WASM_LOADER_FILE" "$WASM_LOADER_BACKUP"
+
+        WASM_LOADER_FILE="$WASM_LOADER_FILE" bun -e '
+                const path = process.env.WASM_LOADER_FILE;
+                if (!path) throw new Error("WASM_LOADER_FILE is not set");
+
+                let text = await Bun.file(path).text();
+
+                const pattern = /new URL\("wa-sqlite\.node\.wasm",\s*import\.meta\.url\)\.href/g;
+                const replacement = `new URL("assets/wa-sqlite.node.wasm",import.meta.url).href`;
+
+                const patched = text.replace(pattern, replacement);
+                if (patched === text) {
+                        console.error(`Patch target not found in ${path}`);
+                        process.exit(1);
+                }
+
+                text = patched;
+                await Bun.write(path, text);
+
+                console.log(`Patched ${path}`);
+        '
+}
+
+# restore the patched wasm loader
+restore_wasm_loader() {
+        if [[ -f "$WASM_LOADER_BACKUP" ]]; then
+                mv "$WASM_LOADER_BACKUP" "$WASM_LOADER_FILE"
+                echo "Restored $WASM_LOADER_FILE"
+        fi
+}
+
+build_exe_prepare() {
+        mkdir -p "./assets"
+        cp "../../node_modules/@livestore/wa-sqlite/dist/wa-sqlite.node.wasm" "./assets/wa-sqlite.node.wasm"
+        cp -R "../common/src/base/skills" "./assets/skills"
+        cp -R "../common/src/base/agents" "./assets/agents"
+
+        patch_wasm_loader
+}
+
+build_exe_cleanup() {
+        rm -f "./assets/wa-sqlite.node.wasm"
+        rm -rf "./assets/skills"
+        rm -rf "./assets/agents"
+
+        restore_wasm_loader
+}
+
+build_exe_collect_inputs() {
+        printf '%s\0' "src/cli.ts"
+        find "./assets" -type f -print0
 }
 
 build_exe() {
-        local md_files
-        md_files=$(find ../common/src/base/skills ../common/src/base/agents \
-                -type f -name "*.md")
+        build_exe_prepare
+        trap build_exe_cleanup RETURN
 
-        bun build src/cli.ts $md_files \
+        local input_files=()
+        mapfile -d '' -t input_files < <(build_exe_collect_inputs)
+
+        bun build "${input_files[@]}" \
                 --banner='import * as undici from "undici";' \
                 --asset-naming="[dir]/[name].[ext]" \
                 --loader .md:file \

--- a/packages/cli/scripts/build-cli.sh
+++ b/packages/cli/scripts/build-cli.sh
@@ -56,25 +56,30 @@ WASM_LOADER_BACKUP="${WASM_LOADER_FILE}.bak"
 
 # patch wasm loader to load `assets/wa-sqlite.node.wasm`
 patch_wasm_loader() {
-        cp "$WASM_LOADER_FILE" "$WASM_LOADER_BACKUP"
-
-        WASM_LOADER_FILE="$WASM_LOADER_FILE" bun -e '
+        WASM_LOADER_FILE="$WASM_LOADER_FILE" WASM_LOADER_BACKUP="$WASM_LOADER_BACKUP" bun -e '
                 const path = process.env.WASM_LOADER_FILE;
+                const backupPath = process.env.WASM_LOADER_BACKUP;
                 if (!path) throw new Error("WASM_LOADER_FILE is not set");
+                if (!backupPath) throw new Error("WASM_LOADER_BACKUP is not set");
 
-                let text = await Bun.file(path).text();
+                const text = await Bun.file(path).text();
 
                 const pattern = /new URL\("wa-sqlite\.node\.wasm",\s*import\.meta\.url\)\.href/g;
                 const replacement = `new URL("assets/wa-sqlite.node.wasm",import.meta.url).href`;
 
                 const patched = text.replace(pattern, replacement);
                 if (patched === text) {
+                        if (text.includes(replacement)) {
+                                console.log(`Already patched ${path}`);
+                                process.exit(0);
+                        }
+
                         console.error(`Patch target not found in ${path}`);
                         process.exit(1);
                 }
 
-                text = patched;
-                await Bun.write(path, text);
+                await Bun.write(backupPath, text);
+                await Bun.write(path, patched);
 
                 console.log(`Patched ${path}`);
         '
@@ -89,6 +94,7 @@ restore_wasm_loader() {
 }
 
 build_exe_prepare() {
+        rm -rf "./assets"
         mkdir -p "./assets"
         cp "../../node_modules/@livestore/wa-sqlite/dist/wa-sqlite.node.wasm" "./assets/wa-sqlite.node.wasm"
         cp -R "../common/src/base/skills" "./assets/skills"
@@ -98,9 +104,7 @@ build_exe_prepare() {
 }
 
 build_exe_cleanup() {
-        rm -f "./assets/wa-sqlite.node.wasm"
-        rm -rf "./assets/skills"
-        rm -rf "./assets/agents"
+        rm -rf "./assets"
 
         restore_wasm_loader
 }
@@ -111,11 +115,15 @@ build_exe_collect_inputs() {
 }
 
 build_exe() {
+        build_exe_cleanup
+        trap build_exe_cleanup EXIT
         build_exe_prepare
-        trap build_exe_cleanup RETURN
 
         local input_files=()
-        mapfile -d '' -t input_files < <(build_exe_collect_inputs)
+        local input_file
+        while IFS= read -r -d '' input_file; do
+                input_files+=("$input_file")
+        done < <(build_exe_collect_inputs)
 
         bun build "${input_files[@]}" \
                 --banner='import * as undici from "undici";' \

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env bun
-// Workaround for https://github.com/oven-sh/bun/issues/18145
-import "@livestore/wa-sqlite/dist/wa-sqlite.node.wasm" with { type: "file" };
 
 import fs from "node:fs";
 import os from "node:os";

--- a/scripts/dep-check.ts
+++ b/scripts/dep-check.ts
@@ -237,7 +237,7 @@ const PackageIgnoreList: Record<string, string[]> = {
     // Releasing
     "ovsx",
   ],
-  cli: ["@types/bun", "bun"],
+  cli: ["@types/bun", "bun", "@livestore/wa-sqlite"],
   livekit: ["@ai-sdk/provider-utils", "@ai-sdk/provider"],
   docs: ["@tailwindcss/postcss", "postcss", "tailwindcss", "typescript"],
 };


### PR DESCRIPTION
## Summary

- Consolidated `copy_builtin_skills` and `copy_builtin_agents` into a single `build_js_copy_assets` function that also copies `wa-sqlite.node.wasm` into the JS dist output
- Rewrote the `build_exe` flow with dedicated `build_exe_prepare` / `build_exe_cleanup` / `build_exe_collect_inputs` helpers that stage all assets (wasm + skills + agents) under a local `./assets/` directory before bundling, and restore everything on exit via `trap`
- Added a `patch_wasm_loader` step that rewrites the wasm URL in `@livestore/wa-sqlite`'s loader from `wa-sqlite.node.wasm` → `assets/wa-sqlite.node.wasm` so `Bun.embeddedFiles` can resolve it correctly inside the standalone binary
- Removed the source-level `import ... with { type: "file" }` workaround from `cli.ts` (no longer needed)
- Added `@livestore/wa-sqlite` to the dep-check ignore list for the `cli` package since it is now handled by the build script directly

## Test plan

- [ ] Run `build_js` and verify `dist/` contains `cli.js`, `wa-sqlite.node.wasm`, `skills/`, and `agents/`
- [ ] Run `build_exe` and verify the standalone `pochi` binary embeds the wasm and asset files and resolves them at runtime
- [ ] Confirm the wasm loader patch is reverted after `build_exe` completes
- [ ] Run `bun scripts/dep-check.ts` and confirm no errors for the `cli` package

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-b867d7c837814fa483cd6dce9c364d8c)

Co-Authored-By: Pochi <noreply@getpochi.com>