### PR TITLE
refactor(tools): rename isCompletionTool* to isUserInputTool*

### DIFF
--- a/packages/cli/src/renderers/output-renderer.ts
+++ b/packages/cli/src/renderers/output-renderer.ts
@@ -3,7 +3,7 @@ import { formatters } from "@getpochi/common";
 import { parseMarkdown } from "@getpochi/common/message-utils";
 import { formatPochiFileDisplayPath } from "@getpochi/common/pochi-file-system";
 import type { Message, UITools } from "@getpochi/livekit";
-import { isAutoSuccessToolPart, isCompletionToolPart } from "@getpochi/tools";
+import { isAutoSuccessToolPart, isUserInputToolPart } from "@getpochi/tools";
 import { type ToolUIPart, getStaticToolName, isStaticToolUIPart } from "ai";
 import chalk from "chalk";
 import {
@@ -536,7 +536,7 @@ function renderSubtaskMessages(messages: Message[]): string {
   let output = "";
   for (const x of messages) {
     for (const p of x.parts) {
-      if (isStaticToolUIPart(p) && !isCompletionToolPart(p)) {
+      if (isStaticToolUIPart(p) && !isUserInputToolPart(p)) {
         const { text } = renderToolPart(p);
         const lines = text.split("\n");
         for (const line of lines) {

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -30,7 +30,7 @@ import {
   type Skill,
   type Todo,
   compileToolPolicies,
-  isCompletionToolPart,
+  isUserInputToolPart,
   validateToolPolicy,
 } from "@getpochi/tools";
 import {
@@ -754,7 +754,7 @@ ${asyncResults}`;
 function isResultMessage(message: Message): boolean {
   return (
     message.role === "assistant" &&
-    (message.parts?.some(isCompletionToolPart) ?? false)
+    (message.parts?.some(isUserInputToolPart) ?? false)
   );
 }
 

--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -8,7 +8,7 @@ vi.mock('@getpochi/tools', async (importOriginal) => {
   const original = await importOriginal<typeof import('@getpochi/tools')>();
   return {
     ...original,
-    isCompletionToolPart: vi.fn(),
+    isUserInputToolPart: vi.fn(),
   };
 });
 

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -1,4 +1,4 @@
-import { isAutoSuccessToolPart, isCompletionToolPart } from "@getpochi/tools";
+import { isAutoSuccessToolPart, isUserInputToolPart } from "@getpochi/tools";
 import {
   type ToolUIPart,
   type UIMessage,
@@ -380,7 +380,7 @@ function resolvePendingToolCallsForShareUI(messages: UIMessage[]) {
   const resolveLastMessage =
     lastMessage &&
     lastMessage.role === "assistant" &&
-    lastMessage.parts.some((x) => isCompletionToolPart(x));
+    lastMessage.parts.some((x) => isUserInputToolPart(x));
 
   return resolvePendingToolCalls(messages, resolveLastMessage);
 }

--- a/packages/livekit/src/chat/filter-completion-tools.ts
+++ b/packages/livekit/src/chat/filter-completion-tools.ts
@@ -1,4 +1,4 @@
-import { isCompletionToolPart } from "@getpochi/tools";
+import { isUserInputToolPart } from "@getpochi/tools";
 import { getStaticToolName, isStaticToolUIPart } from "ai";
 import type { Message } from "../types";
 
@@ -16,16 +16,16 @@ export function filterCompletionTools(message: Message): Message {
       ? message.parts.slice(lastStepStartIndex)
       : message.parts;
 
-  const hasCompletionTools = parts.some(isCompletionToolPart);
+  const hasCompletionTools = parts.some(isUserInputToolPart);
   const hasOtherTools = parts.some(
     (part) =>
       isStaticToolUIPart(part) &&
       getStaticToolName(part) !== "todoWrite" &&
-      !isCompletionToolPart(part),
+      !isUserInputToolPart(part),
   );
 
   if (hasCompletionTools && hasOtherTools) {
-    const lastStepParts = parts.filter((part) => !isCompletionToolPart(part));
+    const lastStepParts = parts.filter((part) => !isUserInputToolPart(part));
     const prevStepsParts =
       lastStepStartIndex > 0 ? message.parts.slice(0, lastStepStartIndex) : [];
     return {

--- a/packages/livekit/src/task.ts
+++ b/packages/livekit/src/task.ts
@@ -1,6 +1,6 @@
 import { isAbortError } from "@ai-sdk/provider-utils";
 import type { GitStatus } from "@getpochi/common";
-import { isCompletionToolPart } from "@getpochi/tools";
+import { isUserInputToolPart } from "@getpochi/tools";
 import {
   APICallError,
   type FinishReason,
@@ -28,7 +28,7 @@ export function toTaskStatus(
 
   let hasToolCall = false;
   for (const part of message.parts.slice(lastStepStart + 1)) {
-    if (isCompletionToolPart(part)) {
+    if (part.type === "tool-askFollowupQuestion" || part.type === "tool-attemptCompletion" || part.type === "tool-renderWidget") {
       return "completed";
     }
 

--- a/packages/livekit/src/task.ts
+++ b/packages/livekit/src/task.ts
@@ -1,6 +1,5 @@
 import { isAbortError } from "@ai-sdk/provider-utils";
 import type { GitStatus } from "@getpochi/common";
-import { isUserInputToolPart } from "@getpochi/tools";
 import {
   APICallError,
   type FinishReason,
@@ -28,7 +27,11 @@ export function toTaskStatus(
 
   let hasToolCall = false;
   for (const part of message.parts.slice(lastStepStart + 1)) {
-    if (part.type === "tool-askFollowupQuestion" || part.type === "tool-attemptCompletion" || part.type === "tool-renderWidget") {
+    if (
+      part.type === "tool-askFollowupQuestion" ||
+      part.type === "tool-attemptCompletion" ||
+      part.type === "tool-renderWidget"
+    ) {
       return "completed";
     }
 

--- a/packages/tools/src/__test__/render-widget-tools.test.ts
+++ b/packages/tools/src/__test__/render-widget-tools.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   createClientTools,
   isAutoSuccessToolName,
-  isCompletionToolName,
-  isCompletionToolPart,
+  isUserInputToolName,
+  isUserInputToolPart,
   isReadonlyToolCall,
   selectAgentTools,
 } from "../index";
@@ -78,10 +78,10 @@ describe("render widget tools", () => {
   });
 
   it("treats renderWidget as a completion and auto-success tool", () => {
-    expect(isCompletionToolName("attemptCompletion")).toBe(true);
-    expect(isCompletionToolName("renderWidget")).toBe(true);
+    expect(isUserInputToolName("attemptCompletion")).toBe(true);
+    expect(isUserInputToolName("renderWidget")).toBe(true);
     expect(
-      isCompletionToolPart({
+      isUserInputToolPart({
         type: "tool-renderWidget",
         toolCallId: "widget-1",
         state: "input-available",

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -94,9 +94,7 @@ export function isUserInputToolName(name: string): boolean {
   );
 }
 
-export function isUserInputToolPart(
-  part: UIMessagePart<UIDataTypes, UITools>,
-) {
+export function isUserInputToolPart(part: UIMessagePart<UIDataTypes, UITools>) {
   if (!isStaticToolUIPart(part)) return false;
   return isUserInputToolName(getStaticToolName(part));
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -86,7 +86,7 @@ export type {
   BatchedToolCall,
 } from "./utils/tool-batch";
 
-export function isCompletionToolName(name: string): boolean {
+export function isUserInputToolName(name: string): boolean {
   return (
     name === "askFollowupQuestion" ||
     name === "attemptCompletion" ||
@@ -94,16 +94,16 @@ export function isCompletionToolName(name: string): boolean {
   );
 }
 
-export function isCompletionToolPart(
+export function isUserInputToolPart(
   part: UIMessagePart<UIDataTypes, UITools>,
 ) {
   if (!isStaticToolUIPart(part)) return false;
-  return isCompletionToolName(getStaticToolName(part));
+  return isUserInputToolName(getStaticToolName(part));
 }
 
 export function isAutoSuccessToolName(name: string): boolean {
   return (
-    isCompletionToolName(name) ||
+    isUserInputToolName(name) ||
     ToolsByPermission.default.some((tool) => name === tool)
   );
 }

--- a/packages/vscode-webui/src/features/approval/hooks/use-pending-tool-call-approval.ts
+++ b/packages/vscode-webui/src/features/approval/hooks/use-pending-tool-call-approval.ts
@@ -1,5 +1,5 @@
 import type { Message, UITools } from "@getpochi/livekit";
-import { type ToolName, isCompletionToolPart } from "@getpochi/tools";
+import { type ToolName, isUserInputToolPart } from "@getpochi/tools";
 import { type ToolUIPart, getStaticToolName, isStaticToolUIPart } from "ai";
 import { useMemo } from "react";
 
@@ -32,7 +32,7 @@ export function usePendingToolCallApproval({
       if (
         isStaticToolUIPart(part) &&
         part.state === "input-available" &&
-        !isCompletionToolPart(part)
+        !isUserInputToolPart(part)
       ) {
         tools.push(part);
       }

--- a/packages/vscode-webui/src/features/chat/components/background-task-worker.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-worker.tsx
@@ -19,7 +19,7 @@ import {
   type ToolSpecInput,
   compileToolPolicies,
   getAllowedToolNames,
-  isCompletionToolName,
+  isUserInputToolName,
 } from "@getpochi/tools";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -176,7 +176,7 @@ function BackgroundTaskWorkerInner({
     onToolCall: ({ toolCall }) => {
       if (completedRef.current) return;
 
-      if (isCompletionToolName(toolCall.toolName)) {
+      if (isUserInputToolName(toolCall.toolName)) {
         terminalToolSeenRef.current = true;
         return;
       }

--- a/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
+++ b/packages/vscode-webui/src/features/chat/lib/task-memory-extraction.ts
@@ -1,7 +1,7 @@
 import type { ContextWindowUsage, TaskMemoryState } from "@getpochi/common";
 import { constants, TaskMemoryFileUri } from "@getpochi/common";
 import type { Message, Task } from "@getpochi/livekit";
-import { isCompletionToolPart } from "@getpochi/tools";
+import { isUserInputToolPart } from "@getpochi/tools";
 import { isStaticToolUIPart } from "ai";
 
 export type ExtractionData = {
@@ -58,7 +58,7 @@ export function lastMessageHasOpenToolCall(messages: Message[]): boolean {
   const last = messages.at(-1);
   if (!last || last.role !== "assistant") return false;
   return last.parts.some((part) => {
-    if (!isStaticToolUIPart(part) || isCompletionToolPart(part)) return false;
+    if (!isStaticToolUIPart(part) || isUserInputToolPart(part)) return false;
     return part.state !== "output-available" && part.state !== "output-error";
   });
 }

--- a/packages/vscode-webui/src/features/settings/hooks/use-tool-auto-approval.ts
+++ b/packages/vscode-webui/src/features/settings/hooks/use-tool-auto-approval.ts
@@ -5,7 +5,7 @@ import type { Message } from "@getpochi/livekit";
 import {
   type ToolName,
   ToolsByPermission,
-  isCompletionToolPart,
+  isUserInputToolPart,
 } from "@getpochi/tools";
 import {
   type ToolUIPart,
@@ -46,7 +46,7 @@ export const getPendingToolcallApproval = (
     if (
       isStaticToolUIPart(part) &&
       part.state === "input-available" &&
-      !isCompletionToolPart(part)
+      !isUserInputToolPart(part)
     ) {
       tools.push(part);
     }

--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -26,7 +26,7 @@ import { useLiveChatKit } from "@getpochi/livekit/react";
 import {
   type Todo,
   compileToolPolicies,
-  isCompletionToolName,
+  isUserInputToolName,
 } from "@getpochi/tools";
 import {
   getStaticToolName,
@@ -119,7 +119,7 @@ export function useLiveSubTask(
       }
 
       // completion tools
-      if (isCompletionToolName(toolCall.toolName)) {
+      if (isUserInputToolName(toolCall.toolName)) {
         // no-op
         return;
       }


### PR DESCRIPTION
## Summary

- Rename `isCompletionToolName` → `isUserInputToolName` in `packages/tools/src/index.ts`
- Rename `isCompletionToolPart` → `isUserInputToolPart` in `packages/tools/src/index.ts`
- Update all consumers across `packages/cli`, `packages/common`, `packages/livekit`, `packages/tools`, and `packages/vscode-webui`

The old names were misleading — these helpers identify tools that require **user interaction** (`askFollowupQuestion`, `attemptCompletion`, `renderWidget`), not merely tools that mark completion. The new names make the intent clear at the call site.

## Test plan

- [ ] Existing unit tests pass (`bun run test`)
- [ ] No type errors (`bun tsc`)

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-12ea5ce6e3f04625ab81efd4a5298557) | [Task](https://app.getpochi.com/share/p-12ea5ce6e3f04625ab81efd4a5298557)