### PR TITLE
fix(webui): hide widget-guidelines from slash candidate list

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/__tests__/slash-candidates.test.ts
+++ b/packages/vscode-webui/src/components/prompt-form/__tests__/slash-candidates.test.ts
@@ -1,0 +1,38 @@
+import type {
+  CustomAgentFile,
+  SkillFile,
+} from "@getpochi/common/vscode-webui-bridge";
+import { describe, expect, it } from "vitest";
+import { createSlashCandidates } from "../slash-mention/slash-candidates";
+
+describe("createSlashCandidates", () => {
+  it("omits widget-guidelines from user slash command skill candidates", () => {
+    const customAgents: CustomAgentFile[] = [
+      {
+        name: "reviewer",
+        description: "Review code",
+        systemPrompt: "Review the selected code",
+        filePath: ".pochi/agents/reviewer.md",
+      },
+    ];
+    const skills: SkillFile[] = [
+      {
+        name: "create-skill",
+        description: "Create a skill",
+        instructions: "Create skill instructions",
+        filePath: "/built-in/create-skill.md",
+      },
+      {
+        name: "widget-guidelines",
+        description: "Render widget guidelines",
+        instructions: "Widget instructions",
+        filePath: "/built-in/widget-guidelines/SKILL.md",
+        isBuiltIn: true,
+      },
+    ];
+
+    expect(
+      createSlashCandidates(customAgents, skills).map((option) => option.id),
+    ).toEqual(["reviewer", "create-skill"]);
+  });
+});

--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -32,10 +32,6 @@ import { useSelectedModels } from "@/features/settings";
 import { useLatest } from "@/lib/hooks/use-latest";
 import { cn } from "@/lib/utils";
 import { resolveModelFromId } from "@/lib/utils/resolve-model-from-id";
-import {
-  isValidCustomAgentFile,
-  isValidSkillFile,
-} from "@getpochi/common/vscode-webui-bridge";
 import { threadSignal } from "@quilted/threads/signals";
 import { ReactRenderer } from "@tiptap/react";
 import {
@@ -61,6 +57,7 @@ import {
   SlashMentionList,
   type SlashMentionListProps,
 } from "./slash-mention/mention-list";
+import { createSlashCandidates } from "./slash-mention/slash-candidates";
 import { SubmitHistoryExtension } from "./submit-history-extension";
 
 const newLineCharacter = "\n";
@@ -722,29 +719,8 @@ export const debouncedListSlashCommand = debounceWithCachedValue(
       threadSignal(await vscodeHost.readCustomAgents()),
       threadSignal(await vscodeHost.readSkills()),
     ]);
-    const options: SlashCandidate[] = [
-      ...customAgents.value
-        .filter((x) => !x.isBuiltIn)
-        .filter((x) => isValidCustomAgentFile(x))
-        .map((x) => ({
-          type: "custom-agent" as const,
-          id: x.name,
-          label: x.name,
-          path: x.filePath,
-          rawData: x,
-        })),
-      ...skills.value
-        .filter((x) => isValidSkillFile(x))
-        .map((x) => ({
-          type: "skill" as const,
-          id: x.name,
-          label: x.name,
-          path: x.filePath,
-          rawData: x,
-        })),
-    ];
     return {
-      options,
+      options: createSlashCandidates(customAgents.value, skills.value),
     };
   },
   1000 * 60,

--- a/packages/vscode-webui/src/components/prompt-form/slash-mention/slash-candidates.ts
+++ b/packages/vscode-webui/src/components/prompt-form/slash-mention/slash-candidates.ts
@@ -1,0 +1,37 @@
+import {
+  type CustomAgentFile,
+  type SkillFile,
+  isValidCustomAgentFile,
+  isValidSkillFile,
+} from "@getpochi/common/vscode-webui-bridge";
+import type { SlashCandidate } from "./mention-list";
+
+const HiddenSlashSkillNames = new Set(["widget-guidelines"]);
+
+export function createSlashCandidates(
+  customAgents: CustomAgentFile[],
+  skills: SkillFile[],
+): SlashCandidate[] {
+  return [
+    ...customAgents
+      .filter((x) => !x.isBuiltIn)
+      .filter((x) => isValidCustomAgentFile(x))
+      .map((x) => ({
+        type: "custom-agent" as const,
+        id: x.name,
+        label: x.name,
+        path: x.filePath,
+        rawData: x,
+      })),
+    ...skills
+      .filter((x) => isValidSkillFile(x))
+      .filter((x) => !HiddenSlashSkillNames.has(x.name))
+      .map((x) => ({
+        type: "skill" as const,
+        id: x.name,
+        label: x.name,
+        path: x.filePath,
+        rawData: x,
+      })),
+  ];
+}


### PR DESCRIPTION
## Summary
- Extract slash candidates creation into a helper function `createSlashCandidates` in `slash-candidates.ts`.
- Filter out the `widget-guidelines` skill from the autocomplete candidates list to prevent it from showing up as a slash command candidate.
- Add unit tests to verify that `widget-guidelines` is successfully omitted.

## Test plan
- [x] Run unit tests: `bun vitest --run slash-candidates` inside `packages/vscode-webui`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8596c984062040738c7fe35e82fad34a)