### PR TITLE
feat(cli): track step duration and emit to trajectory stream

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -62,6 +62,7 @@ import {
   ProcessAbortError,
   createAbortControllerWithGracefulShutdown,
 } from "./lib/shutdown";
+import { StepDurationTracker } from "./lib/step-duration-tracker";
 import { createStore } from "./livekit/store";
 import { initializeMcp, registerMcpCommand } from "./mcp";
 import { registerModelCommand } from "./model";
@@ -316,6 +317,7 @@ const program = new Command()
     const taskFs = new TaskFileSystem(store);
     const filesystem = new CompoundFileSystem(localFs, taskFs);
     const browserSessionStore = new BrowserSessionStore();
+    const stepDurationTracker = new StepDurationTracker();
 
     const runner = new TaskRunner({
       uid,
@@ -346,6 +348,7 @@ const program = new Command()
       asyncWaitTimeoutInMs: options.asyncWaitTimeout,
       filesystem,
       browserSessionStore,
+      stepDurationTracker,
     });
 
     const outputRenderer = new OutputRenderer(process.stdout, runner.state, {
@@ -360,6 +363,7 @@ const program = new Command()
           store,
           blobStore,
           runner.state,
+          stepDurationTracker,
         );
       } else if (options.experimentalOutputAttemptCompletionResult) {
         streamRenderer = new AttemptCompletionResultRenderer(

--- a/packages/cli/src/lib/step-duration-tracker.ts
+++ b/packages/cli/src/lib/step-duration-tracker.ts
@@ -1,0 +1,20 @@
+import { signal } from "@preact/signals-core";
+
+export type StepDurationEntry = {
+  taskId: string;
+  messageId: string;
+  stepIndex: number;
+
+  hasError: boolean;
+  startedAt: Date;
+  finishedAt: Date;
+  duration: number;
+};
+
+export class StepDurationTracker {
+  readonly entries = signal<StepDurationEntry[]>([]);
+
+  trackStep(entry: StepDurationEntry) {
+    this.entries.value = [...this.entries.value, entry];
+  }
+}

--- a/packages/cli/src/renderers/trajectory-stream-renderer.ts
+++ b/packages/cli/src/renderers/trajectory-stream-renderer.ts
@@ -6,29 +6,44 @@ import {
 } from "@getpochi/livekit";
 import * as R from "remeda";
 import * as runExclusive from "run-exclusive";
+import type {
+  StepDurationEntry,
+  StepDurationTracker,
+} from "../lib/step-duration-tracker";
 import type { NodeChatState } from "../livekit/chat.node";
 import type { StreamRenderer } from "./types";
 import { inlineSubTask, mapStoreBlob } from "./utils";
 
 export class TrajectoryStreamRenderer implements StreamRenderer {
+  private runExclusiveGroup = runExclusive.createGroupRef();
   private emittedParts = new Map<string, unknown>();
   private emittedMetadata = new Set<string>();
-  private unsubscribe: (() => void) | undefined;
+  private emittedStepDurationEntryCount = 0;
+  private unsubscribeFns: (() => void)[] | undefined;
 
   constructor(
     private readonly stream: NodeJS.WritableStream,
     private readonly store: LiveKitStore,
     private readonly blobStore: BlobStore,
     private readonly state: NodeChatState,
+    stepDurationTracker?: StepDurationTracker,
   ) {
-    this.unsubscribe = this.state.signal.messages.subscribe(
-      async (messages: Message[]) => {
+    this.unsubscribeFns = [
+      this.state.signal.messages.subscribe(async (messages: Message[]) => {
         await this.outputTrajectory(messages);
-      },
-    );
+      }),
+    ];
+    if (stepDurationTracker) {
+      this.unsubscribeFns.push(
+        stepDurationTracker.entries.subscribe(async (entries) => {
+          await this.outputStepDurationEntries(entries);
+        }),
+      );
+    }
   }
 
   private outputTrajectory = runExclusive.build(
+    this.runExclusiveGroup,
     async (messages: Message[], isFinalFlush = false) => {
       for (let msgIdx = 0; msgIdx < messages.length; msgIdx++) {
         const message = messages[msgIdx];
@@ -74,23 +89,53 @@ export class TrajectoryStreamRenderer implements StreamRenderer {
     },
   );
 
+  private outputStepDurationEntries = runExclusive.build(
+    this.runExclusiveGroup,
+    async (entries: StepDurationEntry[]) => {
+      for (
+        let i = this.emittedStepDurationEntryCount;
+        i < entries.length;
+        i++
+      ) {
+        const entry = entries[i];
+        const outputData = {
+          type: "step-duration",
+          taskId: entry.taskId,
+          messageId: entry.messageId,
+          stepIndex: entry.stepIndex,
+          hasError: entry.hasError,
+          startedAt: entry.startedAt.toISOString(),
+          finishedAt: entry.finishedAt.toISOString(),
+          duration: entry.duration,
+        };
+        this.stream.write(`${JSON.stringify(outputData)}\n`);
+      }
+      this.emittedStepDurationEntryCount = entries.length;
+    },
+  );
+
+  private outputFilesData = runExclusive.build(
+    this.runExclusiveGroup,
+    async () => {
+      const files = this.store.query(catalog.queries.makeStoreFilesQuery());
+      if (files.length > 0) {
+        const data = {
+          type: "files",
+          files,
+        };
+        this.stream.write(`${JSON.stringify(data)}\n`);
+      }
+    },
+  );
+
   async shutdown() {
-    if (this.unsubscribe) {
-      this.unsubscribe();
-      this.unsubscribe = undefined;
+    if (this.unsubscribeFns?.length) {
+      for (const fn of this.unsubscribeFns) {
+        fn();
+      }
+      this.unsubscribeFns = undefined;
     }
     await this.outputTrajectory(this.state.signal.messages.value, true);
     await this.outputFilesData();
-  }
-
-  private async outputFilesData() {
-    const files = this.store.query(catalog.queries.makeStoreFilesQuery());
-    if (files.length > 0) {
-      const data = {
-        type: "files",
-        files,
-      };
-      this.stream.write(`${JSON.stringify(data)}\n`);
-    }
   }
 }

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -45,6 +45,7 @@ import type { FileSystem } from "./lib/file-system";
 import { readEnvironment } from "./lib/read-environment";
 import { createSpinner } from "./lib/spinner";
 import { StepCount } from "./lib/step-count";
+import type { StepDurationTracker } from "./lib/step-duration-tracker";
 import { Chat } from "./livekit";
 import { executeToolCall } from "./tools";
 import type {
@@ -143,6 +144,8 @@ export interface RunnerOptions {
    * Set to 0 to disable waiting.
    */
   asyncWaitTimeoutInMs?: number;
+
+  stepDurationTracker?: StepDurationTracker;
 }
 
 const logger = getLogger("TaskRunner");
@@ -163,6 +166,8 @@ export class TaskRunner {
 
   private attemptCompletionHook?: string;
   private asyncWaitTimeoutInMs: number;
+  private readonly stepDurationTracker?: StepDurationTracker;
+
   private abortSignal?: AbortSignal;
 
   readonly taskId: string;
@@ -266,6 +271,31 @@ export class TaskRunner {
             }
           : {}),
       },
+
+      onStreamFinish: ({
+        messages,
+        error,
+        startedAt: startAt,
+        finishedAt: finishAt,
+      }) => {
+        const lastMessage = messages[messages.length - 1];
+        if (lastMessage !== undefined) {
+          const stepCount = lastMessage.parts.filter(
+            (p) => p.type === "step-start",
+          ).length;
+          if (stepCount > 0 && startAt && finishAt) {
+            this.stepDurationTracker?.trackStep({
+              taskId: this.taskId,
+              messageId: lastMessage.id,
+              stepIndex: stepCount - 1,
+              hasError: error !== undefined,
+              startedAt: startAt,
+              finishedAt: finishAt,
+              duration: finishAt.getTime() - startAt.getTime(),
+            });
+          }
+        }
+      },
     });
     if (options.parts && options.parts.length > 0) {
       if (this.chatKit.inited) {
@@ -284,6 +314,7 @@ export class TaskRunner {
     this.attemptCompletionHook = options.attemptCompletionHook;
     this.attemptCompletionSchemaOverride = !!options.attemptCompletionSchema;
     this.asyncWaitTimeoutInMs = options.asyncWaitTimeoutInMs ?? 60000;
+    this.stepDurationTracker = options.stepDurationTracker;
     this.abortSignal = options.abortSignal;
   }
 

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -178,6 +178,8 @@ export type LiveChatKitOptions<T> = {
       messages: Message[];
       error?: Error;
       contextWindowUsage?: ContextWindowUsage;
+      startedAt?: Date;
+      finishedAt?: Date;
     },
   ) => void;
 
@@ -239,6 +241,8 @@ export class LiveChatKit<
       messages: Message[];
       error?: Error;
       contextWindowUsage?: ContextWindowUsage;
+      startedAt?: Date;
+      finishedAt?: Date;
     },
   ) => void;
   readonly compact: () => Promise<string>;
@@ -691,6 +695,9 @@ export class LiveChatKit<
       }
     }
 
+    const { duration, startedAt, finishedAt } =
+      this.captureStepDuration() ?? {};
+
     store.commit(
       events.chatStreamFinished({
         id: this.taskId,
@@ -698,14 +705,10 @@ export class LiveChatKit<
         data: message,
         totalTokens: message.metadata.totalTokens,
         updatedAt: new Date(),
-        duration: this.lastStepStartTimestamp
-          ? Duration.millis(Date.now() - this.lastStepStartTimestamp)
-          : undefined,
+        duration,
         lastCheckpointHash: getCleanCheckpoint(this.chat.messages),
       }),
     );
-
-    this.clearLastStepTimestamp();
 
     this.onStreamFinish?.({
       id: this.taskId,
@@ -713,16 +716,17 @@ export class LiveChatKit<
       status,
       messages: [...this.chat.messages],
       contextWindowUsage,
+      startedAt,
+      finishedAt,
     });
-  };
-
-  private clearLastStepTimestamp = () => {
-    this.lastStepStartTimestamp = undefined;
   };
 
   private readonly onError: ChatOnErrorCallback = (error) => {
     logger.error("onError", error);
     const lastMessage = this.chat.messages.at(-1) || null;
+
+    const { duration, startedAt, finishedAt } =
+      this.captureStepDuration() ?? {};
 
     this.store.commit(
       events.chatStreamFailed({
@@ -730,14 +734,10 @@ export class LiveChatKit<
         error: toTaskError(error),
         data: lastMessage,
         updatedAt: new Date(),
-        duration: this.lastStepStartTimestamp
-          ? Duration.millis(Date.now() - this.lastStepStartTimestamp)
-          : undefined,
+        duration,
         lastCheckpointHash: getCleanCheckpoint(this.chat.messages),
       }),
     );
-
-    this.clearLastStepTimestamp();
 
     this.onStreamFinish?.({
       id: this.taskId,
@@ -745,8 +745,34 @@ export class LiveChatKit<
       status: "failed",
       messages: [...this.chat.messages],
       error,
+      startedAt,
+      finishedAt,
     });
   };
+
+  /**
+   * Captures the current step duration using the recorded start timestamp.
+   */
+  private captureStepDuration():
+    | {
+        startedAt: Date;
+        finishedAt: Date;
+        duration: ReturnType<typeof Duration.millis>;
+      }
+    | undefined {
+    const startTimestamp = this.lastStepStartTimestamp;
+    this.lastStepStartTimestamp = undefined;
+    const finishTimestamp = Date.now();
+
+    if (startTimestamp === undefined) {
+      return undefined;
+    }
+    return {
+      startedAt: new Date(startTimestamp),
+      finishedAt: new Date(finishTimestamp),
+      duration: Duration.millis(finishTimestamp - startTimestamp),
+    };
+  }
 }
 
 // clean checkpoint means after this checkpoint there are no write or execute toolcalls that may cause file edits


### PR DESCRIPTION
## Summary

- Add `StepDurationTracker` class (`packages/cli/src/lib/step-duration-tracker.ts`) that records per-step timing entries (taskId, messageId, stepIndex, hasError, startedAt, finishedAt, duration) using a preact signal
- Wire `StepDurationTracker` into `TaskRunner` via the new `onStreamFinish` callback which captures start/finish timestamps per stream cycle
- Stream `step-duration` NDJSON entries from `TrajectoryStreamRenderer` by subscribing to tracker entries alongside the existing message subscription; use a shared `runExclusiveGroup` to serialize output
- Refactor `LiveChatKit.captureStepDuration()` to return typed `{ startedAt, finishedAt, duration }` so `onStreamFinish` receives full timing data instead of just a duration

## Test plan

- [ ] Run a task with trajectory stream output (`--output-trajectory`) and verify `step-duration` lines appear in the NDJSON output
- [ ] Verify error cases also emit `step-duration` entries with `hasError: true`
- [ ] Confirm `bun check` / `bun tsc` pass

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-f9537f6e7160427c9f69720c02bb7853) | [Task](https://app.getpochi.com/share/p-f9537f6e7160427c9f69720c02bb7853)