### PR TITLE
feat(webview): add review changes action to attempt completion tool

### DIFF
--- a/packages/common/src/vscode-webui-bridge/types/vscode-settings.ts
+++ b/packages/common/src/vscode-webui-bridge/types/vscode-settings.ts
@@ -8,4 +8,5 @@ export interface VSCodeSettings {
   autoSaveDisabled: boolean;
   commentsOpenViewDisabled: boolean;
   githubCopilotCodeCompletionEnabled: boolean;
+  reviewAgent?: boolean;
 }

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -419,7 +419,9 @@ function shouldStopAutoApprove({ messages }: { messages: Message[] }) {
   const lastToolPart = messages.at(-1)?.parts.at(-1);
   return (
     lastToolPart?.type === "tool-newTask" &&
-    ["planner", "walkthrough"].includes(lastToolPart?.input?.agentType || "") &&
+    ["planner", "reviewer", "walkthrough"].includes(
+      lastToolPart?.input?.agentType || "",
+    ) &&
     lastToolPart?.state === "output-available"
   );
 }

--- a/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
+++ b/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
@@ -7,10 +7,11 @@ import {
 } from "@/components/ui/tooltip";
 import { useSendMessage } from "@/features/chat";
 import { useCurrentWorkspace } from "@/lib/hooks/use-current-workspace";
+import { useVSCodeSettings } from "@/lib/hooks/use-vscode-settings";
 import { useWorktrees } from "@/lib/hooks/use-worktrees";
 import { prompts } from "@getpochi/common";
 import { isStaticToolUIPart } from "ai";
-import { Check, Footprints, GitPullRequest } from "lucide-react";
+import { Check, Footprints, GitPullRequest, MessageSquare } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { ToolProps } from "./types";
@@ -24,6 +25,8 @@ export const AttemptCompletionTool: React.FC<
 
   const { data: currentWorkspace } = useCurrentWorkspace();
   const { worktrees } = useWorktrees();
+  const vscodeSettings = useVSCodeSettings();
+  const reviewAgentEnabled = vscodeSettings?.reviewAgent ?? false;
 
   const currentWorktree = useMemo(() => {
     if (!worktrees || !currentWorkspace) return null;
@@ -62,6 +65,12 @@ export const AttemptCompletionTool: React.FC<
     });
   };
 
+  const onClickReviewChanges = () => {
+    sendMessage({
+      prompt: `${prompts.customAgent("reviewer")} Please review the changes above`,
+    });
+  };
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
@@ -84,6 +93,21 @@ export const AttemptCompletionTool: React.FC<
               </TooltipTrigger>
               <TooltipContent>{t("worktree.createWalkthrough")}</TooltipContent>
             </Tooltip>
+            {reviewAgentEnabled && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6 text-muted-foreground"
+                    onClick={onClickReviewChanges}
+                  >
+                    <MessageSquare className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("worktree.reviewChanges")}</TooltipContent>
+              </Tooltip>
+            )}
             {!hasPR && (
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -112,6 +112,7 @@
   "worktree": {
     "createPr": "Create PR",
     "createWalkthrough": "Create Walkthrough",
+    "reviewChanges": "Review Changes",
     "createDraftPr": "Create Draft PR",
     "createPrManually": "Create PR Manually",
     "installGhCli": "Please install the GitHub CLI to create PRs.",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -112,6 +112,7 @@
   "worktree": {
     "createPr": "PR を作成",
     "createWalkthrough": "ウォークスルーを作成",
+    "reviewChanges": "変更をレビュー",
     "createDraftPr": "ドラフト PR を作成",
     "createPrManually": "手動で PR を作成",
     "installGhCli": "PR を作成するには GitHub CLI をインストールしてください",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -111,6 +111,7 @@
   "worktree": {
     "createPr": "PR 생성",
     "createWalkthrough": "워크스루 생성",
+    "reviewChanges": "변경 사항 검토",
     "createDraftPr": "초안 PR 생성",
     "createPrManually": "수동으로 PR 생성",
     "installGhCli": "PR을 생성하려면 GitHub CLI를 설치하세요",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -111,6 +111,7 @@
   "worktree": {
     "createPr": "创建 PR",
     "createWalkthrough": "创建 Walkthrough",
+    "reviewChanges": "审查变更",
     "createDraftPr": "创建草稿 PR",
     "createPrManually": "手动创建 PR",
     "installGhCli": "请安装 GitHub CLI 以创建 PR",

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -921,6 +921,8 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
             this.pochiConfiguration.commentsOpenViewDisabled.value,
           githubCopilotCodeCompletionEnabled:
             this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value,
+          reviewAgent:
+            this.pochiConfiguration.advancedSettings.value.reviewAgent,
         };
       }),
     );


### PR DESCRIPTION
## Summary
- **Review Changes Action**: Added a "Review Changes" button to the `AttemptCompletionTool` in the webview, allowing users to trigger the `reviewer` agent on demand when `reviewAgent` is enabled.
- **Advanced Settings Support**: Passed `reviewAgent` from VS Code's advanced settings to the webview settings context.
- **Auto-Approve Prevention**: Added `"reviewer"` to the list of agents in `shouldStopAutoApprove` to ensure reviewer output is displayed for manual inspection instead of being automatically approved.
- **I18n Support**: Added localized strings for `"reviewChanges"` in English, Japanese, Korean, and Chinese.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/2dd8ef3e-2069-48ab-8b9a-bdec625ffde7" />

<img width="800" alt="64408a04f925bd8ebc08fdc8d0e1c376" src="https://github.com/user-attachments/assets/21dc7289-9703-4f56-b62d-8a99e4249577" />


## Test plan
- [ ] Verify the "Review Changes" button is visible in `AttemptCompletionTool` when `reviewAgent` is enabled in advanced settings.
- [ ] Verify that clicking the "Review Changes" button correctly triggers the `reviewer` agent.
- [ ] Verify that the reviewer agent's output stops auto-approval and presents the results clearly.
- [ ] Verify translations display correctly in English, Japanese, Korean, and Chinese.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-15fbe98ba4dc44cbac0717a88ffec66b)