### PR TITLE
fix(cli): scope unit tests to __tests__ dirs and add pretest:integration build step

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,8 +54,10 @@
   "scripts": {
     "start": "bun run src/cli.ts",
     "tsc": "tsc",
-    "test": "bun vitest --run",
-    "test:coverage": "bun vitest --run --coverage",
+    "test": "bun run test:unit",
+    "test:unit": "bun vitest --run src/**/__tests__/",
+    "test:coverage": "bun run test:unit --coverage",
+    "pretest:integration": "bun run build",
     "test:integration": "bun vitest --run tests/integration",
     "build": "./scripts/build-cli.sh",
     "build:all": "./scripts/build-platform-binary.sh",


### PR DESCRIPTION
## Summary
- Rename `test` script to delegate to new `test:unit` for clearer separation
- Scope `test:unit` vitest to `src/**/__tests__/` so integration tests are not accidentally picked up when running unit tests
- Add `pretest:integration` hook to automatically build the CLI before running integration tests

## Test plan
- [ ] Run `bun run test` in `packages/cli` — should only execute unit tests under `src/**/__tests__/`
- [ ] Run `bun run test:integration` in `packages/cli` — should trigger a build first, then run integration tests

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b2c93953ef62416c8fc0d89918f3105d)