### PR TITLE
fix(i18n): update browser agent translation key in en.json

### DIFF
--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -582,6 +582,6 @@
   },
   "builtInAgentsSettings": {
     "title": "Built-in Agents",
-    "browser": "Browser"
+    "browser": "browser"
   }
 }


### PR DESCRIPTION
## Summary
- Update the translation key for the browser agent in English locale to use lowercase `"browser"` to match key-value naming standards.

## Test plan
- Verify that the browser agent settings label displays correctly in the UI.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5d54901836eb494f9b550692a57b5443)