### PR TITLE
fix(common): limit listFiles output by character length

### DIFF
--- a/packages/common/src/tool-utils/__tests__/list-files.test.ts
+++ b/packages/common/src/tool-utils/__tests__/list-files.test.ts
@@ -68,6 +68,21 @@ describe("listFiles", () => {
     expect(result.isTruncated).toBe(true);
   });
 
+  it("should truncate results when exceeding maxCharLength limit", async () => {
+    ignoreWalkMock.mockResolvedValue([
+      { filepath: path.join(fakedCwd, "verylongfilename1.txt"), isDir: false, relativePath: "verylongfilename1.txt" },
+      { filepath: path.join(fakedCwd, "verylongfilename2.txt"), isDir: false, relativePath: "verylongfilename2.txt" },
+    ]);
+    const result = await listFiles({
+      cwd: fakedCwd,
+      path: ".",
+      maxCharLength: 25, // only first file (length 22) fits, second file will exceed 25 limit
+    });
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0]).toBe("verylongfilename1.txt");
+    expect(result.isTruncated).toBe(true);
+  });
+
   it("should throw an error when ignoreWalk fails", async () => {
     ignoreWalkMock.mockRejectedValue(new Error("Failed to walk"));
     await expect(
@@ -103,6 +118,20 @@ describe("listWorkspaceFiles", () => {
   it("should respect the maxItems option", async () => {
     const result = await listWorkspaceFiles({ cwd: fakedCwd, maxItems: 15 });
     expect(result.files).toHaveLength(15);
+    expect(result.isTruncated).toBe(true);
+  });
+
+  it("should respect the maxCharLength option", async () => {
+    ignoreWalkMock.mockResolvedValue([
+      { filepath: path.join(fakedCwd, "file1.txt"), isDir: false, relativePath: "file1.txt" },
+      { filepath: path.join(fakedCwd, "file2.txt"), isDir: false, relativePath: "file2.txt" },
+    ]);
+    const result = await listWorkspaceFiles({
+      cwd: fakedCwd,
+      maxCharLength: 10, // only first file (length 9) fits
+    });
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0]).toBe("file1.txt");
     expect(result.isTruncated).toBe(true);
   });
 

--- a/packages/common/src/tool-utils/limits.ts
+++ b/packages/common/src/tool-utils/limits.ts
@@ -1,5 +1,6 @@
 export const MaxRipgrepItems = 500;
 export const MaxListFileItems = 1500;
+export const MaxListFileCharLength = 30_000;
 export const MaxGlobFileItems = 500;
 export const MaxReadFileSize = 30_000;
 export const MaxTerminalOutputSize = 500_000;

--- a/packages/common/src/tool-utils/list-files.ts
+++ b/packages/common/src/tool-utils/list-files.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { getLogger } from "../base";
 import { resolvePath, validateRelativePath } from "./fs";
 import { ignoreWalk } from "./ignore-walk";
-import { MaxListFileItems } from "./limits";
+import { MaxListFileCharLength, MaxListFileItems } from "./limits";
 
 const logger = getLogger("listFiles");
 
@@ -14,6 +14,8 @@ interface ListFilesOptions {
   recursive?: boolean;
   /** AbortSignal for cancellation */
   abortSignal?: AbortSignal;
+  /** Maximum total character length of files to return before truncating */
+  maxCharLength?: number;
 }
 
 interface ListFilesResult {
@@ -31,7 +33,13 @@ interface ListFilesResult {
 export async function listFiles(
   options: ListFilesOptions,
 ): Promise<ListFilesResult> {
-  const { cwd, path: dirPath, recursive, abortSignal } = options;
+  const {
+    cwd,
+    path: dirPath,
+    recursive,
+    abortSignal,
+    maxCharLength = MaxListFileCharLength,
+  } = options;
 
   logger.debug(
     "handling listFile with dirPath",
@@ -57,10 +65,22 @@ export async function listFiles(
       usePochiignore: false,
     });
 
-    const isTruncated = fileResults.length > MaxListFileItems;
-    const files = fileResults
-      .slice(0, MaxListFileItems)
-      .map((x) => path.relative(cwd, x.filepath));
+    const allFiles = fileResults.map((x) => path.relative(cwd, x.filepath));
+
+    let totalChars = 0;
+    const files: string[] = [];
+    for (const file of allFiles) {
+      if (files.length >= MaxListFileItems) {
+        break;
+      }
+      if (files.length > 0 && totalChars + file.length > maxCharLength) {
+        break;
+      }
+      files.push(file);
+      totalChars += file.length;
+    }
+
+    const isTruncated = fileResults.length > files.length;
 
     return { files, isTruncated };
   } catch (error) {
@@ -79,6 +99,8 @@ interface WorkspaceFilesOptions {
   abortSignal?: AbortSignal;
   /** Maximum number of files to return before truncating */
   maxItems?: number;
+  /** Maximum total character length of files to return before truncating */
+  maxCharLength?: number;
   /** Extra ignore patterns to apply on top of gitignore/pochiignore rules */
   extraIgnorePatterns?: string[];
 }
@@ -102,10 +124,18 @@ export async function listWorkspaceFiles(
     recursive = true,
     abortSignal,
     maxItems = MaxListFileItems,
+    maxCharLength = MaxListFileCharLength,
     extraIgnorePatterns,
   } = options;
 
-  logger.debug("Listing workspace files from", cwd, "with maxItems", maxItems);
+  logger.debug(
+    "Listing workspace files from",
+    cwd,
+    "with maxItems",
+    maxItems,
+    "and maxCharLength",
+    maxCharLength,
+  );
 
   try {
     const results = await ignoreWalk({
@@ -115,10 +145,22 @@ export async function listWorkspaceFiles(
       extraIgnorePatterns,
     });
 
-    const isTruncated = results.length > maxItems;
-    const files = results.slice(0, maxItems).map((res) => {
-      return path.relative(cwd, res.filepath);
-    });
+    const allFiles = results.map((res) => path.relative(cwd, res.filepath));
+
+    let totalChars = 0;
+    const files: string[] = [];
+    for (const file of allFiles) {
+      if (files.length >= maxItems) {
+        break;
+      }
+      if (files.length > 0 && totalChars + file.length > maxCharLength) {
+        break;
+      }
+      files.push(file);
+      totalChars += file.length;
+    }
+
+    const isTruncated = results.length > files.length;
 
     return { files, isTruncated };
   } catch (error) {


### PR DESCRIPTION
## Summary
- Introduced `MaxListFileCharLength` limit (30,000 characters) to prevent context window overflow when directories have extremely long paths or many files.
- Applied count and character length limits to both `listFiles` and `listWorkspaceFiles`.
- Added unit tests in `packages/common/src/tool-utils/__tests__/list-files.test.ts` to ensure truncation behavior works correctly.

## Test plan
- [x] Run `bun check` to ensure formatting is correct.
- [x] Run `bun tsc` to verify TypeScript compilation.
- [x] Run `cd packages/common && bun run test` to verify unit tests pass.
- [x] Run `cd packages/vscode && bun run test` to verify integration tests pass.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-789d4ef73eb54b91b5baef383254c932)