### PR TITLE
feat(common): preview first and last parts of large tool outputs

### DIFF
--- a/packages/common/src/tool-utils/__tests__/tool-result-persistence.test.ts
+++ b/packages/common/src/tool-utils/__tests__/tool-result-persistence.test.ts
@@ -80,6 +80,23 @@ describe("maybePersistToolResult", () => {
       expect(result.output.length).toBeLessThan(PersistedToolResultPreviewSize * 3);
     });
 
+    it("preview contains both first and last parts of the large field aligned to newlines", async () => {
+      const firstLines = Array.from({ length: 20 }, (_, i) => `FIRST_LINE_${i}`).join("\n") + "\n";
+      const middle = "x\n".repeat(30000);
+      const lastLines = "\n" + Array.from({ length: 20 }, (_, i) => `LAST_LINE_${i}`).join("\n");
+      const big = firstLines + middle + lastLines;
+      const output = makeOutput(big);
+      const result = await maybePersistToolResult("executeCommand", TOOL_CALL_ID, TASK_ID, output) as typeof output;
+
+      const firstIndex = result.output.indexOf("FIRST_LINE_0");
+      const truncateIndex = result.output.indexOf("[truncated");
+      const lastIndex = result.output.indexOf("LAST_LINE_19");
+
+      expect(firstIndex).toBeGreaterThan(-1);
+      expect(truncateIndex).toBeGreaterThan(firstIndex);
+      expect(lastIndex).toBeGreaterThan(truncateIndex);
+    });
+
     it("skips small string fields", async () => {
       const output: Record<string, unknown> = {};
       const fieldCount = Math.ceil((MaxPersistedToolResultSize + 1) / 100);

--- a/packages/common/src/tool-utils/tool-result-persistence.ts
+++ b/packages/common/src/tool-utils/tool-result-persistence.ts
@@ -22,23 +22,36 @@ function generatePreview(
   if (content.length <= maxSize) {
     return { preview: content, hasMore: false };
   }
-  const truncated = content.slice(0, maxSize);
-  const lastNewline = truncated.lastIndexOf("\n");
-  const cutPoint = lastNewline > maxSize * 0.5 ? lastNewline : maxSize;
-  return { preview: content.slice(0, cutPoint), hasMore: true };
+  const halfSize = Math.floor(maxSize / 2);
+
+  // Get first part up to halfSize, aligned to the last newline
+  let firstPart = content.slice(0, halfSize);
+  const lastNewlineFirst = firstPart.lastIndexOf("\n");
+  if (lastNewlineFirst > halfSize * 0.5) {
+    firstPart = firstPart.slice(0, lastNewlineFirst);
+  }
+
+  // Get last part from content.length - halfSize to end, aligned to the first newline
+  let lastPart = content.slice(-halfSize);
+  const firstNewlineLast = lastPart.indexOf("\n");
+  if (firstNewlineLast !== -1 && firstNewlineLast < halfSize * 0.5) {
+    lastPart = lastPart.slice(firstNewlineLast + 1);
+  }
+
+  const preview = `${firstPart}\n\n... [truncated ${content.length - firstPart.length - lastPart.length} chars] ...\n\n${lastPart}`;
+  return { preview, hasMore: true };
 }
 
 function buildTruncatedValue(fieldValue: string, filePath: string): string {
-  const { preview, hasMore } = generatePreview(
+  const { preview } = generatePreview(
     fieldValue,
     PersistedToolResultPreviewSize,
   );
   let message = `[Output too large: ${fieldValue.length} chars. Full content saved to: ${filePath}\n`;
   message += "Use readFile to access the full content if needed.\n\n";
-  message += `Preview (first ${PersistedToolResultPreviewSize} chars):\n`;
+  message += `Preview (first and last ~${Math.floor(PersistedToolResultPreviewSize / 2)} chars):\n`;
   message += preview;
-  if (hasMore) message += "\n...]";
-  else message += "]";
+  message += "]";
   return message;
 }
 


### PR DESCRIPTION
## Summary
- Improve the preview of truncated large tool outputs by displaying both the first and last parts of the output aligned to newline boundaries, rather than just the first part.
- Align the cuts to newline boundaries to ensure clean lines in the preview, helping the LLM easily see the beginning and end of long outputs (like test results).
- Add integration tests verifying correct truncation behavior and ordering in `tool-result-persistence.test.ts`.

## Test plan
- Run `bun vitest packages/common/src/tool-utils/__tests__/tool-result-persistence.test.ts` to verify the new test case passes.
- Run `bun check` and `bun tsc` to verify formatting and types.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c7366006f8d3496890dc71c9b2867fc7)