### PR TITLE
feat(vscode-webui): print LiveStore events to output panel in debug mode

### DIFF
--- a/packages/vscode-webui/src/components/global-store-initializer.tsx
+++ b/packages/vscode-webui/src/components/global-store-initializer.tsx
@@ -1,12 +1,40 @@
 import { useDefaultStore } from "@/lib/use-default-store";
 import { setGlobalStore } from "@/lib/vscode";
+import { getLogger } from "@getpochi/common";
 import { useEffect } from "react";
+
+const liveStoreLogger = getLogger("LiveStore");
 
 export function GlobalStoreInitializer() {
   const store = useDefaultStore();
+
   useEffect(() => {
     setGlobalStore(store);
     return () => setGlobalStore(null);
   }, [store]);
+
+  useEffect(() => {
+    let active = true;
+    const stream = async () => {
+      try {
+        const events = store.events();
+        for await (const event of events) {
+          if (!active) {
+            break;
+          }
+          liveStoreLogger.debug(event);
+        }
+      } catch (error) {
+        console.error("Failed to stream LiveStore events:", error);
+      }
+    };
+
+    stream();
+
+    return () => {
+      active = false;
+    };
+  }, [store]);
+
   return null;
 }


### PR DESCRIPTION
## Summary
- Stream all LiveStore events inside the webview using `getLogger("LiveStore")` at `debug` level.
- Leverage the pre-attached transport in the webview which automatically forwards these logs to the VS Code extension host.
- Allows developers to inspect LiveStore events in the output panel when the `webviewLogLevel` is set to `debug` or `trace`.

![LiveStore Events Screenshot](https://pochi-file-uploads.getpochi.com/blob-1781591789575.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260616%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260616T063629Z&X-Amz-Expires=561600&X-Amz-Signature=da9d0205002d2211a665ab4f896b9ee8d3dc92e18fc392a43432f1de97badc52&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan
- Set `pochi.advanced.webviewLogLevel` to `debug` or `trace` in VS Code settings.
- Open Pochi Webview and observe the LiveStore events printed directly to the VS Code Pochi output panel.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a519a699abf24091b8bae6a2f3f43138)