### PR TITLE
feat(livekit): pass store-id in header and enforce required storeId

### DIFF
--- a/packages/common/src/base/__tests__/provider-options.test.ts
+++ b/packages/common/src/base/__tests__/provider-options.test.ts
@@ -5,6 +5,7 @@ describe("PochiProviderOptions", () => {
   it("accepts fork agent labels as request use cases", () => {
     const result = PochiProviderOptions.safeParse({
       taskId: "task-1",
+      storeId: "store-1",
       client: "vscode",
       useCase: "task-memory",
     });
@@ -15,6 +16,7 @@ describe("PochiProviderOptions", () => {
   it("rejects unknown request use cases", () => {
     const result = PochiProviderOptions.safeParse({
       taskId: "task-1",
+      storeId: "store-1",
       client: "vscode",
       useCase: "custom-fork-label",
     });

--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -14,6 +14,7 @@ export const DefaultMaxOutputTokens = 4096;
 export const StreamingUpdateThrottleMs = 100;
 
 export const PochiTaskIdHeader = "x-pochi-task-id";
+export const PochiStoreIdHeader = "x-pochi-store-id";
 export const PochiClientHeader = "x-pochi-client";
 export const PochiRequestUseCaseHeader = "x-pochi-request-use-case";
 

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -64,6 +64,7 @@ export type PochiRequestUseCase = z.infer<typeof PochiRequestUseCase>;
 
 export const PochiProviderOptions = z.object({
   taskId: z.string(),
+  storeId: z.string(),
   client: z.string(),
   useCase: PochiRequestUseCase,
 });

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -198,6 +198,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       providerOptions: {
         pochi: {
           taskId: chatId,
+          storeId: this.store.storeId,
           client: globalThis.POCHI_CLIENT,
           useCase: this.requestUseCase,
         } satisfies PochiProviderOptions,

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -146,7 +146,12 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
 
     if (this.outputSchema) {
       middlewares.push(
-        createOutputSchemaMiddleware(chatId, model, this.outputSchema),
+        createOutputSchemaMiddleware(
+          chatId,
+          this.store.storeId,
+          model,
+          this.outputSchema,
+        ),
       );
     }
 
@@ -214,7 +219,11 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       maxRetries: 0,
       // error log is handled in live chat kit.
       onError: () => {},
-      experimental_repairToolCall: makeRepairToolCall(chatId, model),
+      experimental_repairToolCall: makeRepairToolCall(
+        chatId,
+        this.store.storeId,
+        model,
+      ),
       experimental_download: makeDownloadFunction(this.blobStore),
     });
     return stream.toUIMessageStream({

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -359,6 +359,7 @@ export class LiveChatKit<
           await compactTask({
             blobStore: this.blobStore,
             taskId: this.taskId,
+            storeId: this.store.storeId,
             model,
             messages,
             recentFiles: await readRecentFilesForCompact(
@@ -429,6 +430,7 @@ export class LiveChatKit<
         const summary = await compactTask({
           blobStore: this.blobStore,
           taskId: this.taskId,
+          storeId: this.store.storeId,
           model,
           messages,
           recentFiles: await readRecentFilesForCompact(

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -23,6 +23,7 @@ const TaskMemoryStoreFilePath = new URL(TaskMemoryFileUri).pathname;
 export async function compactTask({
   blobStore,
   taskId,
+  storeId,
   model,
   messages,
   recentFiles,
@@ -34,6 +35,7 @@ export async function compactTask({
 }: {
   blobStore: BlobStore;
   taskId: string;
+  storeId: string;
   model: LanguageModelV3;
   messages: Message[];
   recentFiles?: RecentFileState[];
@@ -76,6 +78,7 @@ export async function compactTask({
       summaryText = await createSummary(
         blobStore,
         taskId,
+        storeId,
         model,
         abortSignal,
         inputMessages,
@@ -178,6 +181,7 @@ export function findVerbatimAttachIndex(
 async function createSummary(
   blobStore: BlobStore,
   taskId: string,
+  storeId: string,
   model: LanguageModelV3,
   abortSignal: AbortSignal | undefined,
   inputMessages: Message[],
@@ -201,6 +205,7 @@ async function createSummary(
     providerOptions: {
       pochi: {
         taskId,
+        storeId,
         client: globalThis.POCHI_CLIENT,
         useCase,
       } satisfies PochiProviderOptions,

--- a/packages/livekit/src/chat/llm/generate-task-title.ts
+++ b/packages/livekit/src/chat/llm/generate-task-title.ts
@@ -32,6 +32,7 @@ export async function generateTaskTitle(options: GenerateTaskTitleOptions) {
 }
 
 async function generateTaskTitleImpl({
+  store,
   blobStore,
   taskId,
   title,
@@ -62,6 +63,7 @@ async function generateTaskTitleImpl({
       const title = await generateTitle(
         blobStore,
         taskId,
+        store.storeId,
         model,
         messages,
         abortSignal,
@@ -103,6 +105,7 @@ function isTitleGeneratedByLlm(
 async function generateTitle(
   blobStore: BlobStore,
   taskId: string,
+  storeId: string,
   model: LanguageModelV3,
   inputMessages: Message[],
   abortSignal: AbortSignal | undefined,
@@ -125,6 +128,7 @@ async function generateTitle(
     providerOptions: {
       pochi: {
         taskId,
+        storeId,
         client: globalThis.POCHI_CLIENT,
         useCase: "generate-task-title",
       } satisfies PochiProviderOptions,

--- a/packages/livekit/src/chat/llm/repair-mermaid.ts
+++ b/packages/livekit/src/chat/llm/repair-mermaid.ts
@@ -56,6 +56,7 @@ export async function repairMermaid({
     // Generate the fixed mermaid diagram
     const fixedMermaid = await generateFixedMermaid(
       taskId,
+      store.storeId,
       model,
       abortSignal,
       chart,
@@ -155,6 +156,7 @@ export async function repairMermaid({
 
 async function generateFixedMermaid(
   taskId: string,
+  storeId: string,
   model: LanguageModelV3,
   abortSignal: AbortSignal | undefined,
   chart: string,
@@ -177,6 +179,7 @@ async function generateFixedMermaid(
     providerOptions: {
       pochi: {
         taskId,
+        storeId,
         client: globalThis.POCHI_CLIENT,
         useCase: "repair-mermaid",
       } satisfies PochiProviderOptions,

--- a/packages/livekit/src/chat/llm/repair-tool-call.ts
+++ b/packages/livekit/src/chat/llm/repair-tool-call.ts
@@ -11,9 +11,10 @@ import {
 
 export const makeRepairToolCall: (
   taskId: string,
+  storeId: string,
   model: LanguageModelV3,
 ) => ToolCallRepairFunction<Record<string, Tool>> =
-  (taskId, model) =>
+  (taskId, storeId, model) =>
   async ({ toolCall, inputSchema, error }) => {
     if (NoSuchToolError.isInstance(error)) {
       return null; // do not attempt to fix invalid tool names
@@ -27,6 +28,7 @@ export const makeRepairToolCall: (
       providerOptions: {
         pochi: {
           taskId,
+          storeId,
           client: globalThis.POCHI_CLIENT,
           useCase: "repair-tool-call",
         } satisfies PochiProviderOptions,

--- a/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
+++ b/packages/livekit/src/chat/middlewares/output-schema-middleware.ts
@@ -11,6 +11,7 @@ import z from "zod";
 
 export function createOutputSchemaMiddleware(
   taskId: string,
+  storeId: string,
   model: LanguageModelV3,
   outputSchema: z.ZodAny,
 ): LanguageModelV3Middleware {
@@ -62,6 +63,7 @@ export function createOutputSchemaMiddleware(
                 ...parsedResult.value,
                 result: await ensureOutputSchema(
                   taskId,
+                  storeId,
                   model,
                   outputSchema,
                   result,
@@ -91,6 +93,7 @@ export function createOutputSchemaMiddleware(
 
 async function ensureOutputSchema(
   taskId: string,
+  storeId: string,
   model: LanguageModelV3,
   schema: z.ZodAny,
   content: string,
@@ -100,6 +103,7 @@ async function ensureOutputSchema(
       providerOptions: {
         pochi: {
           taskId,
+          storeId,
           client: globalThis.POCHI_CLIENT,
           useCase: "output-schema",
         } satisfies PochiProviderOptions,

--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -46,6 +46,9 @@ export function createPochiModel({
       );
       if (parsedOptions.success) {
         headers[constants.PochiTaskIdHeader] = parsedOptions.data.taskId;
+        if (parsedOptions.data.storeId) {
+          headers[constants.PochiStoreIdHeader] = parsedOptions.data.storeId;
+        }
         headers[constants.PochiClientHeader] = parsedOptions.data.client;
         headers[constants.PochiRequestUseCaseHeader] =
           parsedOptions.data.useCase;
@@ -89,6 +92,9 @@ export function createPochiModel({
       );
       if (parsedOptions.success) {
         headers[constants.PochiTaskIdHeader] = parsedOptions.data.taskId;
+        if (parsedOptions.data.storeId) {
+          headers[constants.PochiStoreIdHeader] = parsedOptions.data.storeId;
+        }
         headers[constants.PochiClientHeader] = parsedOptions.data.client;
         headers[constants.PochiRequestUseCaseHeader] =
           parsedOptions.data.useCase;

--- a/packages/vendor-pochi/src/model.ts
+++ b/packages/vendor-pochi/src/model.ts
@@ -46,9 +46,7 @@ export function createPochiModel({
       );
       if (parsedOptions.success) {
         headers[constants.PochiTaskIdHeader] = parsedOptions.data.taskId;
-        if (parsedOptions.data.storeId) {
-          headers[constants.PochiStoreIdHeader] = parsedOptions.data.storeId;
-        }
+        headers[constants.PochiStoreIdHeader] = parsedOptions.data.storeId;
         headers[constants.PochiClientHeader] = parsedOptions.data.client;
         headers[constants.PochiRequestUseCaseHeader] =
           parsedOptions.data.useCase;
@@ -92,9 +90,7 @@ export function createPochiModel({
       );
       if (parsedOptions.success) {
         headers[constants.PochiTaskIdHeader] = parsedOptions.data.taskId;
-        if (parsedOptions.data.storeId) {
-          headers[constants.PochiStoreIdHeader] = parsedOptions.data.storeId;
-        }
+        headers[constants.PochiStoreIdHeader] = parsedOptions.data.storeId;
         headers[constants.PochiClientHeader] = parsedOptions.data.client;
         headers[constants.PochiRequestUseCaseHeader] =
           parsedOptions.data.useCase;


### PR DESCRIPTION
Closes #1649

## Summary
Updates the OpenTelemetry tracing during task streaming to log the **Store ID** (`storeId`) in place of the `root-task-id`. Since the client's local LiveStore already manages the base58-encoded `storeId` directly (which contains both the user `sub` and the root `taskId`), we pass it directly from the client via a custom HTTP header to eliminate server-side database queries.

### Client-Side Changes (`pochi`)
- **Header Constants**: Added `PochiStoreIdHeader = "x-pochi-store-id"` to `packages/common/src/base/constants.ts`.
- **Validation Schema**: Enforced `storeId: z.string()` as a required field in `PochiProviderOptions` for the client side in `packages/common/src/base/index.ts`.
- **Client-Side Store ID Injection**: Configured `packages/livekit/src/chat/flexible-chat-transport.ts` to pass the local LiveStore's `storeId` directly.
- **Header Injection**: Configured `packages/vendor-pochi/src/model.ts` to set the `x-pochi-store-id` header on outgoing requests.
- **Enforced Type Safety**: Modified all client-side LLM helper signatures (`compactTask`, `generateTitle`, `repairMermaid`, `repairToolCall`, and `outputSchemaMiddleware`) to require `storeId` as a parameter.
- **Unit Tests**: Updated `packages/common/src/base/__tests__/provider-options.test.ts` to include `storeId` in the validation payloads.

### Server-Side Changes (`ragdoll`)
- **Backward Compatibility**: Kept `storeId` as an optional field (`storeId: z.string().optional()`) in `PochiProviderOptions` schema in `packages/common/src/base/index.ts` to support legacy clients.
- **Unified Trace Attribute**: Replaced `"ragdoll.rootTask.uid"` with `"ragdoll.task.storeId"` in `RagdollAttributes` inside `private/packages/server/src/trace.ts`.
- **Unified Trace Setting**: Combined `applyChatTaskId` and `applyChatStoreId` into a single, unified function `applyChatTaskId(taskId, storeId)` inside `private/packages/server/src/api/utils/chat-core.ts`. It maps `taskId` directly to `"ragdoll.task.uid"` and `storeId` directly to `"ragdoll.task.storeId"`.
- **Server Endpoints**: Updated all chat endpoints in `private/packages/server/src/api/chat.ts` to retrieve `storeId` from request headers using `constants.PochiStoreIdHeader` and call the unified `applyChatTaskId(taskId, storeId)` in a single function call.
- **Graceful Fallback**: Added a `populateStoreId` helper in `private/packages/server/src/api/utils/chat-core.ts` to automatically construct a fallback `storeId` using `encodeStoreId(null, context.taskId)` on the server side for legacy clients or direct API calls where the header is missing.
- **Telemetry Metadata**: Modified `createChatTelemetry` to append `"root-task-id": context.storeId` to the telemetry metadata passed to the Vercel AI SDK's `streamText`.

## Test plan
- Verified that all `@getpochi/common` and `@getpochi/livekit` tests pass perfectly.
- Ran `bun tsc` to ensure total compilation type safety.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-97bc3e38-8569-4ac1-bf22-4a09380bae26)