### PR TITLE
fix(vscode-webui): prevent FileList row-height measurement loop on scroll

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/file-list.tsx
+++ b/packages/vscode-webui/src/features/tools/components/file-list.tsx
@@ -92,6 +92,7 @@ export const FileList: React.FC<{
     };
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: measure the row height once after first paint
   useLayoutEffect(() => {
     const row = rowRef.current;
     if (!row) return;
@@ -103,7 +104,7 @@ export const FileList: React.FC<{
     ) {
       setRowHeight(measuredRowHeight);
     }
-  });
+  }, []);
 
   const virtualRange = useMemo(
     () =>


### PR DESCRIPTION
The row-height useLayoutEffect had no dependency array, so it re-ran after every render. During virtualized scrolling the rowRef points at a different DOM element each frame, and subpixel differences between rows repeatedly triggered setRowHeight, causing React error #185 "Maximum update depth exceeded".

Measure the row height once after first paint instead.