### PR TITLE
fix(vscode-webui): refine checkpoint layout spacing

### DIFF
--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -173,6 +173,7 @@ export const MessageList: React.FC<{
                       }
                       partIndex={index}
                       part={part}
+                      previousPart={m.parts[index - 1]}
                       isLoading={isLoading}
                       isExecuting={isExecuting}
                       messages={renderMessages}
@@ -262,6 +263,7 @@ function Part({
   role,
   part,
   partIndex,
+  previousPart,
   isLastPartInMessages,
   isLoading,
   isExecuting,
@@ -277,6 +279,7 @@ function Part({
   role: Message["role"];
   partIndex: number;
   part: NonNullable<Message["parts"]>[number];
+  previousPart: NonNullable<Message["parts"]>[number] | undefined;
   isLastPartInMessages: boolean;
   isLoading: boolean;
   isExecuting: boolean;
@@ -292,7 +295,8 @@ function Part({
   };
   toolCallCheckpoints: Map<string, ToolCallCheckpoint>;
 }) {
-  const paddingClass = partIndex === 0 ? "" : "mt-2";
+  const paddingClass =
+    partIndex === 0 || previousPart?.type === "data-checkpoint" ? "" : "mt-2";
   if (part.type === "text") {
     return <MemoTextPartUI className={paddingClass} part={part} />;
   }
@@ -314,18 +318,15 @@ function Part({
   if (part.type === "data-checkpoint") {
     if (role === "assistant" && isVSCodeEnvironment() && !isSubTask) {
       return (
-        // Offset the padding of the message container to align the checkpoint UI properly
-        <div className="-mb-2">
-          <CheckpointUI
-            checkpoint={part.data}
-            isLoading={isLoading || isExecuting}
-            forkTask={forkTask}
-            isRestored={
-              lastCheckpointInMessage !== part.data.commit &&
-              latestCheckpoint === part.data.commit
-            }
-          />
-        </div>
+        <CheckpointUI
+          checkpoint={part.data}
+          isLoading={isLoading || isExecuting}
+          forkTask={forkTask}
+          isRestored={
+            lastCheckpointInMessage !== part.data.commit &&
+            latestCheckpoint === part.data.commit
+          }
+        />
       );
     }
     return null;

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -314,15 +314,18 @@ function Part({
   if (part.type === "data-checkpoint") {
     if (role === "assistant" && isVSCodeEnvironment() && !isSubTask) {
       return (
-        <CheckpointUI
-          checkpoint={part.data}
-          isLoading={isLoading || isExecuting}
-          forkTask={forkTask}
-          isRestored={
-            lastCheckpointInMessage !== part.data.commit &&
-            latestCheckpoint === part.data.commit
-          }
-        />
+        // Offset the padding of the message container to align the checkpoint UI properly
+        <div className="-mb-2">
+          <CheckpointUI
+            checkpoint={part.data}
+            isLoading={isLoading || isExecuting}
+            forkTask={forkTask}
+            isRestored={
+              lastCheckpointInMessage !== part.data.commit &&
+              latestCheckpoint === part.data.commit
+            }
+          />
+        </div>
       );
     }
     return null;


### PR DESCRIPTION
## Summary
- Dynamically calculate the top margin of a message part (`paddingClass`). If the previous part is a `data-checkpoint`, do not add the top margin (`mt-2`). This prevents unnecessary layout spacing/padding between a checkpoint and the following text or content.

<img width="400" src="https://github.com/user-attachments/assets/fd094d3a-7d68-4b9d-9360-ee213ecc89d6" />

<img width="400" src="https://github.com/user-attachments/assets/543abf86-a84d-41a5-b067-7bb667c53064" />

## Test plan
- Verify that checkpoints align perfectly in the message list without layout shifts or extra spacing.
- Run `bun check` and `bun tsc` to ensure all checks pass.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-849aa791624341b695436e4f91f8e25f)