### PR TITLE
fix(cli): disable task memory and project memory by default

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -168,12 +168,14 @@ const program = new Command()
     60000,
   )
   .option(
-    "--no-task-memory",
-    "Disable Task Memory background extraction for the current task.",
+    "--task-memory",
+    "Enable Task Memory background extraction for the current task.",
+    false,
   )
   .option(
-    "--no-project-memory",
-    "Disable Project Memory context injection and auto-memory background extraction.",
+    "--project-memory",
+    "Enable Project Memory context injection and auto-memory background extraction.",
+    false,
   )
   .option(
     "--agent <name>",


### PR DESCRIPTION
## Summary
- Replace `--no-task-memory` / `--no-project-memory` with opt-in `--task-memory` / `--project-memory` flags that default to `false`.
- CLI invocations no longer trigger Task Memory background extraction, Project Memory context injection, or auto-memory background extraction unless the user explicitly opts in.

## Test plan
- [ ] `pochi -p \"…\"` (no flags) — verify no Task Memory extraction runs and no auto-memory `MEMORY.md` snapshot is injected.
- [ ] `pochi --task-memory -p \"…\"` — verify Task Memory extraction still kicks off as before.
- [ ] `pochi --project-memory -p \"…\"` — verify auto-memory injection + extraction still work as before.
- [ ] `pochi --help` — confirm the new flag names render with the updated descriptions.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-17970cbc1eee4fdf8a703f2f8cd495a7)