### PR TITLE
fix(vscode-webui): improve checkpoint ui layout and spacing

### DIFF
--- a/packages/vscode-webui/src/components/checkpoint-ui.tsx
+++ b/packages/vscode-webui/src/components/checkpoint-ui.tsx
@@ -185,13 +185,13 @@ export const CheckpointUI: React.FC<{
   return (
     <div
       className={cn(
-        "relative min-h-5 w-full opacity-0 transition-opacity duration-200",
+        "relative w-full opacity-0 transition-opacity duration-200",
         showCheckpoint && "opacity-100",
       )}
     >
       <div
         className={cn(
-          "-translate-x-1/2 -translate-y-1/2 group absolute top-1/2 left-1/2 mx-auto flex w-full max-w-[72px] select-none items-center hover:max-w-full",
+          "-translate-x-1/2 -top-1 group absolute left-1/2 mx-auto flex min-h-5 w-full max-w-[72px] select-none items-center hover:max-w-full",
           isLoading && "pointer-events-none",
           className,
         )}

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -127,7 +127,7 @@ export const MessageList: React.FC<{
               className="message-list-item flex flex-col"
               aria-label={`chat-message-${m.role}`}
             >
-              <div className={cn(showUserAvatar && "py-2")}>
+              <div className={cn(showUserAvatar && "pt-4 pb-2")}>
                 {showUserAvatar && (
                   <div className="flex items-center gap-2">
                     {m.role === "user" ? (
@@ -433,18 +433,20 @@ const SeparatorWithCheckpoint: React.FC<{
   const part = checkpointMessage.parts.at(-1);
   if (part && part.type === "data-checkpoint" && isVSCodeEnvironment()) {
     return (
-      <CheckpointUI
-        checkpoint={part.data}
-        isLoading={isLoading}
-        hideBorderOnHover={false}
-        className="max-w-full"
-        forkTask={forkTask}
-        restoreMessageId={restoreMessageId}
-        isRestored={
-          lastCheckpointInMessage !== part.data.commit &&
-          latestCheckpoint === part.data.commit
-        }
-      />
+      <div className="mt-1 mb-2">
+        <CheckpointUI
+          checkpoint={part.data}
+          isLoading={isLoading}
+          hideBorderOnHover={false}
+          className="max-w-full"
+          forkTask={forkTask}
+          restoreMessageId={restoreMessageId}
+          isRestored={
+            lastCheckpointInMessage !== part.data.commit &&
+            latestCheckpoint === part.data.commit
+          }
+        />
+      </div>
     );
   }
 

--- a/packages/vscode-webui/src/styles.css
+++ b/packages/vscode-webui/src/styles.css
@@ -25,14 +25,6 @@ code {
     monospace;
 }
 
-.message-list-item {
-  contain-intrinsic-size: auto 240px;
-}
-
-.perf-content-visibility-off .message-list-item {
-  contain-intrinsic-size: none;
-}
-
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);

--- a/packages/vscode-webui/src/styles.css
+++ b/packages/vscode-webui/src/styles.css
@@ -26,12 +26,10 @@ code {
 }
 
 .message-list-item {
-  content-visibility: auto;
   contain-intrinsic-size: auto 240px;
 }
 
 .perf-content-visibility-off .message-list-item {
-  content-visibility: visible;
   contain-intrinsic-size: none;
 }
 


### PR DESCRIPTION
## Summary
- Reverts absolute vertical centering layout changes for the checkpoint button introduced in #1616.
- Positions the checkpoint button with absolute top positioning and adds appropriate margin wrappers to prevent layout overlapping.
- Removes `content-visibility` optimizations from `.message-list-item` to prevent layout shifts and measurement loops on virtualized scroll.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/467ee5a0-6c1c-4901-a4ff-e5ca9cccbaf9" />

## Test plan
- Run webui unit tests: `bun vitest --run` inside `packages/vscode-webui` to verify layout components.
- Manually verify checkpoint buttons are correctly positioned and aligned in the chat message list without overlapping adjacent text.
- Scroll through long chat lists to ensure no layout jitter or rendering loops.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-147962ab9078431a9052821ea5536805)