### PR TITLE
chore(vscode): bump version to 0.53.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.51.0-dev",
+  "version": "0.53.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
* Bump VS Code extension version to `0.53.0-dev` in `packages/vscode/package.json`.

## Test plan
* Verify that the version is correctly updated in `packages/vscode/package.json`.
* Ensure CI builds and tests pass.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-31fb892421d345c9a69d3499502d8b7a)