### PR TITLE
feat(vscode-webui): add dev button to copy system prompt of current task

### DIFF
--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -251,6 +251,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
             finishReason: part.finishReason,
             systemPromptTokens,
             toolsTokens,
+            systemPrompt,
           } satisfies Metadata;
         }
       },

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -21,6 +21,7 @@ export type Metadata =
       finishReason: FinishReason;
       systemPromptTokens?: number;
       toolsTokens?: number;
+      systemPrompt?: string;
     }
   | {
       kind: "user";

--- a/packages/vscode-webui/src/components/dev-mode-button.tsx
+++ b/packages/vscode-webui/src/components/dev-mode-button.tsx
@@ -17,7 +17,7 @@ import type { Todo } from "@getpochi/tools";
 import { convertToModelMessages } from "ai";
 import { CheckIcon, CopyIcon, FileDiff, Gavel, StoreIcon } from "lucide-react";
 import type React from "react";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 interface UpdatedCopyMenuItemProps {
@@ -76,7 +76,7 @@ export function DevModeButton({ messages, todos }: DevModeButtonProps) {
     return JSON.stringify(todos, null, 2);
   };
 
-  const getSystemPromptContent = useCallback(() => {
+  const systemPrompt = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
       if (
@@ -87,8 +87,8 @@ export function DevModeButton({ messages, todos }: DevModeButtonProps) {
         return msg.metadata.systemPrompt;
       }
     }
-    return t("devModeButton.noSystemPromptAvailable");
-  }, [messages, t]);
+    return null;
+  }, [messages]);
 
   const getCheckpintCommand = useCallback(async () => {
     const checkpointPath = await vscodeHost.readCheckpointPath();
@@ -135,10 +135,12 @@ export function DevModeButton({ messages, todos }: DevModeButtonProps) {
             fetchContent={getTodosContent}
             text={t("devModeButton.copyTodos")}
           />
-          <CopyMenuItem
-            fetchContent={getSystemPromptContent}
-            text={t("devModeButton.copySystemPrompt")}
-          />
+          {systemPrompt && (
+            <CopyMenuItem
+              fetchContent={() => systemPrompt}
+              text={t("devModeButton.copySystemPrompt")}
+            />
+          )}
           <OpenDevStore />
           <ReviewChangesMenuItem />
         </DropdownMenuContent>

--- a/packages/vscode-webui/src/components/dev-mode-button.tsx
+++ b/packages/vscode-webui/src/components/dev-mode-button.tsx
@@ -50,6 +50,7 @@ function CopyMenuItem({ fetchContent, text }: UpdatedCopyMenuItemProps) {
 interface DevModeButtonProps {
   messages: Message[];
   todos: Todo[] | undefined;
+  taskId?: string;
 }
 
 export function DevModeButton({ messages, todos }: DevModeButtonProps) {
@@ -75,13 +76,27 @@ export function DevModeButton({ messages, todos }: DevModeButtonProps) {
     return JSON.stringify(todos, null, 2);
   };
 
+  const getSystemPromptContent = useCallback(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (
+        msg.role === "assistant" &&
+        msg.metadata?.kind === "assistant" &&
+        msg.metadata.systemPrompt
+      ) {
+        return msg.metadata.systemPrompt;
+      }
+    }
+    return t("devModeButton.noSystemPromptAvailable");
+  }, [messages, t]);
+
   const getCheckpintCommand = useCallback(async () => {
     const checkpointPath = await vscodeHost.readCheckpointPath();
     if (!checkpointPath) {
       return t("devModeButton.noCheckpointAvailable");
     }
     const workspaceInfo = await vscodeHost.readCurrentWorkspace();
-    return `alias pgit="git --git-dir=\\"${checkpointPath}\\" --work-tree=\\"${workspaceInfo.cwd}\\""`;
+    return `alias pgit="git --git-dir=\\\"${checkpointPath}\\\" --work-tree=\\\"${workspaceInfo.cwd}\\\""`;
   }, [t]);
 
   if (!isDevMode) return null;
@@ -119,6 +134,10 @@ export function DevModeButton({ messages, todos }: DevModeButtonProps) {
           <CopyMenuItem
             fetchContent={getTodosContent}
             text={t("devModeButton.copyTodos")}
+          />
+          <CopyMenuItem
+            fetchContent={getSystemPromptContent}
+            text={t("devModeButton.copySystemPrompt")}
           />
           <OpenDevStore />
           <ReviewChangesMenuItem />

--- a/packages/vscode-webui/src/components/dev-mode-button.tsx
+++ b/packages/vscode-webui/src/components/dev-mode-button.tsx
@@ -96,7 +96,7 @@ export function DevModeButton({ messages, todos }: DevModeButtonProps) {
       return t("devModeButton.noCheckpointAvailable");
     }
     const workspaceInfo = await vscodeHost.readCurrentWorkspace();
-    return `alias pgit="git --git-dir=\\\"${checkpointPath}\\\" --work-tree=\\\"${workspaceInfo.cwd}\\\""`;
+    return `alias pgit="git --git-dir=\\"${checkpointPath}\\" --work-tree=\\"${workspaceInfo.cwd}\\""`;
   }, [t]);
 
   if (!isDevMode) return null;

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -443,7 +443,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
               selectedModel={selectedModel}
             />
           )}
-          <DevModeButton messages={messages} todos={todos} />
+          <DevModeButton messages={messages} todos={todos} taskId={taskId} />
           <AutoApproveMenu
             isSubTask={isSubTask}
             mcpConfigOverride={mcpConfigOverride}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -483,7 +483,6 @@
     "copyCheckpointCommand": "Copy Checkpoint Command",
     "copyTodos": "Copy TODOs",
     "noCheckpointAvailable": "No checkpoint available",
-    "noSystemPromptAvailable": "No system prompt available",
     "openStore": "Open Store",
     "reviewChanges": "Review Changes",
     "copySystemPrompt": "Copy System Prompt"

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -483,8 +483,10 @@
     "copyCheckpointCommand": "Copy Checkpoint Command",
     "copyTodos": "Copy TODOs",
     "noCheckpointAvailable": "No checkpoint available",
+    "noSystemPromptAvailable": "No system prompt available",
     "openStore": "Open Store",
-    "reviewChanges": "Review Changes"
+    "reviewChanges": "Review Changes",
+    "copySystemPrompt": "Copy System Prompt"
   },
   "devRetryCountdown": {
     "attempts": "Attempts:",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -482,8 +482,10 @@
     "copyCheckpointCommand": "チェックポイントコマンドをコピー",
     "copyTodos": "TODOをコピー",
     "noCheckpointAvailable": "利用可能なチェックポイントがありません",
+    "noSystemPromptAvailable": "利用可能なシステムプロンプトがありません",
     "openStore": "ストアを開く",
-    "reviewChanges": "変更をレビュー"
+    "reviewChanges": "変更をレビュー",
+    "copySystemPrompt": "システムプロンプトをコピー"
   },
   "devRetryCountdown": {
     "attempts": "試行回数：",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -482,7 +482,6 @@
     "copyCheckpointCommand": "チェックポイントコマンドをコピー",
     "copyTodos": "TODOをコピー",
     "noCheckpointAvailable": "利用可能なチェックポイントがありません",
-    "noSystemPromptAvailable": "利用可能なシステムプロンプトがありません",
     "openStore": "ストアを開く",
     "reviewChanges": "変更をレビュー",
     "copySystemPrompt": "システムプロンプトをコピー"

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -475,7 +475,6 @@
     "copyCheckpointCommand": "체크포인트 명령 복사",
     "copyTodos": "할 일 복사",
     "noCheckpointAvailable": "사용 가능한 체크포인트가 없습니다",
-    "noSystemPromptAvailable": "사용 가능한 시스템 프롬프트가 없습니다",
     "openStore": "스토어 열기",
     "reviewChanges": "변경 사항 검토",
     "copySystemPrompt": "시스템 프롬프트 복사"

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -475,8 +475,10 @@
     "copyCheckpointCommand": "체크포인트 명령 복사",
     "copyTodos": "할 일 복사",
     "noCheckpointAvailable": "사용 가능한 체크포인트가 없습니다",
+    "noSystemPromptAvailable": "사용 가능한 시스템 프롬프트가 없습니다",
     "openStore": "스토어 열기",
-    "reviewChanges": "변경 사항 검토"
+    "reviewChanges": "변경 사항 검토",
+    "copySystemPrompt": "시스템 프롬프트 복사"
   },
   "devRetryCountdown": {
     "attempts": "시도 횟수:",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -480,7 +480,6 @@
     "copyCheckpointCommand": "复制检查点命令",
     "copyTodos": "复制待办事项",
     "noCheckpointAvailable": "没有可用的检查点",
-    "noSystemPromptAvailable": "没有可用的系统提示词",
     "openStore": "打开存储",
     "reviewChanges": "审查变更",
     "copySystemPrompt": "复制系统提示词"

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -480,8 +480,10 @@
     "copyCheckpointCommand": "复制检查点命令",
     "copyTodos": "复制待办事项",
     "noCheckpointAvailable": "没有可用的检查点",
+    "noSystemPromptAvailable": "没有可用的系统提示词",
     "openStore": "打开存储",
-    "reviewChanges": "审查变更"
+    "reviewChanges": "审查变更",
+    "copySystemPrompt": "复制系统提示词"
   },
   "devRetryCountdown": {
     "attempts": "尝试次数：",


### PR DESCRIPTION
## Summary

- Adds `systemPrompt?: string` to the `assistant` metadata variant in `packages/livekit/src/types.ts`
- Stores the actual system prompt in `messageMetadata` inside `FlexibleChatTransport` at send time, alongside the existing `systemPromptTokens`/`toolsTokens`
- Adds a **"Copy System Prompt"** item to the dev mode button dropdown (`packages/vscode-webui/src/components/dev-mode-button.tsx`), which scans messages from the end for the last assistant message carrying `metadata.systemPrompt` and copies it directly — no reconstruction, no async calls

## Test plan

- [ ] Enable dev mode in settings
- [ ] Start a task and send at least one message
- [ ] Click the hammer (🔨) dev mode button → "Copy System Prompt"
- [ ] Verify the copied text matches the full system prompt (Pochi identity, RULES section, custom instructions, project memory if enabled)
- [ ] Verify "No system prompt available" fallback appears on tasks that haven't sent any messages yet

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-9acdd11a566c4bf8966557490aadceab) | [Task](https://app.getpochi.com/share/p-9acdd11a566c4bf8966557490aadceab)