### PR TITLE
fix(vscode-webui): show fork success only after fork action

### DIFF
--- a/packages/vscode-webui/src/components/checkpoint-ui.tsx
+++ b/packages/vscode-webui/src/components/checkpoint-ui.tsx
@@ -132,7 +132,7 @@ export const CheckpointUI: React.FC<{
     if (isPending && currentAction === "fork") {
       return t("checkpointUI.forking");
     }
-    if (showActionSuccessIcon && currentAction === "restore") {
+    if (showActionSuccessIcon && currentAction === "fork") {
       return t("checkpointUI.success");
     }
     return t("checkpointUI.fork");


### PR DESCRIPTION
## Summary
- The Fork button in `CheckpointUI` was flashing the "Success" label whenever a **restore** action succeeded, because `getForkText()` keyed its success branch on `currentAction === "restore"` instead of `"fork"`.
- Fixed the guard so the Fork button only shows "Success" after the fork action itself completes (matching the existing `getForkIcon()` behavior).

## Test plan
- [ ] Open a task with checkpoints, click **Restore** on a checkpoint, and confirm the Fork label no longer flips to "Success" alongside the Restore success state.
- [ ] Click **Fork** on a checkpoint and confirm the Fork label still flips to "Success" for ~2s after the fork resolves.
- [ ] Click **Compare** and confirm the Compare success/no-changes label is unchanged.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-bbd36b3a656a468ab98b820be9548651)