### PR TITLE
feat(cli): add webFetch and webSearch tool renderers

### DIFF
--- a/packages/cli/src/renderers/output-renderer.ts
+++ b/packages/cli/src/renderers/output-renderer.ts
@@ -260,6 +260,25 @@ export function renderToolPart(
     };
   }
 
+  if ((part.type as string) === "tool-webFetch") {
+    const { url = "unknown" } = (part.input as { url?: string }) || {};
+    return {
+      text: `🌐 Fetching ${chalk.bold(url)}`,
+      stop: hasError ? "fail" : "succeed",
+      error: errorText,
+    };
+  }
+
+  if ((part.type as string) === "tool-webSearch") {
+    const { query = "" } = (part.input as { query?: string | string[] }) || {};
+    const queryText = Array.isArray(query) ? query.join(", ") : query;
+    return {
+      text: `🔎 Searching the web for ${chalk.bold(queryText)}`,
+      stop: hasError ? "fail" : "succeed",
+      error: errorText,
+    };
+  }
+
   // Interactive tools
   if (part.type === "tool-askFollowupQuestion") {
     const { questions } = part.input || {};


### PR DESCRIPTION
## Summary
- Add terminal rendering for `tool-webFetch` — displays `🌐 Fetching <url>` with success/fail state
- Add terminal rendering for `tool-webSearch` — displays `🔎 Searching the web for <query>` with success/fail state, supporting both single string and array queries

## Test plan
- [ ] Run CLI agent task that triggers a web fetch and verify `🌐 Fetching ...` spinner appears
- [ ] Run CLI agent task that triggers a web search and verify `🔎 Searching the web for ...` spinner appears
- [ ] Verify error state shows "fail" when tool returns an error

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5d5940be862940699ff9cf736206bea9)