### PR TITLE
feat(vscode-ui): remove reviewer agent option from attempt completion

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
+++ b/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
@@ -7,11 +7,10 @@ import {
 } from "@/components/ui/tooltip";
 import { useSendMessage } from "@/features/chat";
 import { useCurrentWorkspace } from "@/lib/hooks/use-current-workspace";
-import { useVSCodeSettings } from "@/lib/hooks/use-vscode-settings";
 import { useWorktrees } from "@/lib/hooks/use-worktrees";
 import { prompts } from "@getpochi/common";
 import { isStaticToolUIPart } from "ai";
-import { Check, Footprints, GitPullRequest, MessageSquare } from "lucide-react";
+import { Check, Footprints, GitPullRequest } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { getAttemptCompletionResultDisplay } from "./tool-result-display";
@@ -27,8 +26,6 @@ export const AttemptCompletionTool: React.FC<
 
   const { data: currentWorkspace } = useCurrentWorkspace();
   const { worktrees } = useWorktrees();
-  const vscodeSettings = useVSCodeSettings();
-  const reviewAgentEnabled = vscodeSettings?.reviewAgent ?? false;
 
   const currentWorktree = useMemo(() => {
     if (!worktrees || !currentWorkspace) return null;
@@ -67,12 +64,6 @@ export const AttemptCompletionTool: React.FC<
     });
   };
 
-  const onClickReviewChanges = () => {
-    sendMessage({
-      prompt: `${prompts.customAgent("reviewer")} Please review the changes above`,
-    });
-  };
-
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
@@ -95,21 +86,6 @@ export const AttemptCompletionTool: React.FC<
               </TooltipTrigger>
               <TooltipContent>{t("worktree.createWalkthrough")}</TooltipContent>
             </Tooltip>
-            {reviewAgentEnabled && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-6 text-muted-foreground"
-                    onClick={onClickReviewChanges}
-                  >
-                    <MessageSquare className="size-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{t("worktree.reviewChanges")}</TooltipContent>
-              </Tooltip>
-            )}
             {!hasPR && (
               <Tooltip>
                 <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- Removes the reviewer agent option and its button from the attempt completion tool UI.

## Test plan
- [ ] Verify that the "Review Changes" button/tooltip is no longer displayed in the attempt completion tool.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a94cf9ef30b64290ad9e827bdc91c91e)