### PR TITLE
feat(cli): add --experimental-stream-trajectory-strip-duplicates flag

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -76,6 +76,7 @@ import {
   TrajectoryStreamRenderer,
 } from "./renderers";
 import { OutputRenderer } from "./renderers";
+import { deduplicateMessageParts } from "./renderers/trajectory-post-process";
 import { CliRunningTaskAdaptor } from "./running-task-adaptor";
 import { TaskRunner } from "./task-runner";
 import { checkForUpdates, registerUpgradeCommand } from "./upgrade";
@@ -150,6 +151,13 @@ const program = new Command()
     "Initialize the task with messages parsed from the trajectory file specified by --experimental-stream-trajectory, and append the prompt as a new user message.",
     false,
   )
+  .addOption(
+    new Option(
+      "--experimental-stream-trajectory-strip-duplicates",
+      "Only valid when --experimental-stream-trajectory is used with an output filepath. When set, the trajectory file will be post-processed on exit to strip duplicate message parts.",
+    ).hideHelp(),
+  )
+
   .option(
     "--max-steps <number>",
     "Set the maximum number of steps for a task. The task will stop if it exceeds this limit.",
@@ -284,6 +292,15 @@ const program = new Command()
           "The --experimental-stream-trajectory-inherit-context flag requires --experimental-stream-trajectory to be passed a file path.",
         );
       }
+    }
+
+    if (
+      options.experimentalStreamTrajectoryStripDuplicates &&
+      typeof options.experimentalStreamTrajectory !== "string"
+    ) {
+      program.error(
+        "--experimental-stream-trajectory-strip-duplicates requires --experimental-stream-trajectory to be set with an output filepath.",
+      );
     }
 
     let jsonOutputStream: fs.WriteStream | typeof process.stdout | undefined =
@@ -454,13 +471,26 @@ const program = new Command()
       logger.debug(`Task runner exit with error: ${runtimeError.message}.`);
     } finally {
       logger.debug("Shutting down...");
+
       // Cleanup resources
       outputRenderer.shutdown();
+
       await streamRenderer?.shutdown();
       if (jsonOutputStream && jsonOutputStream instanceof fs.WriteStream) {
         jsonOutputStream.end();
         await finished(jsonOutputStream);
       }
+      if (
+        options.experimentalStreamTrajectoryStripDuplicates &&
+        typeof options.experimentalStreamTrajectory === "string"
+      ) {
+        try {
+          await deduplicateMessageParts(options.experimentalStreamTrajectory);
+        } catch {
+          // ignore all errors when shutting down
+        }
+      }
+
       mcpHub?.dispose();
       browserSessionStore.dispose();
       await store.shutdownPromise();

--- a/packages/cli/src/renderers/__tests__/trajectory-post-process.test.ts
+++ b/packages/cli/src/renderers/__tests__/trajectory-post-process.test.ts
@@ -1,0 +1,202 @@
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { deduplicateMessageParts } from "../trajectory-post-process";
+
+// Minimal valid MessagePartLine – only fields MessagePartLine.safeParse checks
+function messagePart(messageId: string, index: number, text = "content"): string {
+  return JSON.stringify({
+    type: "message-part",
+    timestamp: new Date(),
+    messageId,
+    role: "assistant",
+    index,
+    part: { type: "text", text },
+  });
+}
+
+// A non-MessagePartLine trajectory line
+function metadataLine(messageId: string): string {
+  return JSON.stringify({
+    type: "message-metadata",
+    messageId,
+    role: "assistant",
+    metadata: {},
+  });
+}
+
+let tmpDir: string;
+let filePath: string;
+
+async function writeNdjson(lines: string[]): Promise<void> {
+  await writeFile(filePath, lines.join("\n") + "\n");
+}
+
+async function readLines(): Promise<string[]> {
+  const content = await readFile(filePath, "utf8");
+  return content.split("\n").filter((l) => l.length > 0);
+}
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "trajectory-post-process-"));
+  filePath = join(tmpDir, "trajectory.ndjson");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("deduplicateMessageParts", () => {
+  describe("no duplicates", () => {
+    it("leaves a file with unique (messageId, index) pairs unchanged", async () => {
+      const lines = [
+        messagePart("msg-1", 0, "a"),
+        messagePart("msg-1", 1, "b"),
+        messagePart("msg-2", 0, "c"),
+      ];
+      await writeNdjson(lines);
+
+      await deduplicateMessageParts(filePath);
+
+      expect(await readLines()).toEqual(lines);
+    });
+
+    it("leaves an empty file unchanged", async () => {
+      await writeFile(filePath, "");
+      await deduplicateMessageParts(filePath);
+      expect(await readFile(filePath, "utf8")).toBe("");
+    });
+  });
+
+  describe("duplicate MessagePartLines", () => {
+    it("keeps only the last occurrence of a duplicated (messageId, index)", async () => {
+      const first = messagePart("msg-1", 0, "first");
+      const second = messagePart("msg-1", 0, "second");
+      const third = messagePart("msg-1", 0, "third");
+      await writeNdjson([first, second, third]);
+
+      await deduplicateMessageParts(filePath);
+
+      const result = await readLines();
+      expect(result).toHaveLength(1);
+      expect(JSON.parse(result[0]).part.text).toBe("third");
+    });
+
+    it("keeps last occurrence per key independently when multiple keys are duplicated", async () => {
+      const a1 = messagePart("msg-1", 0, "a1");
+      const b1 = messagePart("msg-2", 0, "b1");
+      const a2 = messagePart("msg-1", 0, "a2");
+      const b2 = messagePart("msg-2", 0, "b2");
+      await writeNdjson([a1, b1, a2, b2]);
+
+      await deduplicateMessageParts(filePath);
+
+      const result = await readLines();
+      expect(result).toHaveLength(2);
+      expect(JSON.parse(result[0]).part.text).toBe("a2");
+      expect(JSON.parse(result[1]).part.text).toBe("b2");
+    });
+
+    it("preserves original order of surviving lines", async () => {
+      const lines = [
+        messagePart("msg-1", 0, "drop-me"),
+        messagePart("msg-2", 0, "keep-A"),
+        messagePart("msg-1", 0, "keep-B"),
+        messagePart("msg-3", 0, "keep-C"),
+      ];
+      await writeNdjson(lines);
+
+      await deduplicateMessageParts(filePath);
+
+      const result = await readLines();
+      expect(result).toHaveLength(3);
+      expect(JSON.parse(result[0]).part.text).toBe("keep-A");
+      expect(JSON.parse(result[1]).part.text).toBe("keep-B");
+      expect(JSON.parse(result[2]).part.text).toBe("keep-C");
+    });
+  });
+
+  describe("non-MessagePartLine lines", () => {
+    it("always preserves non-MessagePartLine trajectory lines", async () => {
+      const meta = metadataLine("msg-1");
+      const part = messagePart("msg-1", 0, "hello");
+      await writeNdjson([meta, part]);
+
+      await deduplicateMessageParts(filePath);
+
+      const result = await readLines();
+      expect(result).toHaveLength(2);
+      expect(JSON.parse(result[0]).type).toBe("message-metadata");
+      expect(JSON.parse(result[1]).type).toBe("message-part");
+    });
+
+    it("preserves non-JSON lines as-is", async () => {
+      const raw = "not valid json at all";
+      const part = messagePart("msg-1", 0, "hello");
+      await writeNdjson([raw, part]);
+
+      await deduplicateMessageParts(filePath);
+
+      const result = await readLines();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(raw);
+    });
+
+    it("preserves non-MessagePartLine lines interleaved with duplicates in correct order", async () => {
+      const meta1 = metadataLine("msg-1");
+      const part1 = messagePart("msg-1", 0, "v1");
+      const meta2 = metadataLine("msg-2");
+      const part2 = messagePart("msg-1", 0, "v2");
+      await writeNdjson([meta1, part1, meta2, part2]);
+
+      await deduplicateMessageParts(filePath);
+
+      const result = await readLines();
+      expect(result).toHaveLength(3);
+      expect(JSON.parse(result[0]).type).toBe("message-metadata");
+      expect(JSON.parse(result[0]).messageId).toBe("msg-1");
+      expect(JSON.parse(result[1]).type).toBe("message-metadata");
+      expect(JSON.parse(result[1]).messageId).toBe("msg-2");
+      expect(JSON.parse(result[2]).part.text).toBe("v2");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles a file with only non-JSON lines", async () => {
+      const lines = ["# comment", "plain text", "another line"];
+      await writeNdjson(lines);
+
+      await deduplicateMessageParts(filePath);
+
+      expect(await readLines()).toEqual(lines);
+    });
+
+    it("handles a single MessagePartLine with no duplicates", async () => {
+      const line = messagePart("msg-1", 0);
+      await writeNdjson([line]);
+
+      await deduplicateMessageParts(filePath);
+
+      expect(await readLines()).toEqual([line]);
+    });
+
+    it("writes result back to the same file path", async () => {
+      await writeNdjson([messagePart("msg-1", 0, "v1"), messagePart("msg-1", 0, "v2")]);
+
+      await deduplicateMessageParts(filePath);
+
+      // File at the original path must exist and be correct
+      const result = await readLines();
+      expect(result).toHaveLength(1);
+      expect(JSON.parse(result[0]).part.text).toBe("v2");
+    });
+
+    it("does not leave a .tmp file behind after success", async () => {
+      await writeNdjson([messagePart("msg-1", 0, "v1"), messagePart("msg-1", 0, "v2")]);
+      await deduplicateMessageParts(filePath);
+
+      await expect(readFile(`${filePath}.tmp`, "utf8")).rejects.toThrow();
+    });
+  });
+});

--- a/packages/cli/src/renderers/trajectory-post-process.ts
+++ b/packages/cli/src/renderers/trajectory-post-process.ts
@@ -1,0 +1,112 @@
+import { createReadStream, createWriteStream } from "node:fs";
+import { rename } from "node:fs/promises";
+import * as readline from "node:readline";
+import { MessagePartLine } from "./trajectory-types";
+
+function createLineStream(filePath: string): readline.Interface {
+  return readline.createInterface({
+    input: createReadStream(filePath),
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+}
+
+/**
+ * Reads a trajectory NDJSON file and removes duplicate MessagePartLines,
+ * keeping only the last occurrence of each (messageId, index) pair.
+ * Non-JSON lines and lines that are not MessagePartLine are always preserved.
+ * The result is written back to the same file path.
+ *
+ * Uses a two-pass streaming approach:
+ * - Pass 1: stream lines once; record which line numbers are MessagePartLines
+ *   and track the last line number per (messageId, index) key. Only integers
+ *   are stored — no line content is retained.
+ * - Pass 2: stream lines again; use the precomputed sets to decide keep/drop
+ *   without re-parsing JSON. Non-MessagePartLine lines are written as-is.
+ */
+export async function deduplicateMessageParts(filePath: string): Promise<void> {
+  // Pass 1: collect line-number metadata only, no raw content stored
+  //   messagePartLineNumbers — every line that parsed as a MessagePartLine
+  //   lastSeenAt            — last line number per (messageId, index) key
+  const messagePartLineNumbers = new Set<number>();
+  const lastSeenAt = new Map<string, number>();
+
+  await new Promise<void>((resolve, reject) => {
+    const rl = createLineStream(filePath);
+    let lineNumber = 0;
+
+    rl.on("line", (rawLine) => {
+      const currentLine = lineNumber++;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawLine);
+      } catch {
+        return;
+      }
+
+      const result = MessagePartLine.safeParse(parsed);
+      if (!result.success) {
+        return;
+      }
+
+      const { messageId, index } = result.data;
+      messagePartLineNumbers.add(currentLine);
+      lastSeenAt.set(`${messageId}:${index}`, currentLine);
+    });
+
+    rl.on("close", resolve);
+    rl.on("error", reject);
+  });
+
+  // Derive the set of MessagePartLine numbers that should be kept (last occurrence per key)
+  const keptMessagePartLineNumbers = new Set(lastSeenAt.values());
+
+  // Pass 2: stream again; decide keep/drop purely from line-number sets — no JSON re-parse
+  const tmpPath = `${filePath}.tmp`;
+
+  await new Promise<void>((resolve, reject) => {
+    const rl = createLineStream(filePath);
+    const out = createWriteStream(tmpPath);
+    let lineNumber = 0;
+    let streamError: Error | null = null;
+
+    out.on("error", (err) => {
+      streamError = err;
+      rl.close();
+      reject(err);
+    });
+
+    rl.on("line", (rawLine) => {
+      const currentLine = lineNumber++;
+
+      if (streamError) {
+        return;
+      }
+
+      if (messagePartLineNumbers.has(currentLine)) {
+        // MessagePartLine: only write if this is the last occurrence of its key
+        if (keptMessagePartLineNumbers.has(currentLine)) {
+          out.write(`${rawLine}\n`);
+        }
+      } else {
+        // Non-MessagePartLine: always write, no JSON parse needed
+        out.write(`${rawLine}\n`);
+      }
+    });
+
+    rl.on("close", () => {
+      if (!streamError) {
+        out.end();
+      }
+    });
+
+    rl.on("error", (err) => {
+      out.destroy();
+      reject(err);
+    });
+
+    out.on("finish", resolve);
+  });
+
+  await rename(tmpPath, filePath);
+}


### PR DESCRIPTION
## Summary

- Adds a new hidden CLI option `--experimental-stream-trajectory-strip-duplicates` that runs the `deduplicateMessageParts` post-processor on the output NDJSON file upon exit
- Fixes `trajectory-types.ts` to use `z.coerce.date()` for proper deserialization of date strings read back from NDJSON files
- Includes unit tests for the `deduplicateMessageParts` post-processor in `trajectory-post-process.test.ts`


🤖 Generated with [Pochi](https://app.getpochi.com/share/p-dded2c4ea5224e50b2bb6187b4506187) | [Task](https://app.getpochi.com/share/p-dded2c4ea5224e50b2bb6187b4506187)