### PR TITLE
fix(vscode-webui): enable editing and deleting todos in Todo list UI

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -72,6 +72,8 @@ interface ChatToolbarProps {
   displayError: Error | undefined;
   showRenderWidgetFixButton?: boolean;
   todosRef: React.RefObject<Todo[] | undefined>;
+  todoPaused: boolean;
+  onTodoPausedChange: (paused: boolean) => void;
   onUpdateIsPublicShared?: (isPublicShared: boolean) => void;
   taskId: string;
   isRepairingMermaid?: boolean;
@@ -89,6 +91,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   displayError,
   showRenderWidgetFixButton: shouldShowRenderWidgetFixButton,
   todosRef,
+  todoPaused,
+  onTodoPausedChange,
   onUpdateIsPublicShared,
   taskId,
   isRepairingMermaid = false,
@@ -105,7 +109,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
 
   // Initialize task with prompt if provided and task doesn't exist yet
-  const { todos } = useTodos({
+  const { todos, setTodos } = useTodos({
     initialTodos: task?.todos,
     messages,
     todosRef,
@@ -308,7 +312,13 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           )}
         >
           {todos.length > 0 && (
-            <TodoList todos={todos}>
+            <TodoList
+              todos={todos}
+              editable={!isSubTask}
+              onSaveTodos={setTodos}
+              todoPaused={todoPaused}
+              onTodoPausedChange={isSubTask ? undefined : onTodoPausedChange}
+            >
               <TodoList.Header />
               <TodoList.Items viewportClassname="max-h-48" />
             </TodoList>

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -79,6 +79,7 @@ function Chat({ user, uid, info }: ChatProps) {
 
   const { t } = useTranslation();
   const todosRef = useRef<Todo[] | undefined>(undefined);
+  const [todoPaused, setTodoPaused] = useState(false);
   const { initSubtaskAutoApproveSettings } = useSettingsStore();
   const defaultUser = {
     name: t("chatPage.defaultUserName"),
@@ -365,6 +366,8 @@ function Chat({ user, uid, info }: ChatProps) {
           chat={chat}
           task={task}
           todosRef={todosRef}
+          todoPaused={todoPaused}
+          onTodoPausedChange={setTodoPaused}
           compact={chatKit.compact}
           approvalAndRetry={approvalAndRetry}
           attachmentUpload={attachmentUpload}

--- a/packages/vscode-webui/src/features/todo/components/__tests__/todo-list.test.tsx
+++ b/packages/vscode-webui/src/features/todo/components/__tests__/todo-list.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TodoList } from "../todo-list";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const activeTodo = {
+  id: "todo-1",
+  content: "Increase <file>tests/basic.test.tsx</file> coverage",
+  status: "in-progress",
+  priority: "medium",
+} as const;
+
+const completedTodo = {
+  id: "todo-2",
+  content: "Finished work",
+  status: "completed",
+  priority: "medium",
+} as const;
+
+const cancelledTodo = {
+  id: "todo-3",
+  content: "Stopped work",
+  status: "cancelled",
+  priority: "medium",
+} as const;
+
+describe("TodoList", () => {
+  it("renders edit in the header and pause in the active item row", () => {
+    render(
+      <TodoList
+        todos={[activeTodo]}
+        editable
+        todoPaused={false}
+        onTodoPausedChange={vi.fn()}
+      >
+        <TodoList.Header />
+        <TodoList.Items />
+      </TodoList>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "todoList.editTodos" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "todoList.pauseTodo" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "todoList.deleteTodo" }),
+    ).toBeNull();
+  });
+
+  it("keeps cancelled todos visible", () => {
+    render(
+      <TodoList todos={[cancelledTodo]}>
+        <TodoList.Header />
+        <TodoList.Items />
+      </TodoList>,
+    );
+
+    expect(
+      screen.getAllByText("todoList.cancelledTodo").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Stopped work")).toBeTruthy();
+    expect(screen.queryByText("todoList.allDone")).toBeNull();
+  });
+
+  it("uses animated header text only when active todo is not paused", () => {
+    const { rerender } = render(
+      <TodoList todos={[activeTodo]} todoPaused={false}>
+        <TodoList.Header />
+      </TodoList>,
+    );
+
+    expect(screen.getByText(activeTodo.content).className).toContain(
+      "animated-gradient-text",
+    );
+
+    rerender(
+      <TodoList todos={[activeTodo]} todoPaused>
+        <TodoList.Header />
+      </TodoList>,
+    );
+
+    expect(screen.getByText(activeTodo.content).className).not.toContain(
+      "animated-gradient-text",
+    );
+  });
+
+  it("edits todo content through a shared edit mode", () => {
+    const onSaveTodos = vi.fn();
+
+    render(
+      <TodoList todos={[activeTodo]} editable onSaveTodos={onSaveTodos}>
+        <TodoList.Header />
+        <TodoList.Items />
+      </TodoList>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "todoList.editTodos" }));
+
+    expect(
+      screen.getByRole("button", { name: "todoList.saveTodos" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "todoList.cancelEditing" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "todoList.pauseTodo" }),
+    ).toBeNull();
+
+    const input = screen.getByLabelText("todoList.editTodoContent");
+    fireEvent.change(input, { target: { value: "Increase coverage" } });
+    fireEvent.click(screen.getByRole("button", { name: "todoList.saveTodos" }));
+
+    expect(onSaveTodos).toHaveBeenCalledWith([
+      { ...activeTodo, content: "Increase coverage" },
+    ]);
+  });
+
+  it("deletes todos only from the draft until save", () => {
+    const onSaveTodos = vi.fn();
+
+    render(
+      <TodoList
+        todos={[activeTodo, completedTodo]}
+        editable
+        onSaveTodos={onSaveTodos}
+      >
+        <TodoList.Header />
+        <TodoList.Items />
+      </TodoList>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "todoList.editTodos" }));
+    const activeRow = document.getElementById("todo-item-todo-1");
+    expect(activeRow).toBeTruthy();
+    fireEvent.click(
+      within(activeRow as HTMLElement).getByRole("button", {
+        name: "todoList.deleteTodo",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "todoList.saveTodos" }));
+
+    expect(onSaveTodos).toHaveBeenCalledWith([completedTodo]);
+  });
+
+  it("cancels draft changes with Escape", () => {
+    const onSaveTodos = vi.fn();
+
+    render(
+      <TodoList todos={[activeTodo]} editable onSaveTodos={onSaveTodos}>
+        <TodoList.Header />
+        <TodoList.Items />
+      </TodoList>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "todoList.editTodos" }));
+    const input = screen.getByLabelText("todoList.editTodoContent");
+    fireEvent.change(input, { target: { value: "Draft content" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onSaveTodos).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Increase tests/basic.test.tsx coverage"),
+    ).toBeTruthy();
+  });
+});

--- a/packages/vscode-webui/src/features/todo/components/todo-list.tsx
+++ b/packages/vscode-webui/src/features/todo/components/todo-list.tsx
@@ -1,10 +1,24 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 import { cn } from "@/lib/utils";
 
+import { parseTitle } from "@getpochi/common/message-utils";
 import type { Todo } from "@getpochi/tools";
-import { Circle, CircleCheckBig, CircleDot, CircleX } from "lucide-react";
+import {
+  Circle,
+  CircleCheckBig,
+  CircleDot,
+  CircleX,
+  Pause,
+  Pencil,
+  Play,
+  Save,
+  Trash2,
+  X,
+} from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import {
   type ReactNode,
@@ -12,6 +26,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -40,6 +55,17 @@ interface TodoListContextValue {
   setIsCollapsed: (collapsed: boolean) => void;
   disableCollapse: boolean;
   disableInProgressTodoTitle: boolean;
+  todoPaused: boolean;
+  editable: boolean;
+  isEditMode: boolean;
+  draftTodos: Todo[];
+  hasInvalidDraftTodo: boolean;
+  enterEditMode: () => void;
+  cancelEditMode: () => void;
+  saveDraftTodos: () => void;
+  updateDraftTodoContent: (todoId: string, content: string) => void;
+  deleteDraftTodo: (todoId: string) => void;
+  onTodoPausedChange?: (paused: boolean) => void;
 }
 
 const TodoListContext = createContext<TodoListContextValue | undefined>(
@@ -63,6 +89,10 @@ interface TodoListRootProps {
   children: ReactNode;
   disableCollapse?: boolean;
   disableInProgressTodoTitle?: boolean;
+  todoPaused?: boolean;
+  editable?: boolean;
+  onSaveTodos?: (todos: Todo[]) => void;
+  onTodoPausedChange?: (paused: boolean) => void;
 }
 
 function TodoListRoot({
@@ -71,6 +101,10 @@ function TodoListRoot({
   children,
   disableCollapse,
   disableInProgressTodoTitle,
+  todoPaused = false,
+  editable = false,
+  onSaveTodos,
+  onTodoPausedChange,
 }: TodoListRootProps) {
   const pendingTodosNum = todos.filter(
     (todo) => todo.status === "pending",
@@ -78,6 +112,63 @@ function TodoListRoot({
   const [isCollapsed, setIsCollapsed] = useState(
     pendingTodosNum === 0 && !disableCollapse && todos.length > 0,
   );
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [draftTodos, setDraftTodos] = useState<Todo[]>([]);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const enterEditMode = () => {
+    setDraftTodos(
+      todos.map((todo) => ({
+        ...todo,
+        content: parseTitle(todo.content),
+      })),
+    );
+    setIsEditMode(true);
+  };
+
+  const cancelEditMode = () => {
+    setIsEditMode(false);
+    setDraftTodos([]);
+  };
+
+  const hasInvalidDraftTodo = draftTodos.some(
+    (todo) => todo.content.trim().length === 0,
+  );
+
+  const saveDraftTodos = () => {
+    if (hasInvalidDraftTodo) return;
+    const nextTodos = draftTodos.map((todo) => ({
+      ...todo,
+      content: todo.content.trim(),
+    }));
+    onSaveTodos?.(nextTodos);
+    setIsEditMode(false);
+    setDraftTodos([]);
+  };
+
+  const updateDraftTodoContent = (todoId: string, content: string) => {
+    setDraftTodos((current) =>
+      current.map((todo) => (todo.id === todoId ? { ...todo, content } : todo)),
+    );
+  };
+
+  const deleteDraftTodo = (todoId: string) => {
+    setDraftTodos((current) => current.filter((todo) => todo.id !== todoId));
+  };
+
+  useEffect(() => {
+    if (!isEditMode) return;
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsEditMode(false);
+        setDraftTodos([]);
+      }
+    };
+
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [isEditMode]);
 
   const contextValue: TodoListContextValue = {
     todos,
@@ -85,11 +176,24 @@ function TodoListRoot({
     setIsCollapsed,
     disableCollapse: !!disableCollapse,
     disableInProgressTodoTitle: !!disableInProgressTodoTitle,
+    todoPaused,
+    editable,
+    isEditMode,
+    draftTodos,
+    hasInvalidDraftTodo,
+    enterEditMode,
+    cancelEditMode,
+    saveDraftTodos,
+    updateDraftTodoContent,
+    deleteDraftTodo,
+    onTodoPausedChange,
   };
 
   return (
     <TodoListContext.Provider value={contextValue}>
-      <div className={className}>{children}</div>
+      <div ref={rootRef} className={className}>
+        {children}
+      </div>
     </TodoListContext.Provider>
   );
 }
@@ -107,29 +211,44 @@ function TodoListHeader({ children }: TodoListHeaderProps) {
     setIsCollapsed,
     disableCollapse,
     disableInProgressTodoTitle,
+    todoPaused,
+    editable,
+    isEditMode,
+    hasInvalidDraftTodo,
+    enterEditMode,
+    cancelEditMode,
+    saveDraftTodos,
   } = useTodoListContext();
 
-  // Use draftTodos when in edit mode, otherwise use todos
-  const displayTodos = todos.filter((todo) => todo.status !== "cancelled");
-
   const inProgressTodo = useMemo(
-    () => displayTodos.find((x) => x.status === "in-progress"),
-    [displayTodos],
+    () => todos.find((x) => x.status === "in-progress"),
+    [todos],
   );
 
   const pendingTodosNum = useMemo(
-    () => displayTodos.filter((todo) => todo.status === "pending").length,
-    [displayTodos],
+    () => todos.filter((todo) => todo.status === "pending").length,
+    [todos],
+  );
+  const allTodosCancelled = useMemo(
+    () =>
+      todos.length > 0 && todos.every((todo) => todo.status === "cancelled"),
+    [todos],
   );
 
   useEffect(() => {
-    if (pendingTodosNum === 0 && todos.length > 0 && !disableCollapse) {
+    if (
+      pendingTodosNum === 0 &&
+      todos.length > 0 &&
+      !disableCollapse &&
+      !isEditMode
+    ) {
       setIsCollapsed(true);
     }
-  }, [pendingTodosNum, todos, setIsCollapsed, disableCollapse]);
+  }, [pendingTodosNum, todos, setIsCollapsed, disableCollapse, isEditMode]);
 
   const toggleCollapse = () => {
     if (disableCollapse) return;
+    if (isEditMode) return;
     setIsCollapsed(!isCollapsed);
   };
 
@@ -153,7 +272,11 @@ function TodoListHeader({ children }: TodoListHeaderProps) {
             disableInProgressTodoTitle ? (
               <span>{t("todoList.todos")}</span>
             ) : (
-              <span className="animated-gradient-text">
+              <span
+                className={cn({
+                  "animated-gradient-text": !todoPaused,
+                })}
+              >
                 {inProgressTodo.content}
               </span>
             )
@@ -161,7 +284,9 @@ function TodoListHeader({ children }: TodoListHeaderProps) {
             <span>
               {pendingTodosNum > 0
                 ? t("todoList.todos")
-                : t("todoList.allDone")}
+                : allTodosCancelled
+                  ? t("todoList.cancelledTodo")
+                  : t("todoList.allDone")}
             </span>
           )}
         </span>
@@ -169,6 +294,41 @@ function TodoListHeader({ children }: TodoListHeaderProps) {
       <div className="flex justify-end">
         <div className="flex gap-1 p-2" onClick={(e) => e.stopPropagation()}>
           {children}
+          {editable &&
+            todos.length > 0 &&
+            (isEditMode ? (
+              <>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  aria-label={t("todoList.saveTodos")}
+                  disabled={hasInvalidDraftTodo}
+                  onClick={saveDraftTodos}
+                >
+                  <Save className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  aria-label={t("todoList.cancelEditing")}
+                  onClick={cancelEditMode}
+                >
+                  <X className="size-4" />
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                aria-label={t("todoList.editTodos")}
+                onClick={enterEditMode}
+              >
+                <Pencil className="size-4" />
+              </Button>
+            ))}
         </div>
       </div>
     </div>
@@ -197,14 +357,93 @@ function TodoIcon({ todo }: TodoIconProps) {
 }
 
 // Items component for displaying the todo list
+function getTodoDisplayContent(todo: Todo): string {
+  return parseTitle(todo.content);
+}
+
+function isActiveTodo(todo: Todo): boolean {
+  return todo.status === "pending" || todo.status === "in-progress";
+}
+
+function TodoStatusLabel({ todo }: { todo: Todo }) {
+  const { t } = useTranslation();
+  const { todoPaused } = useTodoListContext();
+
+  const label = isActiveTodo(todo)
+    ? todoPaused
+      ? t("todoList.pausing")
+      : t("todoList.pursuingTodo")
+    : todo.status === "completed"
+      ? t("todoList.completedTodo")
+      : todo.status === "cancelled"
+        ? t("todoList.cancelledTodo")
+        : t("todoList.pendingTodo");
+
+  return <span className="shrink-0 font-medium text-sm">{label}</span>;
+}
+
+function TodoPauseButton({ todo }: { todo: Todo }) {
+  const { t } = useTranslation();
+  const { todoPaused, onTodoPausedChange, isEditMode } = useTodoListContext();
+
+  if (isEditMode || !isActiveTodo(todo) || !onTodoPausedChange) return null;
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="xs"
+      aria-label={
+        todoPaused ? t("todoList.resumeTodo") : t("todoList.pauseTodo")
+      }
+      onClick={(event) => {
+        event.stopPropagation();
+        onTodoPausedChange(!todoPaused);
+      }}
+    >
+      {todoPaused ? <Play className="size-4" /> : <Pause className="size-4" />}
+    </Button>
+  );
+}
+
+function TodoDeleteButton({ todo }: { todo: Todo }) {
+  const { t } = useTranslation();
+  const { isEditMode, deleteDraftTodo } = useTodoListContext();
+
+  if (!isEditMode) return null;
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="xs"
+      aria-label={t("todoList.deleteTodo")}
+      onClick={(event) => {
+        event.stopPropagation();
+        deleteDraftTodo(todo.id);
+      }}
+    >
+      <Trash2 className="size-4" />
+    </Button>
+  );
+}
+
 function TodoListItems({
   className,
   viewportClassname,
 }: { className?: string; viewportClassname?: string }) {
-  const { todos, isCollapsed } = useTodoListContext();
+  const { t } = useTranslation();
+  const {
+    todos,
+    isCollapsed,
+    isEditMode,
+    draftTodos,
+    updateDraftTodoContent,
+    saveDraftTodos,
+    cancelEditMode,
+  } = useTodoListContext();
 
-  // Use draftTodos when in edit mode, otherwise use todos
-  const displayTodos = todos.filter((todo) => todo.status !== "cancelled");
+  const displayTodos = isEditMode ? draftTodos : todos;
 
   return (
     <ScrollArea
@@ -230,8 +469,8 @@ function TodoListItems({
                 id={`todo-item-${todo.id}`}
                 key={todo.id}
                 className={cn(
-                  "flex items-start space-x-2.5 rounded-sm px-1 py-0.5 transition-colors",
-                  "hover:bg-accent/5",
+                  "flex items-start gap-2.5 rounded-sm px-1 py-0.5 transition-colors",
+                  !isEditMode && "hover:bg-accent/5",
                 )}
                 variants={todoItemVariants}
                 initial="initial"
@@ -247,14 +486,47 @@ function TodoListItems({
                 <TodoIcon todo={todo} />
                 <Label
                   htmlFor={`todo-item-${todo.id}`}
-                  className={cn("flex-1 text-md", {
+                  className={cn("min-w-0 flex-1 text-md", {
                     "text-muted-foreground line-through":
-                      todo.status === "completed" ||
-                      todo.status === "cancelled",
+                      !isEditMode &&
+                      (todo.status === "completed" ||
+                        todo.status === "cancelled"),
                   })}
                 >
-                  {todo.content}
+                  <span className="flex min-w-0 items-baseline gap-1.5">
+                    <TodoStatusLabel todo={todo} />
+                    {isEditMode ? (
+                      <Input
+                        id={`todo-item-${todo.id}`}
+                        aria-label={t("todoList.editTodoContent")}
+                        value={todo.content}
+                        onChange={(event) =>
+                          updateDraftTodoContent(todo.id, event.target.value)
+                        }
+                        onClick={(event) => event.stopPropagation()}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            saveDraftTodos();
+                          }
+                          if (event.key === "Escape") {
+                            event.preventDefault();
+                            cancelEditMode();
+                          }
+                        }}
+                        className="h-7 min-w-0 flex-1 text-sm"
+                      />
+                    ) : (
+                      <span className="truncate text-muted-foreground">
+                        {getTodoDisplayContent(todo)}
+                      </span>
+                    )}
+                  </span>
                 </Label>
+                <div className="flex shrink-0 gap-0.5">
+                  <TodoPauseButton todo={todo} />
+                  <TodoDeleteButton todo={todo} />
+                </div>
               </motion.div>
             ))}
           </AnimatePresence>

--- a/packages/vscode-webui/src/features/todo/hooks/use-todos.ts
+++ b/packages/vscode-webui/src/features/todo/hooks/use-todos.ts
@@ -85,6 +85,7 @@ export function useTodos({
   return {
     todosRef,
     todos,
+    setTodos,
   };
 }
 

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -458,7 +458,19 @@
   },
   "todoList": {
     "todos": "TODOs",
-    "allDone": "🎉 All done!"
+    "allDone": "🎉 All done!",
+    "pursuingTodo": "Pursuing todo",
+    "pausing": "Pausing",
+    "pendingTodo": "Pending todo",
+    "completedTodo": "Todo satisfied",
+    "cancelledTodo": "Todo cancelled",
+    "editTodos": "Edit todos",
+    "saveTodos": "Save todos",
+    "cancelEditing": "Cancel editing",
+    "editTodoContent": "Edit todo content",
+    "deleteTodo": "Delete todo",
+    "pauseTodo": "Pause todo",
+    "resumeTodo": "Resume todo"
   },
   "commandExecutionPanel": {
     "copied": "Copied!",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -452,7 +452,19 @@
   },
   "todoList": {
     "todos": "TODO",
-    "allDone": "🎉 すべて完了！"
+    "allDone": "🎉 すべて完了！",
+    "pursuingTodo": "Todoを進行中",
+    "pausing": "一時停止中",
+    "pendingTodo": "保留中のTodo",
+    "completedTodo": "Todoを満たしました",
+    "cancelledTodo": "Todoをキャンセルしました",
+    "editTodos": "Todoを編集",
+    "saveTodos": "Todoを保存",
+    "cancelEditing": "編集をキャンセル",
+    "editTodoContent": "Todo内容を編集",
+    "deleteTodo": "Todoを削除",
+    "pauseTodo": "Todoを一時停止",
+    "resumeTodo": "Todoを再開"
   },
   "commandExecutionPanel": {
     "copied": "コピーしました！",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -450,7 +450,19 @@
   },
   "todoList": {
     "todos": "할 일",
-    "allDone": "🎉 모두 완료!"
+    "allDone": "🎉 모두 완료!",
+    "pursuingTodo": "Todo 진행 중",
+    "pausing": "일시 중지 중",
+    "pendingTodo": "대기 중인 Todo",
+    "completedTodo": "Todo 충족됨",
+    "cancelledTodo": "Todo 취소됨",
+    "editTodos": "Todo 편집",
+    "saveTodos": "Todo 저장",
+    "cancelEditing": "편집 취소",
+    "editTodoContent": "Todo 내용 편집",
+    "deleteTodo": "Todo 삭제",
+    "pauseTodo": "Todo 일시 중지",
+    "resumeTodo": "Todo 다시 시작"
   },
   "commandExecutionPanel": {
     "copied": "복사됨!",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -450,7 +450,19 @@
   },
   "todoList": {
     "todos": "待办事项",
-    "allDone": "🎉 全部完成！"
+    "allDone": "🎉 全部完成！",
+    "pursuingTodo": "推进 Todo",
+    "pausing": "正在暂停",
+    "pendingTodo": "待推进 Todo",
+    "completedTodo": "Todo 已满足",
+    "cancelledTodo": "Todo 已取消",
+    "editTodos": "编辑 Todos",
+    "saveTodos": "保存 Todos",
+    "cancelEditing": "取消编辑",
+    "editTodoContent": "编辑 Todo 内容",
+    "deleteTodo": "删除 Todo",
+    "pauseTodo": "暂停 Todo",
+    "resumeTodo": "继续 Todo"
   },
   "commandExecutionPanel": {
     "copied": "已复制！",


### PR DESCRIPTION
## Summary
- Enable editing and deleting todos in the Todo list UI.
- Wire up `deleteDraftTodo` and `onSaveTodos` to `setTodos` in `chat-toolbar.tsx` to ensure changes are correctly persisted.
- Add unit tests for the editing, deleting, and pausing behaviors of the Todo list.

## Test plan
- [x] Run `bun run test` to verify that all unit and integration tests for the todo list UI pass successfully.
- [x] Manually verify that deleting a todo in edit mode works and persists correctly upon saving.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7c5e1c07a8174edfb35a552cc5424216)