### PR TITLE
fix(livekit): abandon orphan background tasks from previous sessions

### DIFF
--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -98,6 +98,7 @@ export type ContextWindowUsage = {
 export interface BackgroundTaskState {
   tools?: readonly ToolSpecInput[];
   parentTaskId?: string;
+  ownerRunId?: string;
   useCase?: ForkAgentUseCase;
   /** Step-start count inherited from the parent, excluded from the max-step guard. */
   baselineStepCount?: number;

--- a/packages/livekit/src/background-task/task-executor/__tests__/task-executor.test.ts
+++ b/packages/livekit/src/background-task/task-executor/__tests__/task-executor.test.ts
@@ -9,6 +9,7 @@ const mockState = vi.hoisted(() => ({
     chat: { sendMessageCalls: number };
   }>,
 }));
+const TestRunId = "test-run";
 
 class MockChat {
   messages: Message[];
@@ -242,6 +243,39 @@ describe("TaskExecutor", () => {
     expect(clearFileStateCache).toHaveBeenCalledWith("task");
     await executor.dispose();
   });
+
+  it("abandons runnable tasks from a previous task tab session", async () => {
+    const store = new FakeLiveKitStore([
+      makeTask({ id: "task", status: "pending-tool" }),
+    ]);
+    store.setMessages("task", [
+      makeAssistantMessage([makeToolPart("readFile", "read", { path: "a.ts" })]),
+    ]);
+    const executeToolCall = vi.fn(async () => ({ content: "hello" }));
+    const waitUntilReady = vi.fn(async () => undefined);
+    const adaptor = {
+      ...makeAdaptor({ executeToolCall }),
+      waitUntilReady,
+    } satisfies RunningTaskAdaptor;
+    const executor = makeExecutor(store, adaptor, {
+      ownerRunId: "previous-run",
+      tools: ["readFile"],
+    });
+
+    await executor.drain();
+
+    expect(waitUntilReady).not.toHaveBeenCalled();
+    expect(executeToolCall).not.toHaveBeenCalled();
+    expect(mockState.instances[0].chat.sendMessageCalls).toBe(0);
+    expect(store.readTask("task")).toMatchObject({
+      status: "failed",
+      error: {
+        message:
+          "Background task abandoned because it belongs to a previous task tab session.",
+      },
+    });
+    await executor.dispose();
+  });
 });
 
 class FakeLiveKitStore {
@@ -353,7 +387,8 @@ function makeExecutor(
   return new TaskExecutor({
     store: store as never,
     blobStore: {} as never,
-    readTaskState: () => taskState,
+    currentRunId: TestRunId,
+    readTaskState: () => ({ ownerRunId: TestRunId, ...taskState }),
     adaptor,
     clearFileStateCache,
     createChatKit: ({ taskId, store }) =>

--- a/packages/livekit/src/background-task/task-executor/task-executor.ts
+++ b/packages/livekit/src/background-task/task-executor/task-executor.ts
@@ -69,6 +69,7 @@ type MaybePromiseLike<T> = T | PromiseLike<T>;
 type CreateTaskExecutorOptions = {
   store: LiveKitStore;
   blobStore: BlobStore;
+  currentRunId: string;
   readTaskState: (
     taskId: string,
   ) => MaybePromiseLike<BackgroundTaskState | undefined>;
@@ -103,6 +104,7 @@ type CreateRunningTaskChatKit = (options: {
 export class TaskExecutor {
   private readonly store: LiveKitStore;
   private readonly blobStore: BlobStore;
+  private readonly currentRunId: string;
   private readonly readTaskState: CreateTaskExecutorOptions["readTaskState"];
   private readonly adaptor: RunningTaskAdaptor;
   private readonly clearFileStateCache: CreateTaskExecutorOptions["clearFileStateCache"];
@@ -116,6 +118,7 @@ export class TaskExecutor {
   constructor({
     store,
     blobStore,
+    currentRunId,
     readTaskState,
     adaptor,
     clearFileStateCache,
@@ -123,6 +126,7 @@ export class TaskExecutor {
   }: CreateTaskExecutorOptions) {
     this.store = store;
     this.blobStore = blobStore;
+    this.currentRunId = currentRunId;
     this.readTaskState = readTaskState;
     this.adaptor = adaptor;
     this.clearFileStateCache = clearFileStateCache;
@@ -226,6 +230,7 @@ export class TaskExecutor {
       taskId,
       store: this.store,
       blobStore: this.blobStore,
+      currentRunId: this.currentRunId,
       readTaskState: this.readTaskState,
       adaptor: this.adaptor,
       clearFileStateCache: this.clearFileStateCache,
@@ -273,6 +278,7 @@ class RunningTask {
   private readonly taskId: string;
   private readonly store: LiveKitStore;
   private readonly blobStore: BlobStore;
+  private readonly currentRunId: string;
   private readonly readTaskState: CreateTaskExecutorOptions["readTaskState"];
   private readonly adaptor: RunningTaskAdaptor;
   private readonly clearFileStateCache: CreateTaskExecutorOptions["clearFileStateCache"];
@@ -291,6 +297,7 @@ class RunningTask {
     taskId: string;
     store: LiveKitStore;
     blobStore: BlobStore;
+    currentRunId: string;
     readTaskState: CreateTaskExecutorOptions["readTaskState"];
     adaptor: RunningTaskAdaptor;
     clearFileStateCache?: CreateTaskExecutorOptions["clearFileStateCache"];
@@ -299,6 +306,7 @@ class RunningTask {
     this.taskId = options.taskId;
     this.store = options.store;
     this.blobStore = options.blobStore;
+    this.currentRunId = options.currentRunId;
     this.readTaskState = options.readTaskState;
     this.adaptor = options.adaptor;
     this.clearFileStateCache = options.clearFileStateCache;
@@ -316,9 +324,13 @@ class RunningTask {
 
   private async run() {
     try {
-      await this.adaptor.waitUntilReady?.();
       this.taskState = (await this.readTaskState(this.taskId)) ?? {};
       this.chatKit = this.createChatKit(this.task);
+      if (this.taskState.ownerRunId !== this.currentRunId) {
+        await this.chatKit.markAsFailed(createAbandonedTaskError());
+        return;
+      }
+      await this.adaptor.waitUntilReady?.();
 
       while (!this.abortController.signal.aborted) {
         const stepResult = await this.step();
@@ -640,6 +652,14 @@ function isAbortTaskError(error: unknown) {
     "kind" in error &&
     error.kind === "AbortError"
   );
+}
+
+function createAbandonedTaskError() {
+  const error = new Error(
+    "Background task abandoned because it belongs to a previous task tab session.",
+  );
+  error.name = "AbortError";
+  return error;
 }
 
 function normalizeCwd(cwd: string | null | undefined) {

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -99,17 +99,20 @@ async function createBackgroundTaskFromForkAgent({
   store,
   stateStore,
   agent,
+  ownerRunId,
   taskId = crypto.randomUUID(),
   createdAt = new Date(),
 }: {
   store: LiveKitStore;
   stateStore: NonNullable<LiveChatKitBackgroundTaskOptions["stateStore"]>;
   agent: ForkAgent<Message>;
+  ownerRunId: string;
   taskId?: string;
   createdAt?: Date;
 }): Promise<ForkAgentHandle> {
   await stateStore.set(taskId, {
     parentTaskId: agent.parentTaskId,
+    ownerRunId,
     tools: agent.tools,
     useCase: agent.label,
     baselineStepCount: agent.baselineStepCount,
@@ -315,6 +318,7 @@ export class LiveChatKit<
   readonly chat: T;
   private readonly transport: FlexibleChatTransport;
   private readonly backgroundTaskExecutor: TaskExecutor | undefined;
+  private readonly backgroundTaskRunId = crypto.randomUUID();
   private readonly backgroundTaskAdaptor:
     | (RunningTaskAdaptor & { dispose?: () => void })
     | undefined;
@@ -384,6 +388,7 @@ export class LiveChatKit<
             store,
             stateStore: backgroundTaskStateStore,
             agent,
+            ownerRunId: this.backgroundTaskRunId,
           })
       : undefined;
     const waitForTaskDone = backgroundTask?.adaptor
@@ -396,6 +401,7 @@ export class LiveChatKit<
         ? new TaskExecutor({
             store,
             blobStore,
+            currentRunId: this.backgroundTaskRunId,
             readTaskState: (taskId) => backgroundTaskStateStore.read(taskId),
             adaptor: backgroundTask.adaptor,
             clearFileStateCache: backgroundTask.clearFileStateCache,


### PR DESCRIPTION
## Summary
- Tag each background task with the owner `LiveChatKit`'s `runId` (`ownerRunId`) when it is spawned via `createBackgroundTaskFromForkAgent`, and pass the same `currentRunId` into the `TaskExecutor`.
- In `RunningTask.run`, after loading the persisted `BackgroundTaskState`, compare `taskState.ownerRunId` to the executor's `currentRunId`. If they don't match, mark the task as failed with an `AbortError` (`"Background task abandoned because it belongs to a previous task tab session."`) instead of waiting for the adaptor and replaying tool calls.
- This prevents an orphan `pending-tool` task from a closed/reopened tab (or an HMR / login swap of the `LiveChatKit`) from being revived against a fresh executor, which could otherwise miss the original LLM prefix cache and double-execute tool calls.

## Test plan
- [x] `packages/livekit/src/background-task/task-executor/__tests__/task-executor.test.ts` — new "abandons runnable tasks from a previous task tab session" case verifies that with `ownerRunId !== currentRunId` the executor does NOT call `waitUntilReady` / `executeToolCall` / `chat.sendMessage`, and the task ends up `status: "failed"` with the abandoned-task error message.
- [ ] Manual: close a task tab while a background task is `pending-tool`, reopen the tab, and confirm the orphan task is terminalized as failed instead of resuming.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-32336f34617245709f2cc49a79236fec)