### PR TITLE
feat(livekit): reuse parent's system prompt for fork agents

### DIFF
--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -15,7 +15,7 @@ import {
 import { LiveChatKit } from "../live-chat-kit";
 
 describe("LiveChatKit memory lifecycle", () => {
-  it("starts background task scheduling when an adaptor is provided", async () => {
+  it("starts background task scheduling after the first stream finishes", async () => {
     const store = new FakeStore([
       makeTask({
         id: "parent",
@@ -35,6 +35,11 @@ describe("LiveChatKit memory lifecycle", () => {
         adaptor: makeRunningTaskAdaptor(),
       },
     });
+
+    expect(store.subscriptions).not.toContain("runnableTasks");
+
+    chatKit.chat.messages = [userMessage(), assistantMessage()];
+    chatKit.chat.finish(assistantMessage());
 
     expect(store.subscriptions).toContain("runnableTasks");
     await chatKit.disposeBackgroundTasks();

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -48,6 +48,10 @@ export type OnStartCallback = (options: {
   getters: PrepareRequestGetters;
 }) => void;
 
+export type FinishedRequestSnapshot = {
+  systemPrompt: string;
+};
+
 export type PrepareRequestGetters = {
   getLLM: () => RequestData["llm"];
   getEnvironment?: () => Promise<Environment>;
@@ -69,6 +73,10 @@ export type ChatTransportOptions = {
   blobStore: BlobStore;
   customAgent?: CustomAgent;
   attemptCompletionSchema?: z.ZodAny;
+  systemPromptOverride?: string;
+  onRequestFinished?: (
+    snapshot: FinishedRequestSnapshot,
+  ) => void | Promise<void>;
 };
 
 export class FlexibleChatTransport implements ChatTransport<Message> {
@@ -80,6 +88,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
   private readonly blobStore: BlobStore;
   private readonly customAgent?: CustomAgent;
   private readonly attemptCompletionSchema?: z.ZodAny;
+  private readonly systemPromptOverride?: string;
+  private readonly onRequestFinished?: ChatTransportOptions["onRequestFinished"];
 
   constructor(options: ChatTransportOptions) {
     this.onStart = options.onStart;
@@ -91,6 +101,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     this.blobStore = options.blobStore;
     this.customAgent = options.customAgent;
     this.attemptCompletionSchema = options.attemptCompletionSchema;
+    this.systemPromptOverride = options.systemPromptOverride;
+    this.onRequestFinished = options.onRequestFinished;
   }
 
   sendMessages: (
@@ -163,12 +175,13 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       tools.readFile = handleReadFileOutput(this.blobStore, tools.readFile);
     }
 
-    const systemPrompt = prompts.system(
+    const generatedSystemPrompt = prompts.system(
       environment?.info?.customRules,
       this.customAgent,
       mcpInfo?.instructions,
       autoMemory,
     );
+    const systemPrompt = this.systemPromptOverride ?? generatedSystemPrompt;
     const systemPromptChars = systemPrompt.length;
     const toolsChars = JSON.stringify(tools).length;
     const systemPromptTokens = Math.ceil(systemPromptChars / 4);
@@ -235,7 +248,9 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
         }
       },
       onFinish: async () => {
-        // DO NOTHING
+        await this.onRequestFinished?.({
+          systemPrompt,
+        });
       },
     });
   };

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -46,6 +46,7 @@ import {
 import { scheduleGenerateTitleJob } from "./background-job";
 import { filterCompletionTools } from "./filter-completion-tools";
 import {
+  type FinishedRequestSnapshot,
   FlexibleChatTransport,
   type OnStartCallback,
   type PrepareRequestGetters,
@@ -284,6 +285,7 @@ export type LiveChatKitOptions<T> = {
 
   customAgent?: CustomAgent;
   attemptCompletionSchema?: z.ZodAny;
+  systemPromptOverride?: string;
 } & Omit<
   ChatInit<Message>,
   "id" | "messages" | "generateId" | "onFinish" | "onError" | "transport"
@@ -324,6 +326,8 @@ export class LiveChatKit<
   private readonly clearFileStateCacheCallback:
     | (() => MaybePromise<void>)
     | undefined;
+  private latestRequestSnapshot: FinishedRequestSnapshot | undefined;
+  private backgroundTasksStarted = false;
 
   onStreamStart?: (
     data: Pick<Task, "id" | "cwd"> & {
@@ -366,6 +370,7 @@ export class LiveChatKit<
     backgroundTask,
     taskMemory,
     projectMemory,
+    systemPromptOverride,
     ...chatInit
   }: LiveChatKitOptions<T>) {
     this.taskId = taskId;
@@ -417,10 +422,10 @@ export class LiveChatKit<
                 requestUseCase,
                 disableAutoCompact: true,
                 getters,
+                systemPromptOverride: this.latestRequestSnapshot?.systemPrompt,
               }),
           })
         : undefined;
-    this.backgroundTaskExecutor?.start();
     const defaultMemoryParentCwd = () => this.task?.cwd ?? undefined;
     this.taskMemoryAdaptor =
       taskMemory && startForkAgent
@@ -463,6 +468,10 @@ export class LiveChatKit<
       requestUseCase,
       customAgent,
       attemptCompletionSchema,
+      systemPromptOverride,
+      onRequestFinished: (snapshot) => {
+        this.latestRequestSnapshot = snapshot;
+      },
     });
 
     this.chat = new chatClass({
@@ -883,6 +892,7 @@ export class LiveChatKit<
     };
 
     this.scheduleMemoryUpdate(finishData);
+    this.startBackgroundTasks();
 
     this.onStreamFinish?.({
       ...finishData,
@@ -915,6 +925,12 @@ export class LiveChatKit<
   async disposeBackgroundTasks(): Promise<void> {
     await this.backgroundTaskExecutor?.dispose();
     this.backgroundTaskAdaptor?.dispose?.();
+  }
+
+  private startBackgroundTasks(): void {
+    if (this.backgroundTasksStarted) return;
+    this.backgroundTasksStarted = true;
+    this.backgroundTaskExecutor?.start();
   }
 
   private scheduleMemoryUpdate(data: {


### PR DESCRIPTION
## Summary
- `FlexibleChatTransport` gains a `systemPromptOverride` option plus an `onRequestFinished` callback that surfaces the resolved system prompt after each request.
- `LiveChatKit` captures that snapshot and passes it down to the background task executor via `getRequestGetters`, so fork agents reuse the parent's resolved `prompts.system(customRules, customAgent, mcpInstructions, autoMemory)` and Anthropic/OpenAI prompt caching keeps hitting the parent's cached prefix.
- Background task scheduling is deferred until after the first stream finishes so the snapshot is available before any fork agent runs.

## Test plan
- [x] `bun run test` in `packages/livekit` — updated `LiveChatKit memory lifecycle` test now asserts background scheduling starts only after the first stream finishes.
- [ ] Manual smoke: spawn a fork agent (task memory / project memory) and confirm via `POCHI_LOG=...` that the fork's request reuses the parent's resolved system prompt (cache hit on the parent's prefix).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3a9ce25c2dc64ddea91f00a31d6812b1)