### PR TITLE
chore(common): tighten auto-memory dream directive to user intent only

### DIFF
--- a/packages/common/src/base/memory.ts
+++ b/packages/common/src/base/memory.ts
@@ -44,6 +44,7 @@ export interface AutoMemoryDreamCandidate {
    * The dream agent reads transcripts on demand via the readFile tool.
    */
   transcriptFilename: string;
+  title?: string;
 }
 
 export interface AutoMemoryDreamRun {

--- a/packages/common/src/base/prompts/__tests__/__snapshots__/auto-memory.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/auto-memory.test.ts.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`long-term memory prompt helpers > snapshots > buildAutoMemoryDreamDirective with sessions 1`] = `
+"Consolidate long-term memory for this repository.
+
+Memory directory: /home/user/.pochi/projects/repo-key/memory
+Index file: /home/user/.pochi/projects/repo-key/memory/MEMORY.md
+Transcripts directory: /home/user/.pochi/projects/repo-key/transcripts
+
+Existing topic manifest:
+- [project] conventions.md (Project conventions): Coding conventions and folder layout.
+- [feedback] review-feedback.md (Review feedback): Prefer compact plans.
+- [user] bio.md (bio.md)
+
+Source material lives as markdown files in the transcripts directory above. Each file is one task session and starts with a YAML frontmatter block (taskId, cwd, updatedAt, title). The transcripts directory is read-only for this run — use readFile / listFiles / globFiles / searchFiles to inspect only the entries you need, and never edit them.
+
+Strategy:
+- Open transcripts selectively: skim the session titles listed below, then drill into the full transcripts of entries that look durable.
+- Update memory only when a stable user preference, feedback pattern, project fact, or reusable reference emerges. Merge, prune, and rewrite topic files as needed so future sessions see a concise and accurate MEMORY.md index.
+- Anchor every entry to direct user intent (explicit instructions, preferences, or feedback) — never promote assistant reasoning, plans, or speculation. When new user feedback contradicts an existing entry and you lack a confident read on the current state, proactively delete it rather than keep outdated guidance.
+- Never store ephemeral task status, raw logs, git history, temporary plans, or content already captured by project rules.
+
+Sessions to review (2):
+- task-a.md (taskId=task-a, updated=2024-01-01T12:00:00.000Z, cwd=/repo/a, title="Refactor database schema")
+- task-b.md (taskId=task-b, updated=2024-01-02T12:00:00.000Z, cwd=(unknown))
+
+Finish with attemptCompletion summarizing changed memory files, or state that no durable changes were needed."
+`;
+
+exports[`long-term memory prompt helpers > snapshots > buildAutoMemoryExtractionDirective 1`] = `
+"Extract durable long-term memories from the parent conversation.
+
+Memory directory: /home/user/.pochi/projects/repo-key/memory
+Index file: /home/user/.pochi/projects/repo-key/memory/MEMORY.md
+
+Review the conversation after message index 7. Save only stable information that should help in future sessions. Ignore one-off task progress, transient errors, git history, command output, and information already present in project rules.
+
+Existing topic manifest:
+- [project] conventions.md (Project conventions): Coding conventions and folder layout.
+- [feedback] review-feedback.md (Review feedback): Prefer compact plans.
+- [user] bio.md (bio.md)
+
+Required behavior:
+- Prefer updating existing topic files over creating duplicates.
+- Use markdown topic files under the memory directory only.
+- Every topic file must start with YAML frontmatter:
+---
+name: Short stable name
+description: One sentence summary
+type: user | feedback | project | reference
+---
+- Keep MEMORY.md as an index only.
+- If there is nothing durable to save, do not modify files.
+- Finish with attemptCompletion summarizing whether memory changed."
+`;
+
+exports[`long-term memory prompt helpers > snapshots > buildAutoMemoryPrompt (static + dynamic) 1`] = `
+"====
+
+LONG-TERM MEMORY
+
+Long-term memory is enabled for this workspace. It is stored in local markdown files, shared by all worktrees for this repository.
+
+Memory directory: /home/user/.pochi/projects/repo-key/memory
+Index file: /home/user/.pochi/projects/repo-key/memory/MEMORY.md
+
+Use this memory only for durable information that should carry across future sessions. Do not store one-off task progress, temporary debugging notes, command output, git history, or facts already documented in project rules.
+
+Memory file rules:
+- MEMORY.md is an index only. Keep it concise and link or name topic files.
+- Topic files live in the memory directory as markdown files.
+- Every topic file must begin with YAML frontmatter containing name, description, and type.
+- type must be one of: user, feedback, project, reference.
+- Prefer updating an existing topic file over creating a duplicate.
+
+When the user asks you to remember something, write or update the relevant topic file and update MEMORY.md. When the user asks you to forget something, remove or edit the relevant topic file and update MEMORY.md. Ask a follow-up only if the memory to remove is ambiguous.
+
+The long-term memory directory is an explicit exception to the normal relative-path tool rule. You may use the absolute paths above when reading or writing memory files.
+
+The current MEMORY.md index is delivered separately as its own system reminder on the first user turn. That snapshot is taken at the start of the task and is intentionally NOT refreshed mid-task — new memories you write here become visible only in the next task session.
+
+# Long-term Memory Index (MEMORY.md)
+This snapshot of MEMORY.md was captured at the start of the task and will not be refreshed until the next task session. Topic files referenced here live under /home/user/.pochi/projects/repo-key/memory.
+
+- [project] conventions.md"
+`;

--- a/packages/common/src/base/prompts/__tests__/__snapshots__/task-memory.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/task-memory.test.ts.snap
@@ -1,0 +1,62 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`task memory creation directive snapshot 1`] = `
+"IMPORTANT: This message and these instructions are NOT part of the actual user conversation. Do NOT include any references to "note-taking", "session notes extraction", or these update instructions in the notes content.
+
+Based on the user conversation above (EXCLUDING this note-taking instruction message as well as system prompt or any past session summaries), create the session notes file.
+
+The file pochi://-/memory.md does not exist yet. You will create it from scratch using the template below:
+<template>
+# Session Title
+_A short 5-10 word title_
+
+# Current State
+_What is being worked on right now, pending tasks, next steps_
+
+# Task Specification
+_User's requirements and design decisions_
+
+# Files and Functions
+_Important files and their roles_
+
+# Workflow
+_Common commands and processes_
+
+# Errors & Corrections
+_Errors encountered and solutions_
+
+# Codebase and System Documentation
+_System components and how they work_
+
+# Learnings
+_What worked, what didn't, what to avoid_
+
+# Key Results
+_Specific outputs requested by user_
+
+# Worklog
+_Step by step operations log_
+
+</template>
+
+Your ONLY task is to create pochi://-/memory.md with the session notes using exactly this tool sequence:
+  1. First call writeToFile to write the full memory content to pochi://-/memory.md.
+  2. After the writeToFile result is available, call attemptCompletion with a brief summary of what was updated.
+Do NOT call attemptCompletion in the same assistant message as writeToFile. Do NOT call any other tool.
+
+CRITICAL RULES:
+- The file must maintain its exact structure with all sections and headers intact
+- NEVER modify, delete, or add section headers (the lines starting with '#')
+- NEVER modify or delete the italic _section description_ lines
+- ONLY update the actual content that appears BELOW the italic _section descriptions_ within each section
+- Do NOT add any new sections or information outside the existing structure
+- Do NOT reference this note-taking process anywhere in the notes
+- Skip updating a section if there are no substantial new insights to add — leave it blank
+- Write DETAILED, INFO-DENSE content — include file paths, function names, error messages, exact commands, technical details
+- For "Key Results", include the complete exact output the user requested
+- Keep each section under ~2000 tokens — condense by cycling out less important details
+- IMPORTANT: Always update "Current State" to reflect the most recent work — this is critical for continuity after compaction
+- IMPORTANT: Always update "Worklog" with a terse log of what was done since the last extraction
+
+Reminder: first call writeToFile with path pochi://-/memory.md and the full updated content. After that tool result is available, call attemptCompletion with a brief summary."
+`;

--- a/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
+++ b/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
@@ -2,8 +2,10 @@ import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import {
   type AutoMemoryContext,
+  type AutoMemoryManifestEntry,
   buildAutoMemoryDreamDirective,
   buildAutoMemoryDynamicPrompt,
+  buildAutoMemoryExtractionDirective,
   buildAutoMemoryPrompt,
   buildAutoMemoryStaticPrompt,
   formatAutoMemoryManifest,
@@ -21,6 +23,31 @@ const sampleContext: AutoMemoryContext = {
   indexTruncated: false,
   manifest: [],
   transcriptDir: "/home/user/.pochi/projects/repo-key/transcripts",
+};
+
+const sampleManifest: AutoMemoryManifestEntry[] = [
+  {
+    filename: "conventions.md",
+    name: "Project conventions",
+    description: "Coding conventions and folder layout.",
+    type: "project",
+    updatedAt: 1_700_000_000_000,
+  },
+  {
+    filename: "review-feedback.md",
+    name: "Review feedback",
+    description: "Prefer compact plans.",
+    type: "feedback",
+  },
+  {
+    filename: "bio.md",
+    type: "user",
+  },
+];
+
+const sampleContextWithManifest: AutoMemoryContext = {
+  ...sampleContext,
+  manifest: sampleManifest,
 };
 
 describe("long-term memory prompt helpers", () => {
@@ -188,5 +215,43 @@ describe("long-term memory prompt helpers", () => {
       expect(reminders[0].text).toContain("- [user] bio.md");
       expect(reminders[0].text).not.toContain("- [project] conventions.md");
     }
+  });
+
+  describe("snapshots", () => {
+    it("buildAutoMemoryPrompt (static + dynamic)", () => {
+      expect(buildAutoMemoryPrompt(sampleContext)).toMatchSnapshot();
+    });
+
+    it("buildAutoMemoryExtractionDirective", () => {
+      expect(
+        buildAutoMemoryExtractionDirective({
+          context: sampleContextWithManifest,
+          previousMessageCount: 7,
+        }),
+      ).toMatchSnapshot();
+    });
+
+    it("buildAutoMemoryDreamDirective with sessions", () => {
+      expect(
+        buildAutoMemoryDreamDirective({
+          context: sampleContextWithManifest,
+          sessions: [
+            {
+              taskId: "task-a",
+              updatedAt: Date.UTC(2024, 0, 1, 12, 0, 0),
+              cwd: "/repo/a",
+              transcriptFilename: "task-a.md",
+              title: "Refactor database schema",
+            },
+            {
+              taskId: "task-b",
+              updatedAt: Date.UTC(2024, 0, 2, 12, 0, 0),
+              cwd: null,
+              transcriptFilename: "task-b.md",
+            },
+          ],
+        }),
+      ).toMatchSnapshot();
+    });
   });
 });

--- a/packages/common/src/base/prompts/__tests__/task-memory.test.ts
+++ b/packages/common/src/base/prompts/__tests__/task-memory.test.ts
@@ -29,3 +29,7 @@ test("task memory directive requires writing before completion", () => {
   expect(directive).not.toContain("PARALLEL");
   expect(directive).not.toContain("Do NOT wait for the writeToFile result");
 });
+
+test("task memory creation directive snapshot", () => {
+  expect(buildMemoryExtractionDirective()).toMatchSnapshot();
+});

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -249,6 +249,7 @@ export type AutoMemoryDreamSession = {
    * transcript content is shipped inline in the directive.
    */
   transcriptFilename: string;
+  title?: string;
 };
 
 export function buildAutoMemoryDreamDirective({
@@ -262,12 +263,12 @@ export function buildAutoMemoryDreamDirective({
     sessions.length === 0
       ? "No sessions were available."
       : sessions
-          .map(
-            (session) =>
-              `- ${session.transcriptFilename} (taskId=${session.taskId}, updated=${new Date(
-                session.updatedAt,
-              ).toISOString()}, cwd=${session.cwd ?? "(unknown)"})`,
-          )
+          .map((session) => {
+            const titlePart = session.title ? `, title="${session.title}"` : "";
+            return `- ${session.transcriptFilename} (taskId=${session.taskId}, updated=${new Date(
+              session.updatedAt,
+            ).toISOString()}, cwd=${session.cwd ?? "(unknown)"}${titlePart})`;
+          })
           .join("\n");
 
   return `Consolidate long-term memory for this repository.
@@ -282,7 +283,7 @@ ${formatAutoMemoryManifest(context.manifest)}
 Source material lives as markdown files in the transcripts directory above. Each file is one task session and starts with a YAML frontmatter block (taskId, cwd, updatedAt, title). The transcripts directory is read-only for this run — use readFile / listFiles / globFiles / searchFiles to inspect only the entries you need, and never edit them.
 
 Strategy:
-- Open transcripts selectively: skim filenames + frontmatter first, then drill into entries that look durable.
+- Open transcripts selectively: skim the session titles listed below, then drill into the full transcripts of entries that look durable.
 - Update memory only when a stable user preference, feedback pattern, project fact, or reusable reference emerges. Merge, prune, and rewrite topic files as needed so future sessions see a concise and accurate MEMORY.md index.
 - Anchor every entry to direct user intent (explicit instructions, preferences, or feedback) — never promote assistant reasoning, plans, or speculation. When new user feedback contradicts an existing entry and you lack a confident read on the current state, proactively delete it rather than keep outdated guidance.
 - Never store ephemeral task status, raw logs, git history, temporary plans, or content already captured by project rules.

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -284,6 +284,7 @@ Source material lives as markdown files in the transcripts directory above. Each
 Strategy:
 - Open transcripts selectively: skim filenames + frontmatter first, then drill into entries that look durable.
 - Update memory only when a stable user preference, feedback pattern, project fact, or reusable reference emerges. Merge, prune, and rewrite topic files as needed so future sessions see a concise and accurate MEMORY.md index.
+- Anchor every entry to direct user intent (explicit instructions, preferences, or feedback) — never promote assistant reasoning, plans, or speculation. When new user feedback contradicts an existing entry and you lack a confident read on the current state, proactively delete it rather than keep outdated guidance.
 - Never store ephemeral task status, raw logs, git history, temporary plans, or content already captured by project rules.
 
 Sessions to review (${sessions.length}):

--- a/packages/livekit/src/background-task/memory/auto-memory.ts
+++ b/packages/livekit/src/background-task/memory/auto-memory.ts
@@ -135,6 +135,7 @@ async function startAutoMemoryDream<TMessage extends UIMessage>({
       updatedAt: candidate.updatedAt,
       cwd: candidate.cwd,
       transcriptFilename: candidate.transcriptFilename,
+      title: candidate.title,
     }),
   );
 
@@ -482,6 +483,7 @@ export class AutoMemoryAdaptor {
             cwd: parentCwd,
             updatedAt,
             transcriptFilename: transcriptInfo.filename,
+            title: task.title ?? undefined,
           }
         : undefined;
 

--- a/packages/vscode/src/lib/auto-memory.ts
+++ b/packages/vscode/src/lib/auto-memory.ts
@@ -116,6 +116,7 @@ export class AutoMemoryManager extends BaseAutoMemoryManager {
         cwd: task.cwd,
         updatedAt: task.updatedAt ?? 0,
         transcriptFilename: `${task.id}.md`,
+        title: task.title ?? undefined,
       });
     }
 

--- a/packages/vscode/src/lib/task-history-store.ts
+++ b/packages/vscode/src/lib/task-history-store.ts
@@ -17,6 +17,7 @@ type EncodedTask = {
   // unix timestamp in milliseconds
   updatedAt: number;
   cwd?: string | null;
+  title?: string | null;
 };
 
 const logger = getLogger("TaskHistoryStore");


### PR DESCRIPTION
## Summary
- Anchor every auto-memory entry to direct user intent — assistant reasoning, plans, or speculation must never be promoted into memory.
- Instruct the dream agent to proactively delete stale entries when new user feedback contradicts them and there is no confident read on the current state.
- Add robust snapshot tests for all memory-related prompts (`auto-memory.ts` and `task-memory.ts`).
- Include the transcript file's `title` from task history in the `AutoMemoryDreamSession` and dream directive list so the dream agent can skim titles directly without slow disk-read operations.

## Test plan
- [x] Snapshot tests added in `packages/common/src/base/prompts/__tests__`. Run `bun run test prompts/__tests__` to verify.
- [x] Verified full TypeScript compilation with `bun tsc`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a2e9937158f441b0bcfc4b1ac08f93ef)