### PR TITLE
refactor(livekit): move system/tools tokens off Metadata onto FinishedRequestSnapshot

### DIFF
--- a/packages/cli/src/lib/step-metadata-tracker.ts
+++ b/packages/cli/src/lib/step-metadata-tracker.ts
@@ -16,8 +16,6 @@ export const StepMetadataEntry = z.object({
   metadata: z.object({
     finishReason: z.custom<FinishReason>(),
     totalTokens: z.number(),
-    systemPromptTokens: z.number().optional(),
-    toolsTokens: z.number().optional(),
   }),
 });
 export type StepMetadataEntry = z.infer<typeof StepMetadataEntry>;

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -343,8 +343,6 @@ export class TaskRunner {
               metadata: {
                 finishReason: lastMessage.metadata.finishReason,
                 totalTokens: lastMessage.metadata.totalTokens,
-                systemPromptTokens: lastMessage.metadata.systemPromptTokens,
-                toolsTokens: lastMessage.metadata.toolsTokens,
               },
             });
           }

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -102,6 +102,7 @@ describe("LiveChatKit memory lifecycle", () => {
     });
 
     chatKit.chat.messages = [userMessage(), assistantMessage()];
+    setLatestRequestSnapshot(chatKit, 20_000, 0);
     chatKit.chat.finish(assistantMessage());
     await chatKit.drainBackgroundTasksAndSettleMemory();
 
@@ -199,6 +200,7 @@ describe("LiveChatKit memory lifecycle", () => {
     });
 
     chatKit.chat.messages = [userMessage(), assistantMessage()];
+    setLatestRequestSnapshot(chatKit, 20_000, 0);
     chatKit.chat.finish(assistantMessage());
     await chatKit.drainBackgroundTasksAndSettleMemory();
 
@@ -214,6 +216,26 @@ describe("LiveChatKit memory lifecycle", () => {
     });
   });
 });
+
+function setLatestRequestSnapshot(
+  chatKit: LiveChatKit<FakeChat>,
+  systemPromptTokens: number,
+  toolsTokens: number,
+) {
+  (
+    chatKit as unknown as {
+      latestRequestSnapshot: {
+        systemPrompt: string;
+        systemPromptTokens: number;
+        toolsTokens: number;
+      };
+    }
+  ).latestRequestSnapshot = {
+    systemPrompt: "",
+    systemPromptTokens,
+    toolsTokens,
+  };
+}
 
 class BackgroundTaskStateStore {
   private readonly states = new Map<string, BackgroundTaskState>();
@@ -457,8 +479,6 @@ function assistantMessage(): Message {
     metadata: {
       kind: "assistant",
       finishReason: "stop",
-      systemPromptTokens: 20_000,
-      toolsTokens: 0,
       totalTokens: 20_000,
     },
   } as unknown as Message;

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -22,7 +22,6 @@ import {
   type ModelMessage,
   type UIMessageChunk,
   convertToModelMessages,
-  isStaticToolUIPart,
   streamText,
   tool,
   wrapLanguageModel,
@@ -39,7 +38,7 @@ import {
   createToolCallMiddleware,
 } from "./middlewares";
 import { createModel } from "./models";
-import { ImageEstimatedTokens, estimateTokens } from "./token-utils";
+import { estimateTokens, estimateTotalTokens } from "./token-utils";
 
 export type OnStartCallback = (options: {
   messages: Message[];
@@ -50,6 +49,8 @@ export type OnStartCallback = (options: {
 
 export type FinishedRequestSnapshot = {
   systemPrompt: string;
+  systemPromptTokens: number;
+  toolsTokens: number;
 };
 
 export type PrepareRequestGetters = {
@@ -182,10 +183,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       autoMemory,
     );
     const systemPrompt = this.systemPromptOverride ?? generatedSystemPrompt;
-    const systemPromptChars = systemPrompt.length;
-    const toolsChars = JSON.stringify(tools).length;
-    const systemPromptTokens = Math.ceil(systemPromptChars / 4);
-    const toolsTokens = Math.ceil(toolsChars / 4);
+    const systemPromptTokens = estimateTokens(systemPrompt);
+    const toolsTokens = estimateTokens(JSON.stringify(tools));
 
     const preparedMessages = await prepareMessages(messages);
     const modelMessages = (await resolvePromise(
@@ -242,14 +241,14 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
             totalTokens:
               part.totalUsage.totalTokens || estimateTotalTokens(messages),
             finishReason: part.finishReason,
-            systemPromptTokens,
-            toolsTokens,
           } satisfies Metadata;
         }
       },
       onFinish: async () => {
         await this.onRequestFinished?.({
           systemPrompt,
+          systemPromptTokens,
+          toolsTokens,
         });
       },
     });
@@ -277,24 +276,6 @@ function isWellKnownReasoningModel(model?: string): boolean {
     }
   }
   return false;
-}
-
-function estimateTotalTokens(messages: Message[]): number {
-  let totalTokens = 0;
-  for (const message of messages) {
-    for (const part of message.parts) {
-      if (part.type === "text") {
-        totalTokens += estimateTokens(part.text);
-      } else if (part.type === "reasoning") {
-        totalTokens += estimateTokens(part.text);
-      } else if (part.type === "file") {
-        totalTokens += ImageEstimatedTokens;
-      } else if (isStaticToolUIPart(part)) {
-        totalTokens += estimateTokens(JSON.stringify(part));
-      }
-    }
-  }
-  return totalTokens;
 }
 
 async function resolvePromise(o: unknown): Promise<unknown> {

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -5,17 +5,12 @@ import type {
   PochiRequestUseCase,
   TaskMemoryState,
 } from "@getpochi/common";
-import { getLogger, isForkAgentUseCase, prompts } from "@getpochi/common";
+import { getLogger, isForkAgentUseCase } from "@getpochi/common";
 import { prepareLastMessageForRetry as prepareMessageForRetry } from "@getpochi/common/message-utils";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { type CustomAgent, ToolsByPermission } from "@getpochi/tools";
 import { Duration } from "@livestore/utils/effect";
-import {
-  type ChatInit,
-  type ChatOnErrorCallback,
-  type ChatOnFinishCallback,
-  isStaticToolUIPart,
-} from "ai";
+import type { ChatInit, ChatOnErrorCallback, ChatOnFinishCallback } from "ai";
 import type z from "zod";
 import type { ForkAgent, ForkAgentHandle } from "../background-task/fork-agent";
 import type { AutoMemoryManager } from "../background-task/memory/auto-memory";
@@ -54,7 +49,7 @@ import {
 import { prepareForkTaskData } from "./fork-task-tools";
 import { compactTask, repairMermaid } from "./llm";
 import { createModel } from "./models";
-import { ImageEstimatedTokens, estimateTokens } from "./token-utils";
+import { computeContextWindowUsage, estimateTotalTokens } from "./token-utils";
 
 const logger = getLogger("LiveChatKit");
 const OverrideMessagesSideEffectTimeoutMs = 12_000;
@@ -516,7 +511,7 @@ export class LiveChatKit<
           messages,
           llm: getters.getLLM(),
           task: this.task,
-          estimatedTotalTokens: estimateCurrentMessagesTokens(messages),
+          estimatedTotalTokens: estimateTotalTokens(messages),
         });
 
       if (isManualCompact || isAutoCompact) {
@@ -836,37 +831,10 @@ export class LiveChatKit<
     const finishReason = streamFinishReason ?? message.metadata?.finishReason;
     const status = toTaskStatus(message, finishReason);
 
-    let contextWindowUsage: ContextWindowUsage | undefined = undefined;
-    if (message.metadata?.kind === "assistant") {
-      const {
-        messagesTokens,
-        filesTokens,
-        toolResultsTokens,
-        systemReminderTokens,
-        projectMemoryTokens,
-      } = estimateTokenBreakdown(this.chat.messages);
-      const systemTokens =
-        (message.metadata.systemPromptTokens || 0) + systemReminderTokens;
-      const toolsTokens = message.metadata.toolsTokens || 0;
-
-      const totalTokens =
-        systemTokens +
-        toolsTokens +
-        messagesTokens +
-        filesTokens +
-        toolResultsTokens +
-        projectMemoryTokens;
-      if (totalTokens > 0) {
-        contextWindowUsage = {
-          system: systemTokens,
-          tools: toolsTokens,
-          messages: messagesTokens,
-          files: filesTokens,
-          toolResults: toolResultsTokens,
-          projectMemory: projectMemoryTokens,
-        };
-      }
-    }
+    const contextWindowUsage = computeContextWindowUsage(
+      this.chat.messages,
+      this.latestRequestSnapshot,
+    );
 
     const { duration, startedAt, finishedAt } =
       this.captureStepDuration() ?? {};
@@ -1064,88 +1032,3 @@ const getCleanCheckpoint = (messages: Message[]) => {
     return lastPart.data.commit;
   }
 };
-
-function estimateTokenBreakdown(messages: Message[]) {
-  let messagesTokens = 0;
-  let filesTokens = 0;
-  let toolResultsTokens = 0;
-  let systemReminderTokens = 0;
-  let projectMemoryTokens = 0;
-
-  for (const msg of messages) {
-    for (const part of msg.parts) {
-      if (part.type === "text") {
-        let contentStr = part.text;
-        if (msg.role === "user" && contentStr.includes("<system-reminder>")) {
-          const reminderRegex = /<system-reminder>[\s\S]*?<\/system-reminder>/g;
-          const reminders = contentStr.match(reminderRegex);
-          if (reminders) {
-            for (const reminder of reminders) {
-              const tokens = estimateTokens(reminder);
-              if (prompts.isAutoMemorySystemReminder(reminder)) {
-                projectMemoryTokens += tokens;
-              } else {
-                systemReminderTokens += tokens;
-              }
-            }
-            contentStr = contentStr.replace(reminderRegex, "");
-          }
-        }
-        messagesTokens += estimateTokens(contentStr);
-      } else if (part.type === "file") {
-        filesTokens += ImageEstimatedTokens;
-      } else if (isStaticToolUIPart(part)) {
-        messagesTokens += estimateTokens(JSON.stringify(part.input || {}));
-        if (part.state === "output-available" && part.output) {
-          const output = (part as unknown as { output: unknown }).output;
-          let outputTokens = 0;
-
-          if (output instanceof Uint8Array) {
-            outputTokens = ImageEstimatedTokens;
-          } else {
-            const resultStr =
-              typeof output === "string" ? output : JSON.stringify(output);
-            outputTokens = estimateTokens(resultStr);
-          }
-
-          const toolName = part.type.replace(/^tool-/, "");
-          if (["readFile", "searchFiles", "globFiles"].includes(toolName)) {
-            filesTokens += outputTokens;
-          } else {
-            toolResultsTokens += outputTokens;
-          }
-        }
-      } else if (part.type === "reasoning") {
-        messagesTokens += estimateTokens(part.text);
-      } else {
-        messagesTokens += estimateTokens(JSON.stringify(part));
-      }
-    }
-  }
-
-  return {
-    messagesTokens,
-    filesTokens,
-    toolResultsTokens,
-    systemReminderTokens,
-    projectMemoryTokens,
-  };
-}
-
-function estimateCurrentMessagesTokens(messages: Message[]) {
-  const {
-    messagesTokens,
-    filesTokens,
-    toolResultsTokens,
-    systemReminderTokens,
-    projectMemoryTokens,
-  } = estimateTokenBreakdown(messages);
-
-  return (
-    messagesTokens +
-    filesTokens +
-    toolResultsTokens +
-    systemReminderTokens +
-    projectMemoryTokens
-  );
-}

--- a/packages/livekit/src/chat/token-utils.ts
+++ b/packages/livekit/src/chat/token-utils.ts
@@ -1,5 +1,153 @@
+import type { ContextWindowUsage } from "@getpochi/common";
+import { prompts } from "@getpochi/common";
+import { isStaticToolUIPart } from "ai";
+import type { Message } from "../types";
+
 export const ImageEstimatedTokens = 1000;
 
 export function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
+}
+
+/**
+ * Estimates the total number of tokens across all message parts.
+ * Used as a fallback when the provider does not return a usage total.
+ */
+export function estimateTotalTokens(messages: Message[]): number {
+  let totalTokens = 0;
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (part.type === "text") {
+        totalTokens += estimateTokens(part.text);
+      } else if (part.type === "reasoning") {
+        totalTokens += estimateTokens(part.text);
+      } else if (part.type === "file") {
+        totalTokens += ImageEstimatedTokens;
+      } else if (isStaticToolUIPart(part)) {
+        totalTokens += estimateTokens(JSON.stringify(part));
+      }
+    }
+  }
+  return totalTokens;
+}
+
+export type TokenBreakdown = {
+  messagesTokens: number;
+  filesTokens: number;
+  toolResultsTokens: number;
+  systemReminderTokens: number;
+  projectMemoryTokens: number;
+};
+
+/**
+ * Buckets message tokens into non-overlapping breakdown categories used by
+ * `ContextWindowUsage`.
+ */
+export function estimateTokenBreakdown(messages: Message[]): TokenBreakdown {
+  let messagesTokens = 0;
+  let filesTokens = 0;
+  let toolResultsTokens = 0;
+  let systemReminderTokens = 0;
+  let projectMemoryTokens = 0;
+
+  for (const msg of messages) {
+    for (const part of msg.parts) {
+      if (part.type === "text") {
+        let contentStr = part.text;
+        if (msg.role === "user" && contentStr.includes("<system-reminder>")) {
+          const reminderRegex = /<system-reminder>[\s\S]*?<\/system-reminder>/g;
+          const reminders = contentStr.match(reminderRegex);
+          if (reminders) {
+            for (const reminder of reminders) {
+              const tokens = estimateTokens(reminder);
+              if (prompts.isAutoMemorySystemReminder(reminder)) {
+                projectMemoryTokens += tokens;
+              } else {
+                systemReminderTokens += tokens;
+              }
+            }
+            contentStr = contentStr.replace(reminderRegex, "");
+          }
+        }
+        messagesTokens += estimateTokens(contentStr);
+      } else if (part.type === "file") {
+        filesTokens += ImageEstimatedTokens;
+      } else if (isStaticToolUIPart(part)) {
+        messagesTokens += estimateTokens(JSON.stringify(part.input || {}));
+        if (part.state === "output-available" && part.output) {
+          const output = (part as unknown as { output: unknown }).output;
+          let outputTokens = 0;
+
+          if (output instanceof Uint8Array) {
+            outputTokens = ImageEstimatedTokens;
+          } else {
+            const resultStr =
+              typeof output === "string" ? output : JSON.stringify(output);
+            outputTokens = estimateTokens(resultStr);
+          }
+
+          const toolName = part.type.replace(/^tool-/, "");
+          if (["readFile", "searchFiles", "globFiles"].includes(toolName)) {
+            filesTokens += outputTokens;
+          } else {
+            toolResultsTokens += outputTokens;
+          }
+        }
+      } else if (part.type === "reasoning") {
+        messagesTokens += estimateTokens(part.text);
+      } else {
+        messagesTokens += estimateTokens(JSON.stringify(part));
+      }
+    }
+  }
+
+  return {
+    messagesTokens,
+    filesTokens,
+    toolResultsTokens,
+    systemReminderTokens,
+    projectMemoryTokens,
+  };
+}
+
+/**
+ * Builds a `ContextWindowUsage` snapshot by combining the per-message token
+ * breakdown with the system-prompt and tools token counts captured at the
+ * request boundary. Returns `undefined` when the total is zero so callers can
+ * skip persisting an empty usage.
+ */
+export function computeContextWindowUsage(
+  messages: Message[],
+  request: { systemPromptTokens?: number; toolsTokens?: number } | undefined,
+): ContextWindowUsage | undefined {
+  const {
+    messagesTokens,
+    filesTokens,
+    toolResultsTokens,
+    systemReminderTokens,
+    projectMemoryTokens,
+  } = estimateTokenBreakdown(messages);
+
+  const systemTokens =
+    (request?.systemPromptTokens || 0) + systemReminderTokens;
+  const toolsTokens = request?.toolsTokens || 0;
+
+  const totalTokens =
+    systemTokens +
+    toolsTokens +
+    messagesTokens +
+    filesTokens +
+    toolResultsTokens +
+    projectMemoryTokens;
+
+  if (totalTokens <= 0) return undefined;
+
+  return {
+    system: systemTokens,
+    tools: toolsTokens,
+    messages: messagesTokens,
+    files: filesTokens,
+    toolResults: toolResultsTokens,
+    projectMemory: projectMemoryTokens,
+  };
 }

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -19,8 +19,6 @@ export type Metadata =
       kind: "assistant";
       totalTokens: number;
       finishReason: FinishReason;
-      systemPromptTokens?: number;
-      toolsTokens?: number;
     }
   | {
       kind: "user";


### PR DESCRIPTION
## Summary
- Move `systemPromptTokens` / `toolsTokens` off the assistant `Message.metadata` discriminant and onto `FinishedRequestSnapshot`, so per-request derived counts ride alongside the resolved `systemPrompt` on `LiveChatKit.latestRequestSnapshot` instead of being persisted with each assistant message.
- Rebuild `ContextWindowUsage` in `LiveChatKit.onFinish` from the request snapshot via a new `computeContextWindowUsage` helper, and extract `estimateTotalTokens` / `estimateTokenBreakdown` out of `flexible-chat-transport.ts` and `live-chat-kit.ts` into `packages/livekit/src/chat/token-utils.ts`.
- Replace the inline `Math.ceil(text.length / 4)` in `flexible-chat-transport.ts` with the canonical `estimateTokens` helper, and drop the now-dead `systemPromptTokens` / `toolsTokens` fields from the CLI `step-metadata-tracker` schema and `task-runner` writer.

## Test plan
- [ ] `bun run test` in `packages/livekit` (covers `live-chat-kit-memory.test.ts` which now injects `latestRequestSnapshot` via the new test helper before `chat.finish(...)`).
- [ ] `bun tsc` at the repo root to catch any consumer still reading `message.metadata.systemPromptTokens` / `toolsTokens`.
- [ ] Manual smoke: open a task in the VS Code webview, send a turn, confirm the Context Window popover still renders System / Tools / Messages / Files / Tool Results / Project Memory with non-zero values.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7c8e5771bb244559996358cf6bd250ac)