### PR TITLE
fix(cli): support immediate shutdown on second SIGINT

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -351,7 +351,7 @@ const program = new Command()
 
     // FIXME(zhiming): the abort logic does not work as intent in many cases, need more investigation
     // Create AbortController for task cancellation with graceful shutdown
-    const abortController = createAbortControllerWithGracefulShutdown();
+    const abortController = createAbortControllerWithGracefulShutdown(program);
 
     const llm = await createLLMConfig(program, options, {
       customAgents,

--- a/packages/cli/src/lib/shutdown.ts
+++ b/packages/cli/src/lib/shutdown.ts
@@ -1,3 +1,5 @@
+import type { Command } from "@commander-js/extra-typings";
+
 export class ProcessAbortError extends Error {
   constructor(
     message: string,
@@ -13,25 +15,29 @@ export class ProcessAbortError extends Error {
  * The handlers are automatically cleaned up when the controller is aborted.
  * @returns An AbortController that will be aborted on process termination signals
  */
-export function createAbortControllerWithGracefulShutdown(): AbortController {
+export function createAbortControllerWithGracefulShutdown(
+  program: Command,
+): AbortController {
   const abortController = new AbortController();
 
   const handleShutdown = (signal: "SIGINT" | "SIGTERM") => {
+    let exitCode = 1;
+    switch (signal) {
+      case "SIGINT":
+        exitCode = 128 + 2;
+        break;
+      case "SIGTERM":
+        exitCode = 128 + 15;
+        break;
+      default:
+        break;
+    }
     if (!abortController.signal.aborted) {
-      let exitCode = 1;
-      switch (signal) {
-        case "SIGINT":
-          exitCode = 128 + 2;
-          break;
-        case "SIGTERM":
-          exitCode = 128 + 15;
-          break;
-        default:
-          break;
-      }
       abortController.abort(
         new ProcessAbortError(`Process interrupted by ${signal}`, exitCode),
       );
+    } else {
+      program.error(`Process interrupted by ${signal}`, { exitCode });
     }
   };
 
@@ -40,12 +46,6 @@ export function createAbortControllerWithGracefulShutdown(): AbortController {
 
   process.on("SIGINT", sigintHandler);
   process.on("SIGTERM", sigtermHandler);
-
-  // Clean up handlers when the controller is aborted
-  abortController.signal.addEventListener("abort", () => {
-    process.off("SIGINT", sigintHandler);
-    process.off("SIGTERM", sigtermHandler);
-  });
 
   return abortController;
 }

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -350,6 +350,7 @@ export class TaskRunner {
       logger.trace("Start step loop.");
       this.stepCount.reset();
       while (true) {
+        this.abortSignal?.throwIfAborted();
         const stepResult = await this.step();
         if (stepResult === "finished") {
           break;


### PR DESCRIPTION
## Summary
- Update `createAbortControllerWithGracefulShutdown` to accept the commander program.
- Register handlers such that a second SIGINT/SIGTERM will immediately exit using `program.error`.
- Throw if aborted at the start of each task runner step loop to stop execution earlier.
- Fix TypeScript type definition for the commander program in `shutdown.ts`.

### Screenshot 1 (Press two Ctrl-C and display interrupt)
![pasted-file-1782183046477](https://pochi-file-uploads.getpochi.com/blob-1782183100705.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260623%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260623T025140Z&X-Amz-Expires=561600&X-Amz-Signature=36d50ceaa350827b532123cd04f26c0a153c9006f0f1d3b5d8e3363f2533246a&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

### Screenshot 2 (Press one Ctrl-C, stopped after tool call execution)
![pasted-file-1782183098981](https://pochi-file-uploads.getpochi.com/blob-1782183100711.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260623%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260623T025140Z&X-Amz-Expires=561600&X-Amz-Signature=1ac78e083af7855f70a1dcf6bfffddc407f23faed51ed40c84df081e30b56b11&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan
- [x] Run `bun tsc` to verify TypeScript compilation
- [x] Run `bun run test` to verify unit tests pass
- [x] Manually verify signal handling in the CLI

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-6f2d7a0e6abd433ba3edd847cc59e95b)