### PR TITLE
refactor(common): migrate MaybePromise to @getpochi/common

### DIFF
--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import {
   type AutoMemoryContext,
   type ContextWindowUsage,
+  type MaybePromise,
   getLogger,
   prompts,
   toErrorMessage,
@@ -152,9 +153,9 @@ export interface RunnerOptions {
     messages: Message[];
     error?: Error;
     contextWindowUsage?: ContextWindowUsage;
-  }) => void | Promise<void>;
+  }) => MaybePromise<void>;
 
-  onCompactFinish?: (success: boolean) => void | Promise<void>;
+  onCompactFinish?: (success: boolean) => MaybePromise<void>;
 
   getAutoMemory?: () => Promise<AutoMemoryContext | undefined>;
 

--- a/packages/common/src/base/async-utils.ts
+++ b/packages/common/src/base/async-utils.ts
@@ -1,5 +1,7 @@
 import { getLogger } from "./logger";
 
+export type MaybePromise<T> = T | Promise<T>;
+
 const logger = getLogger("AsyncUtils");
 
 /**

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -36,6 +36,7 @@ export { WebsiteTaskCreateEvent } from "./event";
 export { toErrorMessage } from "./error";
 
 export { withTimeout } from "./async-utils";
+export type { MaybePromise } from "./async-utils";
 
 export * from "./message-context";
 export type {

--- a/packages/livekit/src/background-task/fork-agent.ts
+++ b/packages/livekit/src/background-task/fork-agent.ts
@@ -1,4 +1,8 @@
-import { type ForkAgentUseCase, getLogger } from "@getpochi/common";
+import {
+  type ForkAgentUseCase,
+  type MaybePromise,
+  getLogger,
+} from "@getpochi/common";
 import { type ToolSpecInput, parseToolSpec } from "@getpochi/tools";
 import type { UIMessage } from "ai";
 
@@ -32,7 +36,7 @@ export type ForkAgent<TMessage extends UIMessage> = {
 
 export type StartForkAgent<TMessage extends UIMessage> = (
   agent: ForkAgent<TMessage>,
-) => Promise<ForkAgentHandle> | ForkAgentHandle;
+) => MaybePromise<ForkAgentHandle>;
 
 const ForkAgentUseCaseLabels: Record<ForkAgentUseCase, string> = {
   "task-memory": "Task Memory Extraction",

--- a/packages/livekit/src/background-task/memory/__tests__/adaptors.test.ts
+++ b/packages/livekit/src/background-task/memory/__tests__/adaptors.test.ts
@@ -47,7 +47,7 @@ describe("task-memory adaptor", () => {
       status: "pending-model",
       title: "[Task Memory Extraction] Build shared runner",
     });
-    expect(stateStore.read(task.id)).toMatchObject({
+    expect(await stateStore.read(task.id)).toMatchObject({
       parentTaskId: "parent",
       useCase: "task-memory",
     });
@@ -249,7 +249,7 @@ describe("auto-memory adaptor", () => {
       status: "pending-model",
       title: "[Auto Memory Extraction] Build shared runner",
     });
-    expect(stateStore.read(task.id)).toMatchObject({
+    expect(await stateStore.read(task.id)).toMatchObject({
       parentTaskId: "parent",
       useCase: "auto-memory",
       tools: [
@@ -421,9 +421,15 @@ describe("auto-memory adaptor", () => {
 
     await expect(adaptor.settleAndMaybeContinue()).resolves.toBe(true);
 
-    const dreamTask = store.backgroundTasks().find((task) => {
-      return stateStore.read(task.id)?.useCase === "auto-memory-dream";
-    });
+    const tasksWithState = await Promise.all(
+      store.backgroundTasks().map(async (task) => ({
+        task,
+        state: await stateStore.read(task.id),
+      })),
+    );
+    const dreamTask = tasksWithState.find(({ state }) => {
+      return state?.useCase === "auto-memory-dream";
+    })?.task;
     expect(dreamTask).toMatchObject({
       background: true,
       status: "pending-model",
@@ -488,7 +494,7 @@ function createTestBackgroundTask({
 }: {
   store: LiveKitStore;
   stateStore: BackgroundTaskStateStore;
-  waitForTaskDone?: (taskId: string) => void | Promise<void>;
+  waitForTaskDone?: (taskId: string) => Promise<void>;
 }) {
   return {
     startForkAgent: async (agent: ForkAgent<Message>) => {

--- a/packages/livekit/src/background-task/memory/auto-memory.ts
+++ b/packages/livekit/src/background-task/memory/auto-memory.ts
@@ -8,8 +8,9 @@ import {
   getLogger,
   prompts,
 } from "@getpochi/common";
-import type { ToolSpecInput } from "@getpochi/tools";
+import { type ToolSpecInput, ToolsByPermission } from "@getpochi/tools";
 import { type UIMessage, getStaticToolName, isStaticToolUIPart } from "ai";
+import { isPlainObject } from "remeda";
 import { makeTaskQuery } from "../../livestore/default-queries";
 import type { LiveKitStore, Message } from "../../types";
 import {
@@ -17,11 +18,7 @@ import {
   buildForkAgentInitTitle,
   createForkAgent,
 } from "../fork-agent";
-import {
-  type MaybePromise,
-  type MemoryStateStore,
-  createMemoryStateStore,
-} from "../state-store";
+import { type MemoryStateStore, createMemoryStateStore } from "../state-store";
 
 export type { AutoMemoryManager } from "@getpochi/common";
 
@@ -33,19 +30,9 @@ const MemoryReadToolNames = [
   "globFiles",
   "searchFiles",
 ] as const;
-const MemoryWriteToolNames = ["writeToFile", "applyDiff"] as const;
-const MemoryWriteTools = new Set(["writeToFile", "applyDiff", "editNotebook"]);
+const MemoryAgentWriteToolNames = ["writeToFile", "applyDiff"] as const;
 const MaxSessionTranscriptChars = 24_000;
 const MaxPartChars = 4_000;
-
-type SetAutoMemoryState = (state: AutoMemoryTaskState) => Promise<void> | void;
-
-type FinishAutoMemoryDream = (options: {
-  memoryDir: string;
-  token: string;
-  previousLastDreamAt: number;
-  success: boolean;
-}) => Promise<void> | void;
 
 async function startAutoMemoryExtraction<TMessage extends UIMessage>({
   state,
@@ -60,7 +47,7 @@ async function startAutoMemoryExtraction<TMessage extends UIMessage>({
   messageCount,
 }: {
   state: AutoMemoryTaskState;
-  setAutoMemoryState: SetAutoMemoryState;
+  setAutoMemoryState: MemoryStateStore<AutoMemoryTaskState>["set"];
   startForkAgent: StartForkAgent<TMessage>;
   parentTaskId: string;
   parentCwd: string | undefined;
@@ -119,15 +106,15 @@ async function startAutoMemoryDream<TMessage extends UIMessage>({
   run,
 }: {
   state: AutoMemoryTaskState;
-  setAutoMemoryState: SetAutoMemoryState;
+  setAutoMemoryState: MemoryStateStore<AutoMemoryTaskState>["set"];
   startForkAgent: StartForkAgent<TMessage>;
-  finishAutoMemoryDream: FinishAutoMemoryDream;
+  finishAutoMemoryDream: AutoMemoryManager["finishDreamRun"];
   parentTaskId: string;
   parentCwd: string | undefined;
   parentTaskTitle?: string;
-  run: AutoMemoryDreamRun | undefined;
+  run: AutoMemoryDreamRun;
 }) {
-  if (!run || state.isDreaming || state.isExtracting) return false;
+  if (state.isDreaming || state.isExtracting) return false;
 
   const sessions: AutoMemoryDreamSession[] = run.candidates.map(
     (candidate) => ({
@@ -223,7 +210,7 @@ function resolveAutoMemoryDreamState({
 }):
   | {
       nextState: AutoMemoryTaskState;
-      finish: Parameters<FinishAutoMemoryDream>[0];
+      finish: Parameters<AutoMemoryManager["finishDreamRun"]>[0];
     }
   | undefined {
   if (
@@ -268,7 +255,7 @@ function buildMemoryTools(
     tools.push(`${name}(${memoryGlob})`);
     tools.push(`${name}(${transcriptGlob})`);
   }
-  for (const name of MemoryWriteToolNames) {
+  for (const name of MemoryAgentWriteToolNames) {
     tools.push(`${name}(${memoryGlob})`);
   }
   return tools;
@@ -281,15 +268,15 @@ function didConversationWriteMemory(
 ): boolean {
   return messages.some((message) =>
     message.parts.some((part) => {
-      const toolName = getToolName(part);
-      if (!toolName || !MemoryWriteTools.has(toolName)) return false;
+      if (!isStaticToolUIPart(part)) return false;
+      if (!ToolsByPermission.write.includes(getStaticToolName(part))) {
+        return false;
+      }
       if (!isSuccessfulToolOutput(part)) return false;
-
-      const inputPath =
-        "input" in part && isObject(part.input) ? part.input.path : undefined;
-      return (
-        typeof inputPath === "string" && isMemoryPath(inputPath, memoryDir, cwd)
-      );
+      if (!isPlainObject(part.input) || typeof part.input.path !== "string") {
+        return false;
+      }
+      return isMemoryPath(part.input.path, memoryDir, cwd);
     }),
   );
 }
@@ -304,14 +291,12 @@ function serializeSessionTranscript(messages: readonly UIMessage[]): string {
   return truncate(chunks.join("\n\n"), MaxSessionTranscriptChars);
 }
 
-function getToolName(part: UIMessage["parts"][number]): string | undefined {
-  return isStaticToolUIPart(part) ? getStaticToolName(part) : undefined;
-}
-
 function isSuccessfulToolOutput(part: UIMessage["parts"][number]): boolean {
   if (!("state" in part) || part.state !== "output-available") return false;
   const output = "output" in part ? part.output : undefined;
-  return isObject(output) && output.success === true && !("error" in output);
+  return (
+    isPlainObject(output) && output.success === true && !("error" in output)
+  );
 }
 
 function isMemoryPath(
@@ -408,10 +393,6 @@ function truncate(value: string, maxChars: number): string {
   return `${value.slice(0, maxChars)}\n[truncated]`;
 }
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object";
-}
-
 const DefaultAutoMemoryState: AutoMemoryTaskState = {
   lastExtractionMessageCount: 0,
   isExtracting: false,
@@ -423,7 +404,7 @@ type AutoMemoryAdaptorOptions = {
   store: LiveKitStore;
   backgroundTask: {
     startForkAgent: StartForkAgent<Message>;
-    waitForTaskDone?: (taskId: string) => MaybePromise<void>;
+    waitForTaskDone?: (taskId: string) => Promise<void>;
   };
   autoMemoryStateStore?: MemoryStateStore<AutoMemoryTaskState>;
   parentTaskId: string;
@@ -500,13 +481,13 @@ export class AutoMemoryAdaptor {
             ...state,
             lastExtractionMessageCount: messageCount,
           };
-          await this.setAutoMemoryState(nextState);
+          await this.stateStore.set(nextState);
           return this.maybeStartDream(nextState);
         }
 
         const handle = await startAutoMemoryExtraction({
           state,
-          setAutoMemoryState: (nextState) => this.setAutoMemoryState(nextState),
+          setAutoMemoryState: (nextState) => this.stateStore.set(nextState),
           startForkAgent: (agent) =>
             this.options.backgroundTask.startForkAgent(agent),
           parentTaskId: this.options.parentTaskId,
@@ -542,7 +523,7 @@ export class AutoMemoryAdaptor {
           : undefined,
       });
       if (extractionResolution) {
-        await this.setAutoMemoryState(extractionResolution.nextState);
+        await this.stateStore.set(extractionResolution.nextState);
         if (
           extractionResolution.success &&
           (await this.maybeStartDream(extractionResolution.nextState))
@@ -560,7 +541,7 @@ export class AutoMemoryAdaptor {
       });
       if (dreamResolution) {
         await this.options.manager.finishDreamRun(dreamResolution.finish);
-        await this.setAutoMemoryState(dreamResolution.nextState);
+        await this.stateStore.set(dreamResolution.nextState);
       }
     } catch (error) {
       logger.warn("Failed to settle long-term memory update", error);
@@ -582,16 +563,19 @@ export class AutoMemoryAdaptor {
     });
     if (!run) return false;
 
+    const task = this.options.store.query(
+      makeTaskQuery(this.options.parentTaskId),
+    );
     const started = await startAutoMemoryDream<Message>({
       state: baseState,
-      setAutoMemoryState: (nextState) => this.setAutoMemoryState(nextState),
+      setAutoMemoryState: (nextState) => this.stateStore.set(nextState),
       startForkAgent: (agent) =>
         this.options.backgroundTask.startForkAgent(agent),
       finishAutoMemoryDream: (finishOptions) =>
         this.options.manager.finishDreamRun(finishOptions),
       parentTaskId: this.options.parentTaskId,
       parentCwd,
-      parentTaskTitle: this.getParentTaskTitle(),
+      parentTaskTitle: task?.title ?? undefined,
       run,
     });
     if (started) {
@@ -607,22 +591,11 @@ export class AutoMemoryAdaptor {
     const { waitForTaskDone } = this.options.backgroundTask;
     if (!taskId || !waitForTaskDone) return;
 
-    void Promise.resolve(waitForTaskDone(taskId))
+    void waitForTaskDone(taskId)
       .then(() => this.settleAndMaybeContinue())
       .catch((error) => {
         logger.warn(`Failed to settle ${label}`, error);
       });
-  }
-
-  private getParentTaskTitle() {
-    const task = this.options.store.query(
-      makeTaskQuery(this.options.parentTaskId),
-    );
-    return task?.title ?? undefined;
-  }
-
-  private setAutoMemoryState(nextState: AutoMemoryTaskState) {
-    return this.stateStore.set(nextState);
   }
 
   private getParentCwd() {

--- a/packages/livekit/src/background-task/memory/task-memory.ts
+++ b/packages/livekit/src/background-task/memory/task-memory.ts
@@ -6,7 +6,7 @@ import {
   getLogger,
   prompts,
 } from "@getpochi/common";
-import { type ToolSpecInput, isUserInputToolPart } from "@getpochi/tools";
+import type { ToolSpecInput } from "@getpochi/tools";
 import { type UIMessage, isStaticToolUIPart } from "ai";
 import {
   makeMessagesQuery,
@@ -27,7 +27,6 @@ type ExtractionMetrics = {
   tokens: number;
   toolCalls: number;
   trailingMessageId: string | undefined;
-  trailingMessageHasOpenToolCall: boolean;
 };
 
 type TaskMemoryExtractionResult = "pending" | "succeeded" | "failed";
@@ -47,8 +46,6 @@ const TaskMemoryAllowedTools: readonly ToolSpecInput[] = [
 
 const TaskMemoryStoreFilePath = new URL(TaskMemoryFileUri).pathname;
 
-type SetTaskMemoryState = (state: TaskMemoryState) => Promise<void> | void;
-
 function getExtractionMetrics<TMessage extends UIMessage>(data: {
   messages: TMessage[];
   contextWindowUsage?: ContextWindowUsage;
@@ -58,7 +55,6 @@ function getExtractionMetrics<TMessage extends UIMessage>(data: {
     tokens: computeTotalTokens(data.contextWindowUsage),
     toolCalls: countToolCalls(data.messages),
     trailingMessageId: last?.id,
-    trailingMessageHasOpenToolCall: lastMessageHasOpenToolCall(data.messages),
   };
 }
 
@@ -108,7 +104,7 @@ async function startTaskMemoryExtraction<TMessage extends UIMessage>({
 }: {
   state: TaskMemoryState;
   metrics: ExtractionMetrics;
-  setTaskMemoryState: SetTaskMemoryState;
+  setTaskMemoryState: MemoryStateStore<TaskMemoryState>["set"];
   startForkAgent: StartForkAgent<TMessage>;
   parentTaskId: string;
   parentMessages: TMessage[];
@@ -187,11 +183,11 @@ function getTaskMemoryExtractionResult(
 ): TaskMemoryExtractionResult {
   for (const message of messages) {
     for (const part of message.parts) {
-      if (
-        isStaticToolUIPart(part) &&
-        part.state === "output-available" &&
-        isTaskMemoryPath(part.input)
-      ) {
+      if (!isStaticToolUIPart(part) || part.state !== "output-available") {
+        continue;
+      }
+      if (!part.input || typeof part.input !== "object") continue;
+      if ("path" in part.input && part.input.path === TaskMemoryFileUri) {
         return "succeeded";
       }
     }
@@ -203,15 +199,6 @@ function getTaskMemoryExtractionResult(
   }
 
   return "failed";
-}
-
-function lastMessageHasOpenToolCall(messages: UIMessage[]): boolean {
-  const last = messages.at(-1);
-  if (!last || last.role !== "assistant") return false;
-  return last.parts.some((part) => {
-    if (!isStaticToolUIPart(part) || isUserInputToolPart(part)) return false;
-    return part.state !== "output-available" && part.state !== "output-error";
-  });
 }
 
 function computeTotalTokens(usage?: ContextWindowUsage) {
@@ -239,16 +226,11 @@ function countToolCalls(messages: UIMessage[]): number {
   return count;
 }
 
-function isTaskMemoryPath(input: unknown): boolean {
-  if (!input || typeof input !== "object" || !("path" in input)) return false;
-  return input.path === TaskMemoryFileUri;
-}
-
 type TaskMemoryAdaptorOptions = {
   store: LiveKitStore;
   backgroundTask: {
     startForkAgent: StartForkAgent<Message>;
-    waitForTaskDone?: (taskId: string) => Promise<void> | void;
+    waitForTaskDone?: (taskId: string) => Promise<void>;
   };
   taskMemoryStateStore?: MemoryStateStore<TaskMemoryState>;
   parentTaskId: string;
@@ -270,7 +252,7 @@ export class TaskMemoryAdaptor {
   }
 
   resetTokenBaseline() {
-    return this.setTaskMemoryState({
+    return this.stateStore.set({
       ...this.getState(),
       lastExtractionTokens: 0,
     });
@@ -302,7 +284,7 @@ export class TaskMemoryAdaptor {
       const handle = await startTaskMemoryExtraction({
         state,
         metrics,
-        setTaskMemoryState: (nextState) => this.setTaskMemoryState(nextState),
+        setTaskMemoryState: (nextState) => this.stateStore.set(nextState),
         startForkAgent: (agent) =>
           this.options.backgroundTask.startForkAgent(agent),
         parentTaskId: this.options.parentTaskId,
@@ -332,12 +314,8 @@ export class TaskMemoryAdaptor {
     });
     if (!nextState) return false;
 
-    await this.setTaskMemoryState(nextState);
+    await this.stateStore.set(nextState);
     return true;
-  }
-
-  private setTaskMemoryState(nextState: TaskMemoryState) {
-    return this.stateStore.set(nextState);
   }
 
   private getParentCwd() {
@@ -349,7 +327,7 @@ export class TaskMemoryAdaptor {
     const { waitForTaskDone } = this.options.backgroundTask;
     if (!taskId || !waitForTaskDone) return;
 
-    void Promise.resolve(waitForTaskDone(taskId))
+    void waitForTaskDone(taskId)
       .then(() => this.settle())
       .catch((error) => {
         logger.warn("Failed to settle task-memory extraction", error);

--- a/packages/livekit/src/background-task/state-store.ts
+++ b/packages/livekit/src/background-task/state-store.ts
@@ -1,4 +1,4 @@
-export type MaybePromise<T> = T | Promise<T>;
+import type { MaybePromise } from "@getpochi/common";
 
 export type MemoryStateStore<T> = {
   get(): T | undefined;

--- a/packages/livekit/src/background-task/task-executor/__tests__/task-executor.test.ts
+++ b/packages/livekit/src/background-task/task-executor/__tests__/task-executor.test.ts
@@ -1,5 +1,6 @@
-import type { BackgroundTaskState } from "@getpochi/common";
+import type { BackgroundTaskState, MaybePromise } from "@getpochi/common";
 import { TaskExecutor, type RunningTaskAdaptor } from "../task-executor";
+import type { AbstractChat } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Message } from "../../../types";
 
@@ -35,11 +36,7 @@ class MockChat {
   async addToolOutput({
     toolCallId,
     output,
-  }: {
-    tool: string;
-    toolCallId: string;
-    output: unknown;
-  }) {
+  }: Parameters<AbstractChat<Message>["addToolOutput"]>[0]) {
     const lastMessage = this.messages.at(-1);
     if (!lastMessage) return;
 
@@ -348,7 +345,7 @@ function makeExecutor(
   store: FakeLiveKitStore,
   adaptor: RunningTaskAdaptor,
   taskState: BackgroundTaskState,
-  clearFileStateCache?: (taskId: string) => void | Promise<void>,
+  clearFileStateCache?: (taskId: string) => MaybePromise<void>,
 ) {
   return new TaskExecutor({
     store: store as never,

--- a/packages/livekit/src/background-task/task-executor/task-executor.ts
+++ b/packages/livekit/src/background-task/task-executor/task-executor.ts
@@ -1,5 +1,6 @@
 import {
   type BackgroundTaskState,
+  type MaybePromise,
   getLogger,
   prompts,
   toErrorMessage,
@@ -21,6 +22,7 @@ import {
   validateToolPolicy,
 } from "@getpochi/tools";
 import {
+  type AbstractChat,
   type ToolUIPart,
   getStaticToolName,
   isStaticToolUIPart,
@@ -56,7 +58,7 @@ export interface RunningTaskAdaptor {
     cwd: string | undefined;
   }): PrepareRequestGetters;
   executeToolCall(args: TaskExecutorToolCallExecution): Promise<unknown>;
-  onTaskError?(taskId: string, error: Error): void | Promise<void>;
+  onTaskError?(taskId: string, error: Error): MaybePromise<void>;
 }
 
 type TaskToolOutput = {
@@ -64,16 +66,15 @@ type TaskToolOutput = {
   toolCallId: string;
   output: unknown;
 };
-type MaybePromiseLike<T> = T | PromiseLike<T>;
 
 type CreateTaskExecutorOptions = {
   store: LiveKitStore;
   blobStore: BlobStore;
   readTaskState: (
     taskId: string,
-  ) => MaybePromiseLike<BackgroundTaskState | undefined>;
+  ) => MaybePromise<BackgroundTaskState | undefined>;
   adaptor: RunningTaskAdaptor;
-  clearFileStateCache?: (taskId: string) => void | Promise<void>;
+  clearFileStateCache?: (taskId: string) => MaybePromise<void>;
   createChatKit: CreateRunningTaskChatKit;
 };
 
@@ -81,14 +82,14 @@ type RunningTaskChat = {
   messages: Message[];
   stop: () => Promise<void>;
   sendMessage: () => Promise<void>;
-  addToolOutput: (output: never) => MaybePromiseLike<void>;
+  addToolOutput: AbstractChat<Message>["addToolOutput"];
   appendOrReplaceMessage: (message: Message) => void;
 };
 
 type RunningTaskChatKit = {
   chat: RunningTaskChat;
   task?: Task;
-  markAsFailed: (error: Error) => void | Promise<void>;
+  markAsFailed: (error: Error) => MaybePromise<void>;
 };
 
 type CreateRunningTaskChatKit = (options: {

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -106,10 +106,12 @@ describe("LiveChatKit memory lifecycle", () => {
     chatKit.chat.finish(assistantMessage());
     await chatKit.drainBackgroundTasksAndSettleMemory();
 
-    const memoryTasks = store.backgroundTasks().map((task) => ({
-      title: task.title,
-      useCase: backgroundTaskStateStore.read(task.id)?.useCase,
-    }));
+    const memoryTasks = await Promise.all(
+      store.backgroundTasks().map(async (task) => ({
+        title: task.title,
+        useCase: (await backgroundTaskStateStore.read(task.id))?.useCase,
+      })),
+    );
     expect(memoryTasks).toEqual(
       expect.arrayContaining([
         {
@@ -154,10 +156,12 @@ describe("LiveChatKit memory lifecycle", () => {
     chatKit.chat.finish(assistantMessage());
     await chatKit.drainBackgroundTasksAndSettleMemory();
 
-    const memoryTasks = store.backgroundTasks().map((task) => ({
-      title: task.title,
-      useCase: backgroundTaskStateStore.read(task.id)?.useCase,
-    }));
+    const memoryTasks = await Promise.all(
+      store.backgroundTasks().map(async (task) => ({
+        title: task.title,
+        useCase: (await backgroundTaskStateStore.read(task.id))?.useCase,
+      })),
+    );
     expect(memoryTasks).toEqual([
       {
         title: "[Auto Memory Extraction] Build shared runner",

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -2,6 +2,7 @@ import { getErrorMessage } from "@ai-sdk/provider";
 import type {
   AutoMemoryContext,
   Environment,
+  MaybePromise,
   PochiProviderOptions,
   PochiRequestUseCase,
 } from "@getpochi/common";
@@ -75,9 +76,7 @@ export type ChatTransportOptions = {
   customAgent?: CustomAgent;
   attemptCompletionSchema?: z.ZodAny;
   systemPromptOverride?: string;
-  onRequestFinished?: (
-    snapshot: FinishedRequestSnapshot,
-  ) => void | Promise<void>;
+  onRequestFinished?: (snapshot: FinishedRequestSnapshot) => MaybePromise<void>;
 };
 
 export class FlexibleChatTransport implements ChatTransport<Message> {

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -2,6 +2,7 @@ import type {
   AutoMemoryTaskState,
   BackgroundTaskState,
   ContextWindowUsage,
+  MaybePromise,
   PochiRequestUseCase,
   TaskMemoryState,
 } from "@getpochi/common";
@@ -16,10 +17,7 @@ import type { ForkAgent, ForkAgentHandle } from "../background-task/fork-agent";
 import type { AutoMemoryManager } from "../background-task/memory/auto-memory";
 import { AutoMemoryAdaptor } from "../background-task/memory/auto-memory";
 import { TaskMemoryAdaptor } from "../background-task/memory/task-memory";
-import type {
-  MaybePromise,
-  MemoryStateStore,
-} from "../background-task/state-store";
+import type { MemoryStateStore } from "../background-task/state-store";
 import { InMemoryChat } from "../background-task/task-executor/in-memory-chat";
 import {
   type RunningTaskAdaptor,
@@ -57,9 +55,7 @@ const OverrideMessagesSideEffectTimeoutMs = 12_000;
 const TaskMemorySettleTimeoutMs = 5_000;
 const TaskMemorySettlePollIntervalMs = 200;
 
-type GetRecentFilesForCompact = () =>
-  | RecentFileState[]
-  | Promise<RecentFileState[]>;
+type GetRecentFilesForCompact = () => MaybePromise<RecentFileState[]>;
 
 export type LiveChatKitBackgroundTaskOptions = {
   stateStore?: {
@@ -244,7 +240,7 @@ export type LiveChatKitOptions<T> = {
     taskId: string;
     messages: Message[];
     abortSignal: AbortSignal;
-  }) => void | Promise<void>;
+  }) => MaybePromise<void>;
   onStreamStart?: (
     data: Pick<Task, "id" | "cwd"> & {
       messages: Message[];
@@ -262,7 +258,7 @@ export type LiveChatKitOptions<T> = {
 
   onCompactStart?: () => void;
 
-  onCompactFinish?: (success: boolean) => void | Promise<void>;
+  onCompactFinish?: (success: boolean) => MaybePromise<void>;
 
   /**
    * Returns recent file contents the model saw before compaction.
@@ -940,7 +936,7 @@ export class LiveChatKit<
 
   private async handleCompactFinish(
     success: boolean,
-    onCompactFinish: ((success: boolean) => void | Promise<void>) | undefined,
+    onCompactFinish: ((success: boolean) => MaybePromise<void>) | undefined,
   ) {
     if (success) {
       await this.taskMemoryAdaptor?.resetTokenBaseline();

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-memory.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-memory.ts
@@ -6,6 +6,7 @@ import { VscodeRunningTaskAdaptor } from "@/lib/vscode-running-task-adaptor";
 import type {
   AutoMemoryTaskState,
   BackgroundTaskState,
+  MaybePromise,
   TaskMemoryState,
 } from "@getpochi/common";
 import type {
@@ -16,7 +17,7 @@ import type {
 import { threadSignal } from "@quilted/threads/signals";
 import { useMemo } from "react";
 
-type MemoryStateSetter<T> = ((state: T) => Promise<void> | void) | undefined;
+type MemoryStateSetter<T> = ((state: T) => MaybePromise<void>) | undefined;
 
 function createVscodeBackgroundTaskStateStore(): NonNullable<
   LiveChatKitBackgroundTaskOptions["stateStore"]


### PR DESCRIPTION
## Summary

- Adds `MaybePromise<T>` to `packages/common/src/base/async-utils.ts` and re-exports it from `@getpochi/common`
- Removes the duplicate local definition from `packages/livekit/src/background-task/state-store.ts`
- Replaces all inline `void | Promise<void>`, `T | Promise<T>`, `T | PromiseLike<T>`, and local `MaybePromiseLike<T>` spellings with the shared `MaybePromise<T>` at genuinely mixed sync-or-async callback boundaries across `livekit`, `cli`, and `vscode-webui`

## Test plan

- [ ] `bun run test` passes in `packages/livekit` and `packages/cli`
- [ ] `bun tsc` reports no type errors
- [ ] `bun check` passes with no remaining lint issues

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-536f89f2adbc4d39860fd0128975f42a)