### PR TITLE
feat(vscode-webui): add dev button to copy system prompt

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -687,6 +687,10 @@ export class LiveChatKit<
     return countTask > 0;
   }
 
+  get latestSystemPrompt(): string | undefined {
+    return this.latestRequestSnapshot?.systemPrompt;
+  }
+
   updateIsPublicShared = (isPublicShared: boolean) => {
     this.store.commit(
       events.updateIsPublicShared({

--- a/packages/vscode-webui/src/components/dev-mode-button.tsx
+++ b/packages/vscode-webui/src/components/dev-mode-button.tsx
@@ -50,9 +50,14 @@ function CopyMenuItem({ fetchContent, text }: UpdatedCopyMenuItemProps) {
 interface DevModeButtonProps {
   messages: Message[];
   todos: Todo[] | undefined;
+  getSystemPrompt?: () => string | undefined;
 }
 
-export function DevModeButton({ messages, todos }: DevModeButtonProps) {
+export function DevModeButton({
+  messages,
+  todos,
+  getSystemPrompt,
+}: DevModeButtonProps) {
   const { t } = useTranslation();
   const [isDevMode] = useIsDevMode();
   const getMessagesContent = () => {
@@ -83,6 +88,10 @@ export function DevModeButton({ messages, todos }: DevModeButtonProps) {
     const workspaceInfo = await vscodeHost.readCurrentWorkspace();
     return `alias pgit="git --git-dir=\\"${checkpointPath}\\" --work-tree=\\"${workspaceInfo.cwd}\\""`;
   }, [t]);
+
+  const getSystemPromptContent = useCallback(() => {
+    return getSystemPrompt?.() ?? "";
+  }, [getSystemPrompt]);
 
   if (!isDevMode) return null;
 
@@ -120,6 +129,12 @@ export function DevModeButton({ messages, todos }: DevModeButtonProps) {
             fetchContent={getTodosContent}
             text={t("devModeButton.copyTodos")}
           />
+          {getSystemPrompt && (
+            <CopyMenuItem
+              fetchContent={getSystemPromptContent}
+              text={t("devModeButton.copySystemPrompt")}
+            />
+          )}
           <OpenDevStore />
           <ReviewChangesMenuItem />
         </DropdownMenuContent>

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -76,6 +76,7 @@ interface ChatToolbarProps {
   taskId: string;
   isRepairingMermaid?: boolean;
   mcpConfigOverride?: McpConfigOverride;
+  getSystemPrompt?: () => string | undefined;
 }
 
 export const ChatToolbar: React.FC<ChatToolbarProps> = ({
@@ -93,6 +94,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   taskId,
   isRepairingMermaid = false,
   mcpConfigOverride,
+  getSystemPrompt,
 }) => {
   const { t } = useTranslation();
 
@@ -390,7 +392,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
               selectedModel={selectedModel}
             />
           )}
-          <DevModeButton messages={messages} todos={todos} />
+          <DevModeButton
+            messages={messages}
+            todos={todos}
+            getSystemPrompt={getSystemPrompt}
+          />
           <AutoApproveMenu
             isSubTask={isSubTask}
             mcpConfigOverride={mcpConfigOverride}

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -376,6 +376,7 @@ function Chat({ user, uid, info }: ChatProps) {
           taskId={uid}
           isRepairingMermaid={!!repairingChart}
           mcpConfigOverride={mcpConfigOverride}
+          getSystemPrompt={() => chatKit.latestSystemPrompt}
         />
       </div>
       <BackgroundTaskDebugPanel />

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -474,6 +474,7 @@
     "copyCoreMessages": "Copy Core Messages",
     "copyCheckpointCommand": "Copy Checkpoint Command",
     "copyTodos": "Copy TODOs",
+    "copySystemPrompt": "Copy System Prompt",
     "noCheckpointAvailable": "No checkpoint available",
     "openStore": "Open Store",
     "reviewChanges": "Review Changes"

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -473,6 +473,7 @@
     "copyCoreMessages": "コアメッセージをコピー",
     "copyCheckpointCommand": "チェックポイントコマンドをコピー",
     "copyTodos": "TODOをコピー",
+    "copySystemPrompt": "システムプロンプトをコピー",
     "noCheckpointAvailable": "利用可能なチェックポイントがありません",
     "openStore": "ストアを開く",
     "reviewChanges": "変更をレビュー"

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -466,6 +466,7 @@
     "copyCoreMessages": "핵심 메시지 복사",
     "copyCheckpointCommand": "체크포인트 명령 복사",
     "copyTodos": "할 일 복사",
+    "copySystemPrompt": "시스템 프롬프트 복사",
     "noCheckpointAvailable": "사용 가능한 체크포인트가 없습니다",
     "openStore": "스토어 열기",
     "reviewChanges": "변경 사항 검토"

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -471,6 +471,7 @@
     "copyCoreMessages": "复制核心消息",
     "copyCheckpointCommand": "复制检查点命令",
     "copyTodos": "复制待办事项",
+    "copySystemPrompt": "复制系统提示词",
     "noCheckpointAvailable": "没有可用的检查点",
     "openStore": "打开存储",
     "reviewChanges": "审查变更"


### PR DESCRIPTION
## Summary
- Add a `LiveChatKit.latestSystemPrompt` getter that exposes the most recently resolved system prompt captured in `latestRequestSnapshot`.
- Thread a new `getSystemPrompt?: () => string | undefined` prop `page.tsx → ChatToolbar → DevModeButton`, pulled at click time inside `fetchContent`.
- Add a "Copy System Prompt" item to the Dev Mode dropdown (en/zh/jp/ko strings included). Item is gated on the prop being passed, so non-chat surfaces don't render it.

Per long-term project convention, the prompt is **not** persisted on `Message.metadata` — it lives only in `LiveChatKit` RAM. A webview reload before the parent's next turn will cause the very first click to copy an empty string; this matches the trade-off accepted in #1691 and avoids any LiveStore schema change.

This is the reapply of #1671 (reverted in #1688) following the durable plumbing shape called out by zhanba: "不要放在 messageMetadata 里面".

## Test plan
- [x] `bun tsc` clean in `packages/livekit` and `packages/vscode-webui`
- [x] `bun check` clean (biome, ast-grep, i18n consistency, eslint)
- [ ] Manual: enable dev mode → run a chat turn → click the gavel → "Copy System Prompt" copies the actual rendered prompt
- [ ] Manual: open the dev menu before any turn has finished → "Copy System Prompt" copies an empty string

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0dac7765c5324a2b8c8f79e882c7a53b)