### PR TITLE
fix(cli): add abort signal handling to nextRetry and task runner

### DIFF
--- a/packages/cli/src/lib/step-count.ts
+++ b/packages/cli/src/lib/step-count.ts
@@ -70,14 +70,21 @@ export class StepCount implements StepInfo {
     }
   }
 
-  async nextRetry() {
+  async nextRetry(abortSignal?: AbortSignal) {
     this.throwIfReachedMaxRetries();
 
     const baseRetryWaitMs = 3000;
     this.retry++;
-    await new Promise((resolve) =>
-      setTimeout(resolve, baseRetryWaitMs * 2 ** this.retry),
-    );
+    await new Promise((resolve, reject) => {
+      abortSignal?.addEventListener(
+        "abort",
+        () => {
+          reject(new Error("User aborted"));
+        },
+        { once: true },
+      );
+      setTimeout(resolve, baseRetryWaitMs * 2 ** this.retry);
+    }).catch(() => {});
   }
 
   toString() {

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -355,7 +355,7 @@ export class TaskRunner {
           break;
         }
         if (stepResult === "retry") {
-          await this.stepCount.nextRetry();
+          await this.stepCount.nextRetry(this.abortSignal);
         } else {
           this.stepCount.nextStep();
         }
@@ -496,6 +496,7 @@ export class TaskRunner {
       this.stepCount.throwIfReachedMaxRetries();
     }
 
+    this.abortSignal?.throwIfAborted();
     await this.chatKit.chat.sendMessage();
     return result;
   }
@@ -633,6 +634,14 @@ export class TaskRunner {
       });
     }
 
+    this.abortSignal?.throwIfAborted();
+    this.abortSignal?.addEventListener(
+      "abort",
+      () => {
+        queue.abort("user-abort");
+      },
+      { once: true },
+    );
     await queue.start();
 
     logger.trace("All tool calls processed in the last message.");

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -474,9 +474,14 @@ export class LiveChatKit<
       transport: this.transport,
     });
 
-    abortSignal?.addEventListener("abort", () => {
-      this.chat.stop();
-    });
+    abortSignal?.throwIfAborted();
+    abortSignal?.addEventListener(
+      "abort",
+      () => {
+        this.chat.stop();
+      },
+      { once: true },
+    );
 
     // @ts-expect-error: monkey patch
     const chat = this.chat as {


### PR DESCRIPTION
## Summary
- Adds `abortSignal` handling to `stepCount.nextRetry` in the CLI to allow immediate interruption of retry wait times during graceful shutdown.
- Ensures `TaskRunner` respects the abort signal by calling `throwIfAborted()` before sending messages and aborting the tool queue during tool processing.
- Improves abort event registration in `LiveChatKit` using `{ once: true }` and check for pre-existing abort state.

## Test plan
- [x] Run existing test suites (`bun run test` / pre-push hooks already verified).
- [ ] Verify graceful CLI shutdown upon receiving SIGINT, especially during active retry wait.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-203d1029515c440eb194e3c7591126e9)