### PR TITLE
refactor(common): consolidate MessageMetadata and message types

### DIFF
--- a/packages/cli/src/renderers/trajectory-types.ts
+++ b/packages/cli/src/renderers/trajectory-types.ts
@@ -1,4 +1,5 @@
-import { type File, type Message, MessageMetadata } from "@getpochi/livekit";
+import { MessageMetadata } from "@getpochi/common";
+import type { File, Message } from "@getpochi/livekit";
 import hashObject from "object-hash";
 import z from "zod";
 

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -38,7 +38,7 @@ export { toErrorMessage } from "./error";
 export { withTimeout } from "./async-utils";
 export type { MaybePromise } from "./async-utils";
 
-export * from "./message-context";
+export * from "./message";
 export type {
   AutoMemoryDreamCandidate,
   AutoMemoryDreamRun,

--- a/packages/common/src/base/message.ts
+++ b/packages/common/src/base/message.ts
@@ -1,4 +1,21 @@
+import type { FinishReason } from "ai";
 import { z } from "zod";
+
+export const MessageMetadata = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("assistant"),
+    totalTokens: z.number(),
+    finishReason: z.custom<FinishReason>(),
+    startedAt: z.coerce.date().optional(),
+    finishedAt: z.coerce.date().optional(),
+  }),
+  z.object({
+    kind: z.literal("user"),
+    compact: z.boolean().optional(),
+  }),
+]);
+
+export type MessageMetadata = z.infer<typeof MessageMetadata>;
 
 export const ActiveSelection = z
   .object({

--- a/packages/common/src/base/prompts/active-selection.ts
+++ b/packages/common/src/base/prompts/active-selection.ts
@@ -1,4 +1,4 @@
-import type { ActiveSelection } from "../message-context";
+import type { ActiveSelection } from "../message";
 
 export function renderActiveSelection(selection: ActiveSelection): string {
   if (!selection) {

--- a/packages/common/src/base/prompts/bash-outputs.ts
+++ b/packages/common/src/base/prompts/bash-outputs.ts
@@ -1,4 +1,4 @@
-import type { BashOutputs } from "../message-context";
+import type { BashOutputs } from "../message";
 
 export function renderBashOutputs(bashOutputs: BashOutputs): string {
   if (!bashOutputs?.length) {

--- a/packages/common/src/base/prompts/review-comments.ts
+++ b/packages/common/src/base/prompts/review-comments.ts
@@ -1,4 +1,4 @@
-import type { Review } from "../message-context";
+import type { Review } from "../message";
 
 export function renderReviewComments(reviews: Review[]): string {
   if (reviews.length === 0) {

--- a/packages/common/src/base/prompts/user-edits.ts
+++ b/packages/common/src/base/prompts/user-edits.ts
@@ -1,4 +1,4 @@
-import type { UserEdits } from "../message-context";
+import type { UserEdits } from "../message";
 
 export function renderUserEdits(userEdits: UserEdits): string {
   if (!userEdits || userEdits.length === 0) {

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -3,6 +3,7 @@ import type {
   AutoMemoryContext,
   Environment,
   MaybePromise,
+  MessageMetadata,
   PochiProviderOptions,
   PochiRequestUseCase,
 } from "@getpochi/common";
@@ -30,7 +31,7 @@ import {
 import type z from "zod";
 import type { BlobStore } from "../blob-store";
 import { findBlob, makeDownloadFunction } from "../store-blob";
-import type { LiveKitStore, Message, Metadata, RequestData } from "../types";
+import type { LiveKitStore, Message, RequestData } from "../types";
 import { makeRepairToolCall } from "./llm";
 import { parseMcpToolSet } from "./mcp-utils";
 import {
@@ -243,7 +244,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
             finishReason: part.finishReason,
             startedAt: requestStartedAt,
             finishedAt: new Date(),
-          } satisfies Metadata;
+          } satisfies MessageMetadata;
         }
       },
       onFinish: async () => {

--- a/packages/livekit/src/index.ts
+++ b/packages/livekit/src/index.ts
@@ -19,7 +19,6 @@ export type {
   LiveKitStore,
   File,
 } from "./types";
-export { MessageMetadata } from "@getpochi/common";
 export type { BlobStore } from "./blob-store";
 
 export { processContentOutput, fileToUri, findBlob } from "./store-blob";

--- a/packages/livekit/src/index.ts
+++ b/packages/livekit/src/index.ts
@@ -19,7 +19,7 @@ export type {
   LiveKitStore,
   File,
 } from "./types";
-export { ZodMetadata as MessageMetadata } from "./types";
+export { MessageMetadata } from "@getpochi/common";
 export type { BlobStore } from "./blob-store";
 
 export { processContentOutput, fileToUri, findBlob } from "./store-blob";

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -15,8 +15,6 @@ import z from "zod";
 import type { defaultCatalog } from "./livestore";
 import type { tables } from "./livestore/default-schema";
 
-export type Metadata = MessageMetadata;
-
 export type DataParts = {
   checkpoint: {
     commit: string;
@@ -37,7 +35,7 @@ export type DataParts = {
 
 export type UITools = InferUITools<ClientTools>;
 
-export type Message = UIMessage<Metadata, DataParts, UITools>;
+export type Message = UIMessage<MessageMetadata, DataParts, UITools>;
 
 const RequestData = z.object({
   environment: Environment.optional(),

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type {
   ActiveSelection,
   BashOutputs,
+  MessageMetadata,
   Review,
   UserEdits,
 } from "@getpochi/common";
@@ -9,26 +10,12 @@ import { Environment } from "@getpochi/common";
 import { GoogleVertexModel } from "@getpochi/common/configuration";
 import { type ClientTools, McpTool } from "@getpochi/tools";
 import type { Store } from "@livestore/livestore";
-import type { FinishReason, InferUITools, UIMessage } from "ai";
+import type { InferUITools, UIMessage } from "ai";
 import z from "zod";
 import type { defaultCatalog } from "./livestore";
 import type { tables } from "./livestore/default-schema";
 
-export const ZodMetadata = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("assistant"),
-    totalTokens: z.number(),
-    finishReason: z.custom<FinishReason>(),
-    startedAt: z.coerce.date().optional(),
-    finishedAt: z.coerce.date().optional(),
-  }),
-  z.object({
-    kind: z.literal("user"),
-    compact: z.boolean().optional(),
-  }),
-]);
-
-export type Metadata = z.infer<typeof ZodMetadata>;
+export type Metadata = MessageMetadata;
 
 export type DataParts = {
   checkpoint: {


### PR DESCRIPTION
## Summary
- Consolidates `MessageMetadata` and related message context schemas/types (`ActiveSelection`, `UserEdits`, `BashOutputs`, `Review`) from `packages/livekit/src/types.ts` and `packages/common/src/base/message-context.ts` into a unified `packages/common/src/base/message.ts` file.
- Re-exports them from `@getpochi/common` to avoid cyclic dependencies and simplify package imports.
- Updates all consumers across cli, common, and livekit packages to import from the new unified file.

## Test plan
- Run all unit and integration tests: `bun run test` (Passed)
- Perform static type checking: `bun tsc` (Passed)
- Run biome linting and formatting check: `bun check` (Passed)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9f5e1007c6b747de9ea312f1bd20b2ac)