### PR TITLE
feat(common): add parseEnvironmentInfo helper to parse prompt environment

### DIFF
--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -8,10 +8,6 @@ export {
   type LLMFormatterOptions,
 } from "./formatters";
 export { prompts } from "./prompts";
-export {
-  parseEnvironmentInfo,
-  type EnvironmentInfo,
-} from "./prompts/environment";
 
 export { SocialLinks } from "./social";
 export * as constants from "./constants";

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -8,6 +8,10 @@ export {
   type LLMFormatterOptions,
 } from "./formatters";
 export { prompts } from "./prompts";
+export {
+  parseEnvironmentInfo,
+  type EnvironmentInfo,
+} from "./prompts/environment";
 
 export { SocialLinks } from "./social";
 export * as constants from "./constants";

--- a/packages/common/src/base/prompts/__tests__/prompt.test.ts
+++ b/packages/common/src/base/prompts/__tests__/prompt.test.ts
@@ -100,10 +100,7 @@ test("parseEnvironmentInfo from system message content", () => {
   const prompt = [
     {
       role: "system",
-      content: `<system-reminder>${createEnvironmentPrompt(
-        createTestEnvironment(),
-        undefined,
-      )}</system-reminder>`,
+      content: createEnvironmentPrompt(createTestEnvironment(), undefined),
     },
   ] satisfies LanguageModelV3CallOptions["prompt"];
 
@@ -123,10 +120,7 @@ test("parseEnvironmentInfo from user text parts", () => {
         { type: "text", text: "hello" },
         {
           type: "text",
-          text: `<system-reminder>${createEnvironmentPrompt(
-            createTestEnvironment(),
-            undefined,
-          )}</system-reminder>`,
+          text: createEnvironmentPrompt(createTestEnvironment(), undefined),
         },
       ],
     },
@@ -147,7 +141,7 @@ test("parseEnvironmentInfo ignores missing or incomplete environment prompt", ()
       {
         role: "system",
         content:
-          "<system-reminder># System Information\n\nOperating System: darwin</system-reminder>",
+          "# System Information\n\nOperating System: darwin\nDefault Shell: zsh",
       },
     ]),
   ).toBeUndefined();
@@ -156,7 +150,7 @@ test("parseEnvironmentInfo ignores missing or incomplete environment prompt", ()
       {
         role: "system",
         content:
-          "# System Information\n\nOperating System: darwin\nDefault Shell: zsh\nHome Directory: /Users/pochi\nCurrent Working Directory: /Users/pochi/project\nCurrent Time: 2026-06-23T00:00:00.000Z",
+          "# User Information\n\nOperating System: darwin\nDefault Shell: zsh\nHome Directory: /Users/pochi\nCurrent Working Directory: /Users/pochi/project",
       },
     ]),
   ).toBeUndefined();

--- a/packages/common/src/base/prompts/__tests__/prompt.test.ts
+++ b/packages/common/src/base/prompts/__tests__/prompt.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "vitest";
-import { createEnvironmentPrompt } from "../environment";
+import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import type { Environment } from "../../environment";
+import {
+  createEnvironmentPrompt,
+  extractEnvironmentInfo,
+} from "../environment";
 import { createSystemPrompt } from "../system";
 
 test("instructions", () => {
@@ -90,3 +95,83 @@ test("environment", () => {
         }, {name: "Pochi", email: "noreply@getpochi.com"}),
   ).toMatchSnapshot();
 });
+
+test("extractEnvironmentInfo from system message content", () => {
+  const prompt = [
+    {
+      role: "system",
+      content: `<system-reminder>${createEnvironmentPrompt(
+        createTestEnvironment(),
+        undefined,
+      )}</system-reminder>`,
+    },
+  ] satisfies LanguageModelV3CallOptions["prompt"];
+
+  expect(extractEnvironmentInfo(prompt)).toEqual({
+    os: "darwin",
+    shell: "zsh",
+    homedir: "/Users/pochi",
+    cwd: "/Users/pochi/project",
+  });
+});
+
+test("extractEnvironmentInfo from user text parts", () => {
+  const prompt = [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "hello" },
+        {
+          type: "text",
+          text: `<system-reminder>${createEnvironmentPrompt(
+            createTestEnvironment(),
+            undefined,
+          )}</system-reminder>`,
+        },
+      ],
+    },
+  ] satisfies LanguageModelV3CallOptions["prompt"];
+
+  expect(extractEnvironmentInfo(prompt)).toEqual({
+    os: "darwin",
+    shell: "zsh",
+    homedir: "/Users/pochi",
+    cwd: "/Users/pochi/project",
+  });
+});
+
+test("extractEnvironmentInfo ignores missing or incomplete environment prompt", () => {
+  expect(extractEnvironmentInfo(undefined)).toBeUndefined();
+  expect(
+    extractEnvironmentInfo([
+      {
+        role: "system",
+        content:
+          "<system-reminder># System Information\n\nOperating System: darwin</system-reminder>",
+      },
+    ]),
+  ).toBeUndefined();
+  expect(
+    extractEnvironmentInfo([
+      {
+        role: "system",
+        content:
+          "# System Information\n\nOperating System: darwin\nDefault Shell: zsh\nHome Directory: /Users/pochi\nCurrent Working Directory: /Users/pochi/project\nCurrent Time: 2026-06-23T00:00:00.000Z",
+      },
+    ]),
+  ).toBeUndefined();
+});
+
+function createTestEnvironment(): Environment {
+  return {
+    currentTime: "2026-06-23T00:00:00.000Z",
+    workspace: {},
+    todos: [],
+    info: {
+      cwd: "/Users/pochi/project",
+      os: "darwin",
+      homedir: "/Users/pochi",
+      shell: "zsh",
+    },
+  };
+}

--- a/packages/common/src/base/prompts/__tests__/prompt.test.ts
+++ b/packages/common/src/base/prompts/__tests__/prompt.test.ts
@@ -3,7 +3,7 @@ import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
 import type { Environment } from "../../environment";
 import {
   createEnvironmentPrompt,
-  extractEnvironmentInfo,
+  parseEnvironmentInfo,
 } from "../environment";
 import { createSystemPrompt } from "../system";
 
@@ -96,7 +96,7 @@ test("environment", () => {
   ).toMatchSnapshot();
 });
 
-test("extractEnvironmentInfo from system message content", () => {
+test("parseEnvironmentInfo from system message content", () => {
   const prompt = [
     {
       role: "system",
@@ -107,7 +107,7 @@ test("extractEnvironmentInfo from system message content", () => {
     },
   ] satisfies LanguageModelV3CallOptions["prompt"];
 
-  expect(extractEnvironmentInfo(prompt)).toEqual({
+  expect(parseEnvironmentInfo(prompt)).toEqual({
     os: "darwin",
     shell: "zsh",
     homedir: "/Users/pochi",
@@ -115,7 +115,7 @@ test("extractEnvironmentInfo from system message content", () => {
   });
 });
 
-test("extractEnvironmentInfo from user text parts", () => {
+test("parseEnvironmentInfo from user text parts", () => {
   const prompt = [
     {
       role: "user",
@@ -132,7 +132,7 @@ test("extractEnvironmentInfo from user text parts", () => {
     },
   ] satisfies LanguageModelV3CallOptions["prompt"];
 
-  expect(extractEnvironmentInfo(prompt)).toEqual({
+  expect(parseEnvironmentInfo(prompt)).toEqual({
     os: "darwin",
     shell: "zsh",
     homedir: "/Users/pochi",
@@ -140,10 +140,10 @@ test("extractEnvironmentInfo from user text parts", () => {
   });
 });
 
-test("extractEnvironmentInfo ignores missing or incomplete environment prompt", () => {
-  expect(extractEnvironmentInfo(undefined)).toBeUndefined();
+test("parseEnvironmentInfo ignores missing or incomplete environment prompt", () => {
+  expect(parseEnvironmentInfo(undefined)).toBeUndefined();
   expect(
-    extractEnvironmentInfo([
+    parseEnvironmentInfo([
       {
         role: "system",
         content:
@@ -152,7 +152,7 @@ test("extractEnvironmentInfo ignores missing or incomplete environment prompt", 
     ]),
   ).toBeUndefined();
   expect(
-    extractEnvironmentInfo([
+    parseEnvironmentInfo([
       {
         role: "system",
         content:

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -55,10 +55,6 @@ export function parseEnvironmentInfo(
           : [];
 
     for (const text of textParts) {
-      if (!text.includes("<system-reminder># System Information")) {
-        continue;
-      }
-
       const systemInfo = parseSystemInfoLines(text);
       const os = systemInfo["Operating System"];
       const shell = systemInfo["Default Shell"];
@@ -78,9 +74,15 @@ export function parseEnvironmentInfo(
 }
 
 function parseSystemInfoLines(text: string) {
+  const headerIndex = text.indexOf("# System Information");
+  if (headerIndex === -1) {
+    return {};
+  }
+
+  const systemInfoText = text.slice(headerIndex).split(/\n\n# /)[0];
   const lines: Record<string, string> = {};
 
-  for (const line of text.split(/\r?\n/)) {
+  for (const line of systemInfoText.split(/\r?\n/)) {
     const separatorIndex = line.indexOf(":");
     if (separatorIndex === -1) {
       continue;

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -1,8 +1,13 @@
+import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
 import type { TextUIPart, UIMessage } from "ai";
 import type { Environment, GitStatus } from "../environment";
 import { prompts } from "./index";
 
 type User = { name: string; email: string };
+export type EnvironmentInfo = Pick<
+  Environment["info"],
+  "os" | "shell" | "homedir" | "cwd"
+>;
 
 export function createEnvironmentPrompt(
   environment: Environment,
@@ -31,6 +36,57 @@ export function createLiteEnvironmentPrompt(environment: Environment) {
     .filter(Boolean)
     .join("\n\n");
   return sections.trim();
+}
+
+export function extractEnvironmentInfo(
+  prompt: LanguageModelV3CallOptions["prompt"] | undefined,
+): EnvironmentInfo | undefined {
+  if (!prompt) return;
+
+  for (const message of prompt) {
+    const content = message.content;
+    const textParts =
+      typeof content === "string"
+        ? [content]
+        : Array.isArray(content)
+          ? content
+              .filter((part) => part.type === "text")
+              .map((part) => part.text)
+          : [];
+
+    for (const text of textParts) {
+      if (!text.includes("<system-reminder># System Information")) {
+        continue;
+      }
+
+      const os = matchEnvironmentLine(text, "Operating System");
+      const shell = matchEnvironmentLine(text, "Default Shell");
+      const homedir = matchEnvironmentLine(text, "Home Directory");
+      const cwd = matchEnvironmentLine(text, "Current Working Directory");
+
+      if (os && shell && homedir && cwd) {
+        return {
+          os,
+          shell,
+          homedir,
+          cwd,
+        };
+      }
+    }
+  }
+}
+
+function matchEnvironmentLine(text: string, label: string) {
+  const prefix = `${label}:`;
+
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.startsWith(prefix)) {
+      continue;
+    }
+
+    const value = line.slice(prefix.length).trim();
+    return value || undefined;
+  }
 }
 
 function getSystemInfo(environment: Environment) {

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -38,7 +38,7 @@ export function createLiteEnvironmentPrompt(environment: Environment) {
   return sections.trim();
 }
 
-export function extractEnvironmentInfo(
+export function parseEnvironmentInfo(
   prompt: LanguageModelV3CallOptions["prompt"] | undefined,
 ): EnvironmentInfo | undefined {
   if (!prompt) return;
@@ -59,10 +59,11 @@ export function extractEnvironmentInfo(
         continue;
       }
 
-      const os = matchEnvironmentLine(text, "Operating System");
-      const shell = matchEnvironmentLine(text, "Default Shell");
-      const homedir = matchEnvironmentLine(text, "Home Directory");
-      const cwd = matchEnvironmentLine(text, "Current Working Directory");
+      const systemInfo = parseSystemInfoLines(text);
+      const os = systemInfo["Operating System"];
+      const shell = systemInfo["Default Shell"];
+      const homedir = systemInfo["Home Directory"];
+      const cwd = systemInfo["Current Working Directory"];
 
       if (os && shell && homedir && cwd) {
         return {
@@ -76,17 +77,23 @@ export function extractEnvironmentInfo(
   }
 }
 
-function matchEnvironmentLine(text: string, label: string) {
-  const prefix = `${label}:`;
+function parseSystemInfoLines(text: string) {
+  const lines: Record<string, string> = {};
 
   for (const line of text.split(/\r?\n/)) {
-    if (!line.startsWith(prefix)) {
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex === -1) {
       continue;
     }
 
-    const value = line.slice(prefix.length).trim();
-    return value || undefined;
+    const key = line.slice(0, separatorIndex);
+    const value = line.slice(separatorIndex + 1).trim();
+    if (value) {
+      lines[key] = value;
+    }
   }
+
+  return lines;
 }
 
 function getSystemInfo(environment: Environment) {

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -13,7 +13,11 @@ import {
 } from "./auto-memory";
 import { renderBashOutputs } from "./bash-outputs";
 import { createCompactPrompt } from "./compact";
-import { createEnvironmentPrompt, injectEnvironment } from "./environment";
+import {
+  createEnvironmentPrompt,
+  extractEnvironmentInfo,
+  injectEnvironment,
+} from "./environment";
 import { fixMermaidError } from "./fix-mermaid-error";
 import { generateTitle } from "./generate-title";
 import { renderReviewComments } from "./review-comments";
@@ -30,6 +34,7 @@ export const prompts = {
   injectEnvironment,
   injectAutoMemory,
   environment: createEnvironmentPrompt,
+  extractEnvironmentInfo,
   createSystemReminder,
   isSystemReminder,
   isEnvironmentSystemReminder,

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -15,8 +15,8 @@ import { renderBashOutputs } from "./bash-outputs";
 import { createCompactPrompt } from "./compact";
 import {
   createEnvironmentPrompt,
-  extractEnvironmentInfo,
   injectEnvironment,
+  parseEnvironmentInfo,
 } from "./environment";
 import { fixMermaidError } from "./fix-mermaid-error";
 import { generateTitle } from "./generate-title";
@@ -34,7 +34,7 @@ export const prompts = {
   injectEnvironment,
   injectAutoMemory,
   environment: createEnvironmentPrompt,
-  extractEnvironmentInfo,
+  parseEnvironmentInfo,
   createSystemReminder,
   isSystemReminder,
   isEnvironmentSystemReminder,

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -13,11 +13,7 @@ import {
 } from "./auto-memory";
 import { renderBashOutputs } from "./bash-outputs";
 import { createCompactPrompt } from "./compact";
-import {
-  createEnvironmentPrompt,
-  injectEnvironment,
-  parseEnvironmentInfo,
-} from "./environment";
+import { createEnvironmentPrompt, injectEnvironment } from "./environment";
 import { fixMermaidError } from "./fix-mermaid-error";
 import { generateTitle } from "./generate-title";
 import { renderReviewComments } from "./review-comments";
@@ -34,7 +30,6 @@ export const prompts = {
   injectEnvironment,
   injectAutoMemory,
   environment: createEnvironmentPrompt,
-  parseEnvironmentInfo,
   createSystemReminder,
   isSystemReminder,
   isEnvironmentSystemReminder,

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -25,6 +25,8 @@ import {
 } from "./task-memory";
 import { renderUserEdits } from "./user-edits";
 
+export { parseEnvironmentInfo } from "./environment";
+
 export const prompts = {
   system: createSystemPrompt,
   injectEnvironment,


### PR DESCRIPTION
## Summary
- Implement `extractEnvironmentInfo` in `packages/common/src/base/prompts/environment.ts` to retrieve OS, shell, homedir, and cwd from system reminder blocks.
- Support parsing from both system messages and structured user text parts.
- Add comprehensive unit tests in `prompt.test.ts` to verify parsing behavior.

## Test plan
- [x] Run unit tests: `bun run test` (all tests passed)
- [x] Run typecheck: `bun tsc` (completed successfully)
- [x] Run linting/formatting checks: `bun check` (completed successfully)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c4f119ec127a41aea20bd5da2b010d27)