### PR TITLE
fix(vscode-webui): queue submits while tool calls are running

### DIFF
--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -77,16 +77,20 @@ export function useChatSubmit({
 
   const handleStop = useCallback(() => {
     // Compacting is not allowed to be stopped.
-    if (blockingState.isBusy) return;
+    if (blockingState.isBusy) return false;
 
     if (isExecuting) {
-      abortExecutingToolCalls();
-    } else if (isLoading) {
+      void abortExecutingToolCalls();
+      return true;
+    }
+    if (isLoading) {
       stopChat();
       return true;
-    } else if (pendingApproval?.name === "retry") {
+    }
+    if (pendingApproval?.name === "retry") {
       pendingApproval.stopCountdown();
     }
+    return false;
   }, [
     blockingState.isBusy,
     isExecuting,
@@ -124,8 +128,8 @@ export function useChatSubmit({
       if (text.length === 0 && files.length === 0 && reviews.length === 0)
         return;
 
-      const stopIsLoading = handleStop();
-      if (stopIsLoading || isSubmitDisabled) {
+      const stoppedActiveRun = handleStop();
+      if (stoppedActiveRun || isSubmitDisabled) {
         autoApproveGuard.current = "stop";
         if (text.length > 0) {
           setQueuedMessages([text]);


### PR DESCRIPTION
## Summary
- Fix submitting a new message while tool calls are executing: `handleStop` now reports that it interrupted an active run after aborting the current tool-call batch.
- `handleSubmit` now treats that as a stopped active run, sets auto-approve to `stop`, queues the submitted text, and returns without starting a new stream immediately.
- This prevents parallel tool-call results from racing with a newly submitted message while keeping the change scoped to `useChatSubmit`.

## Test plan
- [ ] Start a request that triggers parallel tool calls, submit another message while tools are executing, and confirm the current tool calls are aborted while the new message is queued.
- [ ] Send a normal message while idle and confirm it still sends immediately.
- [ ] Click stop while model streaming and confirm the stream stops and typed input is queued.
- [ ] Submit while compaction (`blockingState.isBusy`) is running and confirm submission is ignored.
- [ ] Stop a `retry` countdown and confirm it stops without queueing a message.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-6f43c1c7c2204aef8630205cccbccbb3)
