### PR TITLE
feat(vscode-webui): add ExpandIconRight component for sub-agent footer toggle

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
@@ -11,7 +11,7 @@ import { useEffect, useRef, useState } from "react";
 import type { NewTaskToolViewProps } from ".";
 import { StatusIcon } from "../status-icon";
 import { ToolCallLite } from "../tool-call-lite";
-import { ExpandIcon } from "../tool-container";
+import { ExpandIconRight } from "../tool-container";
 
 interface SubAgentViewProps {
   uid?: string;
@@ -146,7 +146,7 @@ export function SubAgentView({
               >
                 {canShowFooterTaskThread && (
                   <div className="flex shrink-0 items-center">
-                    <ExpandIcon
+                    <ExpandIconRight
                       isExpanded={showFooterTaskThread}
                       className="cursor-pointer opacity-100 transition-colors hover:bg-secondary hover:text-foreground"
                     />

--- a/packages/vscode-webui/src/features/tools/components/tool-container.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-container.tsx
@@ -26,11 +26,17 @@ export const ToolTitle: React.FC<{
   );
 };
 
-export const ExpandIcon: React.FC<{
+interface ExpandIconBaseProps {
   isExpanded: boolean;
   onClick?: () => void;
   className?: string;
-}> = ({ isExpanded, onClick, className }) => {
+}
+
+export const ExpandIcon: React.FC<ExpandIconBaseProps> = ({
+  isExpanded,
+  onClick,
+  className,
+}) => {
   return (
     <span
       className={cn(
@@ -45,6 +51,27 @@ export const ExpandIcon: React.FC<{
           "size-3 transition-transform",
           isExpanded ? "rotate-90" : "rotate-180",
         )}
+      />
+    </span>
+  );
+};
+
+export const ExpandIconRight: React.FC<ExpandIconBaseProps> = ({
+  isExpanded,
+  onClick,
+  className,
+}) => {
+  return (
+    <span
+      className={cn(
+        "mt-0.5 self-start rounded bg-muted p-1 transition-opacity hover:bg-secondary",
+        !isExpanded && "opacity-0 group-hover:opacity-100",
+        className,
+      )}
+      onClick={onClick}
+    >
+      <ChevronRight
+        className={cn("size-3 transition-transform", isExpanded && "rotate-90")}
       />
     </span>
   );


### PR DESCRIPTION
## Summary

- Adds a new `ExpandIconRight` component in `tool-container.tsx` that uses `ChevronRight` (rotates 90° when expanded) instead of `ChevronDown`, suitable for horizontal expand indicators
- Extracts a shared `ExpandIconBaseProps` interface to reduce duplication between `ExpandIcon` and `ExpandIconRight`
- Updates `SubAgentView` to use `ExpandIconRight` for the footer task thread expand/collapse toggle

## Test plan

- [ ] Verify the sub-agent footer task thread expand/collapse toggle renders a right-pointing chevron that rotates downward when expanded
- [ ] Verify `ExpandIcon` (existing) still works correctly for other usages

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-85735174afef4cd99340b0c0d713605b)