### PR TITLE
fix(livekit): mark unfinished tool calls as errors on stream failure

### DIFF
--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -3,7 +3,7 @@ import type {
   BackgroundTaskState,
   TaskMemoryState,
 } from "@getpochi/common";
-import type { ChatInit, ChatOnFinishCallback } from "ai";
+import type { ChatInit, ChatOnErrorCallback, ChatOnFinishCallback } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import {
   type BlobStore,
@@ -71,6 +71,48 @@ describe("LiveChatKit memory lifecycle", () => {
 
     expect(clearFileStateCache).toHaveBeenCalledTimes(1);
     expect(retryMessage).toBeTruthy();
+  });
+
+  it("marks unfinished tool calls as errors when a stream fails", async () => {
+    const store = new FakeStore([
+      makeTask({
+        id: "parent",
+        status: "pending-model",
+        background: false,
+      }),
+    ]);
+    const chatKit = new LiveChatKit<FakeChat>({
+      taskId: "parent",
+      store: store as unknown as LiveKitStore,
+      blobStore: {} as BlobStore,
+      chatClass: FakeChat,
+      getters: {
+        getLLM: () => ({ id: "test-model" }) as never,
+      },
+    });
+    const message = assistantReadFileMessage("input-available");
+    chatKit.chat.messages = [userMessage(), message];
+
+    const abortError = new Error("Transport is aborted");
+    abortError.name = "AbortError";
+    chatKit.chat.fail(abortError);
+
+    expect(chatKit.chat.messages.at(-1)?.parts[0]).toMatchObject({
+      type: "tool-readFile",
+      toolCallId: "call-read-file",
+      state: "output-error",
+      input: { path: "README.md" },
+      errorText: "User aborted the tool call",
+    });
+
+    const savedMessage = store.taskMessages("parent").at(-1);
+    expect(savedMessage?.parts[0]).toMatchObject({
+      type: "tool-readFile",
+      toolCallId: "call-read-file",
+      state: "output-error",
+      input: { path: "README.md" },
+      errorText: "User aborted the tool call",
+    });
   });
 
   it("starts task-memory and auto-memory from stream finish inside LiveKit", async () => {
@@ -256,10 +298,12 @@ class BackgroundTaskStateStore {
 class FakeChat {
   messages: Message[];
   private readonly onFinish: ChatOnFinishCallback<Message>;
+  private readonly onError: ChatOnErrorCallback;
 
   constructor(init: ChatInit<Message>) {
     this.messages = init.messages ?? [];
     this.onFinish = init.onFinish ?? (() => {});
+    this.onError = init.onError ?? (() => {});
   }
 
   async stop() {}
@@ -273,6 +317,10 @@ class FakeChat {
       isError: false,
       finishReason: "stop",
     });
+  }
+
+  fail(error: Error) {
+    this.onError(error);
   }
 }
 
@@ -357,6 +405,10 @@ class FakeStore {
       this.commitChatStreamFinished(event.args);
       return;
     }
+    if (event.name === "v1.ChatStreamFailed") {
+      this.commitChatStreamFailed(event.args);
+      return;
+    }
     throw new Error(`Unsupported event ${event.name}`);
   }
 
@@ -368,6 +420,10 @@ class FakeStore {
     const task = this.tasks.get(taskId);
     if (!task) throw new Error(`Unknown task ${taskId}`);
     this.tasks.set(taskId, { ...task, status });
+  }
+
+  taskMessages(taskId: string) {
+    return this.messages.get(taskId) ?? [];
   }
 
   private commitTaskInited(args: Record<string, unknown>) {
@@ -406,6 +462,26 @@ class FakeStore {
       ...(this.messages.get(id) ?? []).filter((item) => item.id !== message.id),
       message,
     ]);
+  }
+
+  private commitChatStreamFailed(args: Record<string, unknown>) {
+    const id = args.id as string;
+    const task = this.tasks.get(id);
+    if (!task) throw new Error(`Unknown task ${id}`);
+
+    const message = args.data as Message | null;
+    const updatedAt = args.updatedAt as Date;
+    this.tasks.set(task.id, {
+      ...task,
+      status: "failed",
+      updatedAt,
+    });
+    if (message) {
+      this.messages.set(id, [
+        ...(this.messages.get(id) ?? []).filter((item) => item.id !== message.id),
+        message,
+      ]);
+    }
   }
 
   private extractTaskId(query: { hash?: string }) {
@@ -507,6 +583,23 @@ function retryableAssistantMessage(): Message {
         toolCallId: "call-exec",
         state: "input-streaming",
         input: null,
+      },
+    ],
+  } as unknown as Message;
+}
+
+function assistantReadFileMessage(
+  state: "input-streaming" | "input-available",
+): Message {
+  return {
+    id: "assistant-read-file",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-readFile",
+        toolCallId: "call-read-file",
+        state,
+        input: { path: "README.md" },
       },
     ],
   } as unknown as Message;

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -9,9 +9,18 @@ import type {
 import { getLogger, isForkAgentUseCase } from "@getpochi/common";
 import { prepareLastMessageForRetry as prepareMessageForRetry } from "@getpochi/common/message-utils";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
-import { type CustomAgent, ToolsByPermission } from "@getpochi/tools";
+import {
+  type CustomAgent,
+  ToolsByPermission,
+  getToolCallCancelErrorMessage,
+} from "@getpochi/tools";
 import { Duration } from "@livestore/utils/effect";
-import type { ChatInit, ChatOnErrorCallback, ChatOnFinishCallback } from "ai";
+import {
+  type ChatInit,
+  type ChatOnErrorCallback,
+  type ChatOnFinishCallback,
+  isToolUIPart,
+} from "ai";
 import type z from "zod";
 import type { ForkAgent, ForkAgentHandle } from "../background-task/fork-agent";
 import type { AutoMemoryManager } from "../background-task/memory/auto-memory";
@@ -56,6 +65,52 @@ const TaskMemorySettleTimeoutMs = 5_000;
 const TaskMemorySettlePollIntervalMs = 200;
 
 type GetRecentFilesForCompact = () => MaybePromise<RecentFileState[]>;
+
+function normalizeFailedStreamMessage(
+  message: Message | null,
+  error: unknown,
+): Message | null {
+  if (message?.role !== "assistant") {
+    return message;
+  }
+
+  const errorText = getFailedToolCallErrorText(error);
+  return {
+    ...message,
+    parts: message.parts.map((part) => {
+      if (!isToolUIPart(part)) {
+        return part;
+      }
+
+      if (
+        part.state === "output-available" ||
+        part.state === "output-error" ||
+        part.state === "output-denied"
+      ) {
+        return part;
+      }
+
+      const normalizedPart = { ...(part as Record<string, unknown>) };
+      normalizedPart.output = undefined;
+      normalizedPart.errorText = undefined;
+      normalizedPart.approval = undefined;
+
+      return {
+        ...normalizedPart,
+        state: "output-error",
+        errorText,
+      } as unknown as typeof part;
+    }),
+  };
+}
+
+function getFailedToolCallErrorText(error: unknown): string {
+  if (error instanceof Error && error.name === "AbortError") {
+    return getToolCallCancelErrorMessage("user-abort");
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
 
 export type LiveChatKitBackgroundTaskOptions = {
   stateStore?: {
@@ -961,7 +1016,11 @@ export class LiveChatKit<
 
   private readonly onError: ChatOnErrorCallback = (error) => {
     logger.error("onError", error);
-    const lastMessage = this.chat.messages.at(-1) || null;
+    const rawLastMessage = this.chat.messages.at(-1) || null;
+    const lastMessage = normalizeFailedStreamMessage(rawLastMessage, error);
+    if (lastMessage && rawLastMessage) {
+      this.chat.messages = [...this.chat.messages.slice(0, -1), lastMessage];
+    }
 
     let duration = undefined;
     if (


### PR DESCRIPTION
## Summary

- When a chat stream fails (e.g. user abort, transport error), the last assistant message may contain tool-call parts still in `input-streaming` or `input-available` state. Previously these were persisted as-is, leaving the UI showing unfinished tool calls that would never resolve.
- Now `onError` normalizes the last message via `normalizeFailedStreamMessage` before committing the `ChatStreamFailed` event — unresolved tool parts are set to `output-error` with an appropriate error message, while already-resolved parts (`output-available`, `output-error`, `output-denied`) are preserved.
- For `AbortError`, the error text uses the canonical `getToolCallCancelErrorMessage("user-abort")` → "User aborted the tool call". For other errors, the raw error message is used.
- The in-memory `chat.messages` array is also updated so downstream consumers (e.g. `onStreamFinish`) see the normalized state.

## Test plan

- [x] New test: "marks unfinished tool calls as errors when a stream fails" — verifies that an assistant message with a tool part in `input-available` state is normalized to `output-error` with "User aborted the tool call" after an abort error, and that the normalized message is persisted to the store.
- [x] All existing tests pass (6/6 in `live-chat-kit-memory.test.ts`).
- [x] Lint/format checks pass (`bun check`).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7a7a90369eab462faab2fed1a9c34b18)