### PR TITLE
feat(common): export parseEnvironmentInfo from root base module

### DIFF
--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -7,7 +7,7 @@ export {
   formatters,
   type LLMFormatterOptions,
 } from "./formatters";
-export { prompts } from "./prompts";
+export { prompts, parseEnvironmentInfo } from "./prompts";
 
 export { SocialLinks } from "./social";
 export * as constants from "./constants";


### PR DESCRIPTION
## Summary
- Export `parseEnvironmentInfo` directly from the base module in `packages/common/src/base/index.ts` so consumers can import it from `@getpochi/common` without deep imports.

## Test plan
- Run `bun check` and `bun tsc` to verify formatting and types are correct.
- Run `bun run test` to verify all tests pass successfully.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-87973e3034d5462e816a93b0c8a720dc)