### PR TITLE
fix(chat): preserve inline compact checkpoints

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -107,6 +107,37 @@ describe('formatters', () => {
       expect(formatted.find((m) => m.id === 'user-2')).toBeUndefined();
     });
 
+    it('should merge compact-only user messages into adjacent assistant messages with compact between the two responses', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'First assistant response' }],
+        },
+        {
+          id: 'user-compact',
+          role: 'user',
+          parts: [
+            { type: 'text', text: '<compact>Previous conversation summary (5 messages):\nSummary here\n</compact>' },
+            { type: 'text', text: '<system-reminder>Environment details</system-reminder>' },
+          ],
+        },
+        {
+          id: 'assistant-2',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Second assistant response' }],
+        },
+      ];
+      const formatted = formatters.ui(clone(messages));
+      expect(formatted.find((m) => m.id === 'user-compact')).toBeUndefined();
+      expect(formatted.filter((m) => m.role === 'assistant')).toHaveLength(1);
+      const textParts = formatted[0].parts.filter((p) => p.type === 'text');
+      expect(textParts).toHaveLength(3);
+      expect((textParts[0] as any).text).toBe('First assistant response');
+      expect((textParts[1] as any).text).toContain('<compact>');
+      expect((textParts[2] as any).text).toBe('Second assistant response');
+    });
+
     it('should resolve pending tool calls and combine messages', () => {
       const messages: UIMessage[] = [
         {
@@ -235,6 +266,36 @@ describe('formatters', () => {
       const formatted = formatters.llm(clone(messages));
       const assistantMsg = formatted.find((m) => m.id === 'assistant-1');
       expect(assistantMsg?.parts.some((p) => p.type === 'reasoning')).toBe(true);
+    });
+
+    it('should keep only messages from the latest compact block onward', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'user-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'old request' }],
+        },
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'old response' }],
+        },
+        {
+          id: 'user-compact',
+          role: 'user',
+          parts: [
+            {
+              type: 'text',
+              text: '<compact>Previous conversation summary</compact>',
+            },
+            { type: 'text', text: 'current request' },
+          ],
+        },
+      ];
+
+      const formatted = formatters.llm(clone(messages));
+
+      expect(formatted.map((m) => m.id)).toEqual(['user-compact']);
     });
   });
 

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -100,13 +100,64 @@ function removeSystemReminder(messages: UIMessage[]): UIMessage[] {
     ) {
       return true;
     }
+    // Keep messages that carry a compact checkpoint — the checkpoint
+    // is meaningful UI content even when all other parts were system reminders.
+    if (parts.some((x) => x.type === "text" && prompts.isCompact(x.text))) {
+      return true;
+    }
     return false;
   });
+}
+
+function isCompactOnlyUserMessage(message: UIMessage): boolean {
+  if (message.role !== "user") return false;
+  return message.parts.every(
+    (part) =>
+      (part.type === "text" && prompts.isCompact(part.text)) ||
+      (part.type === "text" && part.text.trim().length === 0) ||
+      part.type === "data-checkpoint",
+  );
 }
 
 function combineConsecutiveAssistantMessages(
   messages: UIMessage[],
 ): UIMessage[] {
+  for (let i = 0; i < messages.length - 1; i++) {
+    if (
+      messages[i].role === "assistant" &&
+      messages[i + 1].role === "assistant"
+    ) {
+      messages[i].parts.push(...messages[i + 1].parts);
+      messages.splice(i + 1, 1);
+      i--;
+    }
+  }
+
+  // Merge compact-only user messages into the adjacent assistant message so
+  // the surrounding assistant messages combine and the compact checkpoint
+  // renders as a separator without a visible user message row.
+  for (let i = 0; i < messages.length; i++) {
+    if (isCompactOnlyUserMessage(messages[i])) {
+      const compactParts = messages[i].parts.filter(
+        (part) => part.type === "text" && prompts.isCompact(part.text),
+      );
+      if (i > 0 && messages[i - 1].role === "assistant") {
+        messages[i - 1].parts.push(...compactParts);
+        messages.splice(i, 1);
+        i--;
+      } else if (
+        i < messages.length - 1 &&
+        messages[i + 1].role === "assistant"
+      ) {
+        messages[i + 1].parts.unshift(...compactParts);
+        messages.splice(i, 1);
+        i--;
+      }
+    }
+  }
+
+  // Re-run consecutive assistant merge now that compact-only user messages
+  // have been removed.
   for (let i = 0; i < messages.length - 1; i++) {
     if (
       messages[i].role === "assistant" &&

--- a/packages/livekit/src/chat/__tests__/compact-task.test.ts
+++ b/packages/livekit/src/chat/__tests__/compact-task.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Message } from "../../types";
 import {
+  compactTask,
   findInlineCompactAttachIndex,
   findVerbatimAttachIndex,
 } from "../llm/compact-task";
@@ -151,5 +152,46 @@ describe("findInlineCompactAttachIndex", () => {
   it("returns undefined when no user message exists", () => {
     const messages = [assistantMsg("a0"), assistantMsg("a1")];
     expect(findInlineCompactAttachIndex(messages)).toBeUndefined();
+  });
+});
+
+describe("compactTask", () => {
+  it("persists an inline compact block attached to a historical user message", async () => {
+    const messages = [
+      userMsg("u0"),
+      assistantMsg("a0"),
+      userMsg("u1"),
+      assistantMsg("a1"),
+      userMsg("u2"),
+    ];
+    const commits: Array<{ name: string; args: { messages?: Message[] } }> =
+      [];
+    const store = {
+      query: () => ({ content: "memory summary" }),
+      commit: (event: { name: string; args: { messages?: Message[] } }) => {
+        commits.push(event);
+      },
+    };
+
+    await compactTask({
+      blobStore: {} as never,
+      taskId: "task-1",
+      storeId: "store-1",
+      model: {} as never,
+      messages,
+      taskMemoryBoundaryMessageId: "u1",
+      inline: true,
+      store: store as never,
+    });
+
+    expect(messages[2].parts[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("<compact>"),
+    });
+    expect(commits).toHaveLength(1);
+    expect(commits[0]).toMatchObject({
+      name: "v1.UpdateMessages",
+      args: { messages: [messages[2]] },
+    });
   });
 });

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -73,6 +73,50 @@ describe("LiveChatKit memory lifecycle", () => {
     expect(retryMessage).toBeTruthy();
   });
 
+  it("updates task total tokens from the formatted compact estimate", () => {
+    const store = new FakeStore([
+      makeTask({
+        id: "parent",
+        status: "pending-model",
+        background: false,
+      }),
+    ]);
+    const chatKit = new LiveChatKit<FakeChat>({
+      taskId: "parent",
+      store: store as unknown as LiveKitStore,
+      blobStore: {} as BlobStore,
+      chatClass: FakeChat,
+      getters: {
+        getLLM: () => ({ id: "test-model" }) as never,
+      },
+    });
+    const messages = [
+      {
+        id: "old-user",
+        role: "user",
+        parts: [{ type: "text", text: "x".repeat(100_000) }],
+      },
+      assistantMessage(),
+      {
+        id: "compact-user",
+        role: "user",
+        parts: [
+          { type: "text", text: "<compact>short summary</compact>" },
+          { type: "text", text: "continue" },
+        ],
+      },
+    ] as Message[];
+
+    (
+      chatKit as unknown as {
+        updateTotalTokensEstimate(messages: Message[]): void;
+      }
+    ).updateTotalTokensEstimate(messages);
+
+    expect(chatKit.task?.totalTokens).toBeGreaterThan(0);
+    expect(chatKit.task?.totalTokens).toBeLessThan(100);
+  });
+
   it("starts task-memory and auto-memory from stream finish inside LiveKit", async () => {
     const store = new FakeStore([
       makeTask({
@@ -357,6 +401,10 @@ class FakeStore {
       this.commitChatStreamFinished(event.args);
       return;
     }
+    if (event.name === "v1.UpdateTotalTokens") {
+      this.commitUpdateTotalTokens(event.args);
+      return;
+    }
     throw new Error(`Unsupported event ${event.name}`);
   }
 
@@ -406,6 +454,18 @@ class FakeStore {
       ...(this.messages.get(id) ?? []).filter((item) => item.id !== message.id),
       message,
     ]);
+  }
+
+  private commitUpdateTotalTokens(args: Record<string, unknown>) {
+    const id = args.id as string;
+    const task = this.tasks.get(id);
+    if (!task) throw new Error(`Unknown task ${id}`);
+
+    this.tasks.set(task.id, {
+      ...task,
+      totalTokens: args.totalTokens as number,
+      updatedAt: args.updatedAt as Date,
+    });
   }
 
   private extractTaskId(query: { hash?: string }) {

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -187,9 +187,10 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     const toolsTokens = estimateTokens(JSON.stringify(tools));
 
     const preparedMessages = await prepareMessages(messages);
+    const llmMessages = formatters.llm(preparedMessages);
     const modelMessages = (await resolvePromise(
       await convertToModelMessages(
-        formatters.llm(preparedMessages),
+        llmMessages,
         // toModelOutput is invoked within convertToModelMessages, thus we need to pass the tools here.
         { tools },
       ),
@@ -240,7 +241,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
             // The client only consumes the aggregated total token count here.
             // Detailed usage shape differences are a server/protocol concern.
             totalTokens:
-              part.totalUsage.totalTokens || estimateTotalTokens(messages),
+              part.totalUsage.totalTokens || estimateTotalTokens(llmMessages),
             finishReason: part.finishReason,
             startedAt: requestStartedAt,
             finishedAt: new Date(),

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -6,7 +6,7 @@ import type {
   PochiRequestUseCase,
   TaskMemoryState,
 } from "@getpochi/common";
-import { getLogger, isForkAgentUseCase } from "@getpochi/common";
+import { formatters, getLogger, isForkAgentUseCase } from "@getpochi/common";
 import { prepareLastMessageForRetry as prepareMessageForRetry } from "@getpochi/common/message-utils";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { type CustomAgent, ToolsByPermission } from "@getpochi/tools";
@@ -505,7 +505,7 @@ export class LiveChatKit<
           messages,
           llm: getters.getLLM(),
           task: this.task,
-          estimatedTotalTokens: estimateTotalTokens(messages),
+          estimatedTotalTokens: estimateTotalTokens(formatters.llm(messages)),
         });
 
       if (isManualCompact || isAutoCompact) {
@@ -545,6 +545,7 @@ export class LiveChatKit<
             store: this.store,
             useCase: isAutoCompact ? "auto-compact-task" : "compact-task",
           });
+          this.updateTotalTokensEstimate(messages);
           if (isAutoCompact) {
             this.consecutiveAutoCompactFailures = 0;
           }
@@ -934,6 +935,16 @@ export class LiveChatKit<
     await this.clearFileStateCache();
     return prepared as Message;
   };
+
+  private updateTotalTokensEstimate(messages: Message[]) {
+    this.store.commit(
+      events.updateTotalTokens({
+        id: this.taskId,
+        totalTokens: estimateTotalTokens(formatters.llm(messages)),
+        updatedAt: new Date(),
+      }),
+    );
+  }
 
   private async handleCompactFinish(
     success: boolean,

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -11,6 +11,7 @@ import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { convertToModelMessages, generateText } from "ai";
 import type { BlobStore } from "../../blob-store";
 import { makeStoreFileQuery } from "../../livestore/default-queries";
+import { events } from "../../livestore/default-schema";
 import { makeDownloadFunction } from "../../store-blob";
 import type { LiveKitStore, Message } from "../../types";
 
@@ -105,6 +106,7 @@ export async function compactTask({
           { verbatimTail: true },
         );
         memoryAttachMessage.parts.unshift({ type: "text", text });
+        persistInlineCompactMessage(store, memoryAttachMessage);
         logger.debug(
           `Inline compact attached at index ${memoryAttachIndex}; preserving ${
             messages.length - memoryAttachIndex
@@ -124,6 +126,7 @@ export async function compactTask({
         attachIndex < messages.length - 1 ? { verbatimTail: true } : undefined,
       );
       attachMessage.parts.unshift({ type: "text", text });
+      persistInlineCompactMessage(store, attachMessage);
       return;
     }
 
@@ -137,6 +140,14 @@ export async function compactTask({
     logger.warn("Failed to create summary", err);
     throw err;
   }
+}
+
+function persistInlineCompactMessage(
+  store: LiveKitStore | undefined,
+  message: Message,
+) {
+  if (!store) return;
+  store.commit(events.updateMessages({ messages: [message] }));
 }
 
 export function findInlineCompactAttachIndex(

--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -204,6 +204,14 @@ export const events = {
       updatedAt: Schema.Date,
     }),
   }),
+  updateTotalTokens: Events.synced({
+    name: "v1.UpdateTotalTokens",
+    schema: Schema.Struct({
+      id: Schema.String,
+      totalTokens: Schema.Number,
+      updatedAt: Schema.Date,
+    }),
+  }),
   _blobInserted: Events.synced({
     name: "v1.BlobInserted",
     schema: Schema.Struct({
@@ -439,6 +447,8 @@ const materializers = State.SQLite.materializers(events, {
     tables.tasks.update({ title, updatedAt }).where({ id }),
   "v1.UpdateIsPublicShared": ({ id, isPublicShared, updatedAt }) =>
     tables.tasks.update({ isPublicShared, updatedAt }).where({ id }),
+  "v1.UpdateTotalTokens": ({ id, totalTokens, updatedAt }) =>
+    tables.tasks.update({ totalTokens, updatedAt }).where({ id }),
   // @deprecated materializer kept for backward compatibility
   "v1.WriteTaskFile": ({ filePath, content }) =>
     tables.files

--- a/packages/vscode-webui/src/components/checkpoint-ui.tsx
+++ b/packages/vscode-webui/src/components/checkpoint-ui.tsx
@@ -285,7 +285,7 @@ export const CheckpointUI: React.FC<{
                   }
                 }}
               >
-                {t("checkpointUI.compact")}
+                {t("checkpointUI.summary")}
               </Button>
             </div>
           )}
@@ -360,7 +360,7 @@ export const CompactCheckpointUI: React.FC<{
             className="ml-[1px] hidden h-5 items-center gap-1 rounded-md px-1 py-0.5 text-xs hover:bg-transparent group-hover:flex dark:hover:bg-transparent"
             onClick={handleOpenSummary}
           >
-            {t("checkpointUI.compact")}
+            {t("checkpointUI.summary")}
           </Button>
           <span className="group-hover:hidden">
             <SquareChartGantt className="size-3" />

--- a/packages/vscode-webui/src/components/checkpoint-ui.tsx
+++ b/packages/vscode-webui/src/components/checkpoint-ui.tsx
@@ -7,13 +7,16 @@ import {
   GitBranchPlus,
   GitCommitHorizontal,
   Loader2,
+  SquareChartGantt,
 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 import { useIsDevMode } from "@/features/settings";
 import { cn } from "@/lib/utils";
+import { prompts } from "@getpochi/common";
 import type { DataParts } from "@getpochi/livekit";
+import type { TextUIPart } from "ai";
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
 
 type ActionType = "compare" | "restore" | "fork";
@@ -26,6 +29,8 @@ export const CheckpointUI: React.FC<{
   forkTask?: (commitId: string, messageId?: string) => Promise<void>;
   restoreMessageId?: string;
   isRestored?: boolean;
+  compactPart?: TextUIPart;
+  compactMessageId?: string;
 }> = ({
   checkpoint,
   isLoading,
@@ -34,6 +39,8 @@ export const CheckpointUI: React.FC<{
   forkTask,
   restoreMessageId,
   isRestored,
+  compactPart,
+  compactMessageId,
 }) => {
   const { t } = useTranslation();
   const [isDevMode] = useIsDevMode();
@@ -179,6 +186,9 @@ export const CheckpointUI: React.FC<{
         <Check className="size-4 text-emerald-700 dark:text-emerald-300" />
       );
     }
+    if (compactPart) {
+      return <SquareChartGantt className="size-3" />;
+    }
     return <GitCommitHorizontal className="size-5" />;
   };
 
@@ -252,6 +262,34 @@ export const CheckpointUI: React.FC<{
             </div>
           )}
 
+          {compactPart && (
+            <div className="ml-1 flex items-center">
+              <span className="hidden group-hover:flex">
+                <SquareChartGantt className="size-3" />
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="ml-[1px] hidden h-5 items-center gap-1 rounded-md px-1 py-0.5 text-xs hover:bg-transparent group-hover:flex dark:hover:bg-transparent"
+                onClick={() => {
+                  const parsed = prompts.parseInlineCompact(compactPart.text);
+                  if (parsed && compactMessageId) {
+                    vscodeHost.openFile(
+                      `/task-summary-${compactMessageId}.md`,
+                      {
+                        base64Data: btoa(
+                          unescape(encodeURIComponent(parsed.summary)),
+                        ),
+                      },
+                    );
+                  }
+                }}
+              >
+                {t("checkpointUI.compact")}
+              </Button>
+            </div>
+          )}
+
           <span
             className={cn(
               "group-hover:hidden",
@@ -291,3 +329,45 @@ function Border({
     />
   );
 }
+
+export const CompactCheckpointUI: React.FC<{
+  compactPart: TextUIPart;
+  messageId: string;
+  className?: string;
+}> = ({ compactPart, messageId, className }) => {
+  const { t } = useTranslation();
+
+  const handleOpenSummary = () => {
+    const parsed = prompts.parseInlineCompact(compactPart.text);
+    if (parsed) {
+      vscodeHost.openFile(`/task-summary-${messageId}.md`, {
+        base64Data: btoa(unescape(encodeURIComponent(parsed.summary))),
+      });
+    }
+  };
+
+  return (
+    <div className={cn("relative w-full", className)}>
+      <div className="-translate-x-1/2 -top-1 group absolute left-1/2 mx-auto flex min-h-5 w-full max-w-[72px] select-none items-center hover:max-w-full">
+        <Border hide={false} hideOnHover />
+        <span className="flex items-center px-1 text-muted-foreground/60 group-hover:px-2.5 group-hover:text-foreground">
+          <span className="hidden group-hover:flex">
+            <SquareChartGantt className="size-3" />
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="ml-[1px] hidden h-5 items-center gap-1 rounded-md px-1 py-0.5 text-xs hover:bg-transparent group-hover:flex dark:hover:bg-transparent"
+            onClick={handleOpenSummary}
+          >
+            {t("checkpointUI.compact")}
+          </Button>
+          <span className="group-hover:hidden">
+            <SquareChartGantt className="size-3" />
+          </span>
+        </span>
+        <Border hide={false} hideOnHover />
+      </div>
+    </div>
+  );
+};

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -1,6 +1,5 @@
-import { Loader2, SquareChartGantt, UserIcon } from "lucide-react";
+import { Loader2, UserIcon } from "lucide-react";
 import type React from "react";
-import { useTranslation } from "react-i18next";
 
 import { ReasoningPartUI } from "@/components/reasoning-part.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -14,14 +13,13 @@ import { ToolInvocationPart } from "@/features/tools";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { useLatestCheckpoint } from "@/lib/hooks/use-latest-checkpoint";
 import { cn } from "@/lib/utils";
-import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
+import { isVSCodeEnvironment } from "@/lib/vscode";
 import { prompts } from "@getpochi/common";
 import type { ActiveSelection } from "@getpochi/common/vscode-webui-bridge";
 import type { Message } from "@getpochi/livekit";
 import { type FileUIPart, type TextUIPart, isStaticToolUIPart } from "ai";
 import { memo, useEffect, useMemo } from "react";
-import { CheckpointUI } from "../checkpoint-ui";
-import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import { CheckpointUI, CompactCheckpointUI } from "../checkpoint-ui";
 import { ActiveSelectionPart } from "./active-selection";
 import { MessageAttachments } from "./attachments";
 import { MessageMarkdown } from "./markdown";
@@ -155,9 +153,6 @@ export const MessageList: React.FC<{
                     <strong>
                       {m.role === "user" ? user?.name : assistantName}
                     </strong>
-                    {findCompactPart(m) && (
-                      <CompactPartToolTip className="ml-1" message={m} />
-                    )}
                   </div>
                 )}
                 <div
@@ -167,6 +162,7 @@ export const MessageList: React.FC<{
                     <Part
                       role={m.role}
                       key={index}
+                      messageId={m.id}
                       isLastPartInMessages={
                         index === m.parts.length - 1 &&
                         messageIndex === renderMessages.length - 1
@@ -262,6 +258,7 @@ function Part({
   role,
   part,
   partIndex,
+  messageId,
   isLastPartInMessages,
   isLoading,
   isExecuting,
@@ -276,6 +273,7 @@ function Part({
 }: {
   role: Message["role"];
   partIndex: number;
+  messageId: string;
   part: NonNullable<Message["parts"]>[number];
   isLastPartInMessages: boolean;
   isLoading: boolean;
@@ -294,7 +292,14 @@ function Part({
 }) {
   const paddingClass = partIndex === 0 ? "" : "mt-2";
   if (part.type === "text") {
-    return <MemoTextPartUI className={paddingClass} part={part} />;
+    return (
+      <MemoTextPartUI
+        className={paddingClass}
+        part={part}
+        role={role}
+        messageId={messageId}
+      />
+    );
   }
 
   if (part.type === "reasoning") {
@@ -366,21 +371,39 @@ function Part({
 function TextPartUI({
   className,
   part,
-}: { part: TextUIPart; className?: string }) {
+  role,
+  messageId,
+}: {
+  part: TextUIPart;
+  role: Message["role"];
+  messageId: string;
+  className?: string;
+}) {
   if (part.text.trim().length === 0) {
     return null; // Skip empty text parts
   }
 
   if (prompts.isCompact(part.text)) {
-    return null; // Skip compact parts
+    // Only render the compact checkpoint inline for assistant messages
+    // (the compact-only user message was merged into the assistant message
+    // by the formatter). For user messages, the compact checkpoint is
+    // rendered by SeparatorWithCheckpoint.
+    if (role === "assistant") {
+      return <CompactCheckpointUI compactPart={part} messageId={messageId} />;
+    }
+    return null;
   }
 
   return <MessageMarkdown className={className}>{part.text}</MessageMarkdown>;
 }
 
-const MemoTextPartUI = memo(TextPartUI, (prev, next) => {
-  return prev.part.text === next.part.text;
-});
+const MemoTextPartUI = memo(
+  TextPartUI,
+  (prev, next) =>
+    prev.part.text === next.part.text &&
+    prev.messageId === next.messageId &&
+    prev.role === next.role,
+);
 MemoTextPartUI.displayName = "MemoTextPartUI";
 
 function ReasoningPartRenderer(props: Parameters<typeof ReasoningPartUI>[0]) {
@@ -428,23 +451,46 @@ const SeparatorWithCheckpoint: React.FC<{
     checkpointMessage = nextMessage;
     restoreMessageId = message.id;
   }
+
+  // When a compact-only user message was merged into an adjacent assistant
+  // message by the formatter, the compact part lives on the assistant message.
+  // The compact checkpoint is then rendered inline by TextPartUI.
   if (!checkpointMessage) return sep;
 
-  const part = checkpointMessage.parts.at(-1);
-  if (part && part.type === "data-checkpoint" && isVSCodeEnvironment()) {
+  const compactPart = findCompactPart(checkpointMessage);
+  const lastPart = checkpointMessage.parts.at(-1);
+
+  if (
+    lastPart &&
+    lastPart.type === "data-checkpoint" &&
+    isVSCodeEnvironment()
+  ) {
     return (
       <div className="mt-1 mb-2">
         <CheckpointUI
-          checkpoint={part.data}
+          checkpoint={lastPart.data}
           isLoading={isLoading}
           hideBorderOnHover={false}
           className="max-w-full"
           forkTask={forkTask}
           restoreMessageId={restoreMessageId}
           isRestored={
-            lastCheckpointInMessage !== part.data.commit &&
-            latestCheckpoint === part.data.commit
+            lastCheckpointInMessage !== lastPart.data.commit &&
+            latestCheckpoint === lastPart.data.commit
           }
+          compactPart={compactPart}
+          compactMessageId={checkpointMessage.id}
+        />
+      </div>
+    );
+  }
+
+  if (compactPart) {
+    return (
+      <div className="mt-1 mb-2">
+        <CompactCheckpointUI
+          compactPart={compactPart}
+          messageId={checkpointMessage.id}
         />
       </div>
     );
@@ -507,35 +553,6 @@ function findCompactPart(message: Message): TextUIPart | undefined {
       return x;
     }
   }
-}
-
-function CompactPartToolTip({
-  message,
-  className,
-}: { message: Message; className?: string }) {
-  const { t } = useTranslation();
-  const compactPart = findCompactPart(message);
-  const parsed = compactPart && prompts.parseInlineCompact(compactPart.text);
-  if (!parsed) return null;
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild className={className}>
-        <SquareChartGantt
-          className="size-5 cursor-pointer"
-          onClick={() =>
-            vscodeHost.openFile(`/task-summary-${message.id}.md`, {
-              base64Data: btoa(unescape(encodeURIComponent(parsed.summary))),
-            })
-          }
-        />
-      </TooltipTrigger>
-      <TooltipContent sideOffset={2} side="right">
-        <p className="m-0 w-48">
-          {t("messageList.compactedConversationTooltip")}
-        </p>
-      </TooltipContent>
-    </Tooltip>
-  );
 }
 
 function buildUserEditsCheckpoints(messages: Message[]) {

--- a/packages/vscode-webui/src/features/chat/hooks/use-inline-compact-task.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-inline-compact-task.ts
@@ -1,4 +1,5 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
+import { prompts } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
 import { useState } from "react";
 
@@ -13,7 +14,9 @@ export const useInlineCompactTask = ({
     setIsPending(true);
     try {
       await sendMessage({
-        text: "I've summarized the task and please analysis the current status, and use askFollowupQuestion with me to confirm the next steps",
+        text: prompts.createSystemReminder(
+          "The task has been summarized. Please analyze the current status, then use askFollowupQuestion to confirm the next steps with the user.",
+        ),
         metadata: {
           kind: "user",
           compact: true,

--- a/packages/vscode-webui/src/features/chat/hooks/use-manual-compact-task.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-manual-compact-task.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import type { UseChatHelpers } from "@ai-sdk/react";
+import { prompts } from "@getpochi/common";
+import type { Message } from "@getpochi/livekit";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useInlineCompactTask } from "./use-inline-compact-task";
+
+describe("useInlineCompactTask", () => {
+  it("sends the manual compact follow-up as a system reminder", async () => {
+    const sendMessage = vi
+      .fn<UseChatHelpers<Message>["sendMessage"]>()
+      .mockResolvedValue(undefined);
+    const { result } = renderHook(() => useInlineCompactTask({ sendMessage }));
+
+    await act(async () => {
+      await result.current.inlineCompactTask();
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      text: expect.stringContaining("<system-reminder>"),
+      metadata: {
+        kind: "user",
+        compact: true,
+      },
+    });
+
+    const sentMessage = sendMessage.mock.calls[0]?.[0];
+    if (
+      !sentMessage ||
+      !("text" in sentMessage) ||
+      typeof sentMessage.text !== "string"
+    ) {
+      throw new Error("Expected inline compact to send a text message.");
+    }
+    expect(prompts.isSystemReminder(sentMessage.text)).toBe(true);
+  });
+});

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -373,7 +373,9 @@
     "noChangesDetected": "No changes detected",
     "compare": "Compare",
     "fork": "Fork",
-    "forking": "Forking"
+    "forking": "Forking",
+    "summary": "Summary",
+    "compact": "Compact"
   },
   "reviewUI": {
     "reviews": "Reviews",

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -374,8 +374,7 @@
     "compare": "Compare",
     "fork": "Fork",
     "forking": "Forking",
-    "summary": "Summary",
-    "compact": "Compact"
+    "summary": "Summary"
   },
   "reviewUI": {
     "reviews": "Reviews",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -367,7 +367,9 @@
     "noChangesDetected": "変更が検出されませんでした",
     "compare": "比較",
     "fork": "フォーク",
-    "forking": "フォーク中..."
+    "forking": "フォーク中...",
+    "summary": "要約",
+    "compact": "圧縮"
   },
   "reviewUI": {
     "reviews": "レビュー",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -368,8 +368,7 @@
     "compare": "比較",
     "fork": "フォーク",
     "forking": "フォーク中...",
-    "summary": "要約",
-    "compact": "圧縮"
+    "summary": "要約"
   },
   "reviewUI": {
     "reviews": "レビュー",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -365,7 +365,9 @@
     "noChangesDetected": "변경 사항이 감지되지 않았습니다",
     "compare": "비교",
     "fork": "포크하기",
-    "forking": "포크 중..."
+    "forking": "포크 중...",
+    "summary": "요약",
+    "compact": "압축"
   },
   "reviewUI": {
     "reviews": "리뷰",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -366,8 +366,7 @@
     "compare": "비교",
     "fork": "포크하기",
     "forking": "포크 중...",
-    "summary": "요약",
-    "compact": "압축"
+    "summary": "요약"
   },
   "reviewUI": {
     "reviews": "리뷰",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -366,8 +366,7 @@
     "compare": "比较",
     "fork": "新建分支任务",
     "forking": "创建中...",
-    "summary": "摘要",
-    "compact": "压缩"
+    "summary": "摘要"
   },
   "reviewUI": {
     "reviews": "评审",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -365,7 +365,9 @@
     "noChangesDetected": "未检测到更改",
     "compare": "比较",
     "fork": "新建分支任务",
-    "forking": "创建中..."
+    "forking": "创建中...",
+    "summary": "摘要",
+    "compact": "压缩"
   },
   "reviewUI": {
     "reviews": "评审",


### PR DESCRIPTION
## Summary
- Persist inline compact summary blocks back to LiveStore and refresh task token estimates from the LLM-formatted message set.
- Render compact checkpoints as separators with a summary action instead of hiding compact text parts in the message header.
- Add formatter, compact-task, LiveChatKit, and manual compact hook coverage for the inline compact flow.

## Test plan
- Not run (not requested).

<img width="1904" height="284" alt="image" src="https://github.com/user-attachments/assets/d1e4d016-a918-4366-8521-3ba4b5357b39" />


<img width="1928" height="306" alt="image" src="https://github.com/user-attachments/assets/cc0ef5be-df18-4a1e-99ee-074a0b4135be" />

<img width="1908" height="240" alt="image" src="https://github.com/user-attachments/assets/f8351466-f1bc-431f-9b0e-63b949698324" />


<img width="1994" height="266" alt="image" src="https://github.com/user-attachments/assets/0457967d-1bf7-44cb-bf10-a1628e7a5795" />

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c83cef5264b4437ebbaa6c633be83424)