### PR TITLE
fix(livekit): add chunk timeout to prevent indefinitely stalled streams

### DIFF
--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -216,6 +216,10 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       abortSignal,
       tools,
       maxRetries: 0,
+      timeout: {
+        // Abort if no chunk is received within 15s to prevent indefinitely stalled streams.
+        chunkMs: 15_000,
+      },
       // error log is handled in live chat kit.
       onError: () => {},
       experimental_repairToolCall: makeRepairToolCall(


### PR DESCRIPTION
## Summary
- Adds a `timeout.chunkMs: 15_000` option to the `FlexibleChatTransport` stream call
- Aborts streams that stop producing chunks for more than 15 seconds, preventing indefinitely stalled sessions

## Test plan
- [ ] Trigger a chat request and verify normal streaming still works
- [ ] Simulate a stalled stream and verify it is aborted after ~15s

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-5d267a83da99401ba58ec5c112175191)