### PR TITLE
chore(vscode): bump version to 0.55.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.53.0-dev",
+  "version": "0.55.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bumps VS Code extension version from `0.53.0-dev` to `0.55.0-dev`

## Test plan
- [ ] Extension builds successfully with the new version

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-fba82e47db0c4edc9c9f711032d115a4) | [Task](https://app.getpochi.com/share/p-fba82e47db0c4edc9c9f711032d115a4)