### PR TITLE
docs(browser-agent): simplify executeCommand permissions for pgrep and powershell

### DIFF
--- a/packages/common/src/base/agents/browser.md
+++ b/packages/common/src/base/agents/browser.md
@@ -91,6 +91,8 @@ Before running browser commands, run `agent-browser --version`. If `agent-browse
 
 After installing, run `agent-browser --version` again. If `agent-browser` is still missing because the updated PATH is not active in the current shell, check the install directory directly. On macOS/Linux or PowerShell, run `~/.pochi/bin/agent-browser --version`; on Windows cmd, run `%USERPROFILE%/.pochi/bin/agent-browser --version`. If the direct path reports version `0.27.3-pochi`, use that same direct path for subsequent agent-browser commands.
 
+If installation still fails, do not continue to the browser workflows. Call `attemptCompletion` with the error summary, required version, install command, expected install path, and verification commands so the user can install `agent-browser` manually.
+
 ### Managed Browser Workflow
 
 If the settings or user request require the managed browser, you must run these steps in order:

--- a/packages/common/src/base/agents/browser.md
+++ b/packages/common/src/base/agents/browser.md
@@ -7,8 +7,8 @@ tools:
   - "executeCommand(~/.pochi/bin/agent-browser *)"
   - "executeCommand(%USERPROFILE%/.pochi/bin/agent-browser *)"
   - "executeCommand(curl -fsSL https://github.com/TabbyML/agent-browser/releases/download/v0.27.3-pochi/install.sh | bash)"
-  - "executeCommand(pgrep -x Google Chrome|chrome|google-chrome|chromium)"
-  - "executeCommand(powershell -NoProfile -Command Get-Process chrome -ErrorAction SilentlyContinue)"
+  - "executeCommand(pgrep *)"
+  - "executeCommand(powershell -NoProfile -Command Get-Process *)"
   - startBackgroundJob
   - readBackgroundJobOutput
   - killBackgroundJob


### PR DESCRIPTION
## Summary
- Simplify the `executeCommand` permissions for checking active Chrome processes by using wildcard patterns for `pgrep` and `powershell` (`pgrep *` and `powershell -NoProfile -Command Get-Process *`).

## Test plan
- Verify that the browser agent tools can check for Chrome processes correctly on different platforms using the updated permissions.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c75c57268ee34508a5df7d75f7f3a973)