### PR TITLE
fix(livekit): introduce abort-aware UI stream transform

### DIFF
--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -56,6 +56,40 @@ export type FinishedRequestSnapshot = {
   toolsTokens: number;
 };
 
+function createAbortAwareUIStreamTransform(
+  abortSignal: AbortSignal | undefined,
+) {
+  let onAbort: (() => void) | undefined;
+  return new TransformStream<UIMessageChunk, UIMessageChunk>({
+    start(controller) {
+      if (!abortSignal) return;
+      if (abortSignal.aborted) {
+        controller.terminate();
+        return;
+      }
+      onAbort = () => {
+        controller.terminate();
+      };
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    },
+    transform(chunk, controller) {
+      // `streamText` receives the same abort signal, but provider/SDK chunks can
+      // already be queued locally when abort fires. Gate the UI stream too so
+      // post-abort chunks cannot mutate the chat message state.
+      if (abortSignal?.aborted) {
+        controller.terminate();
+        return;
+      }
+      controller.enqueue(chunk);
+    },
+    flush() {
+      if (onAbort) {
+        abortSignal?.removeEventListener("abort", onAbort);
+      }
+    },
+  });
+}
+
 export type PrepareRequestGetters = {
   getLLM: () => RequestData["llm"];
   getEnvironment?: () => Promise<Environment>;
@@ -235,37 +269,39 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       ),
       experimental_download: makeDownloadFunction(this.blobStore),
     });
-    return stream.toUIMessageStream({
-      onError: (error) => {
-        if (APICallError.isInstance(error)) {
-          // throw error so we can handle it on Chat class onError
-          throw error;
-        }
-        return getErrorMessage(error);
-      },
-      originalMessages: preparedMessages,
-      messageMetadata: ({ part }) => {
-        if (part.type === "finish") {
-          return {
-            kind: "assistant",
-            // The client only consumes the aggregated total token count here.
-            // Detailed usage shape differences are a server/protocol concern.
-            totalTokens:
-              part.totalUsage.totalTokens || estimateTotalTokens(llmMessages),
-            finishReason: part.finishReason,
-            startedAt: requestStartedAt,
-            finishedAt: new Date(),
-          } satisfies MessageMetadata;
-        }
-      },
-      onFinish: async () => {
-        await this.onRequestFinished?.({
-          systemPrompt,
-          systemPromptTokens,
-          toolsTokens,
-        });
-      },
-    });
+    return stream
+      .toUIMessageStream({
+        onError: (error) => {
+          if (APICallError.isInstance(error)) {
+            // throw error so we can handle it on Chat class onError
+            throw error;
+          }
+          return getErrorMessage(error);
+        },
+        originalMessages: preparedMessages,
+        messageMetadata: ({ part }) => {
+          if (part.type === "finish") {
+            return {
+              kind: "assistant",
+              // The client only consumes the aggregated total token count here.
+              // Detailed usage shape differences are a server/protocol concern.
+              totalTokens:
+                part.totalUsage.totalTokens || estimateTotalTokens(llmMessages),
+              finishReason: part.finishReason,
+              startedAt: requestStartedAt,
+              finishedAt: new Date(),
+            } satisfies MessageMetadata;
+          }
+        },
+        onFinish: async () => {
+          await this.onRequestFinished?.({
+            systemPrompt,
+            systemPromptTokens,
+            toolsTokens,
+          });
+        },
+      })
+      .pipeThrough(createAbortAwareUIStreamTransform(abortSignal));
   };
 
   reconnectToStream: (

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -17,7 +17,7 @@ import {
   isRetryApprovalCountingDown,
   type useApprovalAndRetry,
 } from "@/features/approval";
-import { useAutoApproveGuard } from "@/features/chat";
+import { useAutoApproveGuard, useToolCallLifeCycle } from "@/features/chat";
 import {
   AutoApproveMenu,
   useAutoApprove,
@@ -107,6 +107,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   const { messages, sendMessage, addToolOutput, status } = chat;
   const isLoading = status === "streaming" || status === "submitted";
   const totalTokens = task?.totalTokens || 0;
+  const { completeToolCalls } = useToolCallLifeCycle();
 
   const { input, setInput, clearInput } = useChatInputState();
 
@@ -231,6 +232,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
       status === "ready" &&
       !isExecuting &&
       !isBusyCore &&
+      completeToolCalls.length === 0 &&
       !!selectedModel &&
       (!pendingApproval || pendingApproval.name === "retry");
 
@@ -241,14 +243,14 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     status,
     isExecuting,
     isBusyCore,
+    completeToolCalls.length,
     selectedModel,
     queuedMessages.length,
     pendingApproval,
     handleSubmit,
   ]);
 
-  // Only allow adding tool results when not loading
-  const allowAddToolResult = !(isLoading || blockingState.isBusy);
+  const allowAddToolResult = !blockingState.isBusy;
   useAddCompleteToolCalls({
     messages,
     enable: allowAddToolResult,
@@ -258,6 +260,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     todosRef,
   });
 
+  const allowInteractiveToolAction = !(isLoading || blockingState.isBusy);
   const compactOptions = {
     enabled:
       compactEnabled && !inlineCompactTaskPending && !newCompactTaskPending,
@@ -279,7 +282,9 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   );
 
   const showRenderWidgetFixButton =
-    !!shouldShowRenderWidgetFixButton && allowAddToolResult && !pendingApproval;
+    !!shouldShowRenderWidgetFixButton &&
+    allowInteractiveToolAction &&
+    !pendingApproval;
 
   const showSubmitReviewButton =
     !isSubmitDisabled &&
@@ -307,7 +312,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           <ApprovalButton
             pendingApproval={pendingApproval}
             retry={retry}
-            allowAddToolResult={allowAddToolResult}
+            allowAddToolResult={allowInteractiveToolAction}
             isSubTask={isSubTask}
             task={task}
             subtask={subtask}

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -81,6 +81,7 @@ export function useChatSubmit({
 
     if (isExecuting) {
       abortExecutingToolCalls();
+      return true;
     } else if (isLoading) {
       stopChat();
       return true;

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -82,10 +82,14 @@ export function useChatSubmit({
     if (isExecuting) {
       abortExecutingToolCalls();
       return true;
-    } else if (isLoading) {
+    }
+
+    if (isLoading) {
       stopChat();
       return true;
-    } else if (pendingApproval?.name === "retry") {
+    }
+
+    if (pendingApproval?.name === "retry") {
       pendingApproval.stopCountdown();
     }
   }, [

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -209,10 +209,6 @@ function Chat({ user, uid, info }: ChatProps) {
         return false;
       }
 
-      if (chatAbortController.current.signal.aborted) {
-        return false;
-      }
-
       // AI SDK v5 can ask for automatic continuation after the user has
       // already submitted a newer message. Only continue from the exact state
       // that is still the current tail of the stream.
@@ -482,5 +478,20 @@ function shouldStopAutoApprove({ messages }: { messages: Message[] }) {
 
 function getLastMessageState(messages: Message[]) {
   const lastMessage = messages.at(-1);
-  return lastMessage ? JSON.stringify(lastMessage) : undefined;
+  if (!lastMessage) {
+    return undefined;
+  }
+
+  // Build a lightweight fingerprint instead of serializing the whole message,
+  // whose tool outputs / text parts can be large. This still changes whenever a
+  // part is added, a tool part transitions state, or streamed text grows, which
+  // is all the auto-continue decision depends on.
+  const partsFingerprint = lastMessage.parts
+    .map((part) => {
+      const state = "state" in part ? part.state : "";
+      const size = "text" in part ? part.text.length : 0;
+      return `${part.type}:${state}:${size}`;
+    })
+    .join("|");
+  return `${lastMessage.id}@${partsFingerprint}`;
 }

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -90,6 +90,7 @@ function Chat({ user, uid, info }: ChatProps) {
   const [todoPaused, setTodoPaused] = useState(false);
   const todoPausedRef = useLatest(todoPaused);
   const todoModeActiveRef = useRef(false);
+  const lastAutoContinueStateRef = useRef<string | undefined>(undefined);
   const { initSubtaskAutoApproveSettings } = useSettingsStore();
   const defaultUser = {
     name: t("chatPage.defaultUserName"),
@@ -189,21 +190,46 @@ function Chat({ user, uid, info }: ChatProps) {
     taskMemory,
     projectMemory,
     sendAutomaticallyWhen: (x) => {
+      const candidateMessages = x.messages;
+      const candidateLastMessageState = getLastMessageState(candidateMessages);
+      const claimAutoContinue = (shouldContinue: boolean) => {
+        if (
+          !shouldContinue ||
+          !candidateLastMessageState ||
+          lastAutoContinueStateRef.current === candidateLastMessageState
+        ) {
+          return false;
+        }
+
+        lastAutoContinueStateRef.current = candidateLastMessageState;
+        return true;
+      };
+
       if (chatAbortController.current.signal.aborted) {
         return false;
       }
 
-      // AI SDK v5 will retry regardless of the status if sendAutomaticallyWhen is set.
-      if (chatKit.chat.status === "error") {
+      if (chatAbortController.current.signal.aborted) {
         return false;
       }
 
-      const shouldContinueTodo = getTodoContinuationDecision(x.messages);
-      if (shouldContinueTodo !== undefined) {
-        return !todoPausedRef.current && shouldContinueTodo;
+      // AI SDK v5 can ask for automatic continuation after the user has
+      // already submitted a newer message. Only continue from the exact state
+      // that is still the current tail of the stream.
+      if (
+        chatKit.chat.status !== "ready" ||
+        !candidateLastMessageState ||
+        getLastMessageState(chatKit.chat.messages) !== candidateLastMessageState
+      ) {
+        return false;
       }
 
-      if (shouldStopAutoApprove(x)) {
+      const shouldContinueTodo = getTodoContinuationDecision(candidateMessages);
+      if (shouldContinueTodo !== undefined) {
+        return claimAutoContinue(!todoPausedRef.current && shouldContinueTodo);
+      }
+
+      if (shouldStopAutoApprove({ messages: candidateMessages })) {
         autoApproveGuard.current = "stop";
       }
 
@@ -211,7 +237,11 @@ function Chat({ user, uid, info }: ChatProps) {
         return false;
       }
 
-      return lastAssistantMessageIsCompleteWithToolCalls(x);
+      return claimAutoContinue(
+        lastAssistantMessageIsCompleteWithToolCalls({
+          messages: candidateMessages,
+        }),
+      );
     },
     onOverrideMessages,
     onStreamStart(data) {
@@ -448,4 +478,9 @@ function shouldStopAutoApprove({ messages }: { messages: Message[] }) {
     ) &&
     lastToolPart?.state === "output-available"
   );
+}
+
+function getLastMessageState(messages: Message[]) {
+  const lastMessage = messages.at(-1);
+  return lastMessage ? JSON.stringify(lastMessage) : undefined;
 }


### PR DESCRIPTION
## Summary
- Introduce `createAbortAwareUIStreamTransform` to terminate the UI message stream when the abort signal is triggered.
- Pipe the UI message stream in `FlexibleChatTransport` through this transform to gate post-abort chunks and prevent unwanted chat message state mutations.

## Test plan
- [x] Run `bun check` to verify formatting and linting.
- [x] Run `bun tsc` to verify there are no TypeScript/type-check errors.
- [ ] Verify that UI stream terminates properly upon abort signaling.

## Screen record
- before
https://jam.dev/c/5b2d7c36-e184-48c5-b339-f904ed0b90e2

- after
https://jam.dev/c/22b541b4-89a0-45bf-b2c1-defad3c788b1

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4dc6de4142f94d05ba532e41a80393fc)