### PR TITLE
feat: improve retry reminder and optimize attemptCompletion output

### DIFF
--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -586,9 +586,7 @@ export class TaskRunner {
         "Last message is assistant with no tool calls, sending a new user reminder.",
       );
       const message = createUserMessage(
-        prompts.createSystemReminder(
-          "You should use tool calls to answer the question, for example, use attemptCompletion if the job is done, or use askFollowupQuestion to clarify the request.",
-        ),
+        prompts.createSystemReminder(prompts.toolCallsReminder),
       );
       this.chat.appendOrReplaceMessage(message);
       return "retry";

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -67,6 +67,9 @@ export const prompts = {
     truncateIndex: truncateAutoMemoryIndex,
     serializeMessage: serializeMemoryMessage,
   },
+  toolCallsReminder: `You should use tool calls to answer the question, for example, use attemptCompletion if the job is done, or use askFollowupQuestion to clarify the request.
+
+If you have already provided a response or explanation in your text above, do NOT repeat or copy that content into the \`result\` parameter of \`attemptCompletion\`. Instead, simply refer to your response above with a brief sentence (e.g., "See response above." or "The task is completed as described above.") to save output tokens.`,
 };
 
 function createSystemReminder(content: string) {

--- a/packages/livekit/src/background-task/task-executor/task-executor.ts
+++ b/packages/livekit/src/background-task/task-executor/task-executor.ts
@@ -440,9 +440,7 @@ class RunningTask {
     if (isAssistantMessageWithNoToolCalls(message)) {
       this.chat.appendOrReplaceMessage(
         createUserMessage(
-          prompts.createSystemReminder(
-            "You should use tool calls to answer the question, for example, use attemptCompletion if the job is done, or use askFollowupQuestion to clarify the request.",
-          ),
+          prompts.createSystemReminder(prompts.toolCallsReminder),
         ),
       );
       return "retry";

--- a/packages/tools/src/attempt-completion.ts
+++ b/packages/tools/src/attempt-completion.ts
@@ -6,7 +6,9 @@ export const attemptCompletionSchema = z.object({
   result: z
     .string()
     .describe(
-      "The result of the task. Formulate this result in a way that is final and does not require further input from the user.",
+      "The result of the task. Formulate this result in a way that is final and does not require further input from the user. " +
+        "If you have already provided a detailed response or explanation in your text above, do NOT repeat or copy that content here. " +
+        "Instead, simply refer to your response above with a brief sentence (e.g., 'See response above.' or 'The task is completed as described above.') to save output tokens.",
     ),
 });
 

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
@@ -36,9 +36,7 @@ export function useRetry({
         error.kind === "no-tool-calls"
       ) {
         return sendMessage({
-          text: prompts.createSystemReminder(
-            "You should use tool calls to answer the question, for example, use attemptCompletion if the job is done, or use askFollowupQuestion to clarify the request.",
-          ),
+          text: prompts.createSystemReminder(prompts.toolCallsReminder),
         });
       }
 


### PR DESCRIPTION
## Summary
- Extract the no-tool-calls retry reminder prompt into a shared constant `prompts.toolCallsReminder` in `packages/common`.
- Update the retry logic in the VSCode webui, CLI task runner, and LiveKit task executor to use the shared reminder prompt.
- Update the description of the `result` parameter in the `attemptCompletion` schema to instruct the model to avoid repeating content already generated in previous text blocks, saving output tokens.

## Test plan
- Verified that `bun check` passes.
- Verified that `bun tsc` passes.
- Verified that `bun run test` passes.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ede0f9e9bf184a7e90a10336aca7c234)