### PR TITLE
fix: hide Todo mode for non-dev users

### DIFF
--- a/packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx
+++ b/packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { SubmitDropdownButton } from "../submit-dropdown-button";
 
@@ -35,5 +35,21 @@ describe("SubmitDropdownButton", () => {
     const targetIcon = button.querySelector(".lucide-target");
     expect(targetIcon).not.toBeNull();
     expect(targetIcon?.parentElement?.className).toContain("opacity-100");
+  });
+
+  it("hides the todo mode toggle by default", () => {
+    render(<SubmitDropdownButton {...defaultProps} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+
+    expect(screen.queryByText("chat.todoModeLabel")).toBeNull();
+  });
+
+  it("shows the todo mode toggle when todo mode is enabled", () => {
+    render(<SubmitDropdownButton {...defaultProps} showTodoMode />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+
+    expect(screen.getByText("chat.todoModeLabel")).not.toBeNull();
   });
 });

--- a/packages/vscode-webui/src/components/submit-dropdown-button.tsx
+++ b/packages/vscode-webui/src/components/submit-dropdown-button.tsx
@@ -46,6 +46,7 @@ interface SubmitDropdownButtonProps {
   isPlanMode?: boolean;
   onTogglePlanMode?: () => void;
   isTodoMode?: boolean;
+  showTodoMode?: boolean;
   onToggleTodoMode?: () => void;
   onSwitchSubmitMode?: () => void;
 }
@@ -61,6 +62,7 @@ export function SubmitDropdownButton({
   isPlanMode = false,
   onTogglePlanMode,
   isTodoMode = false,
+  showTodoMode = false,
   onToggleTodoMode,
   onSwitchSubmitMode,
 }: SubmitDropdownButtonProps) {
@@ -226,22 +228,24 @@ export function SubmitDropdownButton({
                 </Tooltip>
               </TooltipProvider>
 
-              <DropdownMenuItem
-                className="flex cursor-pointer items-center gap-2 px-2 py-1"
-                onSelect={(e) => e.preventDefault()}
-                onClick={() => onToggleTodoMode?.()}
-              >
-                <Target className="size-3.5 transition-colors duration-200" />
-                <span>{t("chat.todoModeLabel")}</span>
-                <Switch
-                  checked={isTodoMode}
-                  className="ml-auto scale-75"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleTodoMode?.();
-                  }}
-                />
-              </DropdownMenuItem>
+              {showTodoMode && (
+                <DropdownMenuItem
+                  className="flex cursor-pointer items-center gap-2 px-2 py-1"
+                  onSelect={(e) => e.preventDefault()}
+                  onClick={() => onToggleTodoMode?.()}
+                >
+                  <Target className="size-3.5 transition-colors duration-200" />
+                  <span>{t("chat.todoModeLabel")}</span>
+                  <Switch
+                    checked={isTodoMode}
+                    className="ml-auto scale-75"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onToggleTodoMode?.();
+                    }}
+                  />
+                </DropdownMenuItem>
+              )}
 
               <DropdownMenuSeparator />
 

--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -12,7 +12,11 @@ import {
   type CreateWorktreeType,
   WorktreeSelect,
 } from "@/components/worktree-select";
-import { useSelectedModels, useSettingsStore } from "@/features/settings";
+import {
+  useIsDevMode,
+  useSelectedModels,
+  useSettingsStore,
+} from "@/features/settings";
 import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import type { useAttachmentUpload } from "@/lib/hooks/use-attachment-upload";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
@@ -54,21 +58,27 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
   const activeSelection = useActiveSelection();
   const { draft: input, setDraft: setInput, clearDraft } = useTaskInputDraft();
   const [submitMode, setSubmitMode] = useState<SubmitMode>("default");
+  const [isDevMode] = useIsDevMode();
+  const canUseTodoMode = isDevMode === true;
   const planMode = submitMode === "plan";
   const todoMode = submitMode === "todo";
   const togglePlanMode = useCallback(() => {
     setSubmitMode((mode) => (mode === "plan" ? "default" : "plan"));
   }, []);
   const toggleTodoMode = useCallback(() => {
+    if (!canUseTodoMode) return;
     setSubmitMode((mode) => (mode === "todo" ? "default" : "todo"));
-  }, []);
+  }, [canUseTodoMode]);
   const switchSubmitMode = useCallback(() => {
     setSubmitMode((mode) => {
       if (mode === "default") return "plan";
-      if (mode === "plan") return "todo";
+      if (mode === "plan" && canUseTodoMode) {
+        // Rotate from plan mode into todo mode.
+        return "todo";
+      }
       return "default";
     });
-  }, []);
+  }, [canUseTodoMode]);
   const {
     globalMcpConfig,
     mcpConfigOverride,
@@ -231,9 +241,8 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
     }) => {
       const { shouldCreateWorktree } = options || {};
       const shouldCreatePlan = options?.shouldCreatePlan ?? planMode;
-      const shouldCreateTodo = shouldCreatePlan
-        ? false
-        : (options?.shouldCreateTodo ?? todoMode);
+      const shouldCreateTodo =
+        canUseTodoMode && (options?.shouldCreateTodo ?? todoMode);
 
       if (isCreatingTask) return;
 
@@ -305,6 +314,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       createWorktreeAndOpenTask,
       planMode,
       todoMode,
+      canUseTodoMode,
     ],
   );
 
@@ -438,7 +448,8 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
             resetMcpTools={resetMcpTools}
             isPlanMode={planMode}
             onTogglePlanMode={togglePlanMode}
-            isTodoMode={todoMode}
+            isTodoMode={canUseTodoMode && todoMode}
+            showTodoMode={canUseTodoMode}
             onToggleTodoMode={toggleTodoMode}
             onSwitchSubmitMode={switchSubmitMode}
           />


### PR DESCRIPTION
## Summary
- Restrict Todo mode visibility to users with `isDevMode` enabled.
- Add `showTodoMode` prop to `SubmitDropdownButton` to control Todo mode toggle visibility.
- Update `CreateTaskInput` to only allow switching to Todo mode when dev mode is active.
- Add unit tests for `SubmitDropdownButton` Todo mode visibility.

## Test plan
- [x] Run `bun run vitest --run src/components/__tests__/submit-dropdown-button.test.tsx` in `packages/vscode-webui` and verify all tests pass.
- [x] Manually verify in the UI that the Todo mode toggle is hidden when dev mode is disabled and visible when enabled.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9db9e3c3ac6a4790b5885454876b215b)