### PR TITLE
refactor(tools): resolve attemptTodoCompletion results with full todos

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -356,7 +356,14 @@ describe('formatters', () => {
       const auditResult = {
         success: false,
         summary: 'More work remains.',
-        todoUpdates: [{ status: 'in-progress' }],
+        todos: [
+          {
+            id: 'todo-1',
+            content: 'Implement todo mode',
+            status: 'in-progress',
+            priority: 'medium',
+          },
+        ],
       };
       const attemptCompletionInput = {
         result: 'The implementation is complete.',
@@ -401,6 +408,14 @@ describe('formatters', () => {
       expect(formattedToolPart.output).toEqual({
         success: false,
         reason: 'More work remains.',
+        todos: [
+          {
+            id: 'todo-1',
+            content: 'Implement todo mode',
+            status: 'in-progress',
+            priority: 'medium',
+          },
+        ],
       });
       expect(formattedToolPart.callProviderMetadata).toEqual({
         google: {

--- a/packages/common/src/base/agents/attemptTodoCompletion.md
+++ b/packages/common/src/base/agents/attemptTodoCompletion.md
@@ -1,7 +1,7 @@
 ---
 name: attemptTodoCompletion
 description: |
-  Audit whether the active todo is satisfied. Use this only as the todo-mode satisfaction audit after an earlier work summary says the todo may be satisfied.
+  Audit whether todos are satisfied. Use this only as the todo-mode satisfaction audit after an earlier work summary says the todos may be satisfied.
 omitAgentsMd: true
 _internal:
   resultSchema: |
@@ -9,8 +9,9 @@ _internal:
       success: z.boolean().describe("Whether automatic todo continuation should stop after this audit."),
       summary: z.string().describe("A concise summary of the todo satisfaction audit result."),
       todoUpdates: z.array(z.object({
-        status: z.enum(["in-progress", "completed", "cancelled"]).describe("The next status for the active todo."),
-      })).describe("Status update for the active todo. Return exactly one item."),
+        id: z.string().describe("The id of the todo whose status should be updated."),
+        status: z.enum(["in-progress", "completed", "cancelled"]).describe("The next status for the todo."),
+      })).describe("Status updates for audited todos."),
     })
 tools:
   - readFile
@@ -23,14 +24,17 @@ tools:
 
 You are the todo satisfaction audit agent.
 
-## Role
+## Audit Scope
 
-Audit whether the active todo is satisfied using current workspace and runtime evidence.
+Audit whether the todos listed below are satisfied using current workspace and runtime evidence.
 
-The prompt you receive may include:
+IMPORTANT: The todos below are audit targets only. Do not execute, implement, or make progress on them. Your job is only to verify whether the current workspace and runtime state already satisfies each todo.
 
-- the current todo content
-- a prior work summary for lightweight reference
+{{TODOS}}
+
+## Additional Context
+
+The prompt you receive may include a prior work summary for lightweight reference.
 
 ## Rules
 
@@ -42,14 +46,15 @@ The prompt you receive may include:
   - "in-progress" means the todo is actively being pursued.
   - "completed" means the todo has been audited and verified as satisfied.
   - "cancelled" means the todo is blocked at a true impasse without meaningful progress unless the user provides input or external state changes.
-- Return exactly one `todoUpdates` item with the next status for the active todo.
+- Return `todoUpdates` items with the exact `id` values from the todos listed above.
+- Include a `todoUpdates` item for each todo whose status should change.
 - Use status "completed" only when current evidence proves the todo is satisfied.
 - Use status "cancelled" only when the todo should stop because you have verified a true impasse: no meaningful progress is possible without user input or an external state change.
 - Do not use status "cancelled" merely because the todo is hard, slow, uncertain, incomplete, or would benefit from clarification. If meaningful progress is still possible, use "in-progress".
 - Use status "in-progress" when the todo should continue.
-- Do not return or change todo id, content, or priority.
-- Set success to true only when the returned status is "completed" or "cancelled".
-- Set success to false only when the returned status is "in-progress".
+- Do not return or change todo content or priority.
+- Set success to true only when all todos listed above are resolved as "completed" or "cancelled".
+- Set success to false when any todo listed above should remain "in-progress".
 
 ## Completion
 

--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -13,6 +13,8 @@ export const DefaultMaxOutputTokens = 4096;
 
 export const StreamingUpdateThrottleMs = 100;
 
+export const AttemptTodoCompletionAgentName = "attemptTodoCompletion";
+
 export const PochiTaskIdHeader = "x-pochi-task-id";
 export const PochiStoreIdHeader = "x-pochi-store-id";
 export const PochiClientHeader = "x-pochi-client";

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -6,7 +6,7 @@ import {
   isStaticToolUIPart,
 } from "ai";
 import { clone } from "remeda";
-import { KnownTags } from "./constants";
+import { AttemptTodoCompletionAgentName, KnownTags } from "./constants";
 import { prompts } from "./prompts";
 
 function resolvePendingToolCalls(
@@ -315,7 +315,7 @@ function isAttemptTodoCompletionNewTaskPart(
     typeof part.input === "object" &&
     part.input !== null &&
     "agentType" in part.input &&
-    part.input.agentType === "attemptTodoCompletion"
+    part.input.agentType === AttemptTodoCompletionAgentName
   );
 }
 

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -354,19 +354,25 @@ type AttemptTodoCompletionOutput = {
   result?: {
     success?: boolean;
     summary?: string;
+    todos?: unknown;
   };
 };
 
 function getReplacementAttemptCompletionOutput(part: ToolUIPart) {
   const output = part.output as AttemptTodoCompletionOutput | undefined;
+  const todos =
+    output?.result && "todos" in output.result
+      ? { todos: output.result.todos }
+      : {};
   if (output?.result?.success === false) {
     return {
       success: false,
       reason: output.result.summary ?? "Todo completion was not accepted.",
+      ...todos,
     };
   }
 
-  return { success: true };
+  return { success: true, ...todos };
 }
 
 function getCallProviderMetadataWithThoughtSignature(part: ToolUIPart) {

--- a/packages/common/src/base/prompts/__tests__/attempt-todo-completion.test.ts
+++ b/packages/common/src/base/prompts/__tests__/attempt-todo-completion.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { prompts } from "../index";
 
 describe("attemptTodoCompletion prompt", () => {
-  it("renders the active todo and quotes the prior summary", () => {
+  it("asks to audit the todo without exposing system prompt details", () => {
     const prompt = prompts.attemptTodoCompletion.buildPrompt(
       [
         {
@@ -17,15 +17,12 @@ describe("attemptTodoCompletion prompt", () => {
 
     expect(prompt).toBe(
       [
-        "Audit whether the todo below is satisfied in the current workspace:",
-        "Implement todo mode",
+        "Audit whether the todo is satisfied in the current workspace.",
         "",
-        "> Prior work summary",
-        "> First line.",
-        "> Second line.",
         "",
-        "**Verification rule**",
-        "Treat the summary as context, not proof. Verify the current workspace state before deciding the todo status.",
+        "**Prior work summary**",
+        "First line.",
+        "Second line.",
       ].join("\n"),
     );
   });

--- a/packages/common/src/base/prompts/__tests__/prompt.test.ts
+++ b/packages/common/src/base/prompts/__tests__/prompt.test.ts
@@ -80,6 +80,33 @@ test("custom agent can omit custom rules", () => {
   ).not.toContain("USER'S CUSTOM INSTRUCTIONS");
 });
 
+test("attemptTodoCompletion custom agent replaces todo audit placeholder", () => {
+  const prompt = createSystemPrompt(
+    "",
+    {
+      name: "attemptTodoCompletion",
+      description: "audit todos",
+      systemPrompt: "Todos to audit:\n{{TODOS}}",
+    },
+    undefined,
+    undefined,
+    {
+      todos: [
+        {
+          id: "todo-1",
+          content: "Implement todo mode",
+          status: "in-progress",
+          priority: "medium",
+        },
+      ],
+    },
+  );
+
+  expect(prompt).toContain('"id": "todo-1"');
+  expect(prompt).toContain('"content": "Implement todo mode"');
+  expect(prompt).not.toContain("{{TODOS}}");
+});
+
 test("environment", () => {
   expect(
     createEnvironmentPrompt({

--- a/packages/common/src/base/prompts/attempt-todo-completion.ts
+++ b/packages/common/src/base/prompts/attempt-todo-completion.ts
@@ -1,29 +1,22 @@
 import type { Todo } from "@getpochi/tools";
 
 export function buildAttemptTodoCompletionPrompt(
-  todos: readonly Todo[],
+  _todos: readonly Todo[],
   completionResult: unknown,
 ): string {
   const resultText =
     typeof completionResult === "string"
       ? completionResult
       : JSON.stringify(completionResult);
-  const quotedResult = quotePriorSummary(
-    "Prior work summary",
-    resultText ?? "",
-  );
 
   return [
-    "Audit whether the todo below is satisfied in the current workspace:",
-    todos[0]?.content ?? "",
+    "Audit whether the todo is satisfied in the current workspace.",
     "",
-    quotedResult,
     "",
-    "**Verification rule**",
-    "Treat the summary as context, not proof. Verify the current workspace state before deciding the todo status.",
+    renderPriorSummary(resultText ?? ""),
   ].join("\n");
 }
 
-function quotePriorSummary(title: string, text: string): string {
-  return [title, ...text.split("\n")].map((line) => `> ${line}`).join("\n");
+function renderPriorSummary(text: string): string {
+  return ["**Prior work summary**", ...text.split("\n")].join("\n");
 }

--- a/packages/common/src/base/prompts/system.ts
+++ b/packages/common/src/base/prompts/system.ts
@@ -1,4 +1,5 @@
-import type { CustomAgent } from "@getpochi/tools";
+import type { CustomAgent, Todo } from "@getpochi/tools";
+import { AttemptTodoCompletionAgentName } from "../constants";
 import type { Environment } from "../environment";
 import type { AutoMemoryContext } from "./auto-memory";
 import { buildAutoMemoryStaticPrompt } from "./auto-memory";
@@ -7,7 +8,10 @@ type CustomRules = Environment["info"]["customRules"];
 
 export interface SystemPromptOptions {
   todoModeEnabled?: boolean;
+  todos?: readonly Todo[];
 }
+
+const TodosPlaceholder = "{{TODOS}}";
 
 export function createSystemPrompt(
   customRules: CustomRules,
@@ -16,13 +20,18 @@ export function createSystemPrompt(
   autoMemory?: AutoMemoryContext,
   options?: SystemPromptOptions,
 ) {
-  const agentSystemPromptBody =
+  const rawAgentSystemPrompt =
     customAgent?.systemPrompt ||
     `You are Pochi, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
 
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 
 `.trim();
+  const agentSystemPromptBody = replaceTodoAuditTodosPlaceholder(
+    rawAgentSystemPrompt,
+    customAgent,
+    options,
+  );
   const agentSystemPrompt =
     customAgent?.systemPrompt && customAgent.filePath
       ? `${agentSystemPromptBody.trim()}\n\n[Agent location: ${customAgent.filePath}]\nUse the directory containing this agent's source file as the base directory for resolving any reference files mentioned above (e.g. \`references/<name>.md\` → \`<dir>/references/<name>.md\`).`
@@ -46,6 +55,19 @@ IMPORTANT: You must NEVER generate or guess URLs for the user unless you are con
     .trim();
 
   return `${agentSystemPrompt.trim()}\n\n${sections}`.trim();
+}
+
+function replaceTodoAuditTodosPlaceholder(
+  prompt: string,
+  customAgent?: CustomAgent,
+  options?: SystemPromptOptions,
+) {
+  if (customAgent?.name !== AttemptTodoCompletionAgentName) return prompt;
+
+  return prompt.replaceAll(
+    TodosPlaceholder,
+    JSON.stringify(options?.todos ?? [], null, 2),
+  );
 }
 
 function getRulesPrompt() {

--- a/packages/livekit/src/chat/__tests__/todo-completion-utils.test.ts
+++ b/packages/livekit/src/chat/__tests__/todo-completion-utils.test.ts
@@ -70,18 +70,15 @@ describe("replaceAttemptCompletionWithTodoSubtask", () => {
       >
     ).input?.prompt;
     expect(prompt).toBe([
-      "Audit whether the todo below is satisfied in the current workspace:",
-      "Implement todo mode",
+      "Audit whether the todo is satisfied in the current workspace.",
       "",
-      "> Prior work summary",
-      "> The implementation is complete.",
       "",
-      "**Verification rule**",
-      "Treat the summary as context, not proof. Verify the current workspace state before deciding the todo status.",
+      "**Prior work summary**",
+      "The implementation is complete.",
     ].join("\n"));
   });
 
-  it("quotes multi-line prior summaries without XML tags", () => {
+  it("renders multi-line prior summaries without XML tags or blockquotes", () => {
     const message: Message = {
       id: "assistant-1",
       role: "assistant",
@@ -116,7 +113,8 @@ describe("replaceAttemptCompletionWithTodoSubtask", () => {
         { type: "tool-newTask" }
       >
     ).input?.prompt;
-    expect(prompt).toContain("> First line.\n> Second line.");
+    expect(prompt).toContain("**Prior work summary**\nFirst line.\nSecond line.");
+    expect(prompt).not.toContain("> First line.");
     expect(prompt).not.toContain("<attemptCompletionResult>");
   });
 

--- a/packages/livekit/src/chat/__tests__/todo-completion-utils.test.ts
+++ b/packages/livekit/src/chat/__tests__/todo-completion-utils.test.ts
@@ -52,6 +52,14 @@ describe("replaceAttemptCompletionWithTodoSubtask", () => {
               result: "The implementation is complete.",
             },
           },
+          todos: [
+            {
+              id: "todo-1",
+              content: "Implement todo mode",
+              status: "in-progress",
+              priority: "medium",
+            },
+          ],
         },
       },
     });

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -186,7 +186,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       this.customAgent,
       mcpInfo?.instructions,
       autoMemory,
-      { todoModeEnabled },
+      { todoModeEnabled, todos: environment?.todos },
     );
     const systemPrompt = this.systemPromptOverride ?? generatedSystemPrompt;
     const systemPromptTokens = estimateTokens(systemPrompt);

--- a/packages/livekit/src/chat/todo-completion-utils.ts
+++ b/packages/livekit/src/chat/todo-completion-utils.ts
@@ -18,6 +18,7 @@ export function buildAttemptTodoCompletionInput(
   const meta = options?.uid
     ? {
         uid: options.uid,
+        todos: todos.map((todo) => ({ ...todo })),
         ...(options.sourceAttemptCompletion
           ? { sourceAttemptCompletion: options.sourceAttemptCompletion }
           : {}),

--- a/packages/livekit/src/chat/todo-completion-utils.ts
+++ b/packages/livekit/src/chat/todo-completion-utils.ts
@@ -2,9 +2,6 @@ import { constants, prompts } from "@getpochi/common";
 import type { Todo } from "@getpochi/tools";
 import type { Message } from "../types";
 
-export const AttemptTodoCompletionAgentName =
-  constants.AttemptTodoCompletionAgentName;
-
 export function buildAttemptTodoCompletionInput(
   todos: readonly Todo[],
   completionResult: unknown,
@@ -28,7 +25,7 @@ export function buildAttemptTodoCompletionInput(
 
   return {
     description: "",
-    agentType: AttemptTodoCompletionAgentName,
+    agentType: constants.AttemptTodoCompletionAgentName,
     prompt: prompts.attemptTodoCompletion.buildPrompt(todos, completionResult),
     ...(meta ? { _meta: meta } : {}),
   };

--- a/packages/livekit/src/chat/todo-completion-utils.ts
+++ b/packages/livekit/src/chat/todo-completion-utils.ts
@@ -1,8 +1,9 @@
-import { prompts } from "@getpochi/common";
+import { constants, prompts } from "@getpochi/common";
 import type { Todo } from "@getpochi/tools";
 import type { Message } from "../types";
 
-export const AttemptTodoCompletionAgentName = "attemptTodoCompletion";
+export const AttemptTodoCompletionAgentName =
+  constants.AttemptTodoCompletionAgentName;
 
 export function buildAttemptTodoCompletionInput(
   todos: readonly Todo[],

--- a/packages/livekit/src/react.tsx
+++ b/packages/livekit/src/react.tsx
@@ -24,6 +24,8 @@ export function useLiveChatKit(
       rest.backgroundTask,
       rest.taskMemory,
       rest.projectMemory,
+      rest.customAgent,
+      rest.attemptCompletionSchema,
     ],
   );
 

--- a/packages/tools/src/__test__/select-agent-tools.test.ts
+++ b/packages/tools/src/__test__/select-agent-tools.test.ts
@@ -295,7 +295,7 @@ describe("selectAgentTools", () => {
         }),
         createAgent({
           name: "attemptTodoCompletion",
-          description: "Audit whether the active todo is satisfied.",
+          description: "Audit whether the main task todos are satisfied.",
         }),
       ],
     });
@@ -303,7 +303,7 @@ describe("selectAgentTools", () => {
     expect(tools.newTask?.description).toContain("child-agent");
     expect(tools.newTask?.description).not.toContain("attemptTodoCompletion");
     expect(tools.newTask?.description).not.toContain(
-      "Audit whether the active todo is satisfied.",
+      "Audit whether the main task todos are satisfied.",
     );
   });
 

--- a/packages/tools/src/__test__/todo.test.ts
+++ b/packages/tools/src/__test__/todo.test.ts
@@ -23,9 +23,10 @@ describe("Todo", () => {
       TodoUpdate.safeParse({
         status: "completed",
       }).success,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       TodoUpdate.safeParse({
+        id: "collect-information",
         status: "in-progress",
       }).success,
     ).toBe(true);
@@ -34,7 +35,7 @@ describe("Todo", () => {
         id: "collect-information",
         status: "completed",
       }),
-    ).toEqual({ status: "completed" });
+    ).toEqual({ id: "collect-information", status: "completed" });
   });
 
   it("accepts attempt todo completion results", () => {
@@ -47,30 +48,73 @@ describe("Todo", () => {
     ).toEqual({
       success: true,
       summary: "Done.",
-      todoUpdates: [{ status: "completed" }],
+      todoUpdates: [{ id: "collect-information", status: "completed" }],
     });
   });
 
-  it("resolves todo updates into a full todos list", () => {
+  it("resolves todo updates by id into a full todos list", () => {
     expect(
       resolveAttemptTodoCompletionResult(
         {
-          success: true,
+          success: false,
           summary: "Done.",
-          todoUpdates: [{ status: "completed" }],
+          todoUpdates: [
+            { id: "review-changes", status: "in-progress" },
+            { id: "collect-information", status: "completed" },
+          ],
         },
-        [todo],
+        [
+          todo,
+          {
+            id: "review-changes",
+            content: "Review changes",
+            status: "pending",
+            priority: "medium",
+          },
+        ],
       ),
     ).toEqual({
-      success: true,
+      success: false,
       summary: "Done.",
       todos: [
         {
           ...todo,
           status: "completed",
         },
+        {
+          id: "review-changes",
+          content: "Review changes",
+          status: "in-progress",
+          priority: "medium",
+        },
       ],
     });
+  });
+
+  it("rejects todo updates for unknown ids", () => {
+    expect(() =>
+      resolveAttemptTodoCompletionResult(
+        {
+          success: true,
+          summary: "Done.",
+          todoUpdates: [{ id: "missing", status: "completed" }],
+        },
+        [todo],
+      ),
+    ).toThrow("Invalid attemptTodoCompletion result");
+  });
+
+  it("rejects successful results when resolved todos still need work", () => {
+    expect(() =>
+      resolveAttemptTodoCompletionResult(
+        {
+          success: true,
+          summary: "Done.",
+          todoUpdates: [],
+        },
+        [todo],
+      ),
+    ).toThrow("Invalid attemptTodoCompletion result");
   });
 
   it("describes cancelled as a blocked state", () => {

--- a/packages/tools/src/__test__/todo.test.ts
+++ b/packages/tools/src/__test__/todo.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { AttemptTodoCompletionResult, Todo, TodoUpdate } from "../todo";
+import {
+  AttemptTodoCompletionResult,
+  Todo,
+  TodoUpdate,
+  resolveAttemptTodoCompletionResult,
+} from "../todo";
 
 describe("Todo", () => {
   const todo = {
@@ -43,6 +48,28 @@ describe("Todo", () => {
       success: true,
       summary: "Done.",
       todoUpdates: [{ status: "completed" }],
+    });
+  });
+
+  it("resolves todo updates into a full todos list", () => {
+    expect(
+      resolveAttemptTodoCompletionResult(
+        {
+          success: true,
+          summary: "Done.",
+          todoUpdates: [{ status: "completed" }],
+        },
+        [todo],
+      ),
+    ).toEqual({
+      success: true,
+      summary: "Done.",
+      todos: [
+        {
+          ...todo,
+          status: "completed",
+        },
+      ],
     });
   });
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -21,7 +21,13 @@ import type { multiApplyDiff } from "./multi-apply-diff";
 import { type CustomAgent, createNewTaskTool } from "./new-task";
 import { renderWidget } from "./render-widget";
 import { searchFiles } from "./search-files";
-export { AttemptTodoCompletionResult, Todo, TodoUpdate } from "./todo";
+export {
+  AttemptTodoCompletionResult,
+  ResolvedAttemptTodoCompletionResult,
+  Todo,
+  TodoUpdate,
+  resolveAttemptTodoCompletionResult,
+} from "./todo";
 export { MediaOutput } from "./read-file";
 export type {
   ToolFunctionType,

--- a/packages/tools/src/new-task.ts
+++ b/packages/tools/src/new-task.ts
@@ -1,6 +1,6 @@
 import type { UIMessage } from "ai";
 import { z } from "zod";
-import type { Todo } from "./todo";
+import { Todo } from "./todo";
 import { defineClientTool } from "./types";
 
 export type SubTask = {
@@ -80,6 +80,7 @@ export const inputSchema = z.object({
         })
         .optional()
         .describe("Internal source attemptCompletion call metadata."),
+      todos: z.array(Todo).optional().describe("Internal source todos."),
     })
     .optional(),
   _transient: z

--- a/packages/tools/src/todo.ts
+++ b/packages/tools/src/todo.ts
@@ -55,3 +55,57 @@ export const AttemptTodoCompletionResult = z.object({
 export type AttemptTodoCompletionResult = z.infer<
   typeof AttemptTodoCompletionResult
 >;
+
+export const ResolvedAttemptTodoCompletionResult =
+  AttemptTodoCompletionResult.pick({
+    success: true,
+    summary: true,
+  }).extend({
+    todos: z.array(Todo).describe("The resolved complete todos list."),
+  });
+
+export type ResolvedAttemptTodoCompletionResult = z.infer<
+  typeof ResolvedAttemptTodoCompletionResult
+>;
+
+export function resolveAttemptTodoCompletionResult(
+  result: unknown,
+  todos: readonly Todo[],
+): ResolvedAttemptTodoCompletionResult {
+  const parsedResult = AttemptTodoCompletionResult.safeParse(
+    parseJsonString(result),
+  );
+  if (!parsedResult.success) {
+    throw new Error("Invalid attemptTodoCompletion result");
+  }
+
+  const update = parsedResult.data.todoUpdates.at(0);
+  const resolvedTodos = update
+    ? applyTodoStatusUpdate(todos, update.status)
+    : todos.map((todo) => ({ ...todo }));
+
+  return ResolvedAttemptTodoCompletionResult.parse({
+    success: parsedResult.data.success,
+    summary: parsedResult.data.summary,
+    todos: resolvedTodos,
+  });
+}
+
+function applyTodoStatusUpdate(
+  todos: readonly Todo[],
+  status: Todo["status"],
+): Todo[] {
+  const [todo, ...rest] = todos;
+  if (!todo) return [];
+  return [{ ...todo, status }, ...rest.map((todo) => ({ ...todo }))];
+}
+
+function parseJsonString(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}

--- a/packages/tools/src/todo.ts
+++ b/packages/tools/src/todo.ts
@@ -33,9 +33,10 @@ export const Todo = z.object({
 export type Todo = z.infer<typeof Todo>;
 
 export const TodoUpdate = z.object({
+  id: z.string().describe("The id of the todo whose status should be updated."),
   status: z
     .enum(["in-progress", "completed", "cancelled"])
-    .describe("The next status for the active todo."),
+    .describe("The next status for the todo."),
 });
 
 export type TodoUpdate = z.infer<typeof TodoUpdate>;
@@ -49,7 +50,7 @@ export const AttemptTodoCompletionResult = z.object({
   summary: z.string().describe("A concise summary of the todo audit result."),
   todoUpdates: z
     .array(TodoUpdate)
-    .describe("Status update for the active todo."),
+    .describe("Status updates for audited todos."),
 });
 
 export type AttemptTodoCompletionResult = z.infer<
@@ -60,9 +61,14 @@ export const ResolvedAttemptTodoCompletionResult =
   AttemptTodoCompletionResult.pick({
     success: true,
     summary: true,
-  }).extend({
-    todos: z.array(Todo).describe("The resolved complete todos list."),
-  });
+  })
+    .extend({
+      todos: z.array(Todo).describe("The resolved complete todos list."),
+    })
+    .refine(
+      (result) => result.success === result.todos.every(isTodoResolved),
+      "Success must match whether all resolved todos are completed or cancelled.",
+    );
 
 export type ResolvedAttemptTodoCompletionResult = z.infer<
   typeof ResolvedAttemptTodoCompletionResult
@@ -79,25 +85,41 @@ export function resolveAttemptTodoCompletionResult(
     throw new Error("Invalid attemptTodoCompletion result");
   }
 
-  const update = parsedResult.data.todoUpdates.at(0);
-  const resolvedTodos = update
-    ? applyTodoStatusUpdate(todos, update.status)
-    : todos.map((todo) => ({ ...todo }));
+  const resolvedTodos = applyTodoStatusUpdates(
+    todos,
+    parsedResult.data.todoUpdates,
+  );
 
-  return ResolvedAttemptTodoCompletionResult.parse({
+  const resolvedResult = ResolvedAttemptTodoCompletionResult.safeParse({
     success: parsedResult.data.success,
     summary: parsedResult.data.summary,
     todos: resolvedTodos,
   });
+  if (!resolvedResult.success) {
+    throw new Error("Invalid attemptTodoCompletion result");
+  }
+
+  return resolvedResult.data;
 }
 
-function applyTodoStatusUpdate(
+function applyTodoStatusUpdates(
   todos: readonly Todo[],
-  status: Todo["status"],
+  updates: readonly TodoUpdate[],
 ): Todo[] {
-  const [todo, ...rest] = todos;
-  if (!todo) return [];
-  return [{ ...todo, status }, ...rest.map((todo) => ({ ...todo }))];
+  const todoIds = new Set(todos.map((todo) => todo.id));
+  const statusById = new Map<string, Todo["status"]>();
+
+  for (const update of updates) {
+    if (!todoIds.has(update.id) || statusById.has(update.id)) {
+      throw new Error("Invalid attemptTodoCompletion result");
+    }
+    statusById.set(update.id, update.status);
+  }
+
+  return todos.map((todo) => ({
+    ...todo,
+    status: statusById.get(todo.id) ?? todo.status,
+  }));
 }
 
 function parseJsonString(value: unknown): unknown {
@@ -108,4 +130,8 @@ function parseJsonString(value: unknown): unknown {
   } catch {
     return value;
   }
+}
+
+function isTodoResolved(todo: Todo) {
+  return todo.status === "completed" || todo.status === "cancelled";
 }

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -1,0 +1,211 @@
+import type { Message, Task } from "@getpochi/livekit";
+import type { Todo } from "@getpochi/tools";
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChatToolbar } from "./chat-toolbar";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/components/attachment-preview-list", () => ({
+  AttachmentPreviewList: () => null,
+}));
+vi.mock("@/components/dev-mode-button", () => ({
+  DevModeButton: () => null,
+}));
+vi.mock("@/components/diff-summary", () => ({
+  DiffSummary: () => null,
+}));
+vi.mock("@/components/model-select", () => ({
+  ModelSelect: () => null,
+}));
+vi.mock("@/components/public-share-button", () => ({
+  PublicShareButton: () => null,
+}));
+vi.mock("@/components/token-usage", () => ({
+  TokenUsage: () => null,
+}));
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  HoverCardContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  HoverCardTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: () => null,
+}));
+
+vi.mock("@/features/approval", () => ({
+  ApprovalButton: () => null,
+  FixWidgetButton: () => null,
+  isRetryApprovalCountingDown: () => false,
+}));
+vi.mock("@/features/chat", () => ({
+  useAutoApproveGuard: () => ({ current: "stop" }),
+}));
+vi.mock("@/features/settings", () => ({
+  AutoApproveMenu: () => null,
+  useAutoApprove: () => ({ autoApproveActive: false }),
+  useSelectedModels: () => ({
+    groupedModels: [],
+    selectedModel: { id: "model-1" },
+    selectedModelFromStore: undefined,
+    isLoading: false,
+    isFetching: false,
+    reload: vi.fn(),
+    updateSelectedModelId: vi.fn(),
+  }),
+}));
+vi.mock("@/features/todo", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/todo")>();
+  const TodoList = Object.assign(
+    ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="todo-list">{children}</div>
+    ),
+    {
+      Header: () => null,
+      Items: () => null,
+    },
+  );
+  return {
+    ...actual,
+    TodoList,
+  };
+});
+vi.mock("@/lib/hooks/use-add-complete-tool-calls", () => ({
+  useAddCompleteToolCalls: () => undefined,
+}));
+vi.mock("@/lib/hooks/use-reviews", () => ({
+  useReviews: () => [],
+}));
+vi.mock("@/lib/hooks/use-task-changed-files", () => ({
+  useTaskChangedFiles: () => ({
+    visibleChangedFiles: [],
+  }),
+}));
+vi.mock("@/lib/use-default-store", () => ({
+  useDefaultStore: () => ({ commit: vi.fn() }),
+}));
+vi.mock("@/lib/vscode", () => ({
+  vscodeHost: {},
+}));
+vi.mock("../hooks/use-chat-input-state", () => ({
+  useChatInputState: () => ({
+    input: { text: "" },
+    setInput: vi.fn(),
+    clearInput: vi.fn(),
+  }),
+}));
+vi.mock("../hooks/use-chat-status", () => ({
+  useChatStatus: () => ({
+    isExecuting: false,
+    isBusyCore: false,
+    isSubmitDisabled: false,
+    showStopButton: false,
+  }),
+}));
+vi.mock("../hooks/use-chat-submit", () => ({
+  useChatSubmit: () => ({
+    handleSubmit: vi.fn(),
+    handleStop: vi.fn(),
+  }),
+}));
+vi.mock("../hooks/use-inline-compact-task", () => ({
+  useInlineCompactTask: () => ({
+    inlineCompactTask: vi.fn(),
+    inlineCompactTaskPending: false,
+  }),
+}));
+vi.mock("../hooks/use-new-compact-task", () => ({
+  useNewCompactTask: () => ({
+    newCompactTask: vi.fn(),
+    newCompactTaskPending: false,
+  }),
+}));
+vi.mock("../hooks/use-subtask-completed", () => ({
+  useShowCompleteSubtaskButton: () => false,
+}));
+vi.mock("./chat-input-form", () => ({
+  ChatInputForm: ({ children }: { children: React.ReactNode }) => (
+    <form>{children}</form>
+  ),
+}));
+vi.mock("./error-message-view", () => ({
+  ErrorMessageView: () => null,
+}));
+vi.mock("./submit-review-button", () => ({
+  SubmitReviewsButton: () => null,
+}));
+vi.mock("./subtask", () => ({
+  CompleteSubtaskButton: () => null,
+}));
+
+const auditTodo: Todo = {
+  id: "todo-1",
+  content: "Audit this todo",
+  status: "in-progress",
+  priority: "medium",
+};
+
+function renderToolbar(isSubTask: boolean) {
+  render(
+    <ChatToolbar
+      chat={
+        {
+          messages: [] as Message[],
+          sendMessage: vi.fn(),
+          addToolOutput: vi.fn(),
+          status: "ready",
+        } as never
+      }
+      approvalAndRetry={{ pendingApproval: undefined, retry: vi.fn() } as never}
+      compact={vi.fn()}
+      attachmentUpload={
+        {
+          files: [],
+          isUploading: false,
+          fileInputRef: { current: null },
+          removeFile: vi.fn(),
+          handleFileSelect: vi.fn(),
+          handlePaste: vi.fn(),
+          handleFileDrop: vi.fn(),
+        } as never
+      }
+      isSubTask={isSubTask}
+      task={
+        { id: "task-1", todos: undefined, totalTokens: 0 } as unknown as Task
+      }
+      displayError={undefined}
+      todosRef={{ current: [auditTodo] }}
+      todoPaused={false}
+      onTodoPausedChange={vi.fn()}
+      taskId="task-1"
+    />,
+  );
+}
+
+describe("ChatToolbar", () => {
+  it("renders todos in root task pages", () => {
+    renderToolbar(false);
+
+    expect(screen.getByTestId("todo-list")).toBeTruthy();
+  });
+
+  it("does not render audit todos in subtask pages", () => {
+    renderToolbar(true);
+
+    expect(screen.queryByTestId("todo-list")).toBeNull();
+  });
+});

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -54,6 +54,7 @@ vi.mock("@/features/approval", () => ({
 }));
 vi.mock("@/features/chat", () => ({
   useAutoApproveGuard: () => ({ current: "stop" }),
+  useToolCallLifeCycle: () => ({ completeToolCalls: [] }),
 }));
 vi.mock("@/features/settings", () => ({
   AutoApproveMenu: () => null,

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -254,7 +254,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     enable: allowAddToolResult,
     addToolOutput,
     taskId,
-    todos,
     todosRef,
   });
 

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -293,6 +293,10 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   // If there are pending reviews, we prioritize submitting them over completing the subtask.
   const showCompleteSubtaskButton =
     useShowCompleteSubtaskButton(subtask, messages) && !showSubmitReviewButton;
+  const visibleTodos = isSubTask ? [] : todos;
+  const hasVisibleTodos = visibleTodos.length > 0;
+  const hasVisibleChangedFiles =
+    useTaskChangedFilesHelpers.visibleChangedFiles.length > 0;
 
   return (
     <>
@@ -322,20 +326,19 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           />
         </div>
       </div>
-      {(todos.length > 0 ||
-        useTaskChangedFilesHelpers.visibleChangedFiles.length > 0) && (
+      {(hasVisibleTodos || hasVisibleChangedFiles) && (
         <div
           className={cn(
             "mt-1.5 rounded-sm rounded-b-none border border-border border-b-0",
           )}
         >
-          {todos.length > 0 && (
+          {hasVisibleTodos && (
             <TodoList
-              todos={todos}
-              editable={!isSubTask}
+              todos={visibleTodos}
+              editable
               onSaveTodos={commitTodos}
               todoPaused={todoPaused}
-              onTodoPausedChange={isSubTask ? undefined : onTodoPausedChange}
+              onTodoPausedChange={onTodoPausedChange}
             >
               <TodoList.Header />
               <TodoList.Items viewportClassname="max-h-48" />
@@ -344,7 +347,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           <DiffSummary
             {...useTaskChangedFilesHelpers}
             className={cn({
-              "rounded-t-none border-border border-t": todos.length > 0,
+              "rounded-t-none border-border border-t": hasVisibleTodos,
             })}
           />
         </div>
@@ -369,9 +372,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
         taskId={taskId}
         lastCheckpointHash={task?.lastCheckpointHash ?? undefined}
         className={cn({
-          "rounded-t-none":
-            todos.length > 0 ||
-            useTaskChangedFilesHelpers.visibleChangedFiles.length > 0,
+          "rounded-t-none": hasVisibleTodos || hasVisibleChangedFiles,
         })}
       >
         {files.length > 0 && (

--- a/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.test.tsx
@@ -1,0 +1,91 @@
+import type { Message } from "@getpochi/livekit";
+import type { Todo } from "@getpochi/tools";
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAddSubtaskResult } from "./use-subtask-completed";
+
+const addResultMock = vi.hoisted(() => vi.fn());
+const autoApproveGuardMock = vi.hoisted(() => ({ current: "stop" }));
+const extractTaskResultMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/use-default-store", () => ({
+  useDefaultStore: () => ({ storeId: "store-1" }),
+}));
+
+vi.mock("../lib/chat-state", () => ({
+  useAutoApproveGuard: () => autoApproveGuardMock,
+  useToolCallLifeCycle: () => ({
+    getToolCallLifeCycle: () => ({
+      status: "init",
+      addResult: addResultMock,
+    }),
+  }),
+}));
+
+vi.mock("@getpochi/livekit", () => ({
+  catalog: {
+    queries: {
+      makeMessagesQuery: vi.fn(),
+    },
+  },
+  extractTaskResult: extractTaskResultMock,
+}));
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    getStaticToolName: () => "newTask",
+  };
+});
+
+const auditTodo: Todo = {
+  id: "todo-1",
+  content: "Add one test",
+  status: "in-progress",
+  priority: "medium",
+};
+
+function makeParentMessage(): Message {
+  return {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-newTask",
+        toolCallId: "tool-call-1",
+        state: "input-available",
+        input: {
+          agentType: "attemptTodoCompletion",
+          _meta: {
+            uid: "subtask-1",
+            todos: [auditTodo],
+          },
+        },
+      },
+    ],
+  } as Message;
+}
+
+describe("useAddSubtaskResult", () => {
+  it("resolves attemptTodoCompletion subtask output before completing the parent tool call", async () => {
+    extractTaskResultMock.mockReturnValue({
+      success: true,
+      summary: "Done.",
+      todoUpdates: [{ id: "todo-1", status: "completed" }],
+    });
+
+    renderHook(() => useAddSubtaskResult({ messages: [makeParentMessage()] }));
+
+    await waitFor(() => expect(addResultMock).toHaveBeenCalled());
+    expect(addResultMock).toHaveBeenCalledWith({
+      result: {
+        success: true,
+        summary: "Done.",
+        todos: [{ ...auditTodo, status: "completed" }],
+      },
+    });
+    expect(autoApproveGuardMock.current).toBe("auto");
+  });
+});

--- a/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.ts
@@ -1,10 +1,15 @@
 import { useDefaultStore } from "@/lib/use-default-store";
 import type { UseChatHelpers } from "@ai-sdk/react";
+import { constants, toErrorMessage } from "@getpochi/common";
 import { type Message, catalog, extractTaskResult } from "@getpochi/livekit";
+import {
+  Todo as TodoSchema,
+  resolveAttemptTodoCompletionResult,
+} from "@getpochi/tools";
 import { getStaticToolName } from "ai";
 import { useEffect, useMemo } from "react";
 import { useAutoApproveGuard, useToolCallLifeCycle } from "../lib/chat-state";
-import type { SubtaskInfo } from "./use-subtask-info";
+import type { NewTaskTool, SubtaskInfo } from "./use-subtask-info";
 
 // Detect if subtask is completed (in subtask)
 export const useShowCompleteSubtaskButton = (
@@ -73,8 +78,27 @@ export const useAddSubtaskResult = ({
       const result = extractTaskResult(store, subtaskUid);
       if (result) {
         autoApproveGuard.current = "auto";
-        lifecycle.addResult({ result });
+        lifecycle.addResult(getSubtaskToolOutput(toolPart, result));
       }
     }
   }, [autoApproveGuard, messages, getToolCallLifeCycle, store]);
 };
+
+function getSubtaskToolOutput(toolPart: NewTaskTool, result: unknown) {
+  if (toolPart.input?.agentType !== constants.AttemptTodoCompletionAgentName) {
+    return { result };
+  }
+
+  const todos = TodoSchema.array().safeParse(toolPart.input?._meta?.todos);
+  if (!todos.success) return { result };
+
+  try {
+    return {
+      result: resolveAttemptTodoCompletionResult(result, todos.data),
+    };
+  } catch (error) {
+    return {
+      error: toErrorMessage(error),
+    };
+  }
+}

--- a/packages/vscode-webui/src/features/chat/hooks/use-subtask-info.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-subtask-info.test.tsx
@@ -1,0 +1,68 @@
+import type { Message } from "@getpochi/livekit";
+import type { Todo } from "@getpochi/tools";
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useSubtaskInfo } from "./use-subtask-info";
+
+const parentMessagesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/features/settings", () => ({
+  useSubtaskOffhand: () => ({ subtaskOffhand: false }),
+}));
+
+vi.mock("@/lib/use-default-store", () => ({
+  useDefaultStore: () => ({
+    useQuery: parentMessagesMock,
+  }),
+}));
+
+vi.mock("@getpochi/livekit", () => ({
+  catalog: {
+    queries: {
+      makeMessagesQuery: vi.fn((taskId: string) => ({ taskId })),
+    },
+  },
+}));
+
+const auditTodo: Todo = {
+  id: "todo-1",
+  content: "Add one test",
+  status: "in-progress",
+  priority: "medium",
+};
+
+describe("useSubtaskInfo", () => {
+  it("returns audit todos from the parent newTask tool input", () => {
+    parentMessagesMock.mockReturnValue([
+      {
+        data: {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-newTask",
+              toolCallId: "tool-call-1",
+              state: "input-available",
+              input: {
+                description: "",
+                agentType: "attemptTodoCompletion",
+                prompt: "",
+                _meta: {
+                  uid: "subtask-1",
+                  todos: [auditTodo],
+                },
+              },
+            },
+          ],
+        } satisfies Message,
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useSubtaskInfo("subtask-1", "parent-1"),
+    );
+
+    expect(result.current?.todos).toEqual([auditTodo]);
+  });
+});

--- a/packages/vscode-webui/src/features/chat/hooks/use-subtask-info.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-subtask-info.ts
@@ -1,6 +1,7 @@
 import { useSubtaskOffhand } from "@/features/settings";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { type Message, type UITools, catalog } from "@getpochi/livekit";
+import { type Todo, Todo as TodoSchema } from "@getpochi/tools";
 import type { ToolUIPart } from "ai";
 
 export interface SubtaskInfo {
@@ -9,6 +10,7 @@ export interface SubtaskInfo {
   manualRun: boolean;
   agent?: string;
   description?: string;
+  todos?: Todo[];
 }
 
 export type NewTaskTool = Extract<
@@ -31,6 +33,7 @@ export function useSubtaskInfo(
     | undefined;
   const agent = newtaskTool?.input?.agentType;
   const description = newtaskTool?.input?.description;
+  const todos = TodoSchema.array().safeParse(newtaskTool?.input?._meta?.todos);
   const isSubTask = !!parentUid;
   const { subtaskOffhand } = useSubtaskOffhand();
 
@@ -43,5 +46,6 @@ export function useSubtaskInfo(
     manualRun: isSubTask && subtaskOffhand === false,
     agent,
     description,
+    todos: todos.success ? todos.data : undefined,
   };
 }

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/todo-continuation.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/todo-continuation.test.ts
@@ -54,7 +54,7 @@ describe("getTodoContinuationDecision", () => {
           result: JSON.stringify({
             success: false,
             summary: "More work remains.",
-            todoUpdates: [{ status: "in-progress" }],
+            todoUpdates: [{ id: "todo-1", status: "in-progress" }],
           }),
         }),
       ]),

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts
@@ -67,7 +67,7 @@ describe("ManagedToolCallLifeCycle", () => {
             result: {
               success: true,
               summary: "Done.",
-              todoUpdates: [{ status: "completed" }],
+              todoUpdates: [{ id: "todo-1", status: "completed" }],
             },
           },
         },

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import type { Message } from "@getpochi/livekit";
+import type { Todo } from "@getpochi/tools";
 import { ManagedToolCallLifeCycle } from "../tool-call-life-cycle";
 
 vi.mock("@/lib/vscode", () => ({
@@ -9,6 +11,23 @@ function makeStore() {
   return {
     storeId: "store-1",
     subscribe: vi.fn(() => vi.fn()),
+  };
+}
+
+function makeCompletingStore(message: Message) {
+  const subscribers: ((task: { status: string }) => void)[] = [];
+  const store = {
+    storeId: "store-1",
+    query: vi.fn(() => [{ data: message }]),
+    subscribe: vi.fn((_query, listener) => {
+      subscribers.push(listener);
+      return vi.fn();
+    }),
+  };
+
+  return {
+    store,
+    completeSubtask: () => subscribers.at(-1)?.({ status: "completed" }),
   };
 }
 
@@ -28,6 +47,112 @@ async function makeStreamingNewTaskLifecycle(
 }
 
 describe("ManagedToolCallLifeCycle", () => {
+  it("resolves attemptTodoCompletion newTask results with full todos", async () => {
+    const todo: Todo = {
+      id: "todo-1",
+      content: "Implement todo mode",
+      status: "in-progress",
+      priority: "medium",
+    };
+    const { store, completeSubtask } = makeCompletingStore({
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        {
+          type: "tool-attemptCompletion",
+          toolCallId: "attempt-tool-1",
+          state: "output-available",
+          input: {
+            result: {
+              success: true,
+              summary: "Done.",
+              todoUpdates: [{ status: "completed" }],
+            },
+          },
+        },
+      ],
+    } as Message);
+    const lifecycle = new ManagedToolCallLifeCycle(
+      store as never,
+      { toolName: "newTask", toolCallId: "tool-call-1" },
+      new AbortController().signal,
+    );
+
+    lifecycle.execute({
+      agentType: "attemptTodoCompletion",
+      _meta: {
+        uid: "subtask-1",
+        todos: [todo],
+      },
+    });
+    await vi.waitFor(() => expect(lifecycle.status).toBe("execute:streaming"));
+
+    completeSubtask();
+
+    await vi.waitFor(() => expect(lifecycle.status).toBe("complete"));
+    expect(lifecycle.complete.result).toEqual({
+      result: {
+        success: true,
+        summary: "Done.",
+        todos: [
+          {
+            ...todo,
+            status: "completed",
+          },
+        ],
+      },
+    });
+  });
+
+  it("completes attemptTodoCompletion newTask with an error when resolving todos fails", async () => {
+    const todo: Todo = {
+      id: "todo-1",
+      content: "Implement todo mode",
+      status: "in-progress",
+      priority: "medium",
+    };
+    const { store, completeSubtask } = makeCompletingStore({
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        {
+          type: "tool-attemptCompletion",
+          toolCallId: "attempt-tool-1",
+          state: "output-available",
+          input: {
+            result: {
+              success: true,
+              summary: "Missing todo updates.",
+            },
+          },
+        },
+      ],
+    } as Message);
+    const lifecycle = new ManagedToolCallLifeCycle(
+      store as never,
+      { toolName: "newTask", toolCallId: "tool-call-1" },
+      new AbortController().signal,
+    );
+
+    lifecycle.execute({
+      agentType: "attemptTodoCompletion",
+      _meta: {
+        uid: "subtask-1",
+        todos: [todo],
+      },
+    });
+    await vi.waitFor(() => expect(lifecycle.status).toBe("execute:streaming"));
+
+    expect(() => completeSubtask()).not.toThrow();
+
+    await vi.waitFor(() => expect(lifecycle.status).toBe("complete"));
+    expect(lifecycle.complete.result).toEqual({
+      error: "Invalid attemptTodoCompletion result",
+    });
+  });
+
   it("aborts a streaming newTask without double-transitioning", async () => {
     const lifecycle = await makeStreamingNewTaskLifecycle();
 

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -1,6 +1,6 @@
 import { blobStore } from "@/lib/remote-blob-store";
 import { vscodeHost } from "@/lib/vscode";
-import { getLogger } from "@getpochi/common";
+import { constants, getLogger, toErrorMessage } from "@getpochi/common";
 import type {
   BuiltinSubAgentInfo,
   ExecuteCommandResult,
@@ -40,8 +40,6 @@ type NewTaskReturnType = {
   todos?: readonly Todo[];
 };
 type ExecuteReturnType = ExecuteCommandReturnType | NewTaskReturnType | unknown;
-
-const AttemptTodoCompletionAgentName = "attemptTodoCompletion";
 
 export type StreamingResult =
   | {
@@ -426,7 +424,7 @@ export class ManagedToolCallLifeCycle
         task?.status === "completed" &&
         this.state.type === "execute:streaming"
       ) {
-        if (agentType === AttemptTodoCompletionAgentName && todos) {
+        if (agentType === constants.AttemptTodoCompletionAgentName && todos) {
           const result = (() => {
             try {
               const rawResult = extractTaskResult(this.store, uid);
@@ -435,7 +433,7 @@ export class ManagedToolCallLifeCycle
               };
             } catch (error) {
               return {
-                error: getErrorMessage(error),
+                error: toErrorMessage(error),
               };
             }
           })();
@@ -518,8 +516,4 @@ export class ManagedToolCallLifeCycle
     );
     this.emit(this.state.type, this.state);
   }
-}
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
+++ b/packages/vscode-webui/src/features/chat/lib/tool-call-life-cycle.ts
@@ -16,6 +16,8 @@ import {
 import {
   type ClientTools,
   type CompiledToolPolicies,
+  type Todo,
+  resolveAttemptTodoCompletionResult,
   validateAgentTypePatternPolicy,
 } from "@getpochi/tools";
 import { ThreadAbortSignal } from "@quilted/threads";
@@ -34,8 +36,12 @@ type ExecuteCommandReturnType = {
 type NewTaskParameterType = InferToolInput<ClientTools["newTask"]>;
 type NewTaskReturnType = {
   result: string;
+  agentType?: string;
+  todos?: readonly Todo[];
 };
 type ExecuteReturnType = ExecuteCommandReturnType | NewTaskReturnType | unknown;
+
+const AttemptTodoCompletionAgentName = "attemptTodoCompletion";
 
 export type StreamingResult =
   | {
@@ -262,7 +268,11 @@ export class ManagedToolCallLifeCycle
       throw new Error("Missing uid in newTask arguments");
     }
 
-    return Promise.resolve({ result: uid });
+    return Promise.resolve({
+      result: uid,
+      agentType: args.agentType,
+      todos: args._meta?.todos,
+    });
   }
 
   addResult(result: unknown): void {
@@ -356,8 +366,11 @@ export class ManagedToolCallLifeCycle
     });
   }
 
-  private onExecuteNewTask({ result }: NewTaskReturnType) {
-    const uid = result;
+  private onExecuteNewTask({
+    result: uid,
+    agentType,
+    todos,
+  }: NewTaskReturnType) {
     if (!uid) {
       throw new Error("Missing uid in newTask result");
     }
@@ -413,8 +426,32 @@ export class ManagedToolCallLifeCycle
         task?.status === "completed" &&
         this.state.type === "execute:streaming"
       ) {
+        if (agentType === AttemptTodoCompletionAgentName && todos) {
+          const result = (() => {
+            try {
+              const rawResult = extractTaskResult(this.store, uid);
+              return {
+                result: resolveAttemptTodoCompletionResult(rawResult, todos),
+              };
+            } catch (error) {
+              return {
+                error: getErrorMessage(error),
+              };
+            }
+          })();
+          this.transitTo("execute:streaming", {
+            type: "complete",
+            result,
+            reason: "execute-finish",
+          });
+
+          cleanup();
+          return;
+        }
+
+        const rawResult = extractTaskResult(this.store, uid);
         const result = {
-          result: extractTaskResult(this.store, uid),
+          result: rawResult,
         };
         this.transitTo("execute:streaming", {
           type: "complete",
@@ -481,4 +518,8 @@ export class ManagedToolCallLifeCycle
     );
     this.emit(this.state.type, this.state);
   }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -5,7 +5,6 @@ import { useMcp } from "@/lib/hooks/use-mcp";
 import { useSkills } from "@/lib/hooks/use-skills";
 import { vscodeAutoMemoryManager, vscodeHost } from "@/lib/vscode";
 import type { AutoMemoryContext } from "@getpochi/common";
-import type { Environment } from "@getpochi/common";
 import {
   type DisplayModel,
   type McpConfigOverride,
@@ -56,11 +55,16 @@ export function useLiveChatKitGetters({
       taskId: taskId || undefined,
     });
 
+    const currentTodos = todos.current;
+    if (!currentTodos) {
+      return environment;
+    }
+
     return {
       ...environment,
-      todos: isSubTask ? undefined : todos.current,
-    } satisfies Environment;
-  }, [todos, isSubTask, omitCustomRules, taskId]);
+      todos: currentTodos,
+    };
+  }, [todos, omitCustomRules, taskId]);
 
   // Snapshot once per task panel so mid-task MEMORY.md rewrites don't bust
   // the cached system+tools prefix. New memory shows on next mount.

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -19,7 +19,7 @@ import { hasActiveTodos } from "@getpochi/common/message-utils";
 import type { PochiTaskInfo } from "@getpochi/common/vscode-webui-bridge";
 import { type Message, type Task, catalog } from "@getpochi/livekit";
 import { useLiveChatKit } from "@getpochi/livekit/react";
-import type { Todo } from "@getpochi/tools";
+import { type Todo, parseOutputSchema } from "@getpochi/tools";
 import { useStoreRegistry } from "@livestore/react";
 import { Schema } from "@livestore/utils/effect";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
@@ -119,7 +119,21 @@ function Chat({ user, uid, info }: ChatProps) {
   } = useSelectedModels({
     isSubTask,
   });
-  const { customAgent } = useCustomAgent(subtask?.agent);
+  const { customAgent, isLoading: isCustomAgentLoading } = useCustomAgent(
+    subtask?.agent,
+  );
+  const attemptCompletionSchema = useMemo(() => {
+    const resultSchema = customAgent?.isBuiltIn
+      ? customAgent._internal?.resultSchema
+      : undefined;
+    return resultSchema ? parseOutputSchema(resultSchema) : undefined;
+  }, [customAgent?.isBuiltIn, customAgent?._internal?.resultSchema]);
+  if (isSubTask) {
+    todosRef.current =
+      subtask?.agent === constants.AttemptTodoCompletionAgentName
+        ? subtask.todos
+        : undefined;
+  }
   const autoApproveGuard = useAutoApproveGuard();
 
   // Get mcpConfigOverride from TaskStateStore
@@ -179,6 +193,7 @@ function Chat({ user, uid, info }: ChatProps) {
     getters,
     isSubTask,
     customAgent,
+    attemptCompletionSchema,
     abortSignal: chatAbortController.current.signal,
     enableAutoCompact: !isSubTask,
     onCompactStart,
@@ -324,7 +339,8 @@ function Chat({ user, uid, info }: ChatProps) {
       messages.length === 1 &&
       !isModelsLoading &&
       !!selectedModel &&
-      info.type !== "fork-task",
+      info.type !== "fork-task" &&
+      (!isSubTask || (!!subtask && !(subtask.agent && isCustomAgentLoading))),
     task,
     retry,
   });

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
@@ -93,7 +93,7 @@ describe("getReadyForRetryError", () => {
                 result: {
                   success: true,
                   summary: "Done.",
-                  todoUpdates: [{ status: "completed" }],
+                  todoUpdates: [{ id: "todo-1", status: "completed" }],
                 },
               },
             },
@@ -123,7 +123,7 @@ describe("getReadyForRetryError", () => {
                 result: {
                   success: false,
                   summary: "More work remains.",
-                  todoUpdates: [{ status: "in-progress" }],
+                  todoUpdates: [{ id: "todo-1", status: "in-progress" }],
                 },
               },
             },
@@ -155,7 +155,7 @@ describe("getReadyForRetryError", () => {
                 result: JSON.stringify({
                   success: false,
                   summary: "More work remains.",
-                  todoUpdates: [{ status: "in-progress" }],
+                  todoUpdates: [{ id: "todo-1", status: "in-progress" }],
                 }),
               },
             },

--- a/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
@@ -5,6 +5,20 @@ import {
   hasNewTaskResult,
 } from "../new-task/result";
 
+function makeResolvedTodos(status: "completed" | "in-progress") {
+  return [
+    {
+      id: "todo-1",
+      content: "Add one test",
+      status,
+      priority: "medium",
+    },
+  ] as const;
+}
+
+const completedTodos = makeResolvedTodos("completed");
+const inProgressTodos = makeResolvedTodos("in-progress");
+
 describe("hasNewTaskResult", () => {
   it("accepts structured subtask results", () => {
     expect(
@@ -26,7 +40,7 @@ describe("getAttemptTodoCompletionSummary", () => {
       getAttemptTodoCompletionSummary({
         success: false,
         summary: "More work remains.",
-        todoUpdates: [{ status: "in-progress" }],
+        todos: inProgressTodos,
       }),
     ).toBe("More work remains.");
   });
@@ -37,7 +51,7 @@ describe("getAttemptTodoCompletionSummary", () => {
         JSON.stringify({
           success: false,
           summary: "More work remains.",
-          todoUpdates: [{ status: "in-progress" }],
+          todos: inProgressTodos,
         }),
       ),
     ).toBe("More work remains.");
@@ -58,13 +72,26 @@ describe("getAttemptTodoCompletionSummary", () => {
 });
 
 describe("getAttemptTodoCompletionState", () => {
+  it("detects resolved satisfied todo completion results", () => {
+    expect(
+      getAttemptTodoCompletionState({
+        success: true,
+        summary: "Todo is satisfied.",
+        todos: completedTodos,
+      }),
+    ).toEqual({
+      status: "satisfied",
+      summary: "Todo is satisfied.",
+    });
+  });
+
   it("detects satisfied todo completion results", () => {
     expect(
       getAttemptTodoCompletionState(
         JSON.stringify({
           success: true,
           summary: "Todo is satisfied.",
-          todoUpdates: [{ status: "completed" }],
+          todos: completedTodos,
         }),
       ),
     ).toEqual({
@@ -78,7 +105,7 @@ describe("getAttemptTodoCompletionState", () => {
       getAttemptTodoCompletionState({
         success: false,
         summary: "More work remains.",
-        todoUpdates: [{ status: "in-progress" }],
+        todos: inProgressTodos,
       }),
     ).toEqual({
       status: "needs-work",

--- a/packages/vscode-webui/src/features/tools/components/new-task/result.ts
+++ b/packages/vscode-webui/src/features/tools/components/new-task/result.ts
@@ -1,4 +1,4 @@
-import { AttemptTodoCompletionResult } from "@getpochi/tools";
+import { ResolvedAttemptTodoCompletionResult } from "@getpochi/tools";
 import { parseJsonObjectString } from "../tool-result-display";
 
 export type AttemptTodoCompletionState = {
@@ -23,7 +23,7 @@ export function getAttemptTodoCompletionState(
   result: unknown,
 ): AttemptTodoCompletionState | undefined {
   const parsed = parseJsonObjectString(result) ?? result;
-  const parsedResult = AttemptTodoCompletionResult.safeParse(parsed);
+  const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(parsed);
   if (!parsedResult.success) return undefined;
   const summary = parsedResult.data.summary.trim();
   if (!summary) return undefined;

--- a/packages/vscode-webui/src/features/tools/hooks/__tests__/use-live-sub-task.test.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/__tests__/use-live-sub-task.test.tsx
@@ -1,0 +1,162 @@
+import type { Todo } from "@getpochi/tools";
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useLiveSubTask } from "../use-live-sub-task";
+
+const useLiveChatKitGettersMock = vi.hoisted(() => vi.fn(() => ({})));
+const storeMock = vi.hoisted(() => ({
+  storeId: "store-1",
+  useQuery: vi.fn(() => ({
+    id: "subtask-1",
+    parentId: "parent-1",
+    status: "pending-model",
+  })),
+}));
+
+vi.mock("@/features/chat", () => ({
+  useBatchExecuteManager: () => ({
+    abort: vi.fn(),
+    enqueue: vi.fn(),
+    processQueue: vi.fn(),
+  }),
+  useLiveChatKitGetters: useLiveChatKitGettersMock,
+  useToolCallLifeCycle: () => ({
+    getToolCallLifeCycle: () => ({
+      streamingResult: undefined,
+    }),
+  }),
+}));
+
+vi.mock("@/features/retry", () => ({
+  ReadyForRetryError: class ReadyForRetryError extends Error {},
+  useMixinReadyForRetryError: () => undefined,
+  useRetry: () => vi.fn(),
+}));
+
+vi.mock("@/lib/hooks/use-custom-agents", () => ({
+  useCustomAgent: () => ({
+    customAgent: undefined,
+    customAgentModel: undefined,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/lib/remote-blob-store", () => ({
+  blobStore: {},
+}));
+
+vi.mock("@/lib/use-default-store", () => ({
+  useDefaultStore: () => storeMock,
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  vscodeHost: {
+    clearFileStateCache: vi.fn(),
+  },
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: () => ({
+    addToolOutput: vi.fn(),
+    error: undefined,
+    messages: [],
+    regenerate: vi.fn(),
+    sendMessage: vi.fn(),
+    setMessages: vi.fn(),
+    status: "ready",
+  }),
+}));
+
+vi.mock("@getpochi/livekit", () => ({
+  catalog: {
+    queries: {
+      makeTaskQuery: vi.fn((taskId: string) => ({ taskId })),
+    },
+  },
+}));
+
+vi.mock("@getpochi/livekit/react", () => ({
+  useLiveChatKit: () => ({
+    chat: {},
+    prepareLastMessageForRetry: vi.fn(),
+  }),
+}));
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    getStaticToolName: () => "newTask",
+    lastAssistantMessageIsCompleteWithToolCalls: () => false,
+  };
+});
+
+const auditTodo: Todo = {
+  id: "todo-1",
+  content: "Add one test",
+  status: "in-progress",
+  priority: "medium",
+};
+
+function makeTool(agentType: string) {
+  return {
+    toolCallId: "tool-call-1",
+    state: "input-available",
+    input: {
+      agentType,
+      _meta: {
+        uid: "subtask-1",
+        todos: [auditTodo],
+      },
+    },
+  } as never;
+}
+
+function makeToolCallStatusRegistry() {
+  return {
+    entries: vi.fn(() => []),
+    on: vi.fn(() => vi.fn()),
+  } as never;
+}
+
+describe("useLiveSubTask", () => {
+  beforeEach(() => {
+    useLiveChatKitGettersMock.mockClear();
+    storeMock.useQuery.mockClear();
+  });
+
+  it("passes audit todos to attemptTodoCompletion subtasks", () => {
+    renderHook(() =>
+      useLiveSubTask(
+        { tool: makeTool("attemptTodoCompletion"), isExecuting: false },
+        makeToolCallStatusRegistry(),
+      ),
+    );
+
+    expect(useLiveChatKitGettersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        todos: expect.objectContaining({
+          current: [auditTodo],
+        }),
+      }),
+    );
+  });
+
+  it("does not pass audit todos to other subtasks", () => {
+    renderHook(() =>
+      useLiveSubTask(
+        { tool: makeTool("planner"), isExecuting: false },
+        makeToolCallStatusRegistry(),
+      ),
+    );
+
+    expect(useLiveChatKitGettersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        todos: expect.objectContaining({
+          current: undefined,
+        }),
+      }),
+    );
+  });
+});

--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -85,6 +85,11 @@ export function useLiveSubTask(
   const store = useDefaultStore();
   const task = store.useQuery(catalog.queries.makeTaskQuery(uid));
   const todosRef = useRef<Todo[] | undefined>(undefined);
+  todosRef.current =
+    tool.state !== "input-streaming" &&
+    agentType === constants.AttemptTodoCompletionAgentName
+      ? tool.input?._meta?.todos
+      : undefined;
   const getters = useLiveChatKitGetters({
     todos: todosRef,
     isSubTask: true,

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
@@ -49,7 +49,6 @@ describe("getTodoCompletionUpdate", () => {
           todos: resolvedTodos,
         },
       },
-      todos,
     });
 
     expect(update).toMatchObject({
@@ -60,23 +59,6 @@ describe("getTodoCompletionUpdate", () => {
     expect(update?.message.parts[0]).toMatchObject({
       state: "output-available",
     });
-  });
-
-  it("does not synthesize todos from unresolved attemptTodoCompletion results", () => {
-    const update = getTodoCompletionUpdate({
-      message: makeAttemptTodoCompletionMessage(),
-      toolCallId: "tool-1",
-      output: {
-        result: {
-          success: true,
-          summary: "Done.",
-          todoUpdates: [{ status: "completed" }],
-        },
-      },
-      todos,
-    });
-
-    expect(update).toBeUndefined();
   });
 
   it("does not parse stringified attemptTodoCompletion results", () => {
@@ -91,7 +73,6 @@ describe("getTodoCompletionUpdate", () => {
           todos: resolvedTodos,
         }),
       },
-      todos,
     });
 
     expect(update).toBeUndefined();
@@ -116,10 +97,33 @@ describe("getTodoCompletionUpdate", () => {
           todos: resolvedTodos,
         },
       },
-      todos,
     });
 
     expect(update?.todos).toEqual(resolvedTodos);
+  });
+
+  it("returns a completion update when resolved todo statuses are unchanged", () => {
+    const resolvedTodos: Todo[] = [
+      {
+        ...todos[0],
+      },
+    ];
+    const update = getTodoCompletionUpdate({
+      message: makeAttemptTodoCompletionMessage(),
+      toolCallId: "tool-1",
+      output: {
+        result: {
+          success: true,
+          summary: "Done.",
+          todos: resolvedTodos,
+        },
+      },
+    });
+
+    expect(update?.todos).toEqual(resolvedTodos);
+    expect(update?.message.parts[0]).toMatchObject({
+      state: "output-available",
+    });
   });
 
   it("does not return a completion update when attemptTodoCompletion rejects completion", () => {
@@ -133,7 +137,6 @@ describe("getTodoCompletionUpdate", () => {
           todos,
         },
       },
-      todos,
     });
 
     expect(update).toBeUndefined();
@@ -151,7 +154,6 @@ describe("getTodoCompletionUpdate", () => {
           todos: resolvedTodos,
         },
       },
-      todos,
     });
 
     expect(update?.todos).toEqual(resolvedTodos);

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
@@ -38,15 +38,16 @@ function makeAttemptTodoCompletionMessage(): Message {
 
 describe("getTodoCompletionUpdate", () => {
   it("returns a completion update when attemptTodoCompletion succeeds", () => {
+    const resolvedTodos: Todo[] = [{ ...todos[0], status: "completed" }];
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
       toolCallId: "tool-1",
       output: {
-        result: JSON.stringify({
+        result: {
           success: true,
           summary: "Done.",
-          todoUpdates: [{ status: "completed" }],
-        }),
+          todos: resolvedTodos,
+        },
       },
       todos,
     });
@@ -61,15 +62,33 @@ describe("getTodoCompletionUpdate", () => {
     });
   });
 
-  it("does not return a completion update when attemptTodoCompletion rejects completion", () => {
+  it("does not synthesize todos from unresolved attemptTodoCompletion results", () => {
+    const update = getTodoCompletionUpdate({
+      message: makeAttemptTodoCompletionMessage(),
+      toolCallId: "tool-1",
+      output: {
+        result: {
+          success: true,
+          summary: "Done.",
+          todoUpdates: [{ status: "completed" }],
+        },
+      },
+      todos,
+    });
+
+    expect(update).toBeUndefined();
+  });
+
+  it("does not parse stringified attemptTodoCompletion results", () => {
+    const resolvedTodos: Todo[] = [{ ...todos[0], status: "completed" }];
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
       toolCallId: "tool-1",
       output: {
         result: JSON.stringify({
-          success: false,
-          summary: "More work remains.",
-          todoUpdates: [{ status: "in-progress" }],
+          success: true,
+          summary: "Done.",
+          todos: resolvedTodos,
         }),
       },
       todos,
@@ -78,20 +97,63 @@ describe("getTodoCompletionUpdate", () => {
     expect(update).toBeUndefined();
   });
 
-  it("does not return a completion update without one todo update", () => {
+  it("uses resolved todos from attemptTodoCompletion results", () => {
+    const resolvedTodos: Todo[] = [
+      {
+        id: "resolved-todo-1",
+        content: "Resolved todo",
+        status: "completed",
+        priority: "medium",
+      },
+    ];
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
       toolCallId: "tool-1",
       output: {
-        result: JSON.stringify({
+        result: {
           success: true,
           summary: "Done.",
-          todoUpdates: [],
-        }),
+          todos: resolvedTodos,
+        },
+      },
+      todos,
+    });
+
+    expect(update?.todos).toEqual(resolvedTodos);
+  });
+
+  it("does not return a completion update when attemptTodoCompletion rejects completion", () => {
+    const update = getTodoCompletionUpdate({
+      message: makeAttemptTodoCompletionMessage(),
+      toolCallId: "tool-1",
+      output: {
+        result: {
+          success: false,
+          summary: "More work remains.",
+          todos,
+        },
       },
       todos,
     });
 
     expect(update).toBeUndefined();
+  });
+
+  it("uses resolved todos without requiring one todo update", () => {
+    const resolvedTodos: Todo[] = [{ ...todos[0], status: "completed" }];
+    const update = getTodoCompletionUpdate({
+      message: makeAttemptTodoCompletionMessage(),
+      toolCallId: "tool-1",
+      output: {
+        result: {
+          success: true,
+          summary: "Done.",
+          todos: resolvedTodos,
+        },
+      },
+      todos,
+    });
+
+    expect(update?.todos).toEqual(resolvedTodos);
   });
 });

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/lib/use-default-store", () => ({
   useDefaultStore: () => ({ commit: vi.fn() }),
 }));
 
-const todos: Todo[] = [
+const baseTodos: Todo[] = [
   {
     id: "todo-1",
     content: "Implement todo mode",
@@ -36,9 +36,15 @@ function makeAttemptTodoCompletionMessage(): Message {
   } as Message;
 }
 
+function findToolPart(message: Message | undefined, toolCallId: string) {
+  return message?.parts.find(
+    (part) => part.type === "tool-newTask" && part.toolCallId === toolCallId,
+  );
+}
+
 describe("getTodoCompletionUpdate", () => {
   it("returns a completion update when attemptTodoCompletion succeeds", () => {
-    const resolvedTodos: Todo[] = [{ ...todos[0], status: "completed" }];
+    const resolvedTodos: Todo[] = [{ ...baseTodos[0], status: "completed" }];
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
       toolCallId: "tool-1",
@@ -56,13 +62,13 @@ describe("getTodoCompletionUpdate", () => {
       status: "completed",
       todos: [{ id: "todo-1", status: "completed" }],
     });
-    expect(update?.message.parts[0]).toMatchObject({
+    expect(findToolPart(update?.message, "tool-1")).toMatchObject({
       state: "output-available",
     });
   });
 
   it("does not parse stringified attemptTodoCompletion results", () => {
-    const resolvedTodos: Todo[] = [{ ...todos[0], status: "completed" }];
+    const resolvedTodos: Todo[] = [{ ...baseTodos[0], status: "completed" }];
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
       toolCallId: "tool-1",
@@ -105,7 +111,7 @@ describe("getTodoCompletionUpdate", () => {
   it("returns a completion update when resolved todo statuses are unchanged", () => {
     const resolvedTodos: Todo[] = [
       {
-        ...todos[0],
+        ...baseTodos[0],
       },
     ];
     const update = getTodoCompletionUpdate({
@@ -121,7 +127,7 @@ describe("getTodoCompletionUpdate", () => {
     });
 
     expect(update?.todos).toEqual(resolvedTodos);
-    expect(update?.message.parts[0]).toMatchObject({
+    expect(findToolPart(update?.message, "tool-1")).toMatchObject({
       state: "output-available",
     });
   });
@@ -134,7 +140,7 @@ describe("getTodoCompletionUpdate", () => {
         result: {
           success: false,
           summary: "More work remains.",
-          todos,
+          todos: baseTodos,
         },
       },
     });
@@ -143,7 +149,7 @@ describe("getTodoCompletionUpdate", () => {
   });
 
   it("uses resolved todos without requiring one todo update", () => {
-    const resolvedTodos: Todo[] = [{ ...todos[0], status: "completed" }];
+    const resolvedTodos: Todo[] = [{ ...baseTodos[0], status: "completed" }];
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
       toolCallId: "tool-1",

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
@@ -108,12 +108,7 @@ describe("getTodoCompletionUpdate", () => {
     expect(update?.todos).toEqual(resolvedTodos);
   });
 
-  it("returns a completion update when resolved todo statuses are unchanged", () => {
-    const resolvedTodos: Todo[] = [
-      {
-        ...baseTodos[0],
-      },
-    ];
+  it("does not return a completion update when resolved todos still need work", () => {
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
       toolCallId: "tool-1",
@@ -121,15 +116,27 @@ describe("getTodoCompletionUpdate", () => {
         result: {
           success: true,
           summary: "Done.",
-          todos: resolvedTodos,
+          todos: baseTodos,
         },
       },
     });
 
-    expect(update?.todos).toEqual(resolvedTodos);
-    expect(findToolPart(update?.message, "tool-1")).toMatchObject({
-      state: "output-available",
+    expect(update).toBeUndefined();
+  });
+
+  it("does not return a completion update for malformed resolved results", () => {
+    const update = getTodoCompletionUpdate({
+      message: makeAttemptTodoCompletionMessage(),
+      toolCallId: "tool-1",
+      output: {
+        result: {
+          success: true,
+          summary: "Done.",
+        },
+      },
     });
+
+    expect(update).toBeUndefined();
   });
 
   it("does not return a completion update when attemptTodoCompletion rejects completion", () => {

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
@@ -70,27 +70,27 @@ export function useAddCompleteToolCalls({
     const lastCompletedToolCall = completedToolCalls.find(
       ({ toolCall }) => toolCall.toolCallId === lastToolPart?.toolCallId,
     );
-    const todoCompletionUpdate =
-      lastCompletedToolCall && taskId
-        ? getTodoCompletionUpdate({
-            message: lastMessage,
-            toolCallId: lastCompletedToolCall.toolCall.toolCallId,
-            output: lastCompletedToolCall.output,
-          })
-        : undefined;
-    if (todoCompletionUpdate && taskId) {
-      if (todosRef) {
-        todosRef.current = todoCompletionUpdate.todos;
+    let todoCompletionUpdate: TodoCompletionUpdate | undefined;
+    if (lastCompletedToolCall && taskId) {
+      todoCompletionUpdate = getTodoCompletionUpdate({
+        message: lastMessage,
+        toolCallId: lastCompletedToolCall.toolCall.toolCallId,
+        output: lastCompletedToolCall.output,
+      });
+      if (todoCompletionUpdate) {
+        if (todosRef) {
+          todosRef.current = todoCompletionUpdate.todos;
+        }
+        store.commit(
+          catalog.events.attemptTodoCompletionFinished({
+            id: taskId,
+            data: todoCompletionUpdate.message,
+            todos: todoCompletionUpdate.todos,
+            status: todoCompletionUpdate.status,
+            updatedAt: new Date(),
+          }),
+        );
       }
-      store.commit(
-        catalog.events.attemptTodoCompletionFinished({
-          id: taskId,
-          data: todoCompletionUpdate.message,
-          todos: todoCompletionUpdate.todos,
-          status: todoCompletionUpdate.status,
-          updatedAt: new Date(),
-        }),
-      );
     }
 
     for (const { toolCall, output } of completedToolCalls) {

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
@@ -4,9 +4,9 @@ import { useDefaultStore } from "@/lib/use-default-store";
 import type { Chat } from "@ai-sdk/react";
 import { getLogger } from "@getpochi/common";
 import { type Message, type TaskStatusLike, catalog } from "@getpochi/livekit";
-import type {
+import {
   ResolvedAttemptTodoCompletionResult,
-  Todo,
+  type Todo,
 } from "@getpochi/tools";
 import { isStaticToolUIPart } from "ai";
 import type { RefObject } from "react";
@@ -163,8 +163,9 @@ export function getTodoCompletionUpdate({
     typeof output === "object" && output !== null && "result" in output
       ? output.result
       : undefined;
-  const result = rawResult as ResolvedAttemptTodoCompletionResult | undefined;
-  if (!result?.success) return undefined;
+  const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(rawResult);
+  if (!parsedResult.success || !parsedResult.data.success) return undefined;
+  const result = parsedResult.data;
 
   const nextTodos = result.todos;
 

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
@@ -4,7 +4,10 @@ import { useDefaultStore } from "@/lib/use-default-store";
 import type { Chat } from "@ai-sdk/react";
 import { getLogger } from "@getpochi/common";
 import { type Message, type TaskStatusLike, catalog } from "@getpochi/livekit";
-import type { Todo } from "@getpochi/tools";
+import type {
+  ResolvedAttemptTodoCompletionResult,
+  Todo,
+} from "@getpochi/tools";
 import { isStaticToolUIPart } from "ai";
 import type { RefObject } from "react";
 import { useEffect } from "react";
@@ -17,7 +20,6 @@ interface UseAddCompleteToolCallsProps {
   enable: boolean;
   addToolOutput: Chat<Message>["addToolOutput"];
   taskId?: string;
-  todos?: readonly Todo[];
   todosRef?: RefObject<Todo[] | undefined>;
 }
 
@@ -41,7 +43,6 @@ export function useAddCompleteToolCalls({
   // setMessages,
   addToolOutput,
   taskId,
-  todos,
   todosRef,
 }: UseAddCompleteToolCallsProps): void {
   const { completeToolCalls } = useToolCallLifeCycle();
@@ -70,12 +71,11 @@ export function useAddCompleteToolCalls({
       ({ toolCall }) => toolCall.toolCallId === lastToolPart?.toolCallId,
     );
     const todoCompletionUpdate =
-      lastCompletedToolCall && taskId && todos
+      lastCompletedToolCall && taskId
         ? getTodoCompletionUpdate({
             message: lastMessage,
             toolCallId: lastCompletedToolCall.toolCall.toolCallId,
             output: lastCompletedToolCall.output,
-            todos,
           })
         : undefined;
     if (todoCompletionUpdate && taskId) {
@@ -120,7 +120,6 @@ export function useAddCompleteToolCalls({
     messages,
     addToolOutput,
     taskId,
-    todos,
     todosRef,
     store,
   ]);
@@ -142,21 +141,14 @@ type TodoCompletionUpdate = {
   output: unknown;
 };
 
-type ResolvedAttemptTodoCompletionOutput = {
-  success?: boolean;
-  todos?: Todo[];
-};
-
 export function getTodoCompletionUpdate({
   message,
   toolCallId,
   output,
-  todos,
 }: {
   message: Message;
   toolCallId: string;
   output: unknown;
-  todos: readonly Todo[];
 }): TodoCompletionUpdate | undefined {
   const targetIndex = message.parts.findIndex(
     (part) =>
@@ -171,12 +163,10 @@ export function getTodoCompletionUpdate({
     typeof output === "object" && output !== null && "result" in output
       ? output.result
       : undefined;
-  const result = rawResult as ResolvedAttemptTodoCompletionOutput | undefined;
+  const result = rawResult as ResolvedAttemptTodoCompletionResult | undefined;
   if (!result?.success) return undefined;
 
   const nextTodos = result.todos;
-  if (!nextTodos) return undefined;
-  if (hasSameTodoStatuses(todos, nextTodos)) return undefined;
 
   return {
     toolCallId,
@@ -196,15 +186,6 @@ export function getTodoCompletionUpdate({
     status: "completed",
     output,
   };
-}
-
-function hasSameTodoStatuses(
-  previousTodos: readonly Todo[],
-  nextTodos: readonly Todo[],
-): boolean {
-  return previousTodos.every(
-    (todo, index) => todo.status === nextTodos[index]?.status,
-  );
 }
 
 function assertUnreachable(_x: never): never {

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
@@ -4,7 +4,7 @@ import { useDefaultStore } from "@/lib/use-default-store";
 import type { Chat } from "@ai-sdk/react";
 import { getLogger } from "@getpochi/common";
 import { type Message, type TaskStatusLike, catalog } from "@getpochi/livekit";
-import { AttemptTodoCompletionResult, type Todo } from "@getpochi/tools";
+import type { Todo } from "@getpochi/tools";
 import { isStaticToolUIPart } from "ai";
 import type { RefObject } from "react";
 import { useEffect } from "react";
@@ -142,6 +142,11 @@ type TodoCompletionUpdate = {
   output: unknown;
 };
 
+type ResolvedAttemptTodoCompletionOutput = {
+  success?: boolean;
+  todos?: Todo[];
+};
+
 export function getTodoCompletionUpdate({
   message,
   toolCallId,
@@ -166,17 +171,11 @@ export function getTodoCompletionUpdate({
     typeof output === "object" && output !== null && "result" in output
       ? output.result
       : undefined;
-  const parsed = AttemptTodoCompletionResult.safeParse(
-    parseJsonString(rawResult),
-  );
-  if (!parsed.success) return undefined;
+  const result = rawResult as ResolvedAttemptTodoCompletionOutput | undefined;
+  if (!result?.success) return undefined;
 
-  const result = parsed.data;
-  if (!result.success) return undefined;
-  const update = result.todoUpdates.at(0);
-  if (!update) return undefined;
-
-  const nextTodos = applyTodoUpdates(todos, update.status);
+  const nextTodos = result.todos;
+  if (!nextTodos) return undefined;
   if (hasSameTodoStatuses(todos, nextTodos)) return undefined;
 
   return {
@@ -206,25 +205,6 @@ function hasSameTodoStatuses(
   return previousTodos.every(
     (todo, index) => todo.status === nextTodos[index]?.status,
   );
-}
-
-function applyTodoUpdates(
-  todos: readonly Todo[],
-  status: Todo["status"],
-): Todo[] {
-  const [todo, ...rest] = todos;
-  if (!todo) return [];
-  return [{ ...todo, status }, ...rest];
-}
-
-function parseJsonString(value: unknown): unknown {
-  if (typeof value !== "string") return value;
-
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
 }
 
 function assertUnreachable(_x: never): never {


### PR DESCRIPTION
## Summary
- Resolve `attemptTodoCompletion` outputs in the `newTask` lifecycle so consumers receive the fully merged todos list instead of raw `todoUpdates`.
- Expose `resolveAttemptTodoCompletionResult` / `ResolvedAttemptTodoCompletionResult` from `@getpochi/tools` and thread `_meta.todos` through `newTask` input.
- Simplify `getTodoCompletionUpdate` to consume the resolved todos directly, drop the now-unused JSON-string parsing path, and surface todos in the `attemptCompletion` formatter output.

## Test plan
- [ ] `bun run test` in `packages/tools`
- [ ] `bun run test` in `packages/common`
- [ ] `bun run test` in `packages/livekit`
- [ ] `bun run test` in `packages/vscode-webui`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-2018bc00a48e41dc88fc67cfc276da53)