### PR TITLE
fix(vscode-webui): show inline task thread only during todo audit

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import type { TaskThreadSource } from "@/components/task-thread";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AttemptTodoCompletionView } from "../new-task/attempt-todo-completion-view";
+
+const subAgentViewMock = vi.hoisted(() =>
+  vi.fn(
+    ({
+      children,
+      showTaskThread,
+    }: {
+      children: ReactNode;
+      showTaskThread?: boolean;
+    }) => <div data-show-task-thread={String(showTaskThread)}>{children}</div>,
+  ),
+);
+
+vi.mock("../new-task/sub-agent-view", () => ({
+  SubAgentView: subAgentViewMock,
+}));
+
+vi.mock("@/components/message", () => ({
+  MessageMarkdown: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/task-thread", () => ({
+  TaskThread: () => <div data-testid="task-thread" />,
+}));
+
+vi.mock("@/features/chat", () => ({
+  FixedStateChatContextProvider: ({
+    children,
+  }: {
+    children: ReactNode;
+  }) => <>{children}</>,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  isVSCodeEnvironment: () => false,
+}));
+
+function makeAttemptTodoCompletionTool() {
+  return {
+    type: "tool-newTask",
+    toolCallId: "attempt-todo-completion",
+    state: "input-available",
+    input: {
+      agentType: "attemptTodoCompletion",
+      description: "Audit todo completion",
+    },
+  } as never;
+}
+
+const taskSource: TaskThreadSource = {
+  messages: [
+    {
+      id: "user-message",
+      role: "user",
+      parts: [{ type: "text", text: "Check the todo" }],
+    },
+    {
+      id: "assistant-message",
+      role: "assistant",
+      parts: [{ type: "text", text: "Still checking" }],
+    },
+  ],
+  todos: [],
+};
+
+describe("AttemptTodoCompletionView", () => {
+  beforeEach(() => {
+    subAgentViewMock.mockClear();
+  });
+
+  it("renders the subagent thread inline while the audit is running", () => {
+    render(
+      <AttemptTodoCompletionView
+        uid="attempt-uid"
+        tool={makeAttemptTodoCompletionTool()}
+        isExecuting={true}
+        isLoading={false}
+        messages={[]}
+        taskSource={taskSource}
+      />,
+    );
+
+    expect(screen.getByTestId("task-thread")).toBeTruthy();
+    expect(subAgentViewMock.mock.calls[0]?.[0]).toMatchObject({
+      showTaskThread: false,
+      showToolCall: false,
+    });
+  });
+
+  it("enables the footer thread drawer after the audit stops running", () => {
+    render(
+      <AttemptTodoCompletionView
+        uid="attempt-uid"
+        tool={makeAttemptTodoCompletionTool()}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+        taskSource={taskSource}
+      />,
+    );
+
+    expect(screen.queryByTestId("task-thread")).toBeNull();
+    expect(subAgentViewMock.mock.calls[0]?.[0]).toMatchObject({
+      showTaskThread: true,
+    });
+  });
+});

--- a/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
@@ -30,7 +30,8 @@ export function AttemptTodoCompletionView({
     !!getToolPartError(tool) ||
     (tool.state === "output-available" && !completion);
   const showTaskThread =
-    !summary && !!taskSource && taskSource.messages.length > 1;
+    isExecuting && !summary && !!taskSource && taskSource.messages.length > 1;
+  const showFooterTaskThread = !isExecuting;
 
   let title = t("attemptTodoCompletionView.auditing");
 
@@ -50,7 +51,8 @@ export function AttemptTodoCompletionView({
       taskSource={taskSource}
       toolCallStatusRegistryRef={toolCallStatusRegistryRef}
       assistantName="Todo"
-      showToolCall
+      showToolCall={false}
+      showTaskThread={showFooterTaskThread}
       headerContent={
         <span
           className={cn(


### PR DESCRIPTION
## Summary
- Show the subagent task thread inline only while executing the todo audit to avoid cluttered UI once finished.
- Enable the footer task thread drawer after the audit stops running to keep access to the thread history.
- Add unit tests for `AttemptTodoCompletionView` to verify correct rendering states under `isExecuting` transitions.

## Screenshot
<img width="874" height="568" alt="image" src="https://github.com/user-attachments/assets/2f97f66e-c402-4939-8d51-19f33ed31318" />


## Test plan
- Run unit tests in `packages/vscode-webui`: `bun run test src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx` and verify they pass.
- Open VSCode WebUI, start a task with Todo audits, and verify that the inline task thread is shown during the audit and correctly transitions to the footer drawer afterwards.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fdd0b3e29ae0437880787e7fd5dc4f9f)