### PR TITLE
feat(share): read dropped file contents as text before sending to channel

### DIFF
--- a/packages/vscode-webui/src/features/share/page.tsx
+++ b/packages/vscode-webui/src/features/share/page.tsx
@@ -57,16 +57,17 @@ export function SharePage() {
       e.preventDefault();
     };
 
-    const handleDrop = (e: DragEvent) => {
+    const handleDrop = async (e: DragEvent) => {
       e.preventDefault();
       dragCounter.current = 0;
 
       const file = e.dataTransfer?.files?.[0];
       if (!file) return;
 
+      const text = await file.text();
       channel.send({
         type: "drop",
-        file,
+        text,
       });
     };
 


### PR DESCRIPTION
## Summary
- Update `handleDrop` in `SharePage` to read dropped file contents as text using `file.text()`.
- Send the text content instead of the raw file object to the channel, ensuring consistent payload format with paste events.

## Test plan
- Verify that dropping a file on the SharePage correctly reads the file as text and sends it to the channel.
- Verify that paste events continue to work as expected.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4171d9b4865d4f44881633bf63b9c81f)