### PR TITLE
fix: align todo terminology to completion and improve todo list UI

### DIFF
--- a/packages/common/src/base/agents/attemptTodoCompletion.md
+++ b/packages/common/src/base/agents/attemptTodoCompletion.md
@@ -7,7 +7,7 @@ _internal:
   resultSchema: |
     z.object({
       success: z.boolean().describe("Whether automatic todo continuation should stop after this audit."),
-      summary: z.string().describe("A concise summary of the todo satisfaction audit result."),
+      summary: z.string().describe("A concise summary of the todo completion audit result."),
       todoUpdates: z.array(z.object({
         id: z.string().describe("The id of the todo whose status should be updated."),
         status: z.enum(["in-progress", "completed", "cancelled"]).describe("The next status for the todo."),
@@ -22,7 +22,7 @@ tools:
   - executeCommand
 ---
 
-You are the todo satisfaction audit agent.
+You are the todo completion audit agent.
 
 ## Audit Scope
 
@@ -39,12 +39,12 @@ The prompt you receive may include a prior work summary for lightweight referenc
 ## Rules
 
 - Work in read-only mode. Do not modify files or project state.
-- Do not rely on prior claims, intent, or conversation as proof that the todo is satisfied.
+- Do not rely on prior claims, intent, or conversation as proof that the todo is complete.
 - Use current evidence from files, command output, tests, runtime behavior, or other authoritative sources.
 - Todo status meanings:
   - "pending" means the todo has not started yet.
   - "in-progress" means the todo is actively being pursued.
-  - "completed" means the todo has been audited and verified as satisfied.
+  - "completed" means the todo has been audited and verified as complete.
   - "cancelled" means the todo is blocked at a true impasse without meaningful progress unless the user provides input or external state changes.
 - Return `todoUpdates` items with the exact `id` values from the todos listed above.
 - Include a `todoUpdates` item for each todo whose status should change.
@@ -60,4 +60,4 @@ The prompt you receive may include a prior work summary for lightweight referenc
 
 When the audit is complete, call `attemptCompletion`.
 
-If the configured `attemptCompletion` result schema is structured, follow that schema exactly. Otherwise, return a concise audit summary that states whether the todo is satisfied and why.
+If the configured `attemptCompletion` result schema is structured, follow that schema exactly. Otherwise, return a concise audit summary that states whether the todo is complete and why.

--- a/packages/common/src/base/agents/attemptTodoCompletion.md
+++ b/packages/common/src/base/agents/attemptTodoCompletion.md
@@ -1,7 +1,7 @@
 ---
 name: attemptTodoCompletion
 description: |
-  Audit whether todos are satisfied. Use this only as the todo-mode satisfaction audit after an earlier work summary says the todos may be satisfied.
+  Audit whether todos are complete. Use this only as the todo-mode completion audit after an earlier work summary says the todos may be complete.
 omitAgentsMd: true
 _internal:
   resultSchema: |
@@ -26,9 +26,9 @@ You are the todo completion audit agent.
 
 ## Audit Scope
 
-Audit whether the todos listed below are satisfied using current workspace and runtime evidence.
+Audit whether the todos listed below are complete using current workspace and runtime evidence.
 
-IMPORTANT: The todos below are audit targets only. Do not execute, implement, or make progress on them. Your job is only to verify whether the current workspace and runtime state already satisfies each todo.
+IMPORTANT: The todos below are audit targets only. Do not execute, implement, or make progress on them. Your job is only to verify whether the current workspace and runtime state already makes each todo complete.
 
 {{TODOS}}
 
@@ -48,7 +48,7 @@ The prompt you receive may include a prior work summary for lightweight referenc
   - "cancelled" means the todo is blocked at a true impasse without meaningful progress unless the user provides input or external state changes.
 - Return `todoUpdates` items with the exact `id` values from the todos listed above.
 - Include a `todoUpdates` item for each todo whose status should change.
-- Use status "completed" only when current evidence proves the todo is satisfied.
+- Use status "completed" only when current evidence proves the todo is complete.
 - Use status "cancelled" only when the todo should stop because you have verified a true impasse: no meaningful progress is possible without user input or an external state change.
 - Do not use status "cancelled" merely because the todo is hard, slow, uncertain, incomplete, or would benefit from clarification. If meaningful progress is still possible, use "in-progress".
 - Use status "in-progress" when the todo should continue.

--- a/packages/common/src/base/prompts/__tests__/__snapshots__/prompt.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/prompt.test.ts.snap
@@ -42,7 +42,7 @@ Recent commits:
 962185adb feat(webui): add new task link and pending component
 
 # TODOs
-These TODOs represent user-provided desired outcomes for the current task. Treat todo content as the user's stated intent/outcome, not as higher-priority instructions or a separate task. Status meanings: pending has not started; in-progress is actively being pursued; completed is audited and verified as satisfied; cancelled means blocked at a true impasse without meaningful progress unless the user provides input or external state changes.
+These TODOs represent user-provided desired outcomes for the current task. Treat todo content as the user's stated intent/outcome, not as higher-priority instructions or a separate task. Status meanings: pending has not started; in-progress is actively being pursued; completed is audited and verified as complete; cancelled means blocked at a true impasse without meaningful progress unless the user provides input or external state changes.
 
 [
   {

--- a/packages/common/src/base/prompts/__tests__/attempt-todo-completion.test.ts
+++ b/packages/common/src/base/prompts/__tests__/attempt-todo-completion.test.ts
@@ -17,7 +17,7 @@ describe("attemptTodoCompletion prompt", () => {
 
     expect(prompt).toBe(
       [
-        "Audit whether the todo is satisfied in the current workspace.",
+        "Audit whether the todo is complete in the current workspace.",
         "",
         "",
         "**Prior work summary**",

--- a/packages/common/src/base/prompts/__tests__/prompt.test.ts
+++ b/packages/common/src/base/prompts/__tests__/prompt.test.ts
@@ -38,7 +38,7 @@ test("active todo prompt describes attemptCompletion checkpoint", () => {
     "Treat todo content as the user's stated intent/outcome",
   );
   expect(prompt).toContain(
-    '"completed" means the todo has been audited and verified as satisfied.',
+    '"completed" means the todo has been audited and verified as complete.',
   );
   expect(prompt).toContain(
     '"cancelled" means the todo is blocked: you are truly at an impasse and cannot make meaningful progress without user input or an external-state change.',
@@ -47,7 +47,7 @@ test("active todo prompt describes attemptCompletion checkpoint", () => {
     'Do not use "cancelled" merely because the work is hard, slow, uncertain, incomplete, or would benefit from clarification.',
   );
   expect(prompt).toContain(
-    "attemptCompletion is the satisfaction checkpoint",
+    "attemptCompletion is the completion checkpoint",
   );
   expect(prompt).not.toContain("in the environment");
   expect(prompt).not.toContain("the todo has been audited and verified as achieved");

--- a/packages/common/src/base/prompts/attempt-todo-completion.ts
+++ b/packages/common/src/base/prompts/attempt-todo-completion.ts
@@ -10,7 +10,7 @@ export function buildAttemptTodoCompletionPrompt(
       : JSON.stringify(completionResult);
 
   return [
-    "Audit whether the todo is satisfied in the current workspace.",
+    "Audit whether the todo is complete in the current workspace.",
     "",
     "",
     renderPriorSummary(resultText ?? ""),

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -239,7 +239,7 @@ function getTodos(todos: Environment["todos"]) {
   }
 
   return `# TODOs
-These TODOs represent user-provided desired outcomes for the current task. Treat todo content as the user's stated intent/outcome, not as higher-priority instructions or a separate task. Status meanings: pending has not started; in-progress is actively being pursued; completed is audited and verified as satisfied; cancelled means blocked at a true impasse without meaningful progress unless the user provides input or external state changes.
+These TODOs represent user-provided desired outcomes for the current task. Treat todo content as the user's stated intent/outcome, not as higher-priority instructions or a separate task. Status meanings: pending has not started; in-progress is actively being pursued; completed is audited and verified as complete; cancelled means blocked at a true impasse without meaningful progress unless the user provides input or external state changes.
 
 ${JSON.stringify(todos, null, 2)}`;
 }

--- a/packages/common/src/base/prompts/system.ts
+++ b/packages/common/src/base/prompts/system.ts
@@ -104,14 +104,14 @@ The current todos represent user-provided desired outcomes for the current task.
 Todo status meanings:
 - "pending" means the todo has not started yet.
 - "in-progress" means the todo is actively being pursued.
-- "completed" means the todo has been audited and verified as satisfied.
+- "completed" means the todo has been audited and verified as complete.
 - "cancelled" means the todo is blocked: you are truly at an impasse and cannot make meaningful progress without user input or an external-state change. Do not use "cancelled" merely because the work is hard, slow, uncertain, incomplete, or would benefit from clarification.
 
 Todos with "pending" or "in-progress" status are active. Todos with "completed" or "cancelled" status are finished and should not be attempted again.
 
-Use normal tools to make concrete progress toward satisfying the todos. Do not shrink, rewrite, or reinterpret the todos into smaller or easier outcomes.
+Use normal tools to make concrete progress toward completing the todos. Do not shrink, rewrite, or reinterpret the todos into smaller or easier outcomes.
 
-When you believe the todos may be satisfied or should stop, call attemptCompletion. In todo mode, attemptCompletion is the satisfaction checkpoint and may be audited before automatic continuation stops. If the satisfaction audit is not accepted, you will receive a reason and should continue working from that feedback.
+When you believe the todos may be complete or should stop, call attemptCompletion. In todo mode, attemptCompletion is the completion checkpoint and may be audited before automatic continuation stops. If the completion audit is not accepted, you will receive a reason and should continue working from that feedback.
 
 Do not call askFollowupQuestion when active todos are present.
 `;

--- a/packages/livekit/src/chat/__tests__/todo-completion-utils.test.ts
+++ b/packages/livekit/src/chat/__tests__/todo-completion-utils.test.ts
@@ -70,7 +70,7 @@ describe("replaceAttemptCompletionWithTodoSubtask", () => {
       >
     ).input?.prompt;
     expect(prompt).toBe([
-      "Audit whether the todo is satisfied in the current workspace.",
+      "Audit whether the todo is complete in the current workspace.",
       "",
       "",
       "**Prior work summary**",

--- a/packages/tools/src/__test__/select-agent-tools.test.ts
+++ b/packages/tools/src/__test__/select-agent-tools.test.ts
@@ -295,7 +295,7 @@ describe("selectAgentTools", () => {
         }),
         createAgent({
           name: "attemptTodoCompletion",
-          description: "Audit whether the main task todos are satisfied.",
+          description: "Audit whether the main task todos are complete.",
         }),
       ],
     });
@@ -303,7 +303,7 @@ describe("selectAgentTools", () => {
     expect(tools.newTask?.description).toContain("child-agent");
     expect(tools.newTask?.description).not.toContain("attemptTodoCompletion");
     expect(tools.newTask?.description).not.toContain(
-      "Audit whether the main task todos are satisfied.",
+      "Audit whether the main task todos are complete.",
     );
   });
 

--- a/packages/tools/src/todo.ts
+++ b/packages/tools/src/todo.ts
@@ -18,7 +18,7 @@ export const Todo = z.object({
         "The state of the todo.",
         '"pending" means the todo has not started yet.',
         '"in-progress" means the todo is actively being pursued.',
-        '"completed" means the todo has been audited and verified as satisfied.',
+        '"completed" means the todo has been audited and verified as complete.',
         '"cancelled" means the todo is blocked: you are truly at an impasse and cannot make meaningful progress without user input or an external-state change.',
         'Do not use "cancelled" merely because the work is hard, slow, uncertain, incomplete, or would benefit from clarification.',
       ].join(" "),

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
@@ -85,8 +85,8 @@ describe("getReadyForRetryError", () => {
               toolCallId: "call-attempt-todo-completion",
               state: "output-available",
               input: {
-                description: "Audit todo satisfaction",
-                prompt: "Audit whether the current todo is satisfied.",
+                description: "Audit todo completion",
+                prompt: "Audit whether the current todo is complete.",
                 agentType: "attemptTodoCompletion",
               },
               output: {
@@ -115,8 +115,8 @@ describe("getReadyForRetryError", () => {
               toolCallId: "call-attempt-todo-completion",
               state: "output-available",
               input: {
-                description: "Audit todo satisfaction",
-                prompt: "Audit whether the current todo is satisfied.",
+                description: "Audit todo completion",
+                prompt: "Audit whether the current todo is complete.",
                 agentType: "attemptTodoCompletion",
               },
               output: {
@@ -147,8 +147,8 @@ describe("getReadyForRetryError", () => {
               toolCallId: "call-attempt-todo-completion",
               state: "output-available",
               input: {
-                description: "Audit todo satisfaction",
-                prompt: "Audit whether the current todo is satisfied.",
+                description: "Audit todo completion",
+                prompt: "Audit whether the current todo is complete.",
                 agentType: "attemptTodoCompletion",
               },
               output: {

--- a/packages/vscode-webui/src/features/todo/components/__tests__/todo-list.test.tsx
+++ b/packages/vscode-webui/src/features/todo/components/__tests__/todo-list.test.tsx
@@ -408,7 +408,7 @@ describe("TodoList", () => {
       within(completedRow as HTMLElement)
         .getAllByRole("button")
         .map((button) => button.getAttribute("aria-label")),
-    ).toEqual(["todoList.cancelTodo", "todoList.deleteTodo"]);
+    ).toEqual(["todoList.deleteTodo"]);
     const deleteButton = within(completedRow as HTMLElement).getByRole(
       "button",
       {
@@ -419,15 +419,11 @@ describe("TodoList", () => {
     expect(deleteButton.className).toContain("w-6");
     expect(deleteButton.className).toContain("ml-2");
     expect(deleteButton.className.split(/\s+/)).not.toContain("border");
-    const cancelButton = within(completedRow as HTMLElement).getByRole(
-      "button",
-      {
+    expect(
+      within(completedRow as HTMLElement).queryByRole("button", {
         name: "todoList.cancelTodo",
-      },
-    );
-    expect(cancelButton.textContent).toBe("todoList.cancelTodo");
-    expect(cancelButton.className).toContain("bg-secondary");
-    expect(cancelButton.className.split(/\s+/)).not.toContain("border");
+      }),
+    ).toBeNull();
   });
 
   it("deletes todos from the trailing delete action", () => {

--- a/packages/vscode-webui/src/features/todo/components/__tests__/todo-list.test.tsx
+++ b/packages/vscode-webui/src/features/todo/components/__tests__/todo-list.test.tsx
@@ -146,7 +146,7 @@ describe("TodoList", () => {
     expect(screen.queryByText("todoList.allDone")).toBeNull();
   });
 
-  it("collapses and expands todos from the header", async () => {
+  it("defaults todo lists to collapsed and toggles from the header", async () => {
     render(
       <TodoList todos={[pendingTodo]}>
         <TodoList.Header />
@@ -157,7 +157,6 @@ describe("TodoList", () => {
     const row = document.getElementById("todo-item-todo-4");
     expect(row).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button"));
     await waitFor(() =>
       expect(
         row?.parentElement?.parentElement?.getAttribute("style"),
@@ -182,9 +181,18 @@ describe("TodoList", () => {
 
     const row = document.getElementById("todo-item-todo-1");
     expect(row).toBeTruthy();
-    expect(
-      row?.parentElement?.parentElement?.getAttribute("style"),
-    ).not.toContain("height: 0px");
+    await waitFor(() =>
+      expect(
+        row?.parentElement?.parentElement?.getAttribute("style"),
+      ).toContain("height: 0px"),
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(
+        row?.parentElement?.parentElement?.getAttribute("style"),
+      ).not.toContain("height: 0px"),
+    );
 
     rerender(
       <TodoList
@@ -282,13 +290,40 @@ describe("TodoList", () => {
         name: "todoList.deleteTodo",
       }),
     ).toBeNull();
+    expect(
+      within(editActions)
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual([
+      "todoList.saveTodo",
+      "todoList.cancelTodo",
+      "todoList.deleteTodo",
+    ]);
+    const saveButton = within(editActions).getByRole("button", {
+      name: "todoList.saveTodo",
+    });
+    expect(saveButton.className).toContain("h-6");
+    expect(saveButton.className).toContain("w-14");
+    const cancelButton = within(editActions).getByRole("button", {
+      name: "todoList.cancelTodo",
+    });
+    expect(cancelButton.textContent).toBe("todoList.cancelTodo");
+    expect(cancelButton.className).toContain("h-6");
+    expect(cancelButton.className).toContain("w-14");
+    expect(cancelButton.className).toContain("bg-secondary");
+    expect(cancelButton.className.split(/\s+/)).not.toContain("border");
     const deleteButton = within(editActions).getByRole("button", {
       name: "todoList.deleteTodo",
     });
-    expect(deleteButton.textContent).toBe("todoList.deleteTodo");
-    expect(deleteButton.className).toContain("bg-background");
+    expect(deleteButton.textContent).toBe("");
+    expect(deleteButton.className).toContain("h-6");
+    expect(deleteButton.className).toContain("w-6");
+    expect(deleteButton.className).toContain("ml-2");
+    expect(deleteButton.className.split(/\s+/)).not.toContain("border");
     expect(
-      within(editActions).queryByRole("button", { name: "todoList.cancel" }),
+      within(editActions).queryByRole("button", {
+        name: "todoList.editTodo",
+      }),
     ).toBeNull();
     expect(
       within(activeRow as HTMLElement).queryByRole("button", {
@@ -369,17 +404,33 @@ describe("TodoList", () => {
         name: "todoList.saveTodo",
       }),
     ).toBeNull();
+    expect(
+      within(completedRow as HTMLElement)
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["todoList.cancelTodo", "todoList.deleteTodo"]);
     const deleteButton = within(completedRow as HTMLElement).getByRole(
       "button",
       {
         name: "todoList.deleteTodo",
       },
     );
-    expect(deleteButton.textContent).toBe("todoList.deleteTodo");
-    expect(deleteButton.className).toContain("bg-background");
+    expect(deleteButton.textContent).toBe("");
+    expect(deleteButton.className).toContain("w-6");
+    expect(deleteButton.className).toContain("ml-2");
+    expect(deleteButton.className.split(/\s+/)).not.toContain("border");
+    const cancelButton = within(completedRow as HTMLElement).getByRole(
+      "button",
+      {
+        name: "todoList.cancelTodo",
+      },
+    );
+    expect(cancelButton.textContent).toBe("todoList.cancelTodo");
+    expect(cancelButton.className).toContain("bg-secondary");
+    expect(cancelButton.className.split(/\s+/)).not.toContain("border");
   });
 
-  it("deletes todos from the item edit state", () => {
+  it("deletes todos from the trailing delete action", () => {
     const onSaveTodos = vi.fn();
 
     render(
@@ -409,7 +460,7 @@ describe("TodoList", () => {
     expect(onSaveTodos).toHaveBeenCalledWith([completedTodo]);
   });
 
-  it("can delete the only todo", () => {
+  it("can delete the only todo from the trailing delete action", () => {
     const onSaveTodos = vi.fn();
 
     render(
@@ -427,10 +478,83 @@ describe("TodoList", () => {
       }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: "todoList.deleteTodo" }),
+      within(activeRow as HTMLElement).getByRole("button", {
+        name: "todoList.deleteTodo",
+      }),
     );
 
     expect(onSaveTodos).toHaveBeenCalledWith([]);
+  });
+
+  it("cancels draft changes from the item edit state", () => {
+    const onSaveTodos = vi.fn();
+
+    render(
+      <TodoList
+        todos={[activeTodo, completedTodo]}
+        editable
+        onSaveTodos={onSaveTodos}
+      >
+        <TodoList.Header />
+        <TodoList.Items />
+      </TodoList>,
+    );
+
+    const activeRow = document.getElementById("todo-item-todo-1");
+    expect(activeRow).toBeTruthy();
+    fireEvent.click(
+      within(activeRow as HTMLElement).getByRole("button", {
+        name: "todoList.editTodo",
+      }),
+    );
+    fireEvent.click(
+      within(activeRow as HTMLElement).getByRole("button", {
+        name: "todoList.cancelTodo",
+      }),
+    );
+
+    expect(onSaveTodos).not.toHaveBeenCalled();
+    expect(
+      screen.getAllByText("Increase tests/basic.test.tsx coverage").length,
+    ).toBeGreaterThan(0);
+    expect(
+      within(activeRow as HTMLElement).getByRole("button", {
+        name: "todoList.editTodo",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "todoList.cancelTodo" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "todoList.deleteTodo" }),
+    ).toBeNull();
+  });
+
+  it("can cancel editing the only todo", () => {
+    const onSaveTodos = vi.fn();
+
+    render(
+      <TodoList todos={[activeTodo]} editable onSaveTodos={onSaveTodos}>
+        <TodoList.Header />
+        <TodoList.Items />
+      </TodoList>,
+    );
+
+    const activeRow = document.getElementById("todo-item-todo-1");
+    expect(activeRow).toBeTruthy();
+    fireEvent.click(
+      within(activeRow as HTMLElement).getByRole("button", {
+        name: "todoList.editTodo",
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "todoList.cancelTodo" }),
+    );
+
+    expect(onSaveTodos).not.toHaveBeenCalled();
+    expect(
+      screen.getAllByText("Increase tests/basic.test.tsx coverage").length,
+    ).toBeGreaterThan(0);
   });
 
   it("cancels draft changes with Escape", () => {

--- a/packages/vscode-webui/src/features/todo/components/todo-list.tsx
+++ b/packages/vscode-webui/src/features/todo/components/todo-list.tsx
@@ -20,6 +20,7 @@ import {
   Edit,
   Pause,
   Play,
+  Trash2,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import {
@@ -51,6 +52,8 @@ const todoItemVariants = {
   animate: { opacity: 1, y: 0, scale: 1 },
   exit: { opacity: 0, y: -5, scale: 0.97 },
 };
+const TodoEditActionButtonClassName = "h-6 w-14 gap-1.5";
+const TodoEditIconButtonClassName = "ml-2 h-6 w-6 p-0";
 
 // Context for sharing state between compound components
 interface TodoListContextValue {
@@ -111,9 +114,8 @@ function TodoListRoot({
   onSaveTodos,
   onTodoPausedChange,
 }: TodoListRootProps) {
-  const hasActiveTodo = todos.some(isActiveTodo);
   const [isCollapsed, setIsCollapsed] = useState(
-    !hasActiveTodo && !disableCollapse && todos.length > 0,
+    !disableCollapse && todos.length > 0,
   );
   const [editingTodoId, setEditingTodoId] = useState<string>();
   const [draftContent, setDraftContent] = useState("");
@@ -369,29 +371,54 @@ function TodoPauseButton({
   );
 }
 
-function TodoDeleteButton({ todo }: { todo: Todo }) {
+function TodoCancelButton() {
   const { t } = useTranslation();
-  const { editable, editingTodoId, deleteTodo } = useTodoListContext();
-
-  if (!editable || (editingTodoId && editingTodoId !== todo.id)) return null;
-
-  const label = t("todoList.deleteTodo");
+  const { cancelEditMode } = useTodoListContext();
+  const label = t("todoList.cancelTodo");
 
   return (
     <Button
       type="button"
-      variant="outline"
+      variant="secondary"
       size="xs"
-      className="h-6 gap-1.5"
+      className={TodoEditActionButtonClassName}
       aria-label={label}
       data-todo-edit-action
       onClick={(event) => {
         event.stopPropagation();
-        deleteTodo(todo.id);
+        cancelEditMode();
       }}
     >
       {label}
     </Button>
+  );
+}
+
+function TodoDeleteButton({ todo }: { todo: Todo }) {
+  const { t } = useTranslation();
+  const { deleteTodo } = useTodoListContext();
+  const label = t("todoList.deleteTodo");
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className={TodoEditIconButtonClassName}
+          aria-label={label}
+          data-todo-edit-action
+          onClick={(event) => {
+            event.stopPropagation();
+            deleteTodo(todo.id);
+          }}
+        >
+          <Trash2 className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -433,7 +460,7 @@ function TodoSaveButton() {
       type="button"
       variant="default"
       size="xs"
-      className="h-6 gap-1.5"
+      className={TodoEditActionButtonClassName}
       aria-label={t("todoList.saveTodo")}
       data-todo-edit-action
       disabled={hasInvalidDraftTodo}
@@ -486,6 +513,7 @@ function TodoTrailingActions({ todo }: { todo: Todo }) {
   return (
     <div className="flex shrink-0 items-center gap-1">
       {isActiveTodo(todo) && <TodoSaveButton />}
+      <TodoCancelButton />
       <TodoDeleteButton todo={todo} />
     </div>
   );

--- a/packages/vscode-webui/src/features/todo/components/todo-list.tsx
+++ b/packages/vscode-webui/src/features/todo/components/todo-list.tsx
@@ -512,8 +512,12 @@ function TodoTrailingActions({ todo }: { todo: Todo }) {
 
   return (
     <div className="flex shrink-0 items-center gap-1">
-      {isActiveTodo(todo) && <TodoSaveButton />}
-      <TodoCancelButton />
+      {isActiveTodo(todo) && (
+        <>
+          <TodoSaveButton />
+          <TodoCancelButton />
+        </>
+      )}
       <TodoDeleteButton todo={todo} />
     </div>
   );

--- a/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
@@ -95,8 +95,8 @@ describe("getAttemptTodoCompletionState", () => {
         }),
       ),
     ).toEqual({
-      status: "satisfied",
-      summary: "Todo is satisfied.",
+      status: "completed",
+      summary: "All todos are complete.",
     });
   });
 

--- a/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
@@ -72,25 +72,25 @@ describe("getAttemptTodoCompletionSummary", () => {
 });
 
 describe("getAttemptTodoCompletionState", () => {
-  it("detects resolved satisfied todo completion results", () => {
+  it("detects resolved completed todo completion results", () => {
     expect(
       getAttemptTodoCompletionState({
         success: true,
-        summary: "Todo is satisfied.",
+        summary: "All todos are complete.",
         todos: completedTodos,
       }),
     ).toEqual({
-      status: "satisfied",
-      summary: "Todo is satisfied.",
+      status: "completed",
+      summary: "All todos are complete.",
     });
   });
 
-  it("detects satisfied todo completion results", () => {
+  it("detects completed todo completion results", () => {
     expect(
       getAttemptTodoCompletionState(
         JSON.stringify({
           success: true,
-          summary: "Todo is satisfied.",
+          summary: "All todos are complete.",
           todos: completedTodos,
         }),
       ),

--- a/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
@@ -35,8 +35,8 @@ export function AttemptTodoCompletionView({
 
   let title = t("attemptTodoCompletionView.auditing");
 
-  if (completion?.status === "satisfied") {
-    title = t("attemptTodoCompletionView.satisfied");
+  if (completion?.status === "completed") {
+    title = t("attemptTodoCompletionView.completed");
   } else if (completion?.status === "needs-work") {
     title = t("attemptTodoCompletionView.needsWork");
   } else if (hasAuditFailure) {

--- a/packages/vscode-webui/src/features/tools/components/new-task/result.ts
+++ b/packages/vscode-webui/src/features/tools/components/new-task/result.ts
@@ -2,7 +2,7 @@ import { ResolvedAttemptTodoCompletionResult } from "@getpochi/tools";
 import { parseJsonObjectString } from "../tool-result-display";
 
 export type AttemptTodoCompletionState = {
-  status: "satisfied" | "needs-work";
+  status: "completed" | "needs-work";
   summary: string;
 };
 
@@ -28,7 +28,7 @@ export function getAttemptTodoCompletionState(
   const summary = parsedResult.data.summary.trim();
   if (!summary) return undefined;
   return {
-    status: parsedResult.data.success ? "satisfied" : "needs-work",
+    status: parsedResult.data.success ? "completed" : "needs-work",
     summary,
   };
 }

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -469,13 +469,14 @@
     "todos": "TODOs",
     "allDone": "🎉 All done!",
     "cancelledTodo": "Todo cancelled",
-    "editTodo": "Edit todo",
+    "editTodo": "Edit",
     "editTodos": "Edit todos",
     "saveTodo": "Save",
     "saveTodos": "Save todos",
     "editTodoContent": "Edit todo content",
+    "cancelTodo": "Cancel",
     "deleteTodo": "Delete",
-    "pauseTodo": "Pause todo",
+    "pauseTodo": "Pause",
     "resumeTodo": "Resume todo"
   },
   "commandExecutionPanel": {
@@ -579,8 +580,8 @@
     "paused": "Paused"
   },
   "attemptTodoCompletionView": {
-    "auditing": "Auditing todo",
-    "satisfied": "Todo satisfied",
+    "auditing": "Auditing todos",
+    "completed": "All todos completed",
     "needsWork": "Todo needs more work",
     "failed": "Todo audit failed"
   },

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -463,13 +463,14 @@
     "todos": "TODO",
     "allDone": "🎉 すべて完了！",
     "cancelledTodo": "Todoをキャンセルしました",
-    "editTodo": "Todoを編集",
+    "editTodo": "編集",
     "editTodos": "Todoを編集",
     "saveTodo": "保存",
     "saveTodos": "Todoを保存",
     "editTodoContent": "Todo内容を編集",
+    "cancelTodo": "キャンセル",
     "deleteTodo": "削除",
-    "pauseTodo": "Todoを一時停止",
+    "pauseTodo": "一時停止",
     "resumeTodo": "Todoを再開"
   },
   "commandExecutionPanel": {
@@ -577,8 +578,8 @@
     "paused": "一時停止"
   },
   "attemptTodoCompletionView": {
-    "auditing": "Todo を監査中",
-    "satisfied": "Todo は満たされています",
+    "auditing": "Todos を監査中",
+    "completed": "すべての Todos が完了しました",
     "needsWork": "Todo はさらに作業が必要です",
     "failed": "Todo 監査に失敗しました"
   },

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -461,13 +461,14 @@
     "todos": "할 일",
     "allDone": "🎉 모두 완료!",
     "cancelledTodo": "Todo 취소됨",
-    "editTodo": "Todo 편집",
+    "editTodo": "편집",
     "editTodos": "Todo 편집",
     "saveTodo": "저장",
     "saveTodos": "Todo 저장",
     "editTodoContent": "Todo 내용 편집",
+    "cancelTodo": "취소",
     "deleteTodo": "삭제",
-    "pauseTodo": "Todo 일시 중지",
+    "pauseTodo": "일시 중지",
     "resumeTodo": "Todo 다시 시작"
   },
   "commandExecutionPanel": {
@@ -570,8 +571,8 @@
     "paused": "일시 중지됨"
   },
   "attemptTodoCompletionView": {
-    "auditing": "Todo 감사 중",
-    "satisfied": "Todo 충족됨",
+    "auditing": "Todos 감사 중",
+    "completed": "모든 Todos 완료됨",
     "needsWork": "Todo에 추가 작업 필요",
     "failed": "Todo 감사 실패"
   },

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -461,13 +461,14 @@
     "todos": "待办事项",
     "allDone": "🎉 全部完成！",
     "cancelledTodo": "Todo 已取消",
-    "editTodo": "编辑 Todo",
+    "editTodo": "编辑",
     "editTodos": "编辑 Todos",
     "saveTodo": "保存",
     "saveTodos": "保存 Todos",
     "editTodoContent": "编辑 Todo 内容",
+    "cancelTodo": "取消",
     "deleteTodo": "删除",
-    "pauseTodo": "暂停 Todo",
+    "pauseTodo": "暂停",
     "resumeTodo": "继续 Todo"
   },
   "commandExecutionPanel": {
@@ -575,8 +576,8 @@
     "paused": "暂停"
   },
   "attemptTodoCompletionView": {
-    "auditing": "正在审计 Todo",
-    "satisfied": "Todo 已满足",
+    "auditing": "正在审计 Todos",
+    "completed": "所有 Todos 已完成",
     "needsWork": "Todo 需要继续推进",
     "failed": "Todo 审计失败"
   },


### PR DESCRIPTION
## Summary
- **Terminology Alignment**: Standardized all todo auditing terminology from "satisfaction" to "completion" across prompts, schemas, views, and test suites.
- **UI Enhancements**: Refactored the todo list component to default lists to collapsed and added a "Cancel" action for draft edits.
- **Action Refinement**: Moved the "Delete" action to a trailing tooltip-wrapped button and updated translations for Edit/Save/Cancel/Delete/Pause/Resume across all supported locales.

## Screenshot
<img width="1168" height="204" alt="image" src="https://github.com/user-attachments/assets/440119fb-d59c-4fd3-aa1c-d1de818c489e" />


## Test plan
- [x] Run `bun run test` to verify all test suites pass successfully.
- [x] Run `bun check` and `bun tsc` to ensure no linting/formatting or typescript errors exist.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-26495e89ae204869bce27c4517d17b0c)