### PR TITLE
fix(chat): preserve and restore selected model ID when compacting tasks

### DIFF
--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -43,6 +43,7 @@ export type PochiTaskParams = { cwd: string } & (
   | {
       type: "compact-task";
       messages: string;
+      modelId?: string;
     }
   | {
       type: "open-task";

--- a/packages/vscode-webui/src/features/chat/hooks/use-new-compact-task.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-new-compact-task.ts
@@ -43,6 +43,7 @@ export const useNewCompactTask = ({
         type: "compact-task",
         cwd,
         messages: JSON.stringify(initMessages),
+        modelId: task?.modelId ?? undefined,
       });
     },
   });

--- a/packages/vscode-webui/src/features/chat/hooks/use-restore-task-model.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-restore-task-model.ts
@@ -1,16 +1,21 @@
+import type { PochiTaskInfo } from "@getpochi/common/vscode-webui-bridge";
 import type { Task } from "@getpochi/livekit";
 import { useEffect, useRef } from "react";
 
 export const useRestoreTaskModel = (
   task: Task | undefined,
+  info: PochiTaskInfo,
   isModelsLoading: boolean,
   updateSelectedModelId: (modelId: string) => void,
 ) => {
   const restored = useRef(false);
+  const infoModelId = info.type === "compact-task" ? info.modelId : undefined;
+
   useEffect(() => {
-    if (task?.modelId && !isModelsLoading && !restored.current) {
+    const modelId = infoModelId ?? task?.modelId;
+    if (modelId && !isModelsLoading && !restored.current) {
       restored.current = true;
-      updateSelectedModelId(task.modelId);
+      updateSelectedModelId(modelId);
     }
-  }, [task?.modelId, updateSelectedModelId, isModelsLoading]);
+  }, [task?.modelId, infoModelId, updateSelectedModelId, isModelsLoading]);
 };

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -140,7 +140,7 @@ function Chat({ user, uid, info }: ChatProps) {
     taskId: uid,
   });
 
-  useRestoreTaskModel(task, isModelsLoading, updateSelectedModelId);
+  useRestoreTaskModel(task, info, isModelsLoading, updateSelectedModelId);
 
   const { autoApproveActive, autoApproveSettings } = useAutoApprove({
     autoApproveGuard: autoApproveGuard.current === "auto",


### PR DESCRIPTION
## Summary
- Pass `modelId` as part of `PochiTaskParams` when creating a `compact-task`
- Update the `useRestoreTaskModel` hook to accept `info` and extract the compact task's `modelId` if available
- Restore the selected model in the chat UI using the extracted `modelId`

## Test plan
- Verified that type checking (`bun tsc`) and lint checking (`bun check`) pass successfully.
- Verified the code logic to ensure the selected model ID is correctly passed and restored for compact tasks.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1fa3616fb2b344efb2d6ce8bbaaa8783)