### PR TITLE
feat(memory): support clearing project long-term memory from UI

### DIFF
--- a/packages/common/src/auto-memory/node.ts
+++ b/packages/common/src/auto-memory/node.ts
@@ -266,6 +266,30 @@ export class AutoMemoryManager {
       success ? Date.now() : previousLastDreamAt,
     );
   }
+
+  async clearProjectMemory({ cwd }: { cwd?: string } = {}): Promise<void> {
+    const context = await this.readContext(cwd, { ensure: false });
+    if (!context) return;
+
+    const exists = await fs
+      .stat(context.memoryDir)
+      .then(() => true)
+      .catch(() => false);
+    if (!exists) return;
+
+    const entries = await fs.readdir(context.memoryDir).catch(() => []);
+    await Promise.all(
+      entries
+        .filter(
+          (entry) => entry.endsWith(".md") || entry === AutoMemoryLockName,
+        )
+        .map((entry) =>
+          fs.rm(path.join(context.memoryDir, entry), { force: true }),
+        ),
+    );
+    // Re-create the default index file so the memory dir is still usable.
+    await ensureIndexFile(context.indexPath);
+  }
 }
 
 export async function resolveMainWorktreePath(cwd: string): Promise<string> {

--- a/packages/common/src/base/memory.ts
+++ b/packages/common/src/base/memory.ts
@@ -95,4 +95,5 @@ export interface AutoMemoryManager {
     previousLastDreamAt: number;
     success: boolean;
   }): Promise<void>;
+  clearProjectMemory(options?: { cwd?: string }): Promise<void>;
 }

--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -412,6 +412,7 @@ const VSCodeHostStub = {
     writeTaskTranscript: async () => undefined,
     beginDreamRun: async () => undefined,
     finishDreamRun: async () => undefined,
+    clearProjectMemory: async () => undefined,
   }),
   readAutoMemoryEnabled: async (): Promise<{
     value: ThreadSignalSerialization<boolean>;

--- a/packages/livekit/src/background-task/memory/__tests__/adaptors.test.ts
+++ b/packages/livekit/src/background-task/memory/__tests__/adaptors.test.ts
@@ -483,6 +483,7 @@ function makeAutoMemoryManager(
     })),
     beginDreamRun: vi.fn(async () => undefined),
     finishDreamRun: vi.fn(async () => undefined),
+    clearProjectMemory: vi.fn(async () => undefined),
     ...overrides,
   };
 }

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -388,6 +388,7 @@ function makeAutoMemoryManager() {
     })),
     beginDreamRun: vi.fn(async () => undefined),
     finishDreamRun: vi.fn(async () => undefined),
+    clearProjectMemory: vi.fn(async () => undefined),
   };
 }
 

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -365,16 +365,17 @@ export function TokenUsage({
 
                   <div className="flex items-center gap-1.5">
                     {autoMemoryAvailable && (
-                      <button
-                        type="button"
+                      <Button
+                        variant="outline"
+                        size="sm"
                         aria-label={t("tokenUsage.projectMemoryClear")}
-                        className="invisible cursor-pointer text-muted-foreground hover:text-foreground group-hover/project-memory:visible"
+                        className="invisible h-auto px-1.5 py-0.5 text-xs group-hover/project-memory:visible"
                         onClick={() => {
                           void handleClearProjectMemory();
                         }}
                       >
                         {t("tokenUsage.projectMemoryReset")}
-                      </button>
+                      </Button>
                     )}
                     {autoMemoryAvailable && (
                       <span className="text-muted-foreground">

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -20,7 +20,7 @@ import { vscodeAutoMemoryManager, vscodeHost } from "@/lib/vscode";
 import { constants, TaskMemoryFileUri } from "@getpochi/common";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
 import { useQuery } from "@tanstack/react-query";
-import { CircleAlert, Loader2, Trash2 } from "lucide-react";
+import { CircleAlert, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
@@ -293,7 +293,7 @@ export function TokenUsage({
                 </div>
 
                 {/* Project Memory row (label + toggle on the left, percentage on the right) */}
-                <div className="ml-3 flex items-center justify-between gap-2">
+                <div className="group/project-memory ml-3 flex items-center justify-between gap-2">
                   <div className="flex items-center gap-2">
                     <TooltipProvider>
                       <Tooltip>
@@ -365,25 +365,16 @@ export function TokenUsage({
 
                   <div className="flex items-center gap-1.5">
                     {autoMemoryAvailable && (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label={t("tokenUsage.projectMemoryClear")}
-                              className="inline-flex cursor-pointer items-center text-muted-foreground hover:text-destructive"
-                              onClick={() => {
-                                void handleClearProjectMemory();
-                              }}
-                            >
-                              <Trash2 className="size-3" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {t("tokenUsage.projectMemoryClear")}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
+                      <button
+                        type="button"
+                        aria-label={t("tokenUsage.projectMemoryClear")}
+                        className="invisible cursor-pointer text-muted-foreground hover:text-foreground group-hover/project-memory:visible"
+                        onClick={() => {
+                          void handleClearProjectMemory();
+                        }}
+                      >
+                        {t("tokenUsage.projectMemoryReset")}
+                      </button>
                     )}
                     {autoMemoryAvailable && (
                       <span className="text-muted-foreground">

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -20,7 +20,7 @@ import { vscodeAutoMemoryManager, vscodeHost } from "@/lib/vscode";
 import { constants, TaskMemoryFileUri } from "@getpochi/common";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
 import { useQuery } from "@tanstack/react-query";
-import { CircleAlert, Loader2 } from "lucide-react";
+import { CircleAlert, Loader2, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
@@ -72,6 +72,17 @@ export function TokenUsage({
       vscodeHost.openFile(context.indexPath);
       setIsOpen(false);
     }
+  };
+
+  const handleClearProjectMemory = async () => {
+    const confirmed = await vscodeHost.showInformationMessage(
+      t("tokenUsage.projectMemoryClear"),
+      { modal: true, detail: t("tokenUsage.projectMemoryClearConfirm") },
+      t("tokenUsage.projectMemoryClear"),
+    );
+    if (!confirmed) return;
+    await vscodeAutoMemoryManager.clearProjectMemory();
+    setIsOpen(false);
   };
   const { t } = useTranslation();
   const contextWindow =
@@ -352,11 +363,34 @@ export function TokenUsage({
                     </TooltipProvider>
                   </div>
 
-                  {autoMemoryAvailable && (
-                    <span className="text-muted-foreground">
-                      {formatPercentage(projectMemoryVal)}
-                    </span>
-                  )}
+                  <div className="flex items-center gap-1.5">
+                    {autoMemoryAvailable && (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              aria-label={t("tokenUsage.projectMemoryClear")}
+                              className="inline-flex cursor-pointer items-center text-muted-foreground hover:text-destructive"
+                              onClick={() => {
+                                void handleClearProjectMemory();
+                              }}
+                            >
+                              <Trash2 className="size-3" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {t("tokenUsage.projectMemoryClear")}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
+                    {autoMemoryAvailable && (
+                      <span className="text-muted-foreground">
+                        {formatPercentage(projectMemoryVal)}
+                      </span>
+                    )}
+                  </div>
                 </div>
 
                 {/* Task Memory row (mirrors Project Memory row structure so the tooltip anchors at the same position) */}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -83,6 +83,8 @@
     "viewProjectMemoryTooltip": "Open the MEMORY.md index for this workspace.",
     "viewTaskMemoryButtonTooltip": "Open the task memory summary that compacting will reuse.",
     "projectMemoryUnavailable": "Project memory becomes available after running a task in this workspace.",
+    "projectMemoryClear": "Clear Project Memory",
+    "projectMemoryClearConfirm": "This will delete all project memory files (MEMORY.md and topic files). This action cannot be undone.",
     "taskMemoryUnavailable": "Task memory is generated automatically as the conversation grows."
   },
   "modelSelect": {

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -84,7 +84,8 @@
     "viewTaskMemoryButtonTooltip": "Open the task memory summary that compacting will reuse.",
     "projectMemoryUnavailable": "Project memory becomes available after running a task in this workspace.",
     "projectMemoryClear": "Clear Project Memory",
-    "projectMemoryClearConfirm": "This will delete all project memory files (MEMORY.md and topic files). This action cannot be undone.",
+    "projectMemoryReset": "Reset",
+    "projectMemoryClearConfirm": "This will reset all project memory files (MEMORY.md and topic files). This action cannot be undone.",
     "taskMemoryUnavailable": "Task memory is generated automatically as the conversation grows."
   },
   "modelSelect": {

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -83,6 +83,8 @@
     "viewProjectMemoryTooltip": "このワークスペースの MEMORY.md インデックスを開きます。",
     "viewTaskMemoryButtonTooltip": "タスク圧縮時に再利用されるタスクメモリの要約を開きます。",
     "projectMemoryUnavailable": "このワークスペースでタスクを実行するとプロジェクトメモリが利用可能になります。",
+    "projectMemoryClear": "プロジェクトメモリをクリア",
+    "projectMemoryClearConfirm": "すべてのプロジェクトメモリファイル（MEMORY.md およびトピックファイル）が削除されます。この操作は元に戻せません。",
     "taskMemoryUnavailable": "タスクメモリは会話の進行に伴って自動的に生成されます。"
   },
   "modelSelect": {

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -84,7 +84,8 @@
     "viewTaskMemoryButtonTooltip": "タスク圧縮時に再利用されるタスクメモリの要約を開きます。",
     "projectMemoryUnavailable": "このワークスペースでタスクを実行するとプロジェクトメモリが利用可能になります。",
     "projectMemoryClear": "プロジェクトメモリをクリア",
-    "projectMemoryClearConfirm": "すべてのプロジェクトメモリファイル（MEMORY.md およびトピックファイル）が削除されます。この操作は元に戻せません。",
+    "projectMemoryReset": "リセット",
+    "projectMemoryClearConfirm": "すべてのプロジェクトメモリファイル（MEMORY.md およびトピックファイル）がリセットされます。この操作は元に戻せません。",
     "taskMemoryUnavailable": "タスクメモリは会話の進行に伴って自動的に生成されます。"
   },
   "modelSelect": {

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -83,7 +83,8 @@
     "viewTaskMemoryButtonTooltip": "작업 압축 시 재사용되는 작업 메모리 요약을 엽니다.",
     "projectMemoryUnavailable": "이 워크스페이스에서 작업을 실행하면 프로젝트 메모리를 사용할 수 있습니다.",
     "projectMemoryClear": "프로젝트 메모리 초기화",
-    "projectMemoryClearConfirm": "모든 프로젝트 메모리 파일(MEMORY.md 및 주제 파일)이 삭제됩니다. 이 작업은 취소할 수 없습니다.",
+    "projectMemoryReset": "초기화",
+    "projectMemoryClearConfirm": "모든 프로젝트 메모리 파일(MEMORY.md 및 주제 파일)이 초기화됩니다. 이 작업은 취소할 수 없습니다.",
     "taskMemoryUnavailable": "작업 메모리는 대화가 진행됨에 따라 자동으로 생성됩니다."
   },
   "modelSelect": {

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -82,6 +82,8 @@
     "viewProjectMemoryTooltip": "이 워크스페이스의 MEMORY.md 인덱스를 엽니다.",
     "viewTaskMemoryButtonTooltip": "작업 압축 시 재사용되는 작업 메모리 요약을 엽니다.",
     "projectMemoryUnavailable": "이 워크스페이스에서 작업을 실행하면 프로젝트 메모리를 사용할 수 있습니다.",
+    "projectMemoryClear": "프로젝트 메모리 초기화",
+    "projectMemoryClearConfirm": "모든 프로젝트 메모리 파일(MEMORY.md 및 주제 파일)이 삭제됩니다. 이 작업은 취소할 수 없습니다.",
     "taskMemoryUnavailable": "작업 메모리는 대화가 진행됨에 따라 자동으로 생성됩니다."
   },
   "modelSelect": {

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -82,6 +82,8 @@
     "viewProjectMemoryTooltip": "打开此工作区的 MEMORY.md 索引文件。",
     "viewTaskMemoryButtonTooltip": "打开压缩任务时复用的任务记忆摘要。",
     "projectMemoryUnavailable": "在此工作区运行任务后，项目记忆将可用。",
+    "projectMemoryClear": "清除项目记忆",
+    "projectMemoryClearConfirm": "这将删除所有项目记忆文件（MEMORY.md 及主题文件），此操作无法撤销。",
     "taskMemoryUnavailable": "任务记忆将随着对话进行自动生成。"
   },
   "modelSelect": {

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -83,7 +83,8 @@
     "viewTaskMemoryButtonTooltip": "打开压缩任务时复用的任务记忆摘要。",
     "projectMemoryUnavailable": "在此工作区运行任务后，项目记忆将可用。",
     "projectMemoryClear": "清除项目记忆",
-    "projectMemoryClearConfirm": "这将删除所有项目记忆文件（MEMORY.md 及主题文件），此操作无法撤销。",
+    "projectMemoryReset": "重置",
+    "projectMemoryClearConfirm": "这将重置所有项目记忆文件（MEMORY.md 及主题文件），此操作无法撤销。",
     "taskMemoryUnavailable": "任务记忆将随着对话进行自动生成。"
   },
   "modelSelect": {

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -292,4 +292,6 @@ export const vscodeAutoMemoryManager: AutoMemoryManager = {
     (await loadAutoMemoryManager()).beginDreamRun(options),
   finishDreamRun: async (options) =>
     (await loadAutoMemoryManager()).finishDreamRun(options),
+  clearProjectMemory: async (options) =>
+    (await loadAutoMemoryManager()).clearProjectMemory(options),
 };

--- a/packages/vscode/src/lib/auto-memory.ts
+++ b/packages/vscode/src/lib/auto-memory.ts
@@ -29,6 +29,8 @@ export class AutoMemoryManager extends BaseAutoMemoryManager {
       writeTaskTranscript: (options) => this.writeHostTaskTranscript(options),
       beginDreamRun: (options) => this.beginHostDreamRun(options),
       finishDreamRun: (options) => this.finishDreamRun(options),
+      clearProjectMemory: (options) =>
+        this.clearProjectMemory({ cwd: options?.cwd ?? this.cwd }),
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `clearProjectMemory` method to `AutoMemoryManager` to delete all workspace memory markdown files and reset the index file.
- Register `clearProjectMemory` in the VSCode host and webui bridge.
- Add a "Clear Project Memory" action (trash icon button) with a confirmation modal in the token usage UI.

## Test plan
- Run `bun run test` to verify all existing and updated tests pass.
- Verify the mock adaptors in livekit and chat tests correctly handle the new `clearProjectMemory` method.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c3f77ce9a550433189f2a9e6aebf8c96)

---

Preview:
Normal | Hover
:-------------------------:|:-------------------------:
<img width="614" height="579" alt="Screenshot from 2026-06-30 10-52-46" src="https://github.com/user-attachments/assets/eb06446a-0570-40b9-a1a4-7c4713c0ab49" /> |  <img width="614" height="579" alt="image" src="https://github.com/user-attachments/assets/cb39a2db-32b9-4ab3-b032-fdb8b81366da" />

