### PR TITLE
chore(tool-utils): temporarily disable read-before-write guard

### DIFF
--- a/packages/common/src/tool-utils/__tests__/file-state-cache.test.ts
+++ b/packages/common/src/tool-utils/__tests__/file-state-cache.test.ts
@@ -44,7 +44,9 @@ describe("FileStateCache", () => {
     expect(cache.sizeBytes).toBe(0);
   });
 
-  it("treats deleted files as stale", async () => {
+  // The staleness guard is temporarily disabled in full, so a deleted/modified
+  // file no longer throws.
+  it("no longer treats deleted files as stale", async () => {
     const cache = new FileStateCache();
     cache.set("/tmp/file.txt", {
       content: "hello",
@@ -55,9 +57,7 @@ describe("FileStateCache", () => {
 
     await expect(
       checkStaleness(cache, "/tmp/file.txt", async () => undefined, "writing"),
-    ).rejects.toThrow(
-      "File has been modified since it was last read (expected mtime 1, got missing). Please read the file again before writing.",
-    );
+    ).resolves.toBeUndefined();
   });
 
   it("allows edits when the mtime still matches the cached state", async () => {
@@ -74,24 +74,22 @@ describe("FileStateCache", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("throws when editing a file that was never read but exists on disk", async () => {
+  // The "read before edit/write" guard is temporarily disabled, so editing or
+  // writing a file that was never read no longer throws.
+  it("allows editing a file that was never read but exists on disk", async () => {
     const cache = new FileStateCache();
 
     await expect(
       checkStaleness(cache, "/tmp/file.txt", async () => 1234, "editing"),
-    ).rejects.toThrow(
-      "File has not been read yet. Please read the file before editing it.",
-    );
+    ).resolves.toBeUndefined();
   });
 
-  it("throws when writing a file that was never read but exists on disk", async () => {
+  it("allows writing a file that was never read but exists on disk", async () => {
     const cache = new FileStateCache();
 
     await expect(
       checkStaleness(cache, "/tmp/file.txt", async () => 1234, "writing"),
-    ).rejects.toThrow(
-      "File has not been read yet. Please read the file before writing it.",
-    );
+    ).resolves.toBeUndefined();
   });
 
   it("allows writing a new file that does not exist on disk and was never read", async () => {
@@ -136,7 +134,9 @@ describe("FileStateCache", () => {
 });
 
 describe("withFileStateCacheGuard", () => {
-  it("throws when editing an existing file that was never read", async () => {
+  // The "read before edit/write" guard is temporarily disabled, so editing an
+  // existing file that was never read no longer throws.
+  it("allows editing an existing file that was never read", async () => {
     const cache = new FileStateCache();
     const getMtime = async (_path: string) => 1000;
 
@@ -152,9 +152,7 @@ describe("withFileStateCacheGuard", () => {
           fileCacheContent: "new content",
         }),
       }),
-    ).rejects.toThrow(
-      "File has not been read yet. Please read the file before editing it.",
-    );
+    ).resolves.toEqual({ success: true });
   });
 
   it("allows writing a brand-new file that does not yet exist on disk", async () => {

--- a/packages/common/src/tool-utils/file-state-cache.ts
+++ b/packages/common/src/tool-utils/file-state-cache.ts
@@ -196,35 +196,40 @@ export class FileStateCache {
  * @param operation - "editing" or "writing" — used in error message
  */
 export async function checkStaleness(
-  cache: IFileStateCache,
-  resolvedPath: string,
-  getMtime: (path: string) => Promise<number | undefined>,
-  operation: "editing" | "writing" = "editing",
+  _cache: IFileStateCache,
+  _resolvedPath: string,
+  _getMtime: (path: string) => Promise<number | undefined>,
+  _operation: "editing" | "writing" = "editing",
 ): Promise<void> {
-  const cachedState = cache.get(resolvedPath);
-
-  if (!cachedState) {
-    // The model hasn't read this file yet.
-    // If the file exists on disk, require the model to read it first to avoid
-    // blindly overwriting content it has never seen.
-    const currentMtime = await getMtime(resolvedPath);
-    if (currentMtime !== undefined) {
-      throw new Error(
-        `File has not been read yet. Please read the file before ${operation} it.`,
-      );
-    }
-    // File doesn't exist on disk — creating a new file is always allowed.
-    return;
-  }
-
-  const currentMtime = await getMtime(resolvedPath);
-  if (currentMtime === cachedState.timestamp) return;
-
-  const actualMtime =
-    currentMtime === undefined ? "missing" : String(currentMtime);
-  throw new Error(
-    `File has been modified since it was last read (expected mtime ${cachedState.timestamp}, got ${actualMtime}). Please read the file again before ${operation}.`,
-  );
+  // NOTE: The "read before edit/write" guard is temporarily disabled in full.
+  // This previously enforced two things before an edit/write:
+  //   1. The file must have been read at least once (otherwise throw
+  //      "File has not been read yet ...").
+  //   2. The file must not have been modified externally since it was last
+  //      read (otherwise throw "File has been modified since it was last
+  //      read ...").
+  // Both checks are now skipped so edits/writes always proceed.
+  //
+  // To re-enable, restore the original implementation below:
+  //
+  //   const cachedState = cache.get(resolvedPath);
+  //   if (!cachedState) {
+  //     const currentMtime = await getMtime(resolvedPath);
+  //     if (currentMtime !== undefined) {
+  //       throw new Error(
+  //         `File has not been read yet. Please read the file before ${operation} it.`,
+  //       );
+  //     }
+  //     return;
+  //   }
+  //   const currentMtime = await getMtime(resolvedPath);
+  //   if (currentMtime === cachedState.timestamp) return;
+  //   const actualMtime =
+  //     currentMtime === undefined ? "missing" : String(currentMtime);
+  //   throw new Error(
+  //     `File has been modified since it was last read (expected mtime ${cachedState.timestamp}, got ${actualMtime}). Please read the file again before ${operation}.`,
+  //   );
+  return;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Turn `checkStaleness` into a no-op so edit/write tools no longer require a prior read, and no longer block on externally-modified/deleted files
- The original two-branch implementation is preserved in comments for easy restoration
- Updated affected unit tests to assert the new pass-through behavior

## Notes
- This removes a safety guard: edits/writes to files that were never read (or modified externally since last read) will now proceed and may overwrite unseen content. Restore by un-commenting the original `checkStaleness` body.

## Test plan
- [x] `bun run test -- file-state-cache` (10/10 passing)
- [x] `bun tsc` (no type errors)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-00f6cdb189204cfeb8b10069ceaefefd)