### PR TITLE
fix(vscode-webui): center compact checkpoint icon on the line

### DIFF
--- a/packages/vscode-webui/src/components/checkpoint-ui.tsx
+++ b/packages/vscode-webui/src/components/checkpoint-ui.tsx
@@ -214,6 +214,10 @@ export const CheckpointUI: React.FC<{
         <span
           className={cn(
             "flex items-center text-muted-foreground/60 group-hover:px-2.5 group-hover:text-foreground",
+            // The compact icon (size-3) is smaller than the git-commit icon
+            // (size-5), so it needs a tiny symmetric gap from the border lines
+            // when unhovered. The git-commit icon stays flush.
+            compactPart && "px-1",
             (isPending || showActionSuccessIcon) &&
               "pointer-events-none px-2.5",
           )}
@@ -248,7 +252,7 @@ export const CheckpointUI: React.FC<{
           </Button>
 
           {forkTask && (
-            <div className="ml-1 flex items-center">
+            <div className="ml-1 hidden items-center group-hover:flex">
               <span className="hidden group-hover:flex">{getForkIcon()}</span>
               <Button
                 size="sm"
@@ -263,7 +267,7 @@ export const CheckpointUI: React.FC<{
           )}
 
           {compactPart && (
-            <div className="ml-1 flex items-center">
+            <div className="ml-1 hidden items-center group-hover:flex">
               <span className="hidden group-hover:flex">
                 <SquareChartGantt className="size-3" />
               </span>


### PR DESCRIPTION
## Summary
- Fix the compact summary icon rendering off-center on the checkpoint separator line. The empty fork/compact action wrappers kept their `ml-1` margins while unhovered, pushing the icon sideways — they now use `hidden group-hover:flex` so they contribute nothing to layout until hover.
- Give the smaller `size-3` compact icon a tiny symmetric `px-1` gap from the border lines when unhovered (matching `CompactCheckpointUI`); the larger `size-5` git-commit icon stays flush as before.

## Test plan
- [ ] Trigger a compaction so a compact checkpoint renders on the assistant→user separator.
- [ ] Verify the compact icon is horizontally centered on the line with an even gap on both sides (unhovered).
- [ ] Hover the checkpoint and confirm Compare/Restore/Fork/Summary actions still expand correctly.
- [ ] Verify a plain git checkpoint (no compact) still shows the git-commit icon flush against the line.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d27203de8d734527bd986671d2b33bc9)