### PR TITLE
fix(livekit): preserve user-input tool parts on stream failure

### DIFF
--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -115,6 +115,63 @@ describe("LiveChatKit memory lifecycle", () => {
     });
   });
 
+  it.each([
+    ["tool-attemptCompletion", "completion-1", { result: "Done." }],
+    [
+      "tool-askFollowupQuestion",
+      "question-1",
+      { questions: [{ question: "Continue?", options: [] }] },
+    ],
+    [
+      "tool-renderWidget",
+      "widget-1",
+      { title: "Preview", widgetCode: "<div />", guidelinesRead: true },
+    ],
+  ])(
+    "does not mark available %s as an error when a stream fails",
+    async (type, toolCallId, input) => {
+      const store = new FakeStore([
+        makeTask({
+          id: "parent",
+          status: "pending-model",
+          background: false,
+        }),
+      ]);
+      const chatKit = new LiveChatKit<FakeChat>({
+        taskId: "parent",
+        store: store as unknown as LiveKitStore,
+        blobStore: {} as BlobStore,
+        chatClass: FakeChat,
+        getters: {
+          getLLM: () => ({ id: "test-model" }) as never,
+        },
+      });
+      const message = assistantUserInputToolMessage(type, toolCallId, input);
+      chatKit.chat.messages = [userMessage(), message];
+
+      chatKit.chat.fail(new Error("network error"));
+
+      expect(chatKit.chat.messages.at(-1)?.parts[1]).toMatchObject({
+        type,
+        toolCallId,
+        state: "input-available",
+        input,
+      });
+      expect(chatKit.chat.messages.at(-1)?.parts[1]).not.toHaveProperty(
+        "errorText",
+      );
+
+      const savedMessage = store.taskMessages("parent").at(-1);
+      expect(savedMessage?.parts[1]).toMatchObject({
+        type,
+        toolCallId,
+        state: "input-available",
+        input,
+      });
+      expect(savedMessage?.parts[1]).not.toHaveProperty("errorText");
+    },
+  );
+
   it("updates task total tokens from the formatted compact estimate", () => {
     const store = new FakeStore([
       makeTask({
@@ -622,6 +679,26 @@ function assistantMessage(): Message {
       finishReason: "stop",
       totalTokens: 20_000,
     },
+  } as unknown as Message;
+}
+
+function assistantUserInputToolMessage(
+  type: string,
+  toolCallId: string,
+  input: unknown,
+): Message {
+  return {
+    id: "assistant-user-input-tool",
+    role: "assistant",
+    parts: [
+      { type: "step-start" },
+      {
+        type,
+        toolCallId,
+        state: "input-available",
+        input,
+      },
+    ],
   } as unknown as Message;
 }
 

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -14,6 +14,7 @@ import {
   type CustomAgent,
   ToolsByPermission,
   getToolCallCancelErrorMessage,
+  isUserInputToolPart,
 } from "@getpochi/tools";
 import { Duration } from "@livestore/utils/effect";
 import {
@@ -89,6 +90,10 @@ function normalizeFailedStreamMessage(
         part.state === "output-error" ||
         part.state === "output-denied"
       ) {
+        return part;
+      }
+
+      if (part.state === "input-available" && isUserInputToolPart(part)) {
         return part;
       }
 


### PR DESCRIPTION
## Summary
- User-input tools (`attemptCompletion`, `askFollowupQuestion`, `renderWidget`) in the `input-available` state are no longer incorrectly marked as errors when a stream fails. These tools require user interaction and their input should be preserved as-is.
- Added parametrized tests covering all three user-input tool types to verify they are not converted to `output-error` on stream failure.

## Test plan
- [ ] Run `bun run test` in `packages/livekit` to verify the new parametrized tests pass
- [ ] Verify that a failed stream with a pending `attemptCompletion` / `askFollowupQuestion` / `renderWidget` preserves the tool input without an `errorText`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-65ad372ff5a04e62b8abf973a6eada85)