### PR TITLE
fix(livekit): keep user message when stream finishes before assistant placeholder is added

### DIFF
--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -172,6 +172,36 @@ describe("LiveChatKit memory lifecycle", () => {
     },
   );
 
+  it("keeps the user message when the stream finishes before the assistant placeholder is added", () => {
+    const store = new FakeStore([
+      makeTask({
+        id: "parent",
+        status: "pending-model",
+        background: false,
+      }),
+    ]);
+    const chatKit = new LiveChatKit<FakeChat>({
+      taskId: "parent",
+      store: store as unknown as LiveKitStore,
+      blobStore: {} as BlobStore,
+      chatClass: FakeChat,
+      getters: {
+        getLLM: () => ({ id: "test-model" }) as never,
+      },
+    });
+
+    // Reproduces an early abort during task init: the abort-aware UI stream
+    // terminates with zero chunks (isAbort=false), so the streamed assistant
+    // message was never pushed into chat.messages, leaving only the user
+    // message when onFinish runs.
+    chatKit.chat.messages = [userMessage()];
+    chatKit.chat.finish(blankAssistantMessage());
+
+    expect(chatKit.chat.messages.map((message) => message.id)).toContain(
+      "user-1",
+    );
+  });
+
   it("updates task total tokens from the formatted compact estimate", () => {
     const store = new FakeStore([
       makeTask({
@@ -699,6 +729,14 @@ function assistantUserInputToolMessage(
         input,
       },
     ],
+  } as unknown as Message;
+}
+
+function blankAssistantMessage(): Message {
+  return {
+    id: "assistant-blank",
+    role: "assistant",
+    parts: [],
   } as unknown as Message;
 }
 

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -892,7 +892,13 @@ export class LiveChatKit<
         })
       : filteredMessage;
 
-    this.chat.messages = [...this.chat.messages.slice(0, -1), message];
+    // Replace the streamed assistant message only when it is the last one;
+    // otherwise append so an early-abort empty stream can't drop the user message.
+    const lastMessage = this.chat.messages.at(-1);
+    this.chat.messages =
+      lastMessage?.id === message.id
+        ? [...this.chat.messages.slice(0, -1), message]
+        : [...this.chat.messages, message];
 
     const { store } = this;
     if (message.metadata?.kind !== "assistant") {


### PR DESCRIPTION
## Summary
- Fixes an issue in `LiveChatKit` where an early-abort empty stream could drop the user's message.
- Replaces the streamed assistant message only when it is the last message in the chat history, otherwise appends.
- Adds an integration test reproducing the early abort scenario during task initialization.

## Screenshot

### Before
https://jam.dev/c/f6761cad-c897-4b01-a658-343d88e83bf4

### After
https://jam.dev/c/9e688c60-e725-4ab7-8ddd-cbdf59748ef9

## Test plan
- Run the added test in `packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts` using `bun run test`.
- Verified that all 17 test suites pass successfully.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9f8c438ef0b64559a861e6accb639554)