### PR TITLE
feat: improve retry reminder and narrow webFetch scope

### DIFF
--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -586,9 +586,7 @@ export class TaskRunner {
         "Last message is assistant with no tool calls, sending a new user reminder.",
       );
       const message = createUserMessage(
-        prompts.createSystemReminder(
-          "You should use tool calls to answer the question, for example, use attemptCompletion if the job is done, or use askFollowupQuestion to clarify the request.",
-        ),
+        prompts.createSystemReminder(prompts.toolCallsReminder),
       );
       this.chat.appendOrReplaceMessage(message);
       return "retry";

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -67,6 +67,9 @@ export const prompts = {
     truncateIndex: truncateAutoMemoryIndex,
     serializeMessage: serializeMemoryMessage,
   },
+  toolCallsReminder: `You should use tool calls to answer the question, for example, use attemptCompletion if the job is done, or use askFollowupQuestion to clarify the request.
+
+If you have already provided a response or explanation in your text above, do NOT repeat or copy that content into the \`result\` parameter of \`attemptCompletion\`. Instead, simply refer to your response above with a brief sentence (e.g., "See response above." or "The task is completed as described above.") to save output tokens.`,
 };
 
 function createSystemReminder(content: string) {

--- a/packages/livekit/src/background-task/task-executor/task-executor.ts
+++ b/packages/livekit/src/background-task/task-executor/task-executor.ts
@@ -440,9 +440,7 @@ class RunningTask {
     if (isAssistantMessageWithNoToolCalls(message)) {
       this.chat.appendOrReplaceMessage(
         createUserMessage(
-          prompts.createSystemReminder(
-            "You should use tool calls to answer the question, for example, use attemptCompletion if the job is done, or use askFollowupQuestion to clarify the request.",
-          ),
+          prompts.createSystemReminder(prompts.toolCallsReminder),
         ),
       );
       return "retry";

--- a/packages/tools/src/attempt-completion.ts
+++ b/packages/tools/src/attempt-completion.ts
@@ -6,7 +6,9 @@ export const attemptCompletionSchema = z.object({
   result: z
     .string()
     .describe(
-      "The result of the task. Formulate this result in a way that is final and does not require further input from the user.",
+      "The result of the task. Formulate this result in a way that is final and does not require further input from the user. " +
+        "If you have already provided a detailed response or explanation in your text above, do NOT repeat or copy that content here. " +
+        "Instead, simply refer to your response above with a brief sentence (e.g., 'See response above.' or 'The task is completed as described above.') to save output tokens.",
     ),
 });
 

--- a/packages/vendor-pochi/src/tools/web-fetch.ts
+++ b/packages/vendor-pochi/src/tools/web-fetch.ts
@@ -3,10 +3,13 @@ import z from "zod";
 
 export const makeWebFetch = (getToken: () => Promise<string>) => ({
   description: `
-- Fetches content from a specified URL and converts HTML to markdown
-- Use this tool when you need to retrieve and analyze web content
+- Fetches the readable content of a public web page and converts HTML to markdown
+- Use this tool ONLY to retrieve and analyze the textual content of a web page (e.g. documentation, articles, references)
 
 Usage notes:
+  - This tool is a content-fetching mechanism ONLY. Do NOT use it for API calls, sending non-GET requests, or interacting with endpoints. For those, use \`curl\` via the terminal.
+  - Do NOT use this tool to access localhost, 127.0.0.1, or other local/internal network addresses. Use \`curl\` (for simple requests) or the browser agent (for pages requiring rendering/interaction) instead.
+  - For web pages that require JavaScript rendering, authentication, or interaction, use the browser agent instead.
   - IMPORTANT: If an MCP-provided web fetch tool is available, prefer using that tool instead of this one, as it may have fewer restrictions.
   - The URL must be a fully-formed valid URL
   - The prompt should describe what information you want to extract from the page

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
@@ -36,9 +36,7 @@ export function useRetry({
         error.kind === "no-tool-calls"
       ) {
         return sendMessage({
-          text: prompts.createSystemReminder(
-            "You should use tool calls to answer the question, for example, use attemptCompletion if the job is done, or use askFollowupQuestion to clarify the request.",
-          ),
+          text: prompts.createSystemReminder(prompts.toolCallsReminder),
         });
       }
 


### PR DESCRIPTION
## Summary
- Extract the no-tool-calls reminder prompt into a shared constant `prompts.toolCallsReminder` and use it across VSCode webui, CLI task runner, and LiveKit task executor.
- Optimize the `attemptCompletion` schema description to instruct the model to avoid repeating content already generated in previous text blocks, saving output tokens.
- Narrow the `webFetch` tool description to strictly content fetching of public pages, directing the model to use `curl` or the browser agent for API calls, local addresses, or pages requiring rendering/interaction.

## Test plan
- Verified that `bun check` and `bun tsc` pass without errors.
- Verified that the `webFetch` tool description is updated correctly.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7c785c5073ba40a8bf08c5c92773b973)