### PR TITLE
fix(tools): remove hard max(12) constraint on askFollowupQuestion header

### DIFF
--- a/packages/tools/src/ask-followup-question.ts
+++ b/packages/tools/src/ask-followup-question.ts
@@ -24,7 +24,6 @@ export const QuestionSchema = z.object({
     ),
   header: z
     .string()
-    .max(12)
     .describe(
       'Very short label displayed as a chip/tag (max 12 chars). Examples: "Auth method", "Library", "Approach".',
     ),


### PR DESCRIPTION
## Summary
- Removes the `.max(12)` Zod validation from the `header` field in `QuestionSchema` inside `ask-followup-question.ts`
- The description still instructs the LLM to keep headers concise (max 12 chars), but no longer throws a hard validation error when the LLM produces a slightly longer label

## Test plan
- [ ] Verify that `askFollowupQuestion` calls with header labels longer than 12 characters no longer fail at the Zod parse step
- [ ] Confirm existing unit tests still pass: `bun run test`

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-9db3235847ca449b8da72d37d96343ae) | [Task](https://app.getpochi.com/share/p-9db3235847ca449b8da72d37d96343ae)