### PR TITLE
fix(tools): refine web-fetch tool description and usage notes

### DIFF
--- a/packages/vendor-pochi/src/tools/web-fetch.ts
+++ b/packages/vendor-pochi/src/tools/web-fetch.ts
@@ -3,10 +3,13 @@ import z from "zod";
 
 export const makeWebFetch = (getToken: () => Promise<string>) => ({
   description: `
-- Fetches content from a specified URL and converts HTML to markdown
-- Use this tool when you need to retrieve and analyze web content
+- Fetches the readable content of a public web page and converts HTML to markdown
+- Use this tool ONLY to retrieve and analyze the textual content of a web page (e.g. documentation, articles, references)
 
 Usage notes:
+  - This tool is a content-fetching mechanism ONLY. Do NOT use it for API calls, sending non-GET requests, or interacting with endpoints. For those, use \`curl\` via the terminal.
+  - Do NOT use this tool to access localhost, 127.0.0.1, or other local/internal network addresses. Use \`curl\` (for simple requests) or the browser agent (for pages requiring rendering/interaction) instead.
+  - For web pages that require JavaScript rendering, authentication, or interaction, use the browser agent instead.
   - IMPORTANT: If an MCP-provided web fetch tool is available, prefer using that tool instead of this one, as it may have fewer restrictions.
   - The URL must be a fully-formed valid URL
   - The prompt should describe what information you want to extract from the page


### PR DESCRIPTION
## Summary
- Refine the description of the `web-fetch` tool to clarify that it is strictly for fetching readable content from public web pages.
- Add usage notes to discourage using the tool for API calls, accessing local addresses, or pages requiring authentication/JS rendering, recommending alternative tools (like `curl` or browser agent) instead.

## Test plan
- Verify that the updated tool description is clear and accurate.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a8a77885291c404a946ba624af5a29f6)