### PR TITLE
fix(memory): honor project memory disable for the current task

### DIFF
--- a/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
+++ b/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
@@ -187,6 +187,36 @@ describe("long-term memory prompt helpers", () => {
     expect(messages[0].parts).toHaveLength(1);
   });
 
+  it("injectAutoMemory strips a persisted reminder when memory is disabled", () => {
+    // Simulate a reminder that was injected on turn 1 and persisted, then
+    // followed by more turns (so the length !== 1 guard would skip re-injection).
+    const messages: UIMessage[] = [makeUserMessage("first")];
+    injectAutoMemory(messages, sampleContext);
+    expect(
+      messages[0].parts.some(
+        (p) => p.type === "text" && isAutoMemorySystemReminder(p.text),
+      ),
+    ).toBe(true);
+
+    messages.push(
+      { id: "asst-1", role: "assistant", parts: [{ type: "text", text: "ok" }] },
+      makeUserMessage("second"),
+    );
+
+    // Disabling memory (context undefined) should remove the persisted reminder.
+    injectAutoMemory(messages, undefined);
+    expect(
+      messages[0].parts.some(
+        (p) => p.type === "text" && isAutoMemorySystemReminder(p.text),
+      ),
+    ).toBe(false);
+    // The user's original text is preserved.
+    expect(messages[0].parts).toHaveLength(1);
+    const userPart = messages[0].parts[0];
+    if (userPart.type !== "text") throw new Error("expected text part");
+    expect(userPart.text).toBe("first");
+  });
+
   it("injectAutoMemory only fires on the first user turn", () => {
     const messages: UIMessage[] = [
       makeUserMessage("first"),

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -158,16 +158,38 @@ ${indexContent}`;
 }
 
 /**
+ * Remove any previously-injected auto-memory reminder from user messages.
+ * Used when project memory is disabled so the snapshot (which may have been
+ * persisted into the first user message on an earlier turn) stops being sent.
+ */
+function stripAutoMemoryReminders(messages: UIMessage[]): UIMessage[] {
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const parts = message.parts ?? [];
+    const filtered = parts.filter(
+      (part) =>
+        part.type !== "text" || !isAutoMemorySystemReminder(part.text ?? ""),
+    );
+    if (filtered.length !== parts.length) {
+      message.parts = filtered;
+    }
+  }
+  return messages;
+}
+
+/**
  * Inject the MEMORY.md snapshot as a dedicated system reminder on the first
  * user turn. Idempotent — replaces any prior auto-memory reminder.
+ *
+ * When memory is disabled (no context), strips any previously-injected
+ * reminder instead, so it stops being sent for the current task.
  */
 export function injectAutoMemory(
   messages: UIMessage[],
   context: AutoMemoryContext | undefined,
 ): UIMessage[] {
-  if (!context) return messages;
-  const memoryBlock = buildAutoMemoryDynamicPrompt(context);
-  if (!memoryBlock) return messages;
+  const memoryBlock = context ? buildAutoMemoryDynamicPrompt(context) : "";
+  if (!memoryBlock) return stripAutoMemoryReminders(messages);
   if (messages.length !== 1) return messages;
 
   const messageToInject = messages.at(-1);

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -1,4 +1,5 @@
 import { useSelectedModels } from "@/features/settings";
+import { useAutoMemoryEnabled } from "@/lib/hooks/use-auto-memory-enabled";
 import { useCustomAgents } from "@/lib/hooks/use-custom-agents";
 import { useLatest } from "@/lib/hooks/use-latest";
 import { useMcp } from "@/lib/hooks/use-mcp";
@@ -62,12 +63,24 @@ export function useLiveChatKitGetters({
     } satisfies Environment;
   }, [todos, isSubTask, omitCustomRules, taskId]);
 
+  // Read the current enable state so disabling the checkbox takes effect for
+  // the current task (not just on the next mount).
+  const { autoMemoryEnabled } = useAutoMemoryEnabled();
+  const autoMemoryEnabledRef = useLatest(autoMemoryEnabled);
+
   // Snapshot once per task panel so mid-task MEMORY.md rewrites don't bust
   // the cached system+tools prefix. New memory shows on next mount.
   const autoMemoryCacheRef = useRef<Promise<
     AutoMemoryContext | undefined
   > | null>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies(autoMemoryEnabledRef.current): ref is stable.
   const getAutoMemory = useCallback(() => {
+    // When project memory is disabled, drop any cached context so it is no
+    // longer injected into the prompt and re-enabling reads it fresh.
+    if (!autoMemoryEnabledRef.current) {
+      autoMemoryCacheRef.current = null;
+      return Promise.resolve(undefined);
+    }
     if (autoMemoryCacheRef.current) return autoMemoryCacheRef.current;
     const pending = vscodeAutoMemoryManager.readContext();
     autoMemoryCacheRef.current = pending;


### PR DESCRIPTION
## Summary
- Disabling the **Project Memory** checkbox now takes effect for the *current* task, not just the next one.
- `getAutoMemory` cached the project-memory context per task-panel mount, so toggling the checkbox off didn't stop injection until remount. It now returns `undefined` and clears the cache when disabled (which also drops the static memory section from the system prompt).
- The MEMORY.md snapshot is injected on the first user turn and persisted into `message[0]`, while `injectAutoMemory` only ran at `messages.length === 1` and no-oped when disabled — so the persisted reminder kept being sent. It now strips any previously-injected auto-memory reminder from user messages when disabled.

## Details
Two gaps combined to cause the bug:
1. **Read/injection cache bypass** (`use-live-chat-kit-getters.ts`): the per-mount `autoMemoryCacheRef` reused a context captured while memory was enabled. Now gated by `useAutoMemoryEnabled()`.
2. **Persisted snapshot** (`common/.../auto-memory.ts`): `injectAutoMemory` relied on the turn-1 snapshot being persisted into `message[0]`; disabling never removed it. Added `stripAutoMemoryReminders` for the disabled path.

Enabled behavior is unchanged (snapshot injected on first turn, retained on later turns). Known limitation preserved: re-enabling mid-task doesn't re-inject until a new task, matching the existing "snapshot at task start" design.

## Test plan
- [x] `packages/common` unit tests pass (21 tests), including a new `injectAutoMemory strips a persisted reminder when memory is disabled`.
- [x] `packages/vscode-webui` tests pass (213 tests) via pre-push hook.
- [x] `tsc` and `biome check` pass on changed files.
- [ ] Manual: enable memory, start a task, disable mid-task, confirm the MEMORY.md `<system-reminder>` is no longer sent.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e67805b5e2f541b0be834e3384209945)