### PR TITLE
fix(vscode): track user edits by workspace instead of active tab

### DIFF
--- a/packages/vscode/src/integrations/checkpoint/user-edit-state.ts
+++ b/packages/vscode/src/integrations/checkpoint/user-edit-state.ts
@@ -78,7 +78,7 @@ export class UserEditState implements vscode.Disposable {
 
         const newEdits = { ...this.edits.value };
         for (const uid of this.trackingTasks.keys()) {
-          if (!tasks[uid] || !tasks[uid].active) {
+          if (!tasks[uid] || tasks[uid].cwd !== this.cwd) {
             this.trackingTasks.delete(uid);
             delete newEdits[uid];
           }
@@ -89,8 +89,8 @@ export class UserEditState implements vscode.Disposable {
 
         let isDirty = false;
         for (const [uid, task] of Object.entries(tasks)) {
-          const { cwd, lastCheckpointHash: hash, active } = task;
-          if (active && cwd === this.cwd) {
+          const { cwd, lastCheckpointHash: hash } = task;
+          if (cwd === this.cwd) {
             logger.trace(
               `Updating edits for task ${uid} with hash ${hash}, original: ${this.trackingTasks.get(uid)}`,
             );


### PR DESCRIPTION
## Summary
- User edits since the last checkpoint were only tracked while the Pochi task was the **active editor tab** (`tasks[uid].active === true`) in `UserEditState`.
- To make edits, the user opens/focuses a file in the editor, which makes the Pochi task tab inactive. This immediately dropped the task from `trackingTasks` and cleared its edits — killing tracking exactly when changes were being made.
- Fix gates tracking on workspace membership (`cwd === this.cwd`) instead of the active-tab flag. The existing `hash === latestCheckpoint` check in `updateEdits` still ensures only the task at the current checkpoint HEAD produces a real diff (others resolve to `[]`), so this is safe and also covers the sidebar task, which is never marked active either.

## Test plan
- [ ] Open a task in an editor tab, let it finish (checkpoint saved).
- [ ] Open/edit another file in the same editor group so the task tab loses focus.
- [ ] Confirm the User Edits badge/diff now reflects the file changes (previously it stayed empty).
- [x] `biome check` clean; `bun tsc` passes for `packages/vscode`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4ba9377e5ef1409c99219202673d913b)