### PR TITLE
fix(vscode): scope task list to the current repository

### DIFF
--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -101,7 +101,7 @@ export type TaskStates = Record<string, TaskState>;
 
 export type TaskArchivedParams =
   | { type: "single"; taskId: string; archived: boolean }
-  | { type: "batch"; cwd?: string };
+  | { type: "batch" };
 
 export type TaskPinnedParams = {
   taskId: string;

--- a/packages/vscode-webui/src/components/worktree-list.tsx
+++ b/packages/vscode-webui/src/components/worktree-list.tsx
@@ -97,7 +97,7 @@ export function WorktreeList({
   const [showArchivedTasks, setShowArchivedTasks] = useState(false);
   const { setTaskArchived, hasArchivableTasks } = useTaskArchived();
 
-  // Archive all tasks older than 7 days across all worktrees (no cwd = all worktrees)
+  // Archive all tasks older than 7 days in the current repository.
   const handleArchiveAllOldTasks = () => {
     setTaskArchived?.({ type: "batch" });
   };

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -275,8 +275,64 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     await this.context.globalState.update(key, value);
   };
 
+  /**
+   * Scope of the currently opened repository: all worktree paths plus the
+   * gitdir prefix used by its worktrees. Undefined when no folder is open.
+   */
+  private getCurrentRepoScope():
+    | { worktreePaths: Set<string>; worktreesGitdirPrefix: string }
+    | undefined {
+    const worktrees = this.worktreeManager.worktrees.value;
+    const repoRoot =
+      worktrees.find((wt) => wt.isMain)?.path ??
+      this.workspaceScope.workspacePath ??
+      undefined;
+    if (!repoRoot) {
+      return undefined;
+    }
+    const worktreePaths = new Set(worktrees.map((wt) => wt.path));
+    worktreePaths.add(repoRoot);
+    return {
+      worktreePaths,
+      worktreesGitdirPrefix: `${repoRoot}/.git/worktrees`,
+    };
+  }
+
+  /**
+   * A task belongs to the current repo when its cwd is one of the repo's
+   * worktrees, or its gitdir points under the repo's `.git/worktrees` (covers
+   * deleted worktrees).
+   */
+  private isTaskInRepoScope(
+    task: {
+      cwd?: string | null;
+      git?: { worktree?: { gitdir?: string } | null } | null;
+    },
+    scope: { worktreePaths: Set<string>; worktreesGitdirPrefix: string },
+  ): boolean {
+    return (
+      (!!task.cwd && scope.worktreePaths.has(task.cwd)) ||
+      !!task.git?.worktree?.gitdir?.startsWith(scope.worktreesGitdirPrefix)
+    );
+  }
+
   readTasks = async () => {
-    return ThreadSignal.serialize(this.taskHistoryStore.tasks);
+    return ThreadSignal.serialize(
+      computed(() => {
+        const tasks = this.taskHistoryStore.tasks.value;
+        const scope = this.getCurrentRepoScope();
+        if (!scope) {
+          return tasks;
+        }
+        const result: typeof tasks = {};
+        for (const [id, task] of Object.entries(tasks)) {
+          if (this.isTaskInRepoScope(task, scope)) {
+            result[id] = task;
+          }
+        }
+        return result;
+      }),
+    );
   };
 
   readBrowserSession = async (taskId: string) => {
@@ -1379,10 +1435,12 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
           const tasks = this.taskHistoryStore.tasks.value;
           const archived = this.taskStateStore.getArchivedSignal().value;
           const pinned = this.taskStateStore.getPinnedSignal().value;
+          const scope = this.getCurrentRepoScope();
           return Object.values(tasks).some((task) => {
             if (task.parentId !== null) return false;
             if (archived[task.id]) return false;
             if (pinned[task.id]) return false;
+            if (scope && !this.isTaskInRepoScope(task, scope)) return false;
             return task.updatedAt < oneWeekAgo;
           });
         }),
@@ -1404,13 +1462,14 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
         } else if (params.type === "batch") {
           const tasks = this.taskHistoryStore.tasks.value;
           const pinned = this.taskStateStore.getPinnedSignal().value;
+          const scope = this.getCurrentRepoScope();
           const updates: Record<string, boolean> = {};
 
           for (const [taskId, task] of Object.entries(tasks)) {
             if (
               task.updatedAt < oneWeekAgo &&
               !pinned[taskId] &&
-              (!params.cwd || task.cwd === params.cwd)
+              (!scope || this.isTaskInRepoScope(task, scope))
             ) {
               updates[taskId] = true;
             }

--- a/packages/vscode/src/lib/task-history-store.ts
+++ b/packages/vscode/src/lib/task-history-store.ts
@@ -18,6 +18,10 @@ type EncodedTask = {
   updatedAt: number;
   cwd?: string | null;
   title?: string | null;
+  // Used to scope tasks to the current repository.
+  git?: {
+    worktree?: { gitdir?: string } | null;
+  } | null;
 };
 
 const logger = getLogger("TaskHistoryStore");


### PR DESCRIPTION
## Summary
- Pinned/archived tasks and the "Archive old tasks" action leaked across unrelated projects because `readTasks` returned every task regardless of the open workspace.
- Scope `readTasks` (and the archive helpers) to the current repository's worktrees using the git worktree info already stored on each task, so **all** task-list consumers (pinned, archived, paginated, deleted-worktrees) are scoped by construction — no cwds threaded from the client.
- Added `getCurrentRepoScope()` / `isTaskInRepoScope()` on the host, reused by `readTasks`, batch-archive, and `hasArchivableTasks`.

## Behavior
- Open the main workspace → tasks from all of the repo's worktrees (incl. deleted worktrees via gitdir prefix) are in scope.
- Open a linked (non-main) worktree → `WorktreeManager` exposes only that worktree, so scope narrows to it, matching the single-worktree UI.

## Test plan
- [ ] Pin/archive a task in project A, open project B → the task no longer appears in B's pinned/archived sections.
- [ ] "Archive old tasks" only archives the current repo's old tasks.
- [ ] Opening a linked worktree shows only that worktree's tasks.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3e0d4a0cb0cc4037bf22e7d3c6962b20)