### PR TITLE
docs(browser-agent): add Windows installation instructions using PowerShell

### DIFF
--- a/packages/common/src/base/agents/browser.md
+++ b/packages/common/src/base/agents/browser.md
@@ -7,6 +7,7 @@ tools:
   - "executeCommand(~/.pochi/bin/agent-browser *)"
   - "executeCommand(%USERPROFILE%/.pochi/bin/agent-browser *)"
   - "executeCommand(curl -fsSL https://github.com/TabbyML/agent-browser/releases/download/v0.27.3-pochi/install.sh | bash)"
+  - 'executeCommand(powershell -c "irm https://github.com/TabbyML/agent-browser/releases/download/v0.27.3-pochi/install.ps1 | iex")'
   - "executeCommand(pgrep *)"
   - "executeCommand(powershell -NoProfile -Command Get-Process *)"
   - startBackgroundJob
@@ -87,11 +88,14 @@ Follow this workflow in order:
 
 Use only `agent-browser` version `0.27.3-pochi`.
 
-Before running browser commands, run `agent-browser --version`. If `agent-browser` is missing or the discovered version is not exactly `0.27.3-pochi`, install the verified version with `curl -fsSL https://github.com/TabbyML/agent-browser/releases/download/v0.27.3-pochi/install.sh | bash`.
+Before running browser commands, run `agent-browser --version`. If `agent-browser` is missing or the discovered version is not exactly `0.27.3-pochi`, install the verified version with the command for the current OS:
+
+- macOS/Linux: `curl -fsSL https://github.com/TabbyML/agent-browser/releases/download/v0.27.3-pochi/install.sh | bash`
+- Windows: `powershell -c "irm https://github.com/TabbyML/agent-browser/releases/download/v0.27.3-pochi/install.ps1 | iex"`
 
 After installing, run `agent-browser --version` again. If `agent-browser` is still missing because the updated PATH is not active in the current shell, check the install directory directly. On macOS/Linux or PowerShell, run `~/.pochi/bin/agent-browser --version`; on Windows cmd, run `%USERPROFILE%/.pochi/bin/agent-browser --version`. If the direct path reports version `0.27.3-pochi`, use that same direct path for subsequent agent-browser commands.
 
-If installation still fails, do not continue to the browser workflows. Call `attemptCompletion` with the error summary, required version, install command, expected install path, and verification commands so the user can install `agent-browser` manually.
+If installation still fails, do not continue to the browser workflows. Call `attemptCompletion` with the error summary, required version, OS-specific install command, expected install path, and verification commands so the user can install `agent-browser` manually.
 
 ### Managed Browser Workflow
 


### PR DESCRIPTION
## Summary
- Add powershell installation command for the browser agent on Windows in `browser.md`.
- Update the installation instructions to be OS-specific (macOS/Linux vs Windows).

<img width="800" alt="image" src="https://github.com/user-attachments/assets/e9fe5d12-1337-4ecd-82d0-86c5279de080" />


## Test plan
- Verify that the markdown file renders correctly on GitHub.
- Verify that the instructions are accurate.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-36509ee39867448196fb1a0e6f779f08)