### PR TITLE
feat(tools): show diff preview for file edits before approval

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -94,6 +94,15 @@ const VSCodeHostStub = {
   ): Promise<unknown> => {
     return Promise.resolve(undefined);
   },
+  previewEdit: (
+    _toolName: string,
+    _input: unknown,
+  ): Promise<
+    | { edit: string; editSummary: { added: number; removed: number } }
+    | undefined
+  > => {
+    return Promise.resolve(undefined);
+  },
   executeBashCommand: (
     _command: string,
     _abortSignal: ThreadAbortSignalSerialization,

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -106,6 +106,25 @@ export interface VSCodeHostApi {
     },
   ): Promise<unknown>;
 
+  /**
+   * Compute a preview diff for a file-editing tool call (applyDiff,
+   * multiApplyDiff, writeToFile) WITHOUT writing to disk.
+   *
+   * This is used to show the diff before the user approves the tool call.
+   * Returns `undefined` when no preview can be computed (e.g. non-editing tool,
+   * search content does not match, or there are no changes).
+   */
+  previewEdit(
+    toolName: string,
+    input: unknown,
+  ): Promise<
+    | {
+        edit: string;
+        editSummary: { added: number; removed: number };
+      }
+    | undefined
+  >;
+
   listFilesInWorkspace(): Promise<
     {
       filepath: string;

--- a/packages/vscode-webui/src/features/tools/components/apply-diff.tsx
+++ b/packages/vscode-webui/src/features/tools/components/apply-diff.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { usePreviewEdit } from "../hooks/use-preview-edit";
 import { ModelEdits } from "./code-edits";
 import { FileBadge } from "./file-badge";
 import { NewProblems, NewProblemsIcon } from "./new-problems";
@@ -18,31 +19,32 @@ export const applyDiffTool: React.FC<ToolProps<"applyDiff">> = ({
       ? tool.output
       : undefined;
 
+  // Before the tool call is approved/executed there is no result yet, so
+  // compute a preview diff from the tool input to show the pending changes.
+  const preview = usePreviewEdit(
+    "applyDiff",
+    tool.input,
+    tool.state === "input-available",
+  );
+
+  const edit = result?._meta?.edit ?? preview?.edit;
+  const editSummary = result?._meta?.editSummary ?? preview?.editSummary;
+
   const title = (
     <>
       <StatusIcon isExecuting={isExecuting} tool={tool} />
       <span className="ml-2" />
       {t("toolInvocation.applyingDiffTo")}
       {path && (
-        <FileBadge
-          className="ml-1"
-          path={path}
-          editSummary={result?._meta?.editSummary}
-        />
+        <FileBadge className="ml-1" path={path} editSummary={editSummary} />
       )}
     </>
   );
 
   const details = [];
 
-  if (result?._meta?.edit) {
-    details.push(
-      <ModelEdits
-        key="model-edits"
-        edit={result?._meta?.edit}
-        filePath={path}
-      />,
-    );
+  if (edit) {
+    details.push(<ModelEdits key="model-edits" edit={edit} filePath={path} />);
   }
 
   if (result?.newProblems) {

--- a/packages/vscode-webui/src/features/tools/components/multi-apply-diff.tsx
+++ b/packages/vscode-webui/src/features/tools/components/multi-apply-diff.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { usePreviewEdit } from "../hooks/use-preview-edit";
 import { ModelEdits } from "./code-edits";
 import { FileBadge } from "./file-badge";
 import { NewProblems, NewProblemsIcon } from "./new-problems";
@@ -20,31 +21,32 @@ export const multiApplyDiffTool: React.FC<ToolProps<"multiApplyDiff">> = ({
       ? tool.output
       : undefined;
 
+  // Before the tool call is approved/executed there is no result yet, so
+  // compute a preview diff from the tool input to show the pending changes.
+  const preview = usePreviewEdit(
+    "multiApplyDiff",
+    tool.input,
+    tool.state === "input-available",
+  );
+
+  const edit = result?._meta?.edit ?? preview?.edit;
+  const editSummary = result?._meta?.editSummary ?? preview?.editSummary;
+
   const title = (
     <>
       <StatusIcon isExecuting={isExecuting} tool={tool} />
       <span className="ml-2" />
       {t("toolInvocation.applyingDiffsTo")}
       {path && (
-        <FileBadge
-          className="ml-1"
-          path={path}
-          editSummary={result?._meta?.editSummary}
-        />
+        <FileBadge className="ml-1" path={path} editSummary={editSummary} />
       )}
     </>
   );
 
   const details = [];
 
-  if (result?._meta?.edit) {
-    details.push(
-      <ModelEdits
-        key="model-edits"
-        edit={result?._meta?.edit}
-        filePath={path}
-      />,
-    );
+  if (edit) {
+    details.push(<ModelEdits key="model-edits" edit={edit} filePath={path} />);
   }
 
   if (result?.newProblems) {

--- a/packages/vscode-webui/src/features/tools/components/write-to-file.tsx
+++ b/packages/vscode-webui/src/features/tools/components/write-to-file.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { usePreviewEdit } from "../hooks/use-preview-edit";
 import { ModelEdits } from "./code-edits";
 import { FileBadge } from "./file-badge";
 import { NewProblems, NewProblemsIcon } from "./new-problems";
@@ -19,31 +20,32 @@ export const writeToFileTool: React.FC<ToolProps<"writeToFile">> = ({
       ? tool.output
       : undefined;
 
+  // Before the tool call is approved/executed there is no result yet, so
+  // compute a preview diff from the tool input to show the pending changes.
+  const preview = usePreviewEdit(
+    "writeToFile",
+    tool.input,
+    tool.state === "input-available",
+  );
+
+  const edit = result?._meta?.edit ?? preview?.edit;
+  const editSummary = result?._meta?.editSummary ?? preview?.editSummary;
+
   const title = (
     <>
       <StatusIcon isExecuting={isExecuting} tool={tool} />
       <span className="ml-2" />
       {t("toolInvocation.writing")}
       {path && (
-        <FileBadge
-          className="ml-1"
-          path={path}
-          editSummary={result?._meta?.editSummary}
-        />
+        <FileBadge className="ml-1" path={path} editSummary={editSummary} />
       )}
     </>
   );
 
   const details = [];
 
-  if (result?._meta?.edit) {
-    details.push(
-      <ModelEdits
-        key="model-edits"
-        edit={result?._meta?.edit}
-        filePath={path}
-      />,
-    );
+  if (edit) {
+    details.push(<ModelEdits key="model-edits" edit={edit} filePath={path} />);
   }
 
   if (result?.newProblems) {

--- a/packages/vscode-webui/src/features/tools/hooks/use-preview-edit.ts
+++ b/packages/vscode-webui/src/features/tools/hooks/use-preview-edit.ts
@@ -1,0 +1,61 @@
+import { vscodeHost } from "@/lib/vscode";
+import { useEffect, useState } from "react";
+
+export type PreviewEdit = {
+  edit: string;
+  editSummary: { added: number; removed: number };
+};
+
+/**
+ * Computes a preview diff for a file-editing tool call (applyDiff, multiApplyDiff,
+ * writeToFile) so that the diff can be shown before the user approves the tool call.
+ *
+ * The preview is only fetched when `enabled` is true (typically while the tool call
+ * is awaiting approval and no result is available yet).
+ */
+export function usePreviewEdit(
+  toolName: string,
+  input: unknown,
+  enabled: boolean,
+): PreviewEdit | undefined {
+  const [preview, setPreview] = useState<PreviewEdit | undefined>(undefined);
+
+  // Stabilize the effect against object identity changes of `input`.
+  const inputKey = enabled ? safeStringify(input) : undefined;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: inputKey stands in for input
+  useEffect(() => {
+    if (!enabled) {
+      setPreview(undefined);
+      return;
+    }
+
+    let cancelled = false;
+    vscodeHost
+      .previewEdit(toolName, input)
+      .then((result) => {
+        if (!cancelled) {
+          setPreview(result ?? undefined);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPreview(undefined);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [toolName, inputKey, enabled]);
+
+  return preview;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -5,6 +5,7 @@ import {
   type VSCodeHostApi,
   type WebviewHostApi,
   resolvePochiUri,
+  resolveToolCallArgs,
 } from "@getpochi/common/vscode-webui-bridge";
 import {
   catalog,
@@ -70,6 +71,7 @@ function createVSCodeHost(): VSCodeHostApi {
         "setGlobalState",
         "readEnvironment",
         "executeToolCall",
+        "previewEdit",
         "executeBashCommand",
         "listFilesInWorkspace",
         "listAutoCompleteCandidates",
@@ -259,9 +261,17 @@ function createVSCodeHost(): VSCodeHostApi {
     );
   };
 
+  const previewEdit: VSCodeHostApi["previewEdit"] = async (toolName, input) => {
+    return vscodeHostApi.previewEdit(
+      toolName,
+      resolveToolCallArgs(input, globalStore?.storeId ?? ""),
+    );
+  };
+
   return {
     ...vscodeHostApi,
     openFile,
+    previewEdit,
   };
 }
 

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -25,6 +25,7 @@ import { ModelList } from "@/lib/model-list";
 import { PochiLanguage } from "@/lib/pochi-language";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { PostHog } from "@/lib/posthog";
+import { computePreviewEdit } from "@/lib/preview-edit";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { SkillManager } from "@/lib/skill-manager";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -582,6 +583,19 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     });
 
     return result;
+  };
+
+  previewEdit = async (
+    toolName: string,
+    input: unknown,
+  ): Promise<
+    | { edit: string; editSummary: { added: number; removed: number } }
+    | undefined
+  > => {
+    if (!this.cwd) {
+      return undefined;
+    }
+    return computePreviewEdit(toolName, input, this.cwd);
   };
 
   openFile = async (

--- a/packages/vscode/src/lib/__test__/preview-edit.test.ts
+++ b/packages/vscode/src/lib/__test__/preview-edit.test.ts
@@ -1,0 +1,172 @@
+import * as assert from "assert";
+import * as os from "node:os";
+import * as _path from "node:path";
+import { after, before, beforeEach, describe, it } from "mocha";
+import * as vscode from "vscode";
+import { computePreviewEdit } from "../preview-edit";
+
+async function createFile(uri: vscode.Uri, content = ""): Promise<void> {
+  await vscode.workspace.fs.writeFile(uri, Buffer.from(content));
+}
+
+async function createDirectory(uri: vscode.Uri): Promise<void> {
+  await vscode.workspace.fs.createDirectory(uri);
+}
+
+describe("computePreviewEdit", () => {
+  let testSuiteRootTempDir: vscode.Uri;
+  let currentTestTempDirUri: vscode.Uri;
+
+  before(async () => {
+    const rootPath = _path.join(
+      os.tmpdir(),
+      `vscode-pochi-preview-edit-suite-${Date.now()}`,
+    );
+    testSuiteRootTempDir = vscode.Uri.file(rootPath);
+    await createDirectory(testSuiteRootTempDir).catch(() => {
+      /* Ignore if already exists */
+    });
+  });
+
+  after(async () => {
+    if (testSuiteRootTempDir) {
+      try {
+        await vscode.workspace.fs.delete(testSuiteRootTempDir, {
+          recursive: true,
+          useTrash: false,
+        });
+      } catch (error) {
+        console.error(
+          `Error cleaning up preview-edit test dir ${testSuiteRootTempDir.fsPath}:`,
+          error,
+        );
+      }
+    }
+  });
+
+  beforeEach(async () => {
+    const testDirName = `test-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+    currentTestTempDirUri = vscode.Uri.joinPath(
+      testSuiteRootTempDir,
+      testDirName,
+    );
+    await createDirectory(currentTestTempDirUri);
+  });
+
+  it("previews an applyDiff without writing to disk", async () => {
+    const fileContent = "Line 1\nLine 2\nLine 3\n";
+    const fileUri = vscode.Uri.joinPath(currentTestTempDirUri, "apply.txt");
+    await createFile(fileUri, fileContent);
+
+    const result = await computePreviewEdit(
+      "applyDiff",
+      {
+        path: fileUri.fsPath,
+        searchContent: "Line 2",
+        replaceContent: "Modified Line 2",
+      },
+      testSuiteRootTempDir.fsPath,
+    );
+
+    assert.ok(result, "expected a preview result");
+    assert.match(result.edit, /-Line 2/);
+    assert.match(result.edit, /\+Modified Line 2/);
+    assert.strictEqual(result.editSummary.added, 1);
+    assert.strictEqual(result.editSummary.removed, 1);
+
+    // The file on disk must remain unchanged.
+    const onDisk = await vscode.workspace.fs.readFile(fileUri);
+    assert.strictEqual(Buffer.from(onDisk).toString(), fileContent);
+  });
+
+  it("previews a multiApplyDiff applied sequentially", async () => {
+    const fileContent = "alpha\nbeta\ngamma\n";
+    const fileUri = vscode.Uri.joinPath(currentTestTempDirUri, "multi.txt");
+    await createFile(fileUri, fileContent);
+
+    const result = await computePreviewEdit(
+      "multiApplyDiff",
+      {
+        path: fileUri.fsPath,
+        edits: [
+          { searchContent: "alpha", replaceContent: "ALPHA" },
+          { searchContent: "gamma", replaceContent: "GAMMA" },
+        ],
+      },
+      testSuiteRootTempDir.fsPath,
+    );
+
+    assert.ok(result, "expected a preview result");
+    assert.match(result.edit, /\+ALPHA/);
+    assert.match(result.edit, /\+GAMMA/);
+
+    const onDisk = await vscode.workspace.fs.readFile(fileUri);
+    assert.strictEqual(Buffer.from(onDisk).toString(), fileContent);
+  });
+
+  it("previews a writeToFile for a new (non-existent) file", async () => {
+    const fileUri = vscode.Uri.joinPath(currentTestTempDirUri, "new-file.txt");
+
+    const result = await computePreviewEdit(
+      "writeToFile",
+      {
+        path: fileUri.fsPath,
+        content: "brand new content\n",
+      },
+      testSuiteRootTempDir.fsPath,
+    );
+
+    assert.ok(result, "expected a preview result");
+    assert.match(result.edit, /\+brand new content/);
+
+    // The file must not have been created on disk.
+    let exists = true;
+    try {
+      await vscode.workspace.fs.stat(fileUri);
+    } catch {
+      exists = false;
+    }
+    assert.strictEqual(exists, false, "preview must not create the file");
+  });
+
+  it("returns undefined when there are no changes", async () => {
+    const fileContent = "unchanged\n";
+    const fileUri = vscode.Uri.joinPath(currentTestTempDirUri, "same.txt");
+    await createFile(fileUri, fileContent);
+
+    const result = await computePreviewEdit(
+      "writeToFile",
+      { path: fileUri.fsPath, content: fileContent },
+      testSuiteRootTempDir.fsPath,
+    );
+
+    assert.strictEqual(result, undefined);
+  });
+
+  it("returns undefined when the search content does not match", async () => {
+    const fileUri = vscode.Uri.joinPath(currentTestTempDirUri, "nomatch.txt");
+    await createFile(fileUri, "hello world\n");
+
+    const result = await computePreviewEdit(
+      "applyDiff",
+      {
+        path: fileUri.fsPath,
+        searchContent: "does not exist",
+        replaceContent: "replacement",
+      },
+      testSuiteRootTempDir.fsPath,
+    );
+
+    assert.strictEqual(result, undefined);
+  });
+
+  it("returns undefined for non-editing tools", async () => {
+    const result = await computePreviewEdit(
+      "readFile",
+      { path: "whatever.txt" },
+      testSuiteRootTempDir.fsPath,
+    );
+
+    assert.strictEqual(result, undefined);
+  });
+});

--- a/packages/vscode/src/lib/preview-edit.ts
+++ b/packages/vscode/src/lib/preview-edit.ts
@@ -1,0 +1,116 @@
+import { getLogger } from "@getpochi/common";
+import {
+  parseDiffAndApply,
+  processMultipleDiffs,
+} from "@getpochi/common/diff-utils";
+import { resolvePath } from "@getpochi/common/tool-utils";
+import * as vscode from "vscode";
+import { createPrettyPatch } from "./fs";
+import { getEditSummary } from "./write-text-document";
+
+const logger = getLogger("PreviewEdit");
+
+export type PreviewEditResult = {
+  edit: string;
+  editSummary: { added: number; removed: number };
+};
+
+/**
+ * Compute a preview diff for a file-editing tool call (applyDiff, multiApplyDiff,
+ * writeToFile) WITHOUT writing to disk. This is used to show the diff before the
+ * user approves the tool call.
+ *
+ * Preview is best-effort: if the edit cannot be computed (e.g. the search content
+ * does not match the current file content), `undefined` is returned instead of
+ * throwing, as the real execution will surface the error.
+ */
+export async function computePreviewEdit(
+  toolName: string,
+  input: unknown,
+  cwd: string,
+): Promise<PreviewEditResult | undefined> {
+  if (!input || typeof input !== "object") {
+    return undefined;
+  }
+
+  const args = input as Record<string, unknown>;
+  const path = args.path;
+  if (typeof path !== "string" || path.length === 0) {
+    return undefined;
+  }
+
+  try {
+    let fileUri = vscode.Uri.parse(path);
+    if (fileUri.scheme !== "pochi") {
+      fileUri = vscode.Uri.file(resolvePath(path, cwd));
+    }
+
+    const fileContent = await readFileContentSafe(fileUri);
+
+    let updatedContent: string;
+    switch (toolName) {
+      case "writeToFile": {
+        if (typeof args.content !== "string") {
+          return undefined;
+        }
+        updatedContent = args.content;
+        break;
+      }
+      case "applyDiff": {
+        if (
+          typeof args.searchContent !== "string" ||
+          typeof args.replaceContent !== "string"
+        ) {
+          return undefined;
+        }
+        updatedContent = await parseDiffAndApply(
+          fileContent,
+          args.searchContent,
+          args.replaceContent,
+          typeof args.expectedReplacements === "number"
+            ? args.expectedReplacements
+            : undefined,
+        );
+        break;
+      }
+      case "multiApplyDiff": {
+        if (!Array.isArray(args.edits)) {
+          return undefined;
+        }
+        updatedContent = await processMultipleDiffs(
+          fileContent,
+          args.edits as Array<{
+            searchContent: string;
+            replaceContent: string;
+            expectedReplacements?: number;
+          }>,
+        );
+        break;
+      }
+      default:
+        return undefined;
+    }
+
+    if (updatedContent === fileContent) {
+      return undefined;
+    }
+
+    return {
+      edit: createPrettyPatch(path, fileContent, updatedContent),
+      editSummary: getEditSummary(fileContent, updatedContent),
+    };
+  } catch (error) {
+    logger.debug(`Failed to preview edit for ${toolName}`, error);
+    return undefined;
+  }
+}
+
+async function readFileContentSafe(fileUri: vscode.Uri): Promise<string> {
+  try {
+    const buffer = await vscode.workspace.fs.readFile(fileUri);
+    return new TextDecoder().decode(buffer);
+  } catch {
+    // File does not exist yet (e.g. creating a new file) -> treat as empty.
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary
- Computes in-memory diff previews for `applyDiff`, `multiApplyDiff`, and `writeToFile` tools before they are executed.
- Exposes `previewEdit` via the VSCode host bridge to allow the web UI to fetch these previews.
- Updates the tool components to render the `DiffViewer` and file badges using the preview data while awaiting approval.
- Includes unit tests for the preview computation logic.

## Preview
![Preview of diff before approval](https://pochi-file-uploads.getpochi.com/blob-1782960513299.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260702%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260702T024833Z&X-Amz-Expires=561600&X-Amz-Signature=b62b2cac624bd70c14ea31d0929307adac6d39d50a923569c0937100df6148dc&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan
1. Disable auto-approve for file editing tools.
2. Trigger an `applyDiff` or `writeToFile` tool call.
3. Verify that the diff preview (changes) and the `+/-` line count badge are visible in the chat before clicking "Approve".
4. Approve the tool call and verify it applies correctly.
5. Verify that for no-op edits or non-matching search content, the UI handles the lack of preview gracefully.
6. Run `bun run test --grep computePreviewEdit` in `packages/vscode` to verify host logic.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0d5c27b58d3548d590f8f220d28db8ff)