### PR TITLE
feat(vscode-webui): toggle auto-approve on click and show status tooltips

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -35,11 +35,16 @@ import { constants } from "@getpochi/common";
 import type { McpConfigOverride } from "@getpochi/common/vscode-webui-bridge";
 import { type Message, type Task, catalog } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
-import { PaperclipIcon, SendHorizonal, StopCircleIcon } from "lucide-react";
+import {
+  PaperclipIcon,
+  SendHorizonal,
+  ShieldCheck,
+  ShieldOff,
+  StopCircleIcon,
+} from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { TbShieldCog } from "react-icons/tb";
 import {
   type BlockingOperation,
   useBlockingOperations,
@@ -198,6 +203,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     isExecuting ||
     totalTokens < constants.CompactTaskMinTokens
   );
+  const AutoApproveIcon = autoApproveActive ? ShieldCheck : ShieldOff;
 
   const { handleSubmit, handleStop } = useChatSubmit({
     chat,
@@ -432,6 +438,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           <AutoApproveMenu
             isSubTask={isSubTask}
             mcpConfigOverride={mcpConfigOverride}
+            tooltip={t(
+              autoApproveActive
+                ? "settings.autoApprove.toolbarTooltipEnabled"
+                : "settings.autoApprove.toolbarTooltipDisabled",
+            )}
             trigger={
               <Button
                 type="button"
@@ -443,7 +454,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
                 )}
                 aria-label={t("settings.autoApprove.approvals")}
               >
-                <TbShieldCog className="size-4 shrink-0 transition-colors duration-200" />
+                <AutoApproveIcon className="size-4 shrink-0 transition-colors duration-200" />
               </Button>
             }
           />

--- a/packages/vscode-webui/src/features/settings/components/auto-approve-menu.tsx
+++ b/packages/vscode-webui/src/features/settings/components/auto-approve-menu.tsx
@@ -1,11 +1,16 @@
 import { McpServerList } from "@/components/mcp-server-list";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { Input } from "@/components/ui/input";
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
-  PopoverTrigger,
 } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
@@ -21,7 +26,7 @@ import {
   SquareChevronRightIcon,
   Terminal,
 } from "lucide-react";
-import type React from "react";
+import type { ComponentProps, MouseEvent, ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAutoApprove } from "../hooks/use-auto-approve";
@@ -38,13 +43,15 @@ interface CoreActionSetting {
 interface AutoApproveMenuProps {
   isSubTask: boolean;
   mcpConfigOverride?: McpConfigOverride;
-  trigger?: React.ReactNode;
+  trigger?: ReactNode;
+  tooltip?: ReactNode;
 }
 
 export function AutoApproveMenu({
   isSubTask,
   mcpConfigOverride,
   trigger,
+  tooltip,
 }: AutoApproveMenuProps) {
   const { t } = useTranslation();
   const {
@@ -57,6 +64,7 @@ export function AutoApproveMenu({
   const [currentMaxRetry, setCurrentMaxRetry] = useState(
     autoApproveSettings.maxRetryLimit.toString(),
   );
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     setCurrentMaxRetry(autoApproveSettings.maxRetryLimit.toString());
@@ -154,11 +162,9 @@ export function AutoApproveMenu({
       subtaskOffhand,
     });
 
-  const onOpenChange = (open: boolean) => {
-    if (isSubTask) return;
-
-    // If the initialSettings are not correctly loaded, establish default settings
-    if (open && !initialSettings?.autoApproveSettings) {
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (open && !isSubTask && !initialSettings?.autoApproveSettings) {
       setInitialSettings({
         autoApproveSettings,
         subtaskOffhand,
@@ -178,55 +184,107 @@ export function AutoApproveMenu({
     setIsDirty(hasChanges);
   }, [autoApproveSettings, subtaskOffhand, initialSettings, isSubTask]);
 
-  return (
-    <Popover onOpenChange={onOpenChange}>
-      <PopoverTrigger asChild>
-        {trigger ?? (
-          <div
-            className={cn(
-              "relative flex cursor-pointer select-none items-center justify-between py-2.5",
+  const handleTriggerClick = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const nextAutoApproveActive = !autoApproveActive;
+    updateAutoApproveActive(nextAutoApproveActive);
+    handleOpenChange(false);
+  };
+
+  const handleTriggerContextMenu = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    handleOpenChange(!isOpen);
+  };
+
+  // Let trigger clicks/right-clicks handle open state instead of closing as outside interactions.
+  const handleInteractOutside: ComponentProps<
+    typeof PopoverContent
+  >["onInteractOutside"] = (event) => {
+    if (
+      event.target instanceof Element &&
+      event.target.closest("[data-auto-approve-menu-trigger]")
+    ) {
+      event.preventDefault();
+    }
+  };
+
+  const defaultTrigger = (
+    <div
+      className={cn(
+        "relative flex cursor-pointer select-none items-center justify-between py-2.5",
+      )}
+    >
+      <div className="flex w-full overflow-x-hidden">
+        <label
+          htmlFor="auto-approve-main-checkbox-trigger-dialog"
+          className="flex shrink-0 cursor-pointer items-center pr-3 pl-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Checkbox
+            id="auto-approve-main-checkbox-trigger-dialog"
+            checked={autoApproveActive}
+            onCheckedChange={(checked) => {
+              updateAutoApproveActive(!!checked);
+            }}
+          />
+        </label>
+        <div className="flex flex-1 flex-nowrap items-center gap-1 overflow-hidden font-medium hover:text-foreground/80">
+          <div className="flex-1 truncate">
+            <span className="whitespace-nowrap">
+              {t("settings.autoApprove.title")}:
+            </span>
+            {autoApproveActive && enabledOptionsSummary.length > 0 ? (
+              <span className="ml-1">{enabledOptionsSummary.join(", ")}</span>
+            ) : (
+              <span className="ml-1 text-[var(--vscode-descriptionForeground)]">
+                {autoApproveActive
+                  ? t("settings.autoApprove.noActionsSelected")
+                  : t("settings.autoApprove.disabled")}
+              </span>
             )}
-          >
-            <div className="flex w-full overflow-x-hidden">
-              <label
-                htmlFor="auto-approve-main-checkbox-trigger-dialog"
-                className="flex shrink-0 cursor-pointer items-center pr-3 pl-1"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Checkbox
-                  id="auto-approve-main-checkbox-trigger-dialog"
-                  checked={autoApproveActive}
-                  onCheckedChange={(checked) => {
-                    updateAutoApproveActive(!!checked);
-                  }}
-                />
-              </label>
-              <div className="flex flex-1 flex-nowrap items-center gap-1 overflow-hidden font-medium hover:text-foreground/80">
-                <div className="flex-1 truncate">
-                  <span className="whitespace-nowrap">
-                    {t("settings.autoApprove.title")}:
-                  </span>
-                  {autoApproveActive && enabledOptionsSummary.length > 0 ? (
-                    <span className="ml-1">
-                      {enabledOptionsSummary.join(", ")}
-                    </span>
-                  ) : (
-                    <span className="ml-1 text-[var(--vscode-descriptionForeground)]">
-                      {autoApproveActive
-                        ? t("settings.autoApprove.noActionsSelected")
-                        : t("settings.autoApprove.disabled")}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </div>
           </div>
-        )}
-      </PopoverTrigger>
+        </div>
+      </div>
+    </div>
+  );
+
+  const triggerWithHandlers = (
+    <span
+      data-auto-approve-menu-trigger=""
+      className="inline-flex"
+      onClick={handleTriggerClick}
+      onContextMenu={handleTriggerContextMenu}
+    >
+      {trigger ?? defaultTrigger}
+    </span>
+  );
+
+  return (
+    <Popover open={isOpen} onOpenChange={handleOpenChange}>
+      {tooltip ? (
+        <HoverCard>
+          <PopoverAnchor asChild>
+            <HoverCardTrigger asChild>{triggerWithHandlers}</HoverCardTrigger>
+          </PopoverAnchor>
+          <HoverCardContent
+            side="top"
+            align="start"
+            sideOffset={6}
+            className="!w-auto max-w-sm bg-background px-3 py-1.5 text-xs"
+          >
+            {tooltip}
+          </HoverCardContent>
+        </HoverCard>
+      ) : (
+        <PopoverAnchor asChild>{triggerWithHandlers}</PopoverAnchor>
+      )}
       <PopoverContent
         className="[@media(min-width:400px)]:w-[400px]"
         side="top"
         align="end"
+        onInteractOutside={handleInteractOutside}
       >
         <div className="grid grid-cols-1 gap-2.5 [@media(min-width:400px)]:grid-cols-2">
           {coreActionSettings

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -178,6 +178,8 @@
     "autoApprove": {
       "title": "Auto-Approve",
       "approvals": "Permissions",
+      "toolbarTooltipEnabled": "Auto-approve is enabled. Permission prompts will be approved automatically.",
+      "toolbarTooltipDisabled": "Auto-approve is disabled. Click to approve permission prompts automatically.",
       "disabled": "Disabled",
       "noActionsSelected": "No actions selected",
       "readFiles": "Read files",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -175,6 +175,8 @@
     "autoApprove": {
       "title": "自動承認",
       "approvals": "権限",
+      "toolbarTooltipEnabled": "自動承認は有効です。権限プロンプトは自動的に承認されます。",
+      "toolbarTooltipDisabled": "自動承認は無効です。クリックすると権限プロンプトを自動承認します。",
       "disabled": "無効",
       "noActionsSelected": "アクションが選択されていません",
       "readFiles": "ファイルを読む",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -174,6 +174,8 @@
     "autoApprove": {
       "title": "자동 승인",
       "approvals": "권한",
+      "toolbarTooltipEnabled": "자동 승인이 활성화되어 있습니다. 권한 요청은 자동으로 승인됩니다.",
+      "toolbarTooltipDisabled": "자동 승인이 비활성화되어 있습니다. 클릭하면 권한 요청을 자동으로 승인합니다.",
       "disabled": "비활성화됨",
       "noActionsSelected": "선택된 작업 없음",
       "readFiles": "파일 읽기",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -174,6 +174,8 @@
     "autoApprove": {
       "title": "自动批准",
       "approvals": "权限",
+      "toolbarTooltipEnabled": "自动批准已开启。权限请求将自动通过。",
+      "toolbarTooltipDisabled": "自动批准已关闭。点击后将自动批准权限请求。",
       "disabled": "已禁用",
       "noActionsSelected": "未选择任何操作",
       "readFiles": "读取文件",


### PR DESCRIPTION
## Summary
- **Toggle Auto-Approve on Click**: Clicking the toolbar shield icon now toggles the master auto-approve state directly instead of opening the popover menu.
- **Access Menu on Right-Click**: The detailed permissions configuration popover can still be opened via right-click (context menu).
- **Status Tooltips**: Added hover tooltips to the toolbar shield icon to clearly communicate whether auto-approve is currently enabled or disabled.

<img width="567" height="186" alt="image" src="https://github.com/user-attachments/assets/b702a4f2-1643-48f9-bada-f297760ab9e4" />

<img width="574" height="223" alt="image" src="https://github.com/user-attachments/assets/e50ebd37-5cf8-4f53-88c6-64cd41aaad73" />

<img width="569" height="181" alt="image" src="https://github.com/user-attachments/assets/3ff35a26-728a-41a7-94be-9fca2a62393c" />


## Test plan
1. Open the chat panel in the VSCode WebUI.
2. Hover over the shield icon in the toolbar to verify that the tooltip shows the correct localized state.
3. Click the shield icon directly to toggle auto-approve on/off, verifying the icon updates between `ShieldCheck` and `ShieldOff`.
4. Right-click the shield icon to verify that the detailed configuration popover menu opens correctly.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5b6973cf51204ae48f485bb78c1d193a)