### PR TITLE
fix: remove the 'success' field from Todo mode

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -354,7 +354,6 @@ describe('formatters', () => {
     
     it('should replace attemptTodoCompletion subtasks with attemptCompletion', () => {
       const auditResult = {
-        success: false,
         summary: 'More work remains.',
         todos: [
           {

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -1,4 +1,9 @@
-import { isAutoSuccessToolPart, isUserInputToolPart } from "@getpochi/tools";
+import {
+  ResolvedAttemptTodoCompletionResult,
+  isAutoSuccessToolPart,
+  isTodoListResolved,
+  isUserInputToolPart,
+} from "@getpochi/tools";
 import {
   type ToolUIPart,
   type UIMessage,
@@ -360,6 +365,23 @@ type AttemptTodoCompletionOutput = {
 
 function getReplacementAttemptCompletionOutput(part: ToolUIPart) {
   const output = part.output as AttemptTodoCompletionOutput | undefined;
+  const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(
+    output?.result,
+  );
+  if (parsedResult.success) {
+    const todos = { todos: parsedResult.data.todos };
+    if (!isTodoListResolved(parsedResult.data.todos)) {
+      return {
+        success: false,
+        reason:
+          parsedResult.data.summary || "Todo completion was not accepted.",
+        ...todos,
+      };
+    }
+
+    return { success: true, ...todos };
+  }
+
   const todos =
     output?.result && "todos" in output.result
       ? { todos: output.result.todos }

--- a/packages/tools/src/__test__/todo.test.ts
+++ b/packages/tools/src/__test__/todo.test.ts
@@ -3,6 +3,7 @@ import {
   AttemptTodoCompletionResult,
   Todo,
   TodoUpdate,
+  isTodoListResolved,
   initTodoModeTodos,
   resolveAttemptTodoCompletionResult,
 } from "../todo";
@@ -51,7 +52,7 @@ describe("Todo", () => {
     });
   });
 
-  it("resolves todo updates by id into a full todos list and infers success", () => {
+  it("resolves todo updates by id into a full todos list", () => {
     expect(
       resolveAttemptTodoCompletionResult(
         {
@@ -72,7 +73,6 @@ describe("Todo", () => {
         ],
       ),
     ).toEqual({
-      success: false,
       summary: "Done.",
       todos: [
         {
@@ -89,7 +89,7 @@ describe("Todo", () => {
     });
   });
 
-  it("infers success when todo updates resolve every todo", () => {
+  it("resolves completed todo updates without a success field", () => {
     expect(
       resolveAttemptTodoCompletionResult(
         {
@@ -99,7 +99,6 @@ describe("Todo", () => {
         [todo],
       ),
     ).toEqual({
-      success: true,
       summary: "Done.",
       todos: [
         {
@@ -122,7 +121,7 @@ describe("Todo", () => {
     ).toThrow("Invalid attemptTodoCompletion result");
   });
 
-  it("infers failure when resolved todos still need work", () => {
+  it("resolves empty todo updates without a success field", () => {
     expect(
       resolveAttemptTodoCompletionResult(
         {
@@ -132,10 +131,19 @@ describe("Todo", () => {
         [todo],
       ),
     ).toEqual({
-      success: false,
       summary: "Done.",
       todos: [todo],
     });
+  });
+
+  it("detects whether all todos are resolved", () => {
+    expect(
+      isTodoListResolved([
+        { ...todo, status: "completed" },
+        { ...todo, id: "blocked", status: "cancelled" },
+      ]),
+    ).toBe(true);
+    expect(isTodoListResolved([todo])).toBe(false);
   });
 
   it("describes cancelled as a blocked state", () => {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -26,6 +26,7 @@ export {
   ResolvedAttemptTodoCompletionResult,
   Todo,
   TodoUpdate,
+  isTodoListResolved,
   initTodoModeTodos,
   resolveAttemptTodoCompletionResult,
 } from "./todo";

--- a/packages/tools/src/todo.ts
+++ b/packages/tools/src/todo.ts
@@ -66,17 +66,9 @@ export type AttemptTodoCompletionResult = z.infer<
 export const ResolvedAttemptTodoCompletionResult =
   AttemptTodoCompletionResult.pick({
     summary: true,
-  })
-    .extend({
-      success: z
-        .boolean()
-        .describe("Whether automatic todo continuation should stop."),
-      todos: z.array(Todo).describe("The resolved complete todos list."),
-    })
-    .refine(
-      (result) => result.success === result.todos.every(isTodoResolved),
-      "Success must match whether all resolved todos are completed or cancelled.",
-    );
+  }).extend({
+    todos: z.array(Todo).describe("The resolved complete todos list."),
+  });
 
 export type ResolvedAttemptTodoCompletionResult = z.infer<
   typeof ResolvedAttemptTodoCompletionResult
@@ -97,12 +89,7 @@ export function resolveAttemptTodoCompletionResult(
     todos,
     parsedResult.data.todoUpdates,
   );
-  const success =
-    parsedResult.data.todoUpdates.length > 0 &&
-    resolvedTodos.every(isTodoResolved);
-
   const resolvedResult = ResolvedAttemptTodoCompletionResult.safeParse({
-    success,
     summary: parsedResult.data.summary,
     todos: resolvedTodos,
   });
@@ -141,6 +128,10 @@ function parseJsonString(value: unknown): unknown {
   } catch {
     return value;
   }
+}
+
+export function isTodoListResolved(todos: readonly Todo[]) {
+  return todos.every(isTodoResolved);
 }
 
 function isTodoResolved(todo: Todo) {

--- a/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.test.tsx
@@ -80,7 +80,6 @@ describe("useAddSubtaskResult", () => {
     await waitFor(() => expect(addResultMock).toHaveBeenCalled());
     expect(addResultMock).toHaveBeenCalledWith({
       result: {
-        success: true,
         summary: "Done.",
         todos: [{ ...auditTodo, status: "completed" }],
       },

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/todo-continuation.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/todo-continuation.test.ts
@@ -20,26 +20,44 @@ function makeAttemptTodoCompletionMessage(output: unknown): Message {
   } as Message;
 }
 
+const completedTodos = [
+  {
+    id: "todo-1",
+    content: "Add one test",
+    status: "completed",
+    priority: "medium",
+  },
+] as const;
+
+const activeTodos = [
+  {
+    id: "todo-1",
+    content: "Add one test",
+    status: "in-progress",
+    priority: "medium",
+  },
+] as const;
+
 describe("getTodoContinuationDecision", () => {
-  it("stops when attemptTodoCompletion succeeds", () => {
+  it("stops when attemptTodoCompletion resolves every todo", () => {
     expect(
       getTodoContinuationDecision([
         makeAttemptTodoCompletionMessage({
           result: {
-            success: true,
             summary: "Done.",
+            todos: completedTodos,
           },
         }),
       ]),
     ).toBe(false);
   });
 
-  it("continues when attemptTodoCompletion rejects completion", () => {
+  it("continues when attemptTodoCompletion leaves active todos", () => {
     const messages = [
       makeAttemptTodoCompletionMessage({
         result: {
-          success: false,
           summary: "More work remains.",
+          todos: activeTodos,
         },
       }),
     ];
@@ -52,16 +70,8 @@ describe("getTodoContinuationDecision", () => {
       getTodoContinuationDecision([
         makeAttemptTodoCompletionMessage({
           result: JSON.stringify({
-            success: false,
             summary: "More work remains.",
-            todos: [
-              {
-                id: "todo-1",
-                content: "Add one test",
-                status: "in-progress",
-                priority: "medium",
-              },
-            ],
+            todos: activeTodos,
           }),
         }),
       ]),
@@ -75,8 +85,8 @@ describe("getTodoContinuationDecision", () => {
           type: "json",
           value: {
             result: {
-              success: true,
               summary: "Done.",
+              todos: completedTodos,
             },
           },
         }),

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/tool-call-life-cycle.test.ts
@@ -92,7 +92,6 @@ describe("ManagedToolCallLifeCycle", () => {
     await vi.waitFor(() => expect(lifecycle.status).toBe("complete"));
     expect(lifecycle.complete.result).toEqual({
       result: {
-        success: true,
         summary: "Done.",
         todos: [
           {

--- a/packages/vscode-webui/src/features/chat/lib/todo-continuation.ts
+++ b/packages/vscode-webui/src/features/chat/lib/todo-continuation.ts
@@ -1,8 +1,5 @@
+import { isAttemptTodoCompletionResolved } from "@/lib/todos-utils";
 import type { Message } from "@getpochi/livekit";
-import {
-  ResolvedAttemptTodoCompletionResult,
-  isTodoListResolved,
-} from "@getpochi/tools";
 
 export function shouldResumeTodoController({
   messages,
@@ -20,7 +17,7 @@ export function getTodoContinuationDecision(
 ): boolean | undefined {
   const attemptTodoCompletion = getLastAttemptTodoCompletion(messages);
   if (attemptTodoCompletion) {
-    const resolved = getAttemptTodoCompletionResolved(
+    const resolved = isAttemptTodoCompletionResolved(
       attemptTodoCompletion.part.output,
     );
     return resolved === false;
@@ -41,57 +38,4 @@ function getLastAttemptTodoCompletion(messages: Message[]) {
   ) {
     return { message, part };
   }
-}
-
-function getAttemptTodoCompletionResolved(
-  output: unknown,
-): boolean | undefined {
-  const normalizedOutput = unwrapJsonOutput(output);
-  const result =
-    isRecord(normalizedOutput) && "result" in normalizedOutput
-      ? unwrapJsonOutput(normalizedOutput.result)
-      : undefined;
-
-  for (const candidate of [result, normalizedOutput]) {
-    const parsedResult =
-      ResolvedAttemptTodoCompletionResult.safeParse(candidate);
-    if (parsedResult.success) {
-      return isTodoListResolved(parsedResult.data.todos);
-    }
-
-    const legacySuccess = getLegacyAttemptTodoCompletionSuccess(candidate);
-    if (legacySuccess !== undefined) return legacySuccess;
-  }
-}
-
-function getLegacyAttemptTodoCompletionSuccess(
-  candidate: unknown,
-): boolean | undefined {
-  if (
-    isRecord(candidate) &&
-    "success" in candidate &&
-    typeof candidate.success === "boolean"
-  ) {
-    return candidate.success;
-  }
-}
-
-function unwrapJsonOutput(output: unknown): unknown {
-  if (isRecord(output) && output.type === "json" && "value" in output) {
-    return output.value;
-  }
-
-  if (typeof output === "string") {
-    try {
-      return JSON.parse(output);
-    } catch {
-      return output;
-    }
-  }
-
-  return output;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/packages/vscode-webui/src/features/chat/lib/todo-continuation.ts
+++ b/packages/vscode-webui/src/features/chat/lib/todo-continuation.ts
@@ -1,4 +1,8 @@
 import type { Message } from "@getpochi/livekit";
+import {
+  ResolvedAttemptTodoCompletionResult,
+  isTodoListResolved,
+} from "@getpochi/tools";
 
 export function shouldResumeTodoController({
   messages,
@@ -16,10 +20,10 @@ export function getTodoContinuationDecision(
 ): boolean | undefined {
   const attemptTodoCompletion = getLastAttemptTodoCompletion(messages);
   if (attemptTodoCompletion) {
-    const success = getAttemptTodoCompletionSuccess(
+    const resolved = getAttemptTodoCompletionResolved(
       attemptTodoCompletion.part.output,
     );
-    return success === false;
+    return resolved === false;
   }
 
   return undefined;
@@ -39,7 +43,9 @@ function getLastAttemptTodoCompletion(messages: Message[]) {
   }
 }
 
-function getAttemptTodoCompletionSuccess(output: unknown): boolean | undefined {
+function getAttemptTodoCompletionResolved(
+  output: unknown,
+): boolean | undefined {
   const normalizedOutput = unwrapJsonOutput(output);
   const result =
     isRecord(normalizedOutput) && "result" in normalizedOutput
@@ -47,13 +53,26 @@ function getAttemptTodoCompletionSuccess(output: unknown): boolean | undefined {
       : undefined;
 
   for (const candidate of [result, normalizedOutput]) {
-    if (
-      isRecord(candidate) &&
-      "success" in candidate &&
-      typeof candidate.success === "boolean"
-    ) {
-      return candidate.success;
+    const parsedResult =
+      ResolvedAttemptTodoCompletionResult.safeParse(candidate);
+    if (parsedResult.success) {
+      return isTodoListResolved(parsedResult.data.todos);
     }
+
+    const legacySuccess = getLegacyAttemptTodoCompletionSuccess(candidate);
+    if (legacySuccess !== undefined) return legacySuccess;
+  }
+}
+
+function getLegacyAttemptTodoCompletionSuccess(
+  candidate: unknown,
+): boolean | undefined {
+  if (
+    isRecord(candidate) &&
+    "success" in candidate &&
+    typeof candidate.success === "boolean"
+  ) {
+    return candidate.success;
   }
 }
 

--- a/packages/vscode-webui/src/features/retry/hooks/use-ready-for-retry-error.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-ready-for-retry-error.ts
@@ -4,6 +4,10 @@ import {
   isAssistantMessageWithPartialToolCalls,
 } from "@getpochi/common/message-utils";
 import type { Message } from "@getpochi/livekit";
+import {
+  ResolvedAttemptTodoCompletionResult,
+  isTodoListResolved,
+} from "@getpochi/tools";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { useMemo } from "react";
 
@@ -35,10 +39,12 @@ export function getReadyForRetryError(messages: Message[]) {
   const attemptTodoCompletionPart =
     getLastAttemptTodoCompletionPart(lastMessage);
   if (attemptTodoCompletionPart) {
-    const success = getAttemptTodoCompletionSuccess(
+    const resolved = getAttemptTodoCompletionResolved(
       attemptTodoCompletionPart.output,
     );
-    return success === false ? new ReadyForRetryError("tool-calls") : undefined;
+    return resolved === false
+      ? new ReadyForRetryError("tool-calls")
+      : undefined;
   }
   if (lastMessage.role === "user") return new ReadyForRetryError();
   if (isAssistantMessageWithEmptyParts(lastMessage)) {
@@ -71,7 +77,7 @@ function getLastAttemptTodoCompletionPart(message: Message) {
   }
 }
 
-function getAttemptTodoCompletionSuccess(outputValue: unknown) {
+function getAttemptTodoCompletionResolved(outputValue: unknown) {
   const output = unwrapJsonOutput(outputValue);
   const result =
     isRecord(output) && "result" in output
@@ -79,13 +85,24 @@ function getAttemptTodoCompletionSuccess(outputValue: unknown) {
       : undefined;
 
   for (const candidate of [result, output]) {
-    if (
-      isRecord(candidate) &&
-      "success" in candidate &&
-      typeof candidate.success === "boolean"
-    ) {
-      return candidate.success;
+    const parsedResult =
+      ResolvedAttemptTodoCompletionResult.safeParse(candidate);
+    if (parsedResult.success) {
+      return isTodoListResolved(parsedResult.data.todos);
     }
+
+    const legacySuccess = getLegacyAttemptTodoCompletionSuccess(candidate);
+    if (legacySuccess !== undefined) return legacySuccess;
+  }
+}
+
+function getLegacyAttemptTodoCompletionSuccess(candidate: unknown) {
+  if (
+    isRecord(candidate) &&
+    "success" in candidate &&
+    typeof candidate.success === "boolean"
+  ) {
+    return candidate.success;
   }
 }
 

--- a/packages/vscode-webui/src/features/retry/hooks/use-ready-for-retry-error.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-ready-for-retry-error.ts
@@ -1,13 +1,10 @@
+import { isAttemptTodoCompletionResolved } from "@/lib/todos-utils";
 import {
   isAssistantMessageWithEmptyParts,
   isAssistantMessageWithNoToolCalls,
   isAssistantMessageWithPartialToolCalls,
 } from "@getpochi/common/message-utils";
 import type { Message } from "@getpochi/livekit";
-import {
-  ResolvedAttemptTodoCompletionResult,
-  isTodoListResolved,
-} from "@getpochi/tools";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { useMemo } from "react";
 
@@ -39,7 +36,7 @@ export function getReadyForRetryError(messages: Message[]) {
   const attemptTodoCompletionPart =
     getLastAttemptTodoCompletionPart(lastMessage);
   if (attemptTodoCompletionPart) {
-    const resolved = getAttemptTodoCompletionResolved(
+    const resolved = isAttemptTodoCompletionResolved(
       attemptTodoCompletionPart.output,
     );
     return resolved === false
@@ -75,53 +72,4 @@ function getLastAttemptTodoCompletionPart(message: Message) {
   ) {
     return part;
   }
-}
-
-function getAttemptTodoCompletionResolved(outputValue: unknown) {
-  const output = unwrapJsonOutput(outputValue);
-  const result =
-    isRecord(output) && "result" in output
-      ? unwrapJsonOutput(output.result)
-      : undefined;
-
-  for (const candidate of [result, output]) {
-    const parsedResult =
-      ResolvedAttemptTodoCompletionResult.safeParse(candidate);
-    if (parsedResult.success) {
-      return isTodoListResolved(parsedResult.data.todos);
-    }
-
-    const legacySuccess = getLegacyAttemptTodoCompletionSuccess(candidate);
-    if (legacySuccess !== undefined) return legacySuccess;
-  }
-}
-
-function getLegacyAttemptTodoCompletionSuccess(candidate: unknown) {
-  if (
-    isRecord(candidate) &&
-    "success" in candidate &&
-    typeof candidate.success === "boolean"
-  ) {
-    return candidate.success;
-  }
-}
-
-function unwrapJsonOutput(output: unknown): unknown {
-  if (isRecord(output) && output.type === "json" && "value" in output) {
-    return output.value;
-  }
-
-  if (typeof output === "string") {
-    try {
-      return JSON.parse(output);
-    } catch {
-      return output;
-    }
-  }
-
-  return output;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
@@ -91,7 +91,6 @@ describe("getReadyForRetryError", () => {
               },
               output: {
                 result: {
-                  success: true,
                   summary: "Done.",
                   todos: [
                     {
@@ -128,7 +127,6 @@ describe("getReadyForRetryError", () => {
               },
               output: {
                 result: {
-                  success: false,
                   summary: "More work remains.",
                   todos: [
                     {
@@ -167,7 +165,6 @@ describe("getReadyForRetryError", () => {
               },
               output: {
                 result: JSON.stringify({
-                  success: false,
                   summary: "More work remains.",
                   todos: [
                     {

--- a/packages/vscode-webui/src/features/todo/hooks/use-todos.test.tsx
+++ b/packages/vscode-webui/src/features/todo/hooks/use-todos.test.tsx
@@ -105,6 +105,69 @@ describe("useTodos", () => {
     });
   });
 
+  it("clears persisted todos when every todo is resolved", () => {
+    const resolvedTodos: Todo[] = [
+      {
+        ...activeTodo,
+        status: "completed",
+      },
+      {
+        id: "todo-2",
+        content: "Wait for user input",
+        status: "cancelled",
+        priority: "medium",
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useTodos({
+        persistedTodos: resolvedTodos,
+        taskId: "task-1",
+      }),
+    );
+
+    expect(result.current.todos).toEqual([]);
+    expect(result.current.todosRef.current).toEqual([]);
+    expect(storeCommitMock).toHaveBeenCalledTimes(1);
+    expect(storeCommitMock.mock.calls[0]?.[0]).toMatchObject({
+      name: "v1.UpdateTodos",
+      args: {
+        id: "task-1",
+        todos: [],
+      },
+    });
+  });
+
+  it("does not restore pending todos after clearing resolved persisted todos", () => {
+    const resolvedTodos: Todo[] = [
+      {
+        ...activeTodo,
+        status: "completed",
+      },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ persistedTodos }: { persistedTodos: readonly Todo[] }) =>
+        useTodos({
+          persistedTodos,
+          pendingTodos: [activeTodo],
+          taskId: "task-1",
+        }),
+      {
+        initialProps: {
+          persistedTodos: resolvedTodos,
+        },
+      },
+    );
+
+    expect(result.current.todos).toEqual([]);
+
+    rerender({ persistedTodos: [] });
+
+    expect(result.current.todos).toEqual([]);
+    expect(result.current.todosRef.current).toEqual([]);
+  });
+
   it("keeps explicit pending todos visible until they are persisted", () => {
     const { result, rerender } = renderHook(
       ({ persistedTodos }: { persistedTodos?: readonly Todo[] }) =>

--- a/packages/vscode-webui/src/features/todo/hooks/use-todos.ts
+++ b/packages/vscode-webui/src/features/todo/hooks/use-todos.ts
@@ -1,6 +1,6 @@
 import { useDefaultStore } from "@/lib/use-default-store";
 import { type Message, type TaskStatusLike, catalog } from "@getpochi/livekit";
-import type { Todo } from "@getpochi/tools";
+import { type Todo, isTodoListResolved } from "@getpochi/tools";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export type TodoCompletionUpdate = {
@@ -89,6 +89,14 @@ export function useTodos({
     }
 
     if (persistedTodos.length > 0) {
+      if (isTodoListResolved(persistedTodos)) {
+        for (const todo of persistedTodos) {
+          consumedTodoIdsRef.current.add(todo.id);
+        }
+        updateTodos([]);
+        return;
+      }
+
       const persistedTodoIds = new Set(persistedTodos.map((todo) => todo.id));
       for (const todo of todosRef.current ?? []) {
         if (persistedTodoIds.has(todo.id)) {
@@ -111,7 +119,7 @@ export function useTodos({
       (todo) => !consumedTodoIdsRef.current.has(todo.id),
     );
     setTodos(unpersistedTodos);
-  }, [persistedTodos, pendingTodos, setTodos]);
+  }, [persistedTodos, pendingTodos, setTodos, updateTodos]);
 
   return {
     todos,
@@ -147,6 +155,10 @@ function getInitialTodos(
 ): Todo[] {
   if (persistedTodos === undefined) {
     return copyTodos(pendingTodos);
+  }
+
+  if (persistedTodos.length > 0 && isTodoListResolved(persistedTodos)) {
+    return [];
   }
 
   if (persistedTodos.length > 0 || !pendingTodos?.length) {

--- a/packages/vscode-webui/src/features/tools/components/__tests__/attempt-completion.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/attempt-completion.test.ts
@@ -32,7 +32,7 @@ describe("getAttemptCompletionResultDisplay", () => {
 });
 
 describe("isAttemptTodoCompletionRejected", () => {
-  it("detects rejected attemptTodoCompletion JSON string results", () => {
+  it("detects unresolved attemptTodoCompletion JSON string results", () => {
     expect(
       isAttemptTodoCompletionRejected({
         type: "tool-newTask",
@@ -42,15 +42,22 @@ describe("isAttemptTodoCompletionRejected", () => {
         },
         output: {
           result: JSON.stringify({
-            success: false,
             summary: "More work remains.",
+            todos: [
+              {
+                id: "todo-1",
+                content: "Add one test",
+                status: "in-progress",
+                priority: "medium",
+              },
+            ],
           }),
         },
       } as any),
     ).toBe(true);
   });
 
-  it("does not reject successful attemptTodoCompletion results", () => {
+  it("does not reject resolved attemptTodoCompletion results", () => {
     expect(
       isAttemptTodoCompletionRejected({
         type: "tool-newTask",
@@ -60,8 +67,15 @@ describe("isAttemptTodoCompletionRejected", () => {
         },
         output: {
           result: {
-            success: true,
             summary: "Done.",
+            todos: [
+              {
+                id: "todo-1",
+                content: "Add one test",
+                status: "completed",
+                priority: "medium",
+              },
+            ],
           },
         },
       } as any),

--- a/packages/vscode-webui/src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx
@@ -9,11 +9,18 @@ const subAgentViewMock = vi.hoisted(() =>
   vi.fn(
     ({
       children,
+      headerContent,
       showTaskThread,
     }: {
       children: ReactNode;
+      headerContent?: ReactNode;
       showTaskThread?: boolean;
-    }) => <div data-show-task-thread={String(showTaskThread)}>{children}</div>,
+    }) => (
+      <div data-show-task-thread={String(showTaskThread)}>
+        {headerContent}
+        {children}
+      </div>
+    ),
   ),
 );
 
@@ -55,6 +62,21 @@ function makeAttemptTodoCompletionTool() {
     input: {
       agentType: "attemptTodoCompletion",
       description: "Audit todo completion",
+    },
+  } as never;
+}
+
+function makeCompletedAttemptTodoCompletionTool(result: unknown) {
+  return {
+    type: "tool-newTask",
+    toolCallId: "attempt-todo-completion",
+    state: "output-available",
+    input: {
+      agentType: "attemptTodoCompletion",
+      description: "Audit todo completion",
+    },
+    output: {
+      result,
     },
   } as never;
 }
@@ -115,5 +137,88 @@ describe("AttemptTodoCompletionView", () => {
     expect(subAgentViewMock.mock.calls[0]?.[0]).toMatchObject({
       showTaskThread: true,
     });
+  });
+
+  it("renders a needs-work title after an unresolved audit stops", () => {
+    render(
+      <AttemptTodoCompletionView
+        uid="attempt-uid"
+        tool={makeCompletedAttemptTodoCompletionTool({
+          summary: "More work remains.",
+          todos: [
+            {
+              id: "todo-1",
+              content: "Add one test",
+              status: "in-progress",
+              priority: "medium",
+            },
+          ],
+        })}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+        taskSource={taskSource}
+      />,
+    );
+
+    expect(screen.getByText("More work remains.")).toBeTruthy();
+    expect(
+      screen.getByText("attemptTodoCompletionView.needsWork"),
+    ).toBeTruthy();
+  });
+
+  it("renders a needs-work title after an unresolved audit stops while chat is still loading", () => {
+    render(
+      <AttemptTodoCompletionView
+        uid="attempt-uid"
+        tool={makeCompletedAttemptTodoCompletionTool({
+          summary: "More work remains.",
+          todos: [
+            {
+              id: "todo-1",
+              content: "Add one test",
+              status: "in-progress",
+              priority: "medium",
+            },
+          ],
+        })}
+        isExecuting={false}
+        isLoading={true}
+        messages={[]}
+        taskSource={taskSource}
+      />,
+    );
+
+    expect(
+      screen.getByText("attemptTodoCompletionView.needsWork"),
+    ).toBeTruthy();
+  });
+
+  it("keeps the auditing title while the audit is still executing", () => {
+    render(
+      <AttemptTodoCompletionView
+        uid="attempt-uid"
+        tool={makeCompletedAttemptTodoCompletionTool({
+          summary: "More work remains.",
+          todos: [
+            {
+              id: "todo-1",
+              content: "Add one test",
+              status: "in-progress",
+              priority: "medium",
+            },
+          ],
+        })}
+        isExecuting={true}
+        isLoading={false}
+        messages={[]}
+        taskSource={taskSource}
+      />,
+    );
+
+    expect(screen.getByText("attemptTodoCompletionView.auditing")).toBeTruthy();
+    expect(
+      screen.queryByText("attemptTodoCompletionView.needsWork"),
+    ).toBeNull();
   });
 });

--- a/packages/vscode-webui/src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx
@@ -194,6 +194,36 @@ describe("AttemptTodoCompletionView", () => {
     ).toBeTruthy();
   });
 
+  it("renders a completed title for resolved audit results", () => {
+    render(
+      <AttemptTodoCompletionView
+        uid="attempt-uid"
+        tool={makeCompletedAttemptTodoCompletionTool(
+          JSON.stringify({
+            summary: "All todos are complete.",
+            todos: [
+              {
+                id: "todo-1",
+                content: "Add one test",
+                status: "completed",
+                priority: "medium",
+              },
+            ],
+          }),
+        )}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+        taskSource={taskSource}
+      />,
+    );
+
+    expect(screen.getByText("All todos are complete.")).toBeTruthy();
+    expect(
+      screen.getByText("attemptTodoCompletionView.completed"),
+    ).toBeTruthy();
+  });
+
   it("keeps the auditing title while the audit is still executing", () => {
     render(
       <AttemptTodoCompletionView

--- a/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
@@ -1,23 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  getAttemptTodoCompletionSummary,
-  hasNewTaskResult,
-  isAttemptTodoCompletionResolved,
-} from "../new-task/result";
-
-function makeResolvedTodos(status: "completed" | "in-progress") {
-  return [
-    {
-      id: "todo-1",
-      content: "Add one test",
-      status,
-      priority: "medium",
-    },
-  ] as const;
-}
-
-const completedTodos = makeResolvedTodos("completed");
-const inProgressTodos = makeResolvedTodos("in-progress");
+import { hasNewTaskResult } from "../new-task/result";
 
 describe("hasNewTaskResult", () => {
   it("accepts structured subtask results", () => {
@@ -31,74 +13,5 @@ describe("hasNewTaskResult", () => {
 
   it("ignores blank string results", () => {
     expect(hasNewTaskResult("   ")).toBe(false);
-  });
-});
-
-describe("getAttemptTodoCompletionSummary", () => {
-  it("returns summary from structured results", () => {
-    expect(
-      getAttemptTodoCompletionSummary({
-        summary: "More work remains.",
-        todos: inProgressTodos,
-      }),
-    ).toBe("More work remains.");
-  });
-
-  it("returns summary from JSON string results", () => {
-    expect(
-      getAttemptTodoCompletionSummary(
-        JSON.stringify({
-          summary: "More work remains.",
-          todos: inProgressTodos,
-        }),
-      ),
-    ).toBe("More work remains.");
-  });
-
-  it("ignores incomplete structured results", () => {
-    expect(
-      getAttemptTodoCompletionSummary({
-        summary: "More work remains.",
-      }),
-    ).toBeUndefined();
-  });
-
-  it("ignores non-summary results", () => {
-    expect(getAttemptTodoCompletionSummary("Done")).toBeUndefined();
-  });
-});
-
-describe("isAttemptTodoCompletionResolved", () => {
-  it("detects resolved completed todo completion results", () => {
-    expect(
-      isAttemptTodoCompletionResolved({
-        summary: "All todos are complete.",
-        todos: completedTodos,
-      }),
-    ).toBe(true);
-  });
-
-  it("detects completed todo completion results", () => {
-    expect(
-      isAttemptTodoCompletionResolved(
-        JSON.stringify({
-          summary: "All todos are complete.",
-          todos: completedTodos,
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it("detects unresolved todo completion results", () => {
-    expect(
-      isAttemptTodoCompletionResolved({
-        summary: "More work remains.",
-        todos: inProgressTodos,
-      }),
-    ).toBe(false);
-  });
-
-  it("ignores malformed todo completion results", () => {
-    expect(isAttemptTodoCompletionResolved("Done")).toBeUndefined();
   });
 });

--- a/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/new-task.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
-  getAttemptTodoCompletionState,
   getAttemptTodoCompletionSummary,
   hasNewTaskResult,
+  isAttemptTodoCompletionResolved,
 } from "../new-task/result";
 
 function makeResolvedTodos(status: "completed" | "in-progress") {
@@ -38,7 +38,6 @@ describe("getAttemptTodoCompletionSummary", () => {
   it("returns summary from structured results", () => {
     expect(
       getAttemptTodoCompletionSummary({
-        success: false,
         summary: "More work remains.",
         todos: inProgressTodos,
       }),
@@ -49,7 +48,6 @@ describe("getAttemptTodoCompletionSummary", () => {
     expect(
       getAttemptTodoCompletionSummary(
         JSON.stringify({
-          success: false,
           summary: "More work remains.",
           todos: inProgressTodos,
         }),
@@ -60,7 +58,6 @@ describe("getAttemptTodoCompletionSummary", () => {
   it("ignores incomplete structured results", () => {
     expect(
       getAttemptTodoCompletionSummary({
-        success: false,
         summary: "More work remains.",
       }),
     ).toBeUndefined();
@@ -71,49 +68,37 @@ describe("getAttemptTodoCompletionSummary", () => {
   });
 });
 
-describe("getAttemptTodoCompletionState", () => {
+describe("isAttemptTodoCompletionResolved", () => {
   it("detects resolved completed todo completion results", () => {
     expect(
-      getAttemptTodoCompletionState({
-        success: true,
+      isAttemptTodoCompletionResolved({
         summary: "All todos are complete.",
         todos: completedTodos,
       }),
-    ).toEqual({
-      status: "completed",
-      summary: "All todos are complete.",
-    });
+    ).toBe(true);
   });
 
   it("detects completed todo completion results", () => {
     expect(
-      getAttemptTodoCompletionState(
+      isAttemptTodoCompletionResolved(
         JSON.stringify({
-          success: true,
           summary: "All todos are complete.",
           todos: completedTodos,
         }),
       ),
-    ).toEqual({
-      status: "completed",
-      summary: "All todos are complete.",
-    });
+    ).toBe(true);
   });
 
-  it("detects todo completion results that need more work", () => {
+  it("detects unresolved todo completion results", () => {
     expect(
-      getAttemptTodoCompletionState({
-        success: false,
+      isAttemptTodoCompletionResolved({
         summary: "More work remains.",
         todos: inProgressTodos,
       }),
-    ).toEqual({
-      status: "needs-work",
-      summary: "More work remains.",
-    });
+    ).toBe(false);
   });
 
   it("ignores malformed todo completion results", () => {
-    expect(getAttemptTodoCompletionState("Done")).toBeUndefined();
+    expect(isAttemptTodoCompletionResolved("Done")).toBeUndefined();
   });
 });

--- a/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
@@ -1,14 +1,15 @@
 import { MessageMarkdown } from "@/components/message";
 import { TaskThread } from "@/components/task-thread";
 import { FixedStateChatContextProvider } from "@/features/chat";
-import { getToolPartError } from "@/lib/tool-call-error";
-import { cn } from "@/lib/utils";
-import { useTranslation } from "react-i18next";
-import type { NewTaskToolViewProps } from ".";
 import {
   getAttemptTodoCompletionSummary,
-  isAttemptTodoCompletionResolved,
-} from "./result";
+  parseAttemptTodoCompletionResult,
+} from "@/lib/todos-utils";
+import { getToolPartError } from "@/lib/tool-call-error";
+import { cn } from "@/lib/utils";
+import { isTodoListResolved } from "@getpochi/tools";
+import { useTranslation } from "react-i18next";
+import type { NewTaskToolViewProps } from ".";
 import { SubAgentView } from "./sub-agent-view";
 
 interface AttemptTodoCompletionViewProps extends NewTaskToolViewProps {
@@ -28,7 +29,10 @@ export function AttemptTodoCompletionView({
       ? tool.output.result
       : undefined;
   const summary = getAttemptTodoCompletionSummary(result);
-  const resolved = isAttemptTodoCompletionResolved(result);
+  const parsedResult = parseAttemptTodoCompletionResult(result);
+  const resolved = parsedResult
+    ? isTodoListResolved(parsedResult.todos)
+    : undefined;
   const hasAuditFailure =
     !!getToolPartError(tool) ||
     (tool.state === "output-available" && resolved === undefined);

--- a/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
@@ -5,7 +5,10 @@ import { getToolPartError } from "@/lib/tool-call-error";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import type { NewTaskToolViewProps } from ".";
-import { getAttemptTodoCompletionState } from "./result";
+import {
+  getAttemptTodoCompletionSummary,
+  isAttemptTodoCompletionResolved,
+} from "./result";
 import { SubAgentView } from "./sub-agent-view";
 
 interface AttemptTodoCompletionViewProps extends NewTaskToolViewProps {
@@ -24,20 +27,20 @@ export function AttemptTodoCompletionView({
     tool.state === "output-available" && "result" in tool.output
       ? tool.output.result
       : undefined;
-  const completion = getAttemptTodoCompletionState(result);
-  const summary = completion?.summary;
+  const summary = getAttemptTodoCompletionSummary(result);
+  const resolved = isAttemptTodoCompletionResolved(result);
   const hasAuditFailure =
     !!getToolPartError(tool) ||
-    (tool.state === "output-available" && !completion);
+    (tool.state === "output-available" && resolved === undefined);
   const showTaskThread =
     isExecuting && !summary && !!taskSource && taskSource.messages.length > 1;
   const showFooterTaskThread = !isExecuting;
 
   let title = t("attemptTodoCompletionView.auditing");
 
-  if (completion?.status === "completed") {
+  if (resolved) {
     title = t("attemptTodoCompletionView.completed");
-  } else if (completion?.status === "needs-work") {
+  } else if (resolved === false && !isExecuting) {
     title = t("attemptTodoCompletionView.needsWork");
   } else if (hasAuditFailure) {
     title = t("attemptTodoCompletionView.failed");
@@ -65,12 +68,7 @@ export function AttemptTodoCompletionView({
       }
     >
       {summary ? (
-        <div
-          className={cn(
-            "px-3 py-2 text-muted-foreground leading-6",
-            completion?.status === "needs-work" && "text-error",
-          )}
-        >
+        <div className="px-3 py-2 text-muted-foreground leading-6">
           <MessageMarkdown>{summary}</MessageMarkdown>
         </div>
       ) : (

--- a/packages/vscode-webui/src/features/tools/components/new-task/result.ts
+++ b/packages/vscode-webui/src/features/tools/components/new-task/result.ts
@@ -1,10 +1,8 @@
-import { ResolvedAttemptTodoCompletionResult } from "@getpochi/tools";
+import {
+  ResolvedAttemptTodoCompletionResult,
+  isTodoListResolved,
+} from "@getpochi/tools";
 import { parseJsonObjectString } from "../tool-result-display";
-
-export type AttemptTodoCompletionState = {
-  status: "completed" | "needs-work";
-  summary: string;
-};
 
 export function hasNewTaskResult(result: unknown): boolean {
   if (typeof result === "string") {
@@ -16,19 +14,20 @@ export function hasNewTaskResult(result: unknown): boolean {
 export function getAttemptTodoCompletionSummary(
   result: unknown,
 ): string | undefined {
-  return getAttemptTodoCompletionState(result)?.summary;
+  const summary = parseAttemptTodoCompletionResult(result)?.summary.trim();
+  return summary || undefined;
 }
 
-export function getAttemptTodoCompletionState(
+export function isAttemptTodoCompletionResolved(
   result: unknown,
-): AttemptTodoCompletionState | undefined {
+): boolean | undefined {
+  const parsedResult = parseAttemptTodoCompletionResult(result);
+  return parsedResult ? isTodoListResolved(parsedResult.todos) : undefined;
+}
+
+function parseAttemptTodoCompletionResult(result: unknown) {
   const parsed = parseJsonObjectString(result) ?? result;
   const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(parsed);
   if (!parsedResult.success) return undefined;
-  const summary = parsedResult.data.summary.trim();
-  if (!summary) return undefined;
-  return {
-    status: parsedResult.data.success ? "completed" : "needs-work",
-    summary,
-  };
+  return parsedResult.data;
 }

--- a/packages/vscode-webui/src/features/tools/components/new-task/result.ts
+++ b/packages/vscode-webui/src/features/tools/components/new-task/result.ts
@@ -1,33 +1,6 @@
-import {
-  ResolvedAttemptTodoCompletionResult,
-  isTodoListResolved,
-} from "@getpochi/tools";
-import { parseJsonObjectString } from "../tool-result-display";
-
 export function hasNewTaskResult(result: unknown): boolean {
   if (typeof result === "string") {
     return result.trim().length > 0;
   }
   return result !== undefined && result !== null;
-}
-
-export function getAttemptTodoCompletionSummary(
-  result: unknown,
-): string | undefined {
-  const summary = parseAttemptTodoCompletionResult(result)?.summary.trim();
-  return summary || undefined;
-}
-
-export function isAttemptTodoCompletionResolved(
-  result: unknown,
-): boolean | undefined {
-  const parsedResult = parseAttemptTodoCompletionResult(result);
-  return parsedResult ? isTodoListResolved(parsedResult.todos) : undefined;
-}
-
-function parseAttemptTodoCompletionResult(result: unknown) {
-  const parsed = parseJsonObjectString(result) ?? result;
-  const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(parsed);
-  if (!parsedResult.success) return undefined;
-  return parsedResult.data;
 }

--- a/packages/vscode-webui/src/features/tools/components/tool-result-display.ts
+++ b/packages/vscode-webui/src/features/tools/components/tool-result-display.ts
@@ -1,7 +1,4 @@
-import {
-  ResolvedAttemptTodoCompletionResult,
-  isTodoListResolved,
-} from "@getpochi/tools";
+import { isAttemptTodoCompletionResolved } from "@/lib/todos-utils";
 
 export type ToolResultDisplay =
   | {
@@ -52,19 +49,7 @@ export function isAttemptTodoCompletionRejected(tool: {
     return false;
   }
 
-  const result = getToolOutputResult(tool.output);
-  const parsed = parseJsonObjectString(result) ?? result;
-  const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(parsed);
-  if (parsedResult.success) {
-    return !isTodoListResolved(parsedResult.data.todos);
-  }
-
-  return (
-    !!parsed &&
-    typeof parsed === "object" &&
-    !Array.isArray(parsed) &&
-    (parsed as { success?: unknown }).success === false
-  );
+  return isAttemptTodoCompletionResolved(tool.output) === false;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -87,12 +72,4 @@ export function parseJsonObjectString(value: unknown): object | undefined {
   } catch {
     return undefined;
   }
-}
-
-function getToolOutputResult(output: unknown): unknown {
-  if (!output || typeof output !== "object" || !("result" in output)) {
-    return undefined;
-  }
-
-  return output.result;
 }

--- a/packages/vscode-webui/src/features/tools/components/tool-result-display.ts
+++ b/packages/vscode-webui/src/features/tools/components/tool-result-display.ts
@@ -1,3 +1,8 @@
+import {
+  ResolvedAttemptTodoCompletionResult,
+  isTodoListResolved,
+} from "@getpochi/tools";
+
 export type ToolResultDisplay =
   | {
       type: "json";
@@ -49,6 +54,11 @@ export function isAttemptTodoCompletionRejected(tool: {
 
   const result = getToolOutputResult(tool.output);
   const parsed = parseJsonObjectString(result) ?? result;
+  const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(parsed);
+  if (parsedResult.success) {
+    return !isTodoListResolved(parsedResult.data.todos);
+  }
+
   return (
     !!parsed &&
     typeof parsed === "object" &&

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -34,7 +34,7 @@
     "planModeLabel": "Plan",
     "todoModeLabel": "Todo",
     "pauseTodo": "Pause todo",
-    "resumeTodo": "Resume todo",
+    "resumeTodo": "Resume",
     "autoContinueTodo": "Auto-continue todo",
     "planModeToggleShortcutTooltip": "Press Shift + Tab to toggle",
     "planModeSubmitTooltip": "Submit as plan",
@@ -477,7 +477,7 @@
     "cancelTodo": "Cancel",
     "deleteTodo": "Delete",
     "pauseTodo": "Pause",
-    "resumeTodo": "Resume todo"
+    "resumeTodo": "Resume"
   },
   "commandExecutionPanel": {
     "copied": "Copied!",

--- a/packages/vscode-webui/src/lib/__tests__/todos-utils.test.ts
+++ b/packages/vscode-webui/src/lib/__tests__/todos-utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAttemptTodoCompletionSummary,
+  isAttemptTodoCompletionResolved,
+} from "../todos-utils";
+
+function makeResolvedTodos(status: "completed" | "in-progress") {
+  return [
+    {
+      id: "todo-1",
+      content: "Add one test",
+      status,
+      priority: "medium",
+    },
+  ] as const;
+}
+
+const completedTodos = makeResolvedTodos("completed");
+const inProgressTodos = makeResolvedTodos("in-progress");
+
+describe("getAttemptTodoCompletionSummary", () => {
+  it("returns summary from structured results", () => {
+    expect(
+      getAttemptTodoCompletionSummary({
+        summary: "More work remains.",
+        todos: inProgressTodos,
+      }),
+    ).toBe("More work remains.");
+  });
+
+  it("returns summary from JSON string results", () => {
+    expect(
+      getAttemptTodoCompletionSummary(
+        JSON.stringify({
+          summary: "More work remains.",
+          todos: inProgressTodos,
+        }),
+      ),
+    ).toBe("More work remains.");
+  });
+
+  it("ignores incomplete structured results", () => {
+    expect(
+      getAttemptTodoCompletionSummary({
+        summary: "More work remains.",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("ignores non-summary results", () => {
+    expect(getAttemptTodoCompletionSummary("Done")).toBeUndefined();
+  });
+});
+
+describe("isAttemptTodoCompletionResolved", () => {
+  it("detects resolved todo completion output envelopes", () => {
+    expect(
+      isAttemptTodoCompletionResolved({
+        result: {
+          summary: "All todos are complete.",
+          todos: completedTodos,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects unresolved JSON output envelopes", () => {
+    expect(
+      isAttemptTodoCompletionResolved({
+        type: "json",
+        value: {
+          result: JSON.stringify({
+            summary: "More work remains.",
+            todos: inProgressTodos,
+          }),
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to legacy success results", () => {
+    expect(isAttemptTodoCompletionResolved({ success: false })).toBe(false);
+  });
+});

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
@@ -60,7 +60,6 @@ describe("getTodoCompletionUpdate", () => {
       toolCallId: "tool-1",
       output: {
         result: {
-          success: true,
           summary: "Done.",
           todos: resolvedTodos,
         },
@@ -84,7 +83,6 @@ describe("getTodoCompletionUpdate", () => {
       toolCallId: "tool-1",
       output: {
         result: JSON.stringify({
-          success: true,
           summary: "Done.",
           todos: resolvedTodos,
         }),
@@ -94,7 +92,7 @@ describe("getTodoCompletionUpdate", () => {
     expect(update).toBeUndefined();
   });
 
-  it("keeps resolved todos unless every todo is completed", () => {
+  it("clears todos when every todo is resolved", () => {
     const resolvedTodos: Todo[] = [
       {
         id: "resolved-todo-1",
@@ -114,14 +112,13 @@ describe("getTodoCompletionUpdate", () => {
       toolCallId: "tool-1",
       output: {
         result: {
-          success: true,
           summary: "Done.",
           todos: resolvedTodos,
         },
       },
     });
 
-    expect(update?.todos).toEqual(resolvedTodos);
+    expect(update?.todos).toEqual([]);
   });
 
   it("does not return a completion update when resolved todos still need work", () => {
@@ -130,7 +127,6 @@ describe("getTodoCompletionUpdate", () => {
       toolCallId: "tool-1",
       output: {
         result: {
-          success: true,
           summary: "Done.",
           todos: baseTodos,
         },
@@ -146,7 +142,6 @@ describe("getTodoCompletionUpdate", () => {
       toolCallId: "tool-1",
       output: {
         result: {
-          success: true,
           summary: "Done.",
         },
       },
@@ -155,13 +150,12 @@ describe("getTodoCompletionUpdate", () => {
     expect(update).toBeUndefined();
   });
 
-  it("does not return a completion update when attemptTodoCompletion rejects completion", () => {
+  it("does not return a completion update when resolved todos still need work", () => {
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
       toolCallId: "tool-1",
       output: {
         result: {
-          success: false,
           summary: "More work remains.",
           todos: baseTodos,
         },
@@ -178,7 +172,6 @@ describe("getTodoCompletionUpdate", () => {
       toolCallId: "tool-1",
       output: {
         result: {
-          success: true,
           summary: "Done.",
           todos: resolvedTodos,
         },
@@ -208,7 +201,6 @@ describe("useAddCompleteToolCalls", () => {
           reason: "execute-finish",
           result: {
             result: {
-              success: true,
               summary: "Done.",
               todos: resolvedTodos,
             },
@@ -240,7 +232,6 @@ describe("useAddCompleteToolCalls", () => {
       toolCallId: "tool-1",
       output: {
         result: {
-          success: true,
           summary: "Done.",
           todos: resolvedTodos,
         },

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
@@ -6,6 +6,7 @@ import type { Message, TaskStatusLike } from "@getpochi/livekit";
 import {
   ResolvedAttemptTodoCompletionResult,
   type Todo,
+  isTodoListResolved,
 } from "@getpochi/tools";
 import { isStaticToolUIPart } from "ai";
 import { useEffect } from "react";
@@ -146,12 +147,9 @@ export function getTodoCompletionUpdate({
       ? output.result
       : undefined;
   const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(rawResult);
-  if (!parsedResult.success || !parsedResult.data.success) return undefined;
-  const result = parsedResult.data;
-
-  const nextTodos = result.todos.every((todo) => todo.status === "completed")
-    ? []
-    : result.todos;
+  if (!parsedResult.success || !isTodoListResolved(parsedResult.data.todos)) {
+    return undefined;
+  }
 
   return {
     toolCallId,
@@ -167,7 +165,7 @@ export function getTodoCompletionUpdate({
           : part,
       ),
     },
-    todos: nextTodos,
+    todos: [],
     status: "completed",
     output,
   };

--- a/packages/vscode-webui/src/lib/todos-utils.ts
+++ b/packages/vscode-webui/src/lib/todos-utils.ts
@@ -1,0 +1,70 @@
+import {
+  ResolvedAttemptTodoCompletionResult,
+  type ResolvedAttemptTodoCompletionResult as ResolvedAttemptTodoCompletionResultData,
+  isTodoListResolved,
+} from "@getpochi/tools";
+
+export function parseAttemptTodoCompletionResult(
+  result: unknown,
+): ResolvedAttemptTodoCompletionResultData | undefined {
+  const parsedResult = ResolvedAttemptTodoCompletionResult.safeParse(
+    unwrapJsonOutput(result),
+  );
+  return parsedResult.success ? parsedResult.data : undefined;
+}
+
+export function getAttemptTodoCompletionSummary(
+  result: unknown,
+): string | undefined {
+  const summary = parseAttemptTodoCompletionResult(result)?.summary.trim();
+  return summary || undefined;
+}
+
+export function isAttemptTodoCompletionResolved(
+  output: unknown,
+): boolean | undefined {
+  const unwrappedOutput = unwrapJsonOutput(output);
+  const outputResult =
+    isRecord(unwrappedOutput) && "result" in unwrappedOutput
+      ? unwrappedOutput.result
+      : undefined;
+
+  for (const candidate of [outputResult, unwrappedOutput]) {
+    const resolved = isCandidateResolved(candidate);
+    if (resolved !== undefined) return resolved;
+  }
+}
+
+function isCandidateResolved(candidate: unknown) {
+  const parsedResult = parseAttemptTodoCompletionResult(candidate);
+  if (parsedResult) return isTodoListResolved(parsedResult.todos);
+
+  const unwrappedCandidate = unwrapJsonOutput(candidate);
+  if (
+    isRecord(unwrappedCandidate) &&
+    "success" in unwrappedCandidate &&
+    typeof unwrappedCandidate.success === "boolean"
+  ) {
+    return unwrappedCandidate.success;
+  }
+}
+
+function unwrapJsonOutput(output: unknown): unknown {
+  if (isRecord(output) && output.type === "json" && "value" in output) {
+    return output.value;
+  }
+
+  if (typeof output === "string") {
+    try {
+      return JSON.parse(output);
+    } catch {
+      return output;
+    }
+  }
+
+  return output;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
## Summary
- Remove the redundant `success` field from `AttemptTodoCompletionResult` and `ResolvedAttemptTodoCompletionResult` schemas.
- Update the controller to infer task success directly from the resolved status of the todo list (whether all todos are completed or cancelled).
- Simplify related components, hooks, and tests to accommodate the schema change.

## Test plan
- Run unit tests with `bun run test` to verify all test suites are passing.
- Verify through type checks with `bun tsc`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8a79ebcea1ad47a0b16f6d6eed01af92)