### PR TITLE
fix(prompt-form): flatten HTML pastes carrying plain text to preserve newlines

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/__tests__/utils.test.ts
+++ b/packages/vscode-webui/src/components/prompt-form/__tests__/utils.test.ts
@@ -1,0 +1,103 @@
+import { Schema } from "@tiptap/pm/model";
+import { describe, expect, it } from "vitest";
+import { createPlainTextSlice, shouldPasteAsPlainText } from "../utils";
+
+const schema = new Schema({
+  nodes: {
+    doc: {
+      content: "block+",
+    },
+    paragraph: {
+      content: "inline*",
+      group: "block",
+    },
+    text: {
+      group: "inline",
+    },
+  },
+});
+
+function paragraphTexts(text: string): string[] {
+  const slice = createPlainTextSlice(schema, text);
+  const texts: string[] = [];
+  slice.content.forEach((node) => texts.push(node.textContent));
+  return texts;
+}
+
+describe("createPlainTextSlice", () => {
+  it("splits newlines into separate paragraphs", () => {
+    expect(paragraphTexts("line1\nline2\nline3")).toEqual([
+      "line1",
+      "line2",
+      "line3",
+    ]);
+  });
+
+  it("normalizes carriage returns", () => {
+    expect(paragraphTexts("a\r\nb\rc")).toEqual(["a", "b", "c"]);
+  });
+
+  it("collapses consecutive blank lines like ProseMirror does", () => {
+    expect(paragraphTexts("a\n\n\nb")).toEqual(["a", "b"]);
+  });
+
+  it("keeps a single paragraph when there are no newlines", () => {
+    expect(paragraphTexts("hello world")).toEqual(["hello world"]);
+  });
+
+  it("produces valid nodes for empty text", () => {
+    expect(paragraphTexts("")).toEqual([""]);
+  });
+});
+
+describe("shouldPasteAsPlainText", () => {
+  it("flattens HTML pastes carrying plain text", () => {
+    expect(
+      shouldPasteAsPlainText({
+        text: "line1\nline2",
+        html: "<p>line1</p><p>line2</p>",
+        hasFiles: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not take over in-editor ProseMirror copies", () => {
+    expect(
+      shouldPasteAsPlainText({
+        text: "hello",
+        html: '<p data-pm-slice="1 1 []">hello</p>',
+        hasFiles: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores plain-text-only pastes", () => {
+    expect(
+      shouldPasteAsPlainText({
+        text: "line1\nline2",
+        html: "",
+        hasFiles: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores pastes containing files", () => {
+    expect(
+      shouldPasteAsPlainText({
+        text: "",
+        html: "",
+        hasFiles: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores file pastes even when HTML is present", () => {
+    expect(
+      shouldPasteAsPlainText({
+        text: "alt text",
+        html: "<img src='blob:...' />",
+        hasFiles: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -59,6 +59,7 @@ import {
 } from "./slash-mention/mention-list";
 import { createSlashCandidates } from "./slash-mention/slash-candidates";
 import { SubmitHistoryExtension } from "./submit-history-extension";
+import { createPlainTextSlice, shouldPasteAsPlainText } from "./utils";
 
 const newLineCharacter = "\n";
 
@@ -414,6 +415,26 @@ export function FormEditor({
         attributes: {
           class:
             "prose max-w-full min-h-[3.5em] font-sans dark:prose-invert focus:outline-none prose-p:my-0 leading-[1.25]",
+        },
+        handlePaste: (view, event) => {
+          const clipboardData = event.clipboardData;
+          if (!clipboardData) return false;
+
+          const text = clipboardData.getData("text/plain");
+          const html = clipboardData.getData("text/html");
+          if (
+            !shouldPasteAsPlainText({
+              text,
+              html,
+              hasFiles: clipboardData.files.length > 0,
+            })
+          ) {
+            return false;
+          }
+
+          const slice = createPlainTextSlice(view.state.schema, text);
+          view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
+          return true;
         },
         handleDOMEvents: {
           dragenter: (_view, event) => {

--- a/packages/vscode-webui/src/components/prompt-form/utils.ts
+++ b/packages/vscode-webui/src/components/prompt-form/utils.ts
@@ -1,3 +1,57 @@
+import { Fragment, type Schema, Slice } from "@tiptap/pm/model";
+
+/**
+ * Builds a ProseMirror slice from plain text, splitting on newlines into
+ * separate paragraphs.
+ *
+ * This mirrors ProseMirror's own plain-text clipboard parsing so that pasting
+ * content that also carries `text/html` (e.g. text copied from a rendered chat
+ * message) preserves newlines instead of collapsing them the way HTML parsing
+ * does.
+ */
+export function createPlainTextSlice(schema: Schema, text: string): Slice {
+  const paragraphType = schema.nodes.paragraph;
+  const paragraphs = text
+    .split(/(?:\r\n?|\n)+/)
+    .map((block) =>
+      paragraphType.create(null, block ? schema.text(block) : null),
+    );
+
+  return new Slice(Fragment.fromArray(paragraphs), 1, 1);
+}
+
+/**
+ * Decides whether a paste should be coerced to plain text.
+ *
+ * The prompt editor only supports plain text plus typed mention/slash nodes,
+ * so HTML pastes (e.g. copied from a rendered chat message) are flattened to
+ * text to preserve newlines instead of letting HTML parsing collapse them.
+ *
+ * The following pastes are intentionally left to ProseMirror's default
+ * handling and are NOT flattened:
+ * - pastes containing files (handled by the attachment paste handler);
+ * - plain-text-only pastes (they already preserve newlines);
+ * - content copied from within a ProseMirror editor, which ProseMirror marks
+ *   with `data-pm-slice`, so structured nodes such as mentions survive a
+ *   copy/paste round-trip.
+ */
+export function shouldPasteAsPlainText({
+  text,
+  html,
+  hasFiles,
+}: {
+  text: string;
+  html: string;
+  hasFiles: boolean;
+}): boolean {
+  if (hasFiles) return false;
+  // Plain-text-only pastes already keep newlines; only HTML pastes lose them.
+  if (!text || !html) return false;
+  // Preserve structured nodes (mentions, etc.) from in-editor copy/paste.
+  if (html.includes("data-pm-slice")) return false;
+  return true;
+}
+
 /**
  * Extracts basename and formats path for display
  */


### PR DESCRIPTION
## Summary
- Intercept paste events in the TipTap editor to coerce HTML pastes carrying plain text to a plain-text slice.
- Split plain text on newlines to create separate ProseMirror paragraph nodes, mimicking ProseMirror's native plain-text clipboard parsing behavior.
- Add comprehensive unit tests verifying multiple paste scenarios, including inline text, blank lines, in-editor ProseMirror copies, and file attachments.

## Test plan
- Run unit tests in `packages/vscode-webui` to verify correct paste logic:
  `bun run test src/components/prompt-form/__tests__/utils.test.ts`
- Verify that types and linter are fully happy with `bun tsc` and `bun check`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-32383ae253f14bba9288b3254746f896)