### PR TITLE
fix(vscode-webui): local override of auto memory hook

### DIFF
--- a/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.test.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useAutoMemoryEnabled } from "./use-auto-memory-enabled";
+import { useQuery } from "@tanstack/react-query";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  vscodeHost: {
+    readAutoMemoryEnabled: vi.fn(),
+  },
+}));
+
+describe("useAutoMemoryEnabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should default to globalEnabled when override is undefined", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: {
+        value: {
+          value: true,
+        },
+      },
+    } as any);
+
+    const { result } = renderHook(() => useAutoMemoryEnabled());
+
+    expect(result.current.autoMemoryEnabled).toBe(true);
+  });
+
+  it("should default to true if globalEnabled data is not yet available", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: undefined,
+    } as any);
+
+    const { result } = renderHook(() => useAutoMemoryEnabled());
+
+    expect(result.current.autoMemoryEnabled).toBe(true);
+  });
+
+  it("should use local override state and override global value", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: {
+        value: {
+          value: false,
+        },
+      },
+    } as any);
+
+    const { result } = renderHook(() => useAutoMemoryEnabled());
+
+    // Initially inherits globalEnabled (false)
+    expect(result.current.autoMemoryEnabled).toBe(false);
+
+    // Override to true
+    act(() => {
+      result.current.setAutoMemoryEnabled?.(true);
+    });
+
+    expect(result.current.autoMemoryEnabled).toBe(true);
+
+    // Override to false
+    act(() => {
+      result.current.setAutoMemoryEnabled?.(false);
+    });
+
+    expect(result.current.autoMemoryEnabled).toBe(false);
+  });
+
+  it("should have higher priority even if global is false", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: {
+        value: {
+          value: false,
+        },
+      },
+    } as any);
+
+    const { result } = renderHook(() => useAutoMemoryEnabled());
+
+    expect(result.current.autoMemoryEnabled).toBe(false);
+
+    act(() => {
+      result.current.setAutoMemoryEnabled?.(true);
+    });
+
+    expect(result.current.autoMemoryEnabled).toBe(true);
+  });
+});

--- a/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.ts
@@ -1,19 +1,24 @@
 import { vscodeHost } from "@/lib/vscode";
 import { threadSignal } from "@quilted/threads/signals";
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 
 /** @useSignals this comment is needed to enable signals in this hook */
 export const useAutoMemoryEnabled = () => {
-  const { data, isLoading } = useQuery({
+  const { data } = useQuery({
     queryKey: ["autoMemoryEnabled"],
     queryFn: () => fetchAutoMemoryEnabled(),
     staleTime: Number.POSITIVE_INFINITY,
   });
 
+  const [overrideDisabled, setOverrideDisabled] = useState(false);
+
+  const globalEnabled = data?.value.value ?? true;
   return {
-    autoMemoryEnabled: data?.value.value ?? true,
-    setAutoMemoryEnabled: data?.setAutoMemoryEnabled,
-    isLoading,
+    autoMemoryEnabled: globalEnabled && !overrideDisabled,
+    setAutoMemoryEnabled: data
+      ? (enabled: boolean) => setOverrideDisabled(!enabled)
+      : undefined,
   };
 };
 

--- a/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.ts
@@ -11,13 +11,15 @@ export const useAutoMemoryEnabled = () => {
     staleTime: Number.POSITIVE_INFINITY,
   });
 
-  const [overrideDisabled, setOverrideDisabled] = useState(false);
+  const [overrideEnabled, setOverrideEnabled] = useState<boolean | undefined>(
+    undefined,
+  );
 
   const globalEnabled = data?.value.value ?? true;
   return {
-    autoMemoryEnabled: globalEnabled && !overrideDisabled,
+    autoMemoryEnabled: overrideEnabled ?? globalEnabled,
     setAutoMemoryEnabled: data
-      ? (enabled: boolean) => setOverrideDisabled(!enabled)
+      ? (enabled: boolean) => setOverrideEnabled(enabled)
       : undefined,
   };
 };


### PR DESCRIPTION
## Summary
- Introduce local state `overrideDisabled` inside `useAutoMemoryEnabled` hook.
- Allow disabling auto-memory locally in the hook instead of modifying global state.

## Test plan
- Verify that types check and code linting passes.
- Run tests to ensure no regressions.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8abb1979418b466b9e8058ff38307278)