### PR TITLE
fix(tools): show line range in file badge when only endLine is provided

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/__tests__/file-badge.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/file-badge.test.tsx
@@ -126,6 +126,45 @@ describe("FileBadge", () => {
     expect(visibleText(container)).toContain("pochi://-/memory.md");
   });
 
+  it("renders the full line range when both startLine and endLine are provided", () => {
+    const { container } = render(
+      <FileBadge path="src/main.tsx" startLine={10} endLine={60} />,
+    );
+
+    expect(visibleText(container)).toContain("src/main.tsx:10-60");
+  });
+
+  it("renders a single line when startLine equals endLine", () => {
+    const { container } = render(
+      <FileBadge path="src/main.tsx" startLine={42} endLine={42} />,
+    );
+
+    expect(visibleText(container)).toContain("src/main.tsx:42");
+  });
+
+  it("renders an open-ended range when only startLine is provided", () => {
+    const { container } = render(
+      <FileBadge path="src/main.tsx" startLine={10} />,
+    );
+
+    expect(visibleText(container)).toContain("src/main.tsx:10-");
+  });
+
+  it("renders a range from the beginning when only endLine is provided", () => {
+    const { container } = render(
+      <FileBadge path="src/main.tsx" endLine={60} />,
+    );
+
+    expect(visibleText(container)).toContain("src/main.tsx:1-60");
+  });
+
+  it("renders no line range when neither startLine nor endLine is provided", () => {
+    const { container } = render(<FileBadge path="src/main.tsx" />);
+
+    expect(visibleText(container)).toContain("src/main.tsx");
+    expect(visibleText(container)).not.toContain(":");
+  });
+
   it("keeps normal paths and explicit labels unchanged", () => {
     const normal = render(
       <FileBadge path="packages/vscode-webui/src/main.tsx" />,

--- a/packages/vscode-webui/src/features/tools/components/file-badge.tsx
+++ b/packages/vscode-webui/src/features/tools/components/file-badge.tsx
@@ -42,12 +42,7 @@ export const FileBadge: React.FC<FileBadgeProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const lineRange =
-    startLine !== undefined
-      ? endLine && startLine !== endLine
-        ? `:${startLine}-${endLine}`
-        : `:${startLine}`
-      : "";
+  const lineRange = formatLineRange(startLine, endLine);
   const displayLabel = label || getFileBadgeDisplayLabel(path);
 
   const defaultOnClick = async () => {
@@ -106,4 +101,24 @@ export function getFileBadgeDisplayLabel(path: string) {
   return formatPochiFileDisplayPath(path, {
     homeDir: globalThis.POCHI_HOME_DIR,
   });
+}
+
+/**
+ * Formats the line range suffix shown after a file path.
+ * - both provided: `:start` when equal, otherwise `:start-end`
+ * - only startLine: `:start-` (from the given line to the end of the file)
+ * - only endLine: `:1-end` (from the beginning of the file to the given line)
+ * - neither: empty string
+ */
+function formatLineRange(startLine?: number, endLine?: number) {
+  if (startLine !== undefined && endLine !== undefined) {
+    return startLine === endLine ? `:${startLine}` : `:${startLine}-${endLine}`;
+  }
+  if (startLine !== undefined) {
+    return `:${startLine}-`;
+  }
+  if (endLine !== undefined) {
+    return `:1-${endLine}`;
+  }
+  return "";
 }


### PR DESCRIPTION
## Summary
- `readFile` tool calls that specify only `endLine` (no `startLine`) previously rendered **no** line-range hint in the VS Code UI, because `FileBadge`'s `lineRange` was gated entirely on `startLine !== undefined`.
- Extracted a `formatLineRange` helper that handles all `startLine`/`endLine` combinations, matching the tool's semantics (missing `startLine` → begins at line 1; missing `endLine` → reads to end):
  - both: `:start` (when equal) or `:start-end`
  - only `startLine`: `:start-`
  - only `endLine`: `:1-end` (the previously-broken case)
  - neither: no suffix
- `FileBadge` is shared across `readFile` and other file badges, so all callers benefit.

## Test plan
- [x] Added 5 unit tests to `file-badge.test.tsx` covering every line-range combination
- [x] `bun run test -- file-badge` passes (15 tests)
- [x] biome check clean

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4e2205fcd9f94efea024f57d79119e3b)