### PR TITLE
feat(vscode-webui): add context menu to attach files and toggle modes

### DIFF
--- a/packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx
+++ b/packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx
@@ -33,19 +33,15 @@ const defaultProps = {
 };
 
 describe("SubmitDropdownButton", () => {
-  it("shows the todo icon when todo mode is active", () => {
-    render(<SubmitDropdownButton {...defaultProps} isTodoMode />);
+  it("shows the plan mode toggle in the dropdown", () => {
+    render(<SubmitDropdownButton {...defaultProps} />);
 
-    const button = screen.getByRole("button", {
-      name: "chat.todoModeSubmitTooltip",
-    });
+    fireEvent.mouseEnter(screen.getByRole("button"));
 
-    const targetIcon = button.querySelector(".lucide-target");
-    expect(targetIcon).not.toBeNull();
-    expect(targetIcon?.parentElement?.className).toContain("opacity-100");
+    expect(screen.getByText("chat.planModeLabel")).not.toBeNull();
   });
 
-  it("hides the todo mode toggle by default", () => {
+  it("no longer renders the todo mode toggle", () => {
     render(<SubmitDropdownButton {...defaultProps} />);
 
     fireEvent.mouseEnter(screen.getByRole("button"));
@@ -53,12 +49,12 @@ describe("SubmitDropdownButton", () => {
     expect(screen.queryByText("chat.todoModeLabel")).toBeNull();
   });
 
-  it("shows the todo mode toggle when todo mode is enabled", () => {
-    render(<SubmitDropdownButton {...defaultProps} showTodoMode />);
+  it("shows the plan submit tooltip when plan mode is active", () => {
+    render(<SubmitDropdownButton {...defaultProps} isPlanMode />);
 
-    fireEvent.mouseEnter(screen.getByRole("button"));
-
-    expect(screen.getByText("chat.todoModeLabel")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "chat.planModeSubmitTooltip" }),
+    ).not.toBeNull();
   });
 
   it("shows the mode switch shortcut when hovering the todo mode toggle", async () => {

--- a/packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx
+++ b/packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { SubmitDropdownButton } from "../submit-dropdown-button";
 
@@ -55,22 +55,5 @@ describe("SubmitDropdownButton", () => {
     expect(
       screen.getByRole("button", { name: "chat.planModeSubmitTooltip" }),
     ).not.toBeNull();
-  });
-
-  it("shows the mode switch shortcut when hovering the todo mode toggle", async () => {
-    render(<SubmitDropdownButton {...defaultProps} showTodoMode />);
-
-    fireEvent.mouseEnter(screen.getByRole("button"));
-    const todoModeItem = screen
-      .getByText("chat.todoModeLabel")
-      .closest("[role='menuitem']");
-    expect(todoModeItem).not.toBeNull();
-    fireEvent.pointerMove(todoModeItem as Element);
-
-    await waitFor(() => {
-      expect(
-        screen.getAllByText("chat.planModeToggleShortcutTooltip").length,
-      ).toBeGreaterThan(0);
-    });
   });
 });

--- a/packages/vscode-webui/src/components/prompt-form/__tests__/add-context-menu.test.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/__tests__/add-context-menu.test.tsx
@@ -92,7 +92,28 @@ describe("AddContextMenu", () => {
     expect(todoItem).not.toBeNull();
     expect(todoItem?.getAttribute("data-disabled")).not.toBeNull();
 
+    // The disabled reason is exposed via a hover tooltip trigger next to the
+    // label rather than an always-visible line.
+    expect(
+      screen.getByLabelText("addContextMenu.todoDisabledDescription"),
+    ).not.toBeNull();
+
     fireEvent.click(screen.getByText("chat.todoModeLabel"));
     expect(onSelectTodoMode).not.toHaveBeenCalled();
+  });
+
+  it("does not render the disabled hint trigger when enabled", () => {
+    render(
+      <AddContextMenu
+        onAddFilesAndFolders={vi.fn()}
+        onSelectTodoMode={vi.fn()}
+      />,
+    );
+
+    openMenu();
+
+    expect(
+      screen.queryByLabelText("addContextMenu.todoDisabledDescription"),
+    ).toBeNull();
   });
 });

--- a/packages/vscode-webui/src/components/prompt-form/__tests__/add-context-menu.test.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/__tests__/add-context-menu.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { AddContextMenu } from "../add-context-menu";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Radix menus rely on pointer capture / scrollIntoView which jsdom does not implement.
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn();
+  window.HTMLElement.prototype.setPointerCapture = vi.fn();
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+});
+
+function openMenu() {
+  const trigger = screen.getByRole("button");
+  trigger.focus();
+  fireEvent.keyDown(trigger, { key: "Enter" });
+}
+
+describe("AddContextMenu", () => {
+  it("triggers files and folders selection", () => {
+    const onAddFilesAndFolders = vi.fn();
+    render(<AddContextMenu onAddFilesAndFolders={onAddFilesAndFolders} />);
+
+    openMenu();
+    fireEvent.click(screen.getByText("addContextMenu.files"));
+
+    expect(onAddFilesAndFolders).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides optional items when their handlers are not provided", () => {
+    render(<AddContextMenu onAddFilesAndFolders={vi.fn()} />);
+
+    openMenu();
+
+    expect(screen.getByText("addContextMenu.files")).not.toBeNull();
+    expect(screen.queryByText("addContextMenu.attach")).toBeNull();
+    expect(screen.queryByText("chat.todoModeLabel")).toBeNull();
+  });
+
+  it("shows and triggers the attach files option when provided", () => {
+    const onAttachFile = vi.fn();
+    render(
+      <AddContextMenu
+        onAddFilesAndFolders={vi.fn()}
+        onAttachFile={onAttachFile}
+      />,
+    );
+
+    openMenu();
+    fireEvent.click(screen.getByText("addContextMenu.attach"));
+
+    expect(onAttachFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows and triggers the todo mode option when provided", () => {
+    const onSelectTodoMode = vi.fn();
+    render(
+      <AddContextMenu
+        onAddFilesAndFolders={vi.fn()}
+        onSelectTodoMode={onSelectTodoMode}
+      />,
+    );
+
+    openMenu();
+    fireEvent.click(screen.getByText("chat.todoModeLabel"));
+
+    expect(onSelectTodoMode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/vscode-webui/src/components/prompt-form/__tests__/add-context-menu.test.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/__tests__/add-context-menu.test.tsx
@@ -73,4 +73,26 @@ describe("AddContextMenu", () => {
 
     expect(onSelectTodoMode).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the todo mode option visible but not selectable when disabled", () => {
+    const onSelectTodoMode = vi.fn();
+    render(
+      <AddContextMenu
+        onAddFilesAndFolders={vi.fn()}
+        onSelectTodoMode={onSelectTodoMode}
+        todoModeDisabled
+      />,
+    );
+
+    openMenu();
+
+    const todoItem = screen
+      .getByText("chat.todoModeLabel")
+      .closest("[role='menuitem']");
+    expect(todoItem).not.toBeNull();
+    expect(todoItem?.getAttribute("data-disabled")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("chat.todoModeLabel"));
+    expect(onSelectTodoMode).not.toHaveBeenCalled();
+  });
 });

--- a/packages/vscode-webui/src/components/prompt-form/active-selection-badge.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/active-selection-badge.tsx
@@ -2,21 +2,19 @@ import { FileBadge } from "@/features/tools";
 import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import { cn } from "@/lib/utils";
 import { getActiveSelectionLabel } from "@/lib/utils/active-selection";
-import { Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { Button } from "../ui/button";
 
 interface ActiveSelectionBadgeProps {
-  onClick?: () => void;
   className?: string;
 }
 
 export const ActiveSelectionBadge: React.FC<ActiveSelectionBadgeProps> = ({
-  onClick,
   className,
 }) => {
   const activeSelection = useActiveSelection();
   const { t } = useTranslation();
+
+  if (!activeSelection) return null;
 
   return (
     <div
@@ -25,35 +23,23 @@ export const ActiveSelectionBadge: React.FC<ActiveSelectionBadgeProps> = ({
         className,
       )}
     >
-      {activeSelection ? (
-        <FileBadge
-          className="hover:!bg-transparent !py-0 m-0 cursor-default truncate rounded-sm border border-[var(--vscode-chat-requestBorder)] pr-1"
-          labelClassName="whitespace-nowrap"
-          label={getActiveSelectionLabel(activeSelection, t)}
-          path={activeSelection.filepath}
-          startLine={
-            // display as 1-based, but not for notebook cells (show cell index instead)
-            activeSelection.content.length > 0 && !activeSelection.notebookCell
-              ? activeSelection.range.start.line + 1
-              : undefined
-          }
-          endLine={
-            activeSelection.content.length > 0 && !activeSelection.notebookCell
-              ? activeSelection.range.end.line + 1
-              : undefined
-          }
-        />
-      ) : (
-        <Button
-          type="button"
-          variant="ghost"
-          className="h-auto min-h-0 justify-start gap-1 border border-[var(--vscode-chat-requestBorder)] border-dashed bg-transparent px-2 py-0 text-muted-foreground text-sm focus-visible:border-[var(--vscode-focusBorder)] focus-visible:border-solid focus-visible:ring-0 focus-visible:ring-transparent"
-          onClick={onClick}
-        >
-          <Plus className="size-3" />
-          {t("activeSelectionBadge.addContext")}
-        </Button>
-      )}
+      <FileBadge
+        className="hover:!bg-transparent !py-0 m-0 cursor-default truncate rounded-sm border border-[var(--vscode-chat-requestBorder)] pr-1"
+        labelClassName="whitespace-nowrap"
+        label={getActiveSelectionLabel(activeSelection, t)}
+        path={activeSelection.filepath}
+        startLine={
+          // display as 1-based, but not for notebook cells (show cell index instead)
+          activeSelection.content.length > 0 && !activeSelection.notebookCell
+            ? activeSelection.range.start.line + 1
+            : undefined
+        }
+        endLine={
+          activeSelection.content.length > 0 && !activeSelection.notebookCell
+            ? activeSelection.range.end.line + 1
+            : undefined
+        }
+      />
     </div>
   );
 };

--- a/packages/vscode-webui/src/components/prompt-form/add-context-menu.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/add-context-menu.tsx
@@ -4,8 +4,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { AtSign, Paperclip, Plus, Target } from "lucide-react";
+import { AtSign, Info, Paperclip, Plus, Target } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../ui/button";
 
@@ -96,13 +101,30 @@ export function AddContextMenu({
           >
             <Target className="mt-0.5 size-4" />
             <div className="min-w-0">
-              <div className="font-medium">{t("chat.todoModeLabel")}</div>
-              <div className="truncate text-muted-foreground text-xs">
-                {t(
-                  todoModeDisabled
-                    ? "addContextMenu.todoDisabledDescription"
-                    : "addContextMenu.todoDescription",
+              <div className="flex items-center gap-1 font-medium">
+                <span>{t("chat.todoModeLabel")}</span>
+                {todoModeDisabled && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      {/* Re-enable pointer events; the disabled item and its
+                          svgs are pointer-events-none, which would otherwise
+                          swallow the hover. */}
+                      <span
+                        className="pointer-events-auto inline-flex"
+                        aria-label={t("addContextMenu.todoDisabledDescription")}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <Info className="size-3.5 text-muted-foreground" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {t("addContextMenu.todoDisabledDescription")}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
+              </div>
+              <div className="truncate text-muted-foreground text-xs">
+                {t("addContextMenu.todoDescription")}
               </div>
             </div>
           </DropdownMenuItem>

--- a/packages/vscode-webui/src/components/prompt-form/add-context-menu.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/add-context-menu.tsx
@@ -13,6 +13,11 @@ interface AddContextMenuProps {
   onAddFilesAndFolders: () => void;
   onAttachFile?: () => void;
   onSelectTodoMode?: () => void;
+  /**
+   * When true, the todo mode item is rendered but not selectable (e.g. the task
+   * already has active todos). The item stays visible for discoverability.
+   */
+  todoModeDisabled?: boolean;
   showLabel?: boolean;
   /**
    * Which side of the trigger the menu opens on. Hardcode "bottom" for the
@@ -26,6 +31,7 @@ export function AddContextMenu({
   onAddFilesAndFolders,
   onAttachFile,
   onSelectTodoMode,
+  todoModeDisabled = false,
   showLabel = false,
   side = "top",
 }: AddContextMenuProps) {
@@ -85,13 +91,18 @@ export function AddContextMenu({
         {onSelectTodoMode && (
           <DropdownMenuItem
             className="cursor-pointer items-start gap-2 px-2 py-1.5"
+            disabled={todoModeDisabled}
             onSelect={onSelectTodoMode}
           >
             <Target className="mt-0.5 size-4" />
             <div className="min-w-0">
               <div className="font-medium">{t("chat.todoModeLabel")}</div>
               <div className="truncate text-muted-foreground text-xs">
-                {t("addContextMenu.todoDescription")}
+                {t(
+                  todoModeDisabled
+                    ? "addContextMenu.todoDisabledDescription"
+                    : "addContextMenu.todoDescription",
+                )}
               </div>
             </div>
           </DropdownMenuItem>

--- a/packages/vscode-webui/src/components/prompt-form/add-context-menu.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/add-context-menu.tsx
@@ -1,0 +1,102 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { AtSign, Paperclip, Plus, Target } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "../ui/button";
+
+interface AddContextMenuProps {
+  onAddFilesAndFolders: () => void;
+  onAttachFile?: () => void;
+  onSelectTodoMode?: () => void;
+  showLabel?: boolean;
+  /**
+   * Which side of the trigger the menu opens on. Hardcode "bottom" for the
+   * sidebar (input near the top) and "top" for the in-task toolbar (input at
+   * the bottom) to avoid the menu flipping into an off-screen position.
+   */
+  side?: "top" | "bottom";
+}
+
+export function AddContextMenu({
+  onAddFilesAndFolders,
+  onAttachFile,
+  onSelectTodoMode,
+  showLabel = false,
+  side = "top",
+}: AddContextMenuProps) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          aria-label={t("addContextMenu.trigger")}
+          className={cn(
+            "h-[1.7rem] shrink-0 border border-[var(--vscode-chat-requestBorder)] bg-transparent py-0 text-muted-foreground focus-visible:border-[var(--vscode-focusBorder)] focus-visible:ring-0 focus-visible:ring-transparent",
+            showLabel ? "gap-1 px-2" : "w-[1.7rem] p-0",
+          )}
+        >
+          <Plus className="size-3.5" />
+          {showLabel && (
+            <span className="text-sm">{t("addContextMenu.trigger")}</span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        side={side}
+        sideOffset={6}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        className="dropdown-menu !bg-background w-[320px] max-w-(--radix-dropdown-menu-content-available-width) border p-2 text-popover-foreground shadow-md"
+      >
+        <DropdownMenuItem
+          className="cursor-pointer items-start gap-2 px-2 py-1.5"
+          onSelect={onAddFilesAndFolders}
+        >
+          <AtSign className="mt-0.5 size-4" />
+          <div className="min-w-0">
+            <div className="font-medium">{t("addContextMenu.files")}</div>
+            <div className="truncate text-muted-foreground text-xs">
+              {t("addContextMenu.filesDescription")}
+            </div>
+          </div>
+        </DropdownMenuItem>
+        {onAttachFile && (
+          <DropdownMenuItem
+            className="cursor-pointer items-start gap-2 px-2 py-1.5"
+            onSelect={onAttachFile}
+          >
+            <Paperclip className="mt-0.5 size-4" />
+            <div className="min-w-0">
+              <div className="font-medium">{t("addContextMenu.attach")}</div>
+              <div className="truncate text-muted-foreground text-xs">
+                {t("addContextMenu.attachDescription")}
+              </div>
+            </div>
+          </DropdownMenuItem>
+        )}
+        {onSelectTodoMode && (
+          <DropdownMenuItem
+            className="cursor-pointer items-start gap-2 px-2 py-1.5"
+            onSelect={onSelectTodoMode}
+          >
+            <Target className="mt-0.5 size-4" />
+            <div className="min-w-0">
+              <div className="font-medium">{t("chat.todoModeLabel")}</div>
+              <div className="truncate text-muted-foreground text-xs">
+                {t("addContextMenu.todoDescription")}
+              </div>
+            </div>
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/vscode-webui/src/components/prompt-form/todo-mode-badge.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/todo-mode-badge.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+import { Target, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "../ui/button";
+
+interface TodoModeBadgeProps {
+  onRemove: () => void;
+}
+
+export function TodoModeBadge({ onRemove }: TodoModeBadgeProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="todo-mode-badge-enter inline-flex h-6 items-center gap-1.5">
+      <span className="h-4 border-border border-l" />
+      <div
+        className={cn(
+          "group inline-flex h-6 max-w-full items-center gap-1 overflow-hidden rounded-md px-1.5 py-0 text-foreground text-sm leading-none",
+          "transition-colors duration-150 ease-out focus-within:bg-muted/50 hover:bg-muted/50",
+        )}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={t("todoModeBadge.remove")}
+          className="relative size-4 shrink-0 p-0 hover:bg-transparent"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove();
+          }}
+        >
+          <Target className="absolute size-3.5 transition-opacity duration-150 group-focus-within:opacity-0 group-hover:opacity-0" />
+          <X className="absolute size-3.5 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100" />
+        </Button>
+        <span className="transition-colors duration-150">
+          {t("chat.todoModeLabel")}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/vscode-webui/src/components/submit-dropdown-button.tsx
+++ b/packages/vscode-webui/src/components/submit-dropdown-button.tsx
@@ -29,7 +29,6 @@ import {
   Loader2,
   SendHorizonal,
   Settings2Icon,
-  Target,
   WrenchIcon,
 } from "lucide-react";
 import { useRef, useState } from "react";
@@ -45,9 +44,6 @@ interface SubmitDropdownButtonProps {
   resetMcpTools: () => void;
   isPlanMode?: boolean;
   onTogglePlanMode?: () => void;
-  isTodoMode?: boolean;
-  showTodoMode?: boolean;
-  onToggleTodoMode?: () => void;
   onSwitchSubmitMode?: () => void;
 }
 
@@ -61,22 +57,16 @@ export function SubmitDropdownButton({
   resetMcpTools,
   isPlanMode = false,
   onTogglePlanMode,
-  isTodoMode = false,
-  showTodoMode = false,
-  onToggleTodoMode,
   onSwitchSubmitMode,
 }: SubmitDropdownButtonProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isHoveringRef = useRef(false);
-  const submitMode = isPlanMode ? "plan" : isTodoMode ? "todo" : "default";
-  const submitTooltip =
-    submitMode === "plan"
-      ? t("chat.planModeSubmitTooltip")
-      : submitMode === "todo"
-        ? t("chat.todoModeSubmitTooltip")
-        : t("chat.submitTooltip");
+  const submitMode = isPlanMode ? "plan" : "default";
+  const submitTooltip = isPlanMode
+    ? t("chat.planModeSubmitTooltip")
+    : t("chat.submitTooltip");
 
   if (isLoading) {
     return (
@@ -158,16 +148,6 @@ export function SubmitDropdownButton({
                     <span
                       className={cn(
                         "absolute inset-0 flex items-center justify-center transition-all duration-200",
-                        submitMode === "todo"
-                          ? "translate-y-0 opacity-100"
-                          : "-translate-y-full opacity-0",
-                      )}
-                    >
-                      <Target className="size-4" />
-                    </span>
-                    <span
-                      className={cn(
-                        "absolute inset-0 flex items-center justify-center transition-all duration-200",
                         submitMode === "default"
                           ? "translate-y-0 opacity-100"
                           : "translate-y-full opacity-0",
@@ -227,34 +207,6 @@ export function SubmitDropdownButton({
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-
-              {showTodoMode && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuItem
-                        className="flex cursor-pointer items-center gap-2 px-2 py-1"
-                        onSelect={(e) => e.preventDefault()}
-                        onClick={() => onToggleTodoMode?.()}
-                      >
-                        <Target className="size-3.5 transition-colors duration-200" />
-                        <span>{t("chat.todoModeLabel")}</span>
-                        <Switch
-                          checked={isTodoMode}
-                          className="ml-auto scale-75"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onToggleTodoMode?.();
-                          }}
-                        />
-                      </DropdownMenuItem>
-                    </TooltipTrigger>
-                    <TooltipContent side="left">
-                      <p>{t("chat.planModeToggleShortcutTooltip")}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
 
               <DropdownMenuSeparator />
 

--- a/packages/vscode-webui/src/features/chat/components/__stories__/queued-messages.stories.tsx
+++ b/packages/vscode-webui/src/features/chat/components/__stories__/queued-messages.stories.tsx
@@ -27,6 +27,7 @@ export const Default: Story = {
       ),
       queuedMessage(`This is a prompt with multi line.
       This is another line`),
+      queuedMessage("This is a todo mode prompt", true),
       queuedMessage("This is a prompt"),
       queuedMessage("This is a prompt"),
       queuedMessage("This is a prompt"),
@@ -35,10 +36,11 @@ export const Default: Story = {
   },
 };
 
-function queuedMessage(text: string): QueuedMessage {
+function queuedMessage(text: string, isTodoMode = false): QueuedMessage {
   return {
     text,
     files: [],
     reviews: [],
+    isTodoMode,
   };
 }

--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useImperativeHandle, useRef } from "react";
 
 import { DevRetryCountdown } from "@/components/dev-retry-countdown";
 import { ActiveSelectionBadge } from "@/components/prompt-form/active-selection-badge";
+import { AddContextMenu } from "@/components/prompt-form/add-context-menu";
 import { FormEditor } from "@/components/prompt-form/form-editor";
 import type { useApprovalAndRetry } from "@/features/approval";
 import type { UseChatHelpers } from "@ai-sdk/react";
@@ -10,6 +11,7 @@ import type { Message } from "@getpochi/livekit";
 
 import { ReviewBadges } from "@/components/prompt-form/review-badges";
 import { UserEditsBadge } from "@/components/prompt-form/user-edits";
+import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import type { Review } from "@getpochi/common/vscode-webui-bridge";
 import type { ReactNode } from "@tanstack/react-router";
 import type { ChatInput } from "../hooks/use-chat-input-state";
@@ -34,6 +36,9 @@ interface ChatInputFormProps {
   lastCheckpointHash?: string;
   onSwitchSubmitMode?: () => void;
   isPlanMode?: boolean;
+  onSelectTodoMode?: () => void;
+  onAttachFile?: () => void;
+  contextMenuSide?: "top" | "bottom";
   className?: string;
 }
 
@@ -64,11 +69,16 @@ export const ChatInputForm = forwardRef<
     lastCheckpointHash,
     children,
     onSwitchSubmitMode,
+    onSelectTodoMode,
+    onAttachFile,
+    contextMenuSide = "top",
     className,
   },
   ref,
 ) {
   const editorRef = useRef<Editor | null>(null);
+  const activeSelection = useActiveSelection();
+  const showAddContextLabel = !activeSelection;
 
   useImperativeHandle(ref, () => ({
     addToSubmitHistory: () => {
@@ -98,11 +108,28 @@ export const ChatInputForm = forwardRef<
       className={className}
     >
       <div className="mt-1 flex select-none flex-wrap items-center gap-1.5 pl-2">
-        <ActiveSelectionBadge
-          onClick={() => {
+        <AddContextMenu
+          side={contextMenuSide}
+          showLabel={showAddContextLabel}
+          onAddFilesAndFolders={() => {
             editorRef.current?.commands.insertContent(" @");
+            setTimeout(() => {
+              editorRef.current?.commands.focus();
+            }, 0);
           }}
+          onAttachFile={onAttachFile}
+          onSelectTodoMode={
+            onSelectTodoMode
+              ? () => {
+                  onSelectTodoMode();
+                  setTimeout(() => {
+                    editorRef.current?.commands.focus();
+                  }, 0);
+                }
+              : undefined
+          }
         />
+        <ActiveSelectionBadge />
         {taskId && lastCheckpointHash && (
           <UserEditsBadge taskId={taskId} lastCheckpoint={lastCheckpointHash} />
         )}

--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -37,6 +37,7 @@ interface ChatInputFormProps {
   onSwitchSubmitMode?: () => void;
   isPlanMode?: boolean;
   onSelectTodoMode?: () => void;
+  todoModeDisabled?: boolean;
   onAttachFile?: () => void;
   contextMenuSide?: "top" | "bottom";
   className?: string;
@@ -70,6 +71,7 @@ export const ChatInputForm = forwardRef<
     children,
     onSwitchSubmitMode,
     onSelectTodoMode,
+    todoModeDisabled,
     onAttachFile,
     contextMenuSide = "top",
     className,
@@ -128,6 +130,7 @@ export const ChatInputForm = forwardRef<
                 }
               : undefined
           }
+          todoModeDisabled={todoModeDisabled}
         />
         <ActiveSelectionBadge />
         {taskId && lastCheckpointHash && (

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -2,8 +2,16 @@ import type { Message, Task } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatToolbar } from "./chat-toolbar";
+
+const chatSubmitMocks = vi.hoisted(() => ({
+  useChatSubmit: vi.fn(() => ({
+    handleSubmit: vi.fn(),
+    handleSteerSubmit: vi.fn(),
+    handleStop: vi.fn(),
+  })),
+}));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -119,10 +127,7 @@ vi.mock("../hooks/use-chat-status", () => ({
   }),
 }));
 vi.mock("../hooks/use-chat-submit", () => ({
-  useChatSubmit: () => ({
-    handleSubmit: vi.fn(),
-    handleStop: vi.fn(),
-  }),
+  useChatSubmit: chatSubmitMocks.useChatSubmit,
 }));
 vi.mock("../hooks/use-inline-compact-task", () => ({
   useInlineCompactTask: () => ({
@@ -201,6 +206,10 @@ function renderToolbar(isSubTask: boolean) {
 }
 
 describe("ChatToolbar", () => {
+  beforeEach(() => {
+    chatSubmitMocks.useChatSubmit.mockClear();
+  });
+
   it("renders todos in root task pages", () => {
     renderToolbar(false);
 
@@ -211,5 +220,15 @@ describe("ChatToolbar", () => {
     renderToolbar(true);
 
     expect(screen.queryByTestId("todo-list")).toBeNull();
+  });
+
+  it("disables todo creation while active todos exist", () => {
+    renderToolbar(false);
+
+    expect(chatSubmitMocks.useChatSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        canCreateTodo: false,
+      }),
+    );
   });
 });

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -59,6 +59,7 @@ vi.mock("@/features/chat", () => ({
 vi.mock("@/features/settings", () => ({
   AutoApproveMenu: () => null,
   useAutoApprove: () => ({ autoApproveActive: false }),
+  useIsDevMode: () => [false, vi.fn()],
   useSelectedModels: () => ({
     groupedModels: [],
     selectedModel: { id: "model-1" },

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -121,8 +121,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   const [isDevMode] = useIsDevMode();
   const canUseTodoMode = isDevMode === true;
   const [todoModeSelected, setTodoModeSelected] = useState(false);
-  const canSelectTodoMode =
-    canUseTodoMode && !isSubTask && !hasActiveTodos(todos);
+  // Show the todo mode entry in dev mode, but disable it (rather than hide it)
+  // while the task already has active todos so it stays discoverable.
+  const showTodoMode = canUseTodoMode && !isSubTask;
+  const todoModeDisabled = hasActiveTodos(todos);
+  const canSelectTodoMode = showTodoMode && !todoModeDisabled;
 
   useEffect(() => {
     if (!canSelectTodoMode && todoModeSelected) {
@@ -401,8 +404,9 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           lastCheckpointHash={task?.lastCheckpointHash ?? undefined}
           onAttachFile={() => fileInputRef.current?.click()}
           onSelectTodoMode={
-            canSelectTodoMode ? () => setTodoModeSelected(true) : undefined
+            showTodoMode ? () => setTodoModeSelected(true) : undefined
           }
+          todoModeDisabled={todoModeDisabled}
           contextMenuSide="top"
           className={cn({
             "rounded-t-none": hasVisibleContextPanel || hasQueuedMessages,

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -2,14 +2,10 @@ import { AttachmentPreviewList } from "@/components/attachment-preview-list";
 import { DevModeButton } from "@/components/dev-mode-button";
 import { DiffSummary } from "@/components/diff-summary";
 import { ModelSelect } from "@/components/model-select";
+import { TodoModeBadge } from "@/components/prompt-form/todo-mode-badge";
 import { PublicShareButton } from "@/components/public-share-button";
 import { TokenUsage } from "@/components/token-usage";
 import { Button } from "@/components/ui/button";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   ApprovalButton,
@@ -21,6 +17,7 @@ import { useAutoApproveGuard, useToolCallLifeCycle } from "@/features/chat";
 import {
   AutoApproveMenu,
   useAutoApprove,
+  useIsDevMode,
   useSelectedModels,
 } from "@/features/settings";
 import { type TodoCompletionUpdate, TodoList } from "@/features/todo";
@@ -31,11 +28,11 @@ import { useTaskChangedFiles } from "@/lib/hooks/use-task-changed-files";
 import { cn, tw } from "@/lib/utils";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { constants } from "@getpochi/common";
+import { hasActiveTodos } from "@getpochi/common/message-utils";
 import type { McpConfigOverride } from "@getpochi/common/vscode-webui-bridge";
 import type { Message, Task } from "@getpochi/livekit";
-import type { Todo } from "@getpochi/tools";
+import { type Todo, initTodoModeTodos } from "@getpochi/tools";
 import {
-  PaperclipIcon,
   SendHorizonal,
   ShieldCheck,
   ShieldOff,
@@ -121,6 +118,30 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
 
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
 
+  const [isDevMode] = useIsDevMode();
+  const canUseTodoMode = isDevMode === true;
+  const [todoModeSelected, setTodoModeSelected] = useState(false);
+  const canSelectTodoMode =
+    canUseTodoMode && !isSubTask && !hasActiveTodos(todos);
+
+  useEffect(() => {
+    if (!canSelectTodoMode && todoModeSelected) {
+      setTodoModeSelected(false);
+    }
+  }, [canSelectTodoMode, todoModeSelected]);
+
+  const createTodoBeforeSend = useCallback(
+    (text: string) => {
+      if (!todoModeSelected) return;
+
+      setTodoModeSelected(false);
+      if (hasActiveTodos(todos)) return;
+
+      updateTodos(initTodoModeTodos(text));
+    },
+    [todoModeSelected, todos, updateTodos],
+  );
+
   const {
     groupedModels,
     selectedModel,
@@ -202,6 +223,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     setQueuedMessages,
     reviews,
     taskId: taskId,
+    onBeforeSendText: createTodoBeforeSend,
   });
 
   const autoApproveGuard = useAutoApproveGuard();
@@ -377,6 +399,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           reviews={reviews}
           taskId={taskId}
           lastCheckpointHash={task?.lastCheckpointHash ?? undefined}
+          onAttachFile={() => fileInputRef.current?.click()}
+          onSelectTodoMode={
+            canSelectTodoMode ? () => setTodoModeSelected(true) : undefined
+          }
+          contextMenuSide="top"
           className={cn({
             "rounded-t-none": hasVisibleContextPanel || hasQueuedMessages,
           })}
@@ -414,6 +441,9 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             onChange={updateSelectedModelId}
             reloadModels={reloadModels}
           />
+          {canSelectTodoMode && todoModeSelected && (
+            <TodoModeBadge onRemove={() => setTodoModeSelected(false)} />
+          )}
         </div>
 
         <div className={FooterRightClassName}>
@@ -463,30 +493,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
               onUpdateIsPublicShared={onUpdateIsPublicShared}
             />
           )}
-          <HoverCard>
-            <HoverCardTrigger asChild>
-              <span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="button-focus relative h-6 w-6 p-0"
-                >
-                  <span className="size-4">
-                    <PaperclipIcon className="size-4 translate-y-[1.5px] scale-105" />
-                  </span>
-                </Button>
-              </span>
-            </HoverCardTrigger>
-            <HoverCardContent
-              side="top"
-              align="start"
-              sideOffset={6}
-              className="!w-auto max-w-sm bg-background px-3 py-1.5 text-xs"
-            >
-              {t("chat.attachmentTooltip")}
-            </HoverCardContent>
-          </HoverCard>
           <SubmitStopButton
             isSubmitDisabled={isSubmitDisabled}
             showStopButton={showStopButton}

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -133,16 +133,18 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     }
   }, [canSelectTodoMode, todoModeSelected]);
 
+  const resetTodoMode = useCallback(() => {
+    setTodoModeSelected(false);
+  }, []);
+
   const createTodoBeforeSend = useCallback(
     (text: string) => {
-      if (!todoModeSelected) return;
-
-      setTodoModeSelected(false);
+      resetTodoMode();
       if (hasActiveTodos(todos)) return;
 
       updateTodos(initTodoModeTodos(text));
     },
-    [todoModeSelected, todos, updateTodos],
+    [resetTodoMode, todos, updateTodos],
   );
 
   const {
@@ -226,6 +228,9 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     setQueuedMessages,
     reviews,
     taskId: taskId,
+    isTodoMode: todoModeSelected,
+    canCreateTodo: !todoModeDisabled,
+    onTodoModeQueued: resetTodoMode,
     onBeforeSendText: createTodoBeforeSend,
   });
 

--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -1,13 +1,7 @@
 import { AttachmentPreviewList } from "@/components/attachment-preview-list";
 import { ModelSelect } from "@/components/model-select";
+import { TodoModeBadge } from "@/components/prompt-form/todo-mode-badge";
 import { SubmitDropdownButton } from "@/components/submit-dropdown-button";
-import { Button } from "@/components/ui/button";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
-
 import {
   type CreateWorktreeType,
   WorktreeSelect,
@@ -27,10 +21,8 @@ import { vscodeHost } from "@/lib/vscode";
 import { prompts } from "@getpochi/common";
 import type { GitWorktree, Review } from "@getpochi/common/vscode-webui-bridge";
 import { type Todo, initTodoModeTodos } from "@getpochi/tools";
-import { PaperclipIcon } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { ChatInputForm, type ChatInputFormHandle } from "./chat-input-form";
 
 interface CreateTaskInputProps {
@@ -43,7 +35,6 @@ interface CreateTaskInputProps {
 }
 
 const emptyReviews: Review[] = [];
-type SubmitMode = "default" | "plan" | "todo";
 
 export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
   cwd,
@@ -53,30 +44,30 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
   setUserSelectedWorktree,
   deletingWorktreePaths,
 }) => {
-  const { t } = useTranslation();
   const activeSelection = useActiveSelection();
   const { draft: input, setDraft: setInput, clearDraft } = useTaskInputDraft();
-  const [submitMode, setSubmitMode] = useState<SubmitMode>("default");
+  const [planMode, setPlanMode] = useState(false);
+  const [todoModeSelected, setTodoModeSelected] = useState(false);
   const [isDevMode] = useIsDevMode();
   const canUseTodoMode = isDevMode === true;
-  const planMode = submitMode === "plan";
-  const todoMode = submitMode === "todo";
+  const todoMode = canUseTodoMode && todoModeSelected;
   const togglePlanMode = useCallback(() => {
-    setSubmitMode((mode) => (mode === "plan" ? "default" : "plan"));
-  }, []);
-  const toggleTodoMode = useCallback(() => {
-    if (!canUseTodoMode) return;
-    setSubmitMode((mode) => (mode === "todo" ? "default" : "todo"));
-  }, [canUseTodoMode]);
-  const switchSubmitMode = useCallback(() => {
-    setSubmitMode((mode) => {
-      if (mode === "default") return "plan";
-      if (mode === "plan" && canUseTodoMode) {
-        // Rotate from plan mode into todo mode.
-        return "todo";
+    setPlanMode((enabled) => {
+      const nextEnabled = !enabled;
+      if (nextEnabled) {
+        setTodoModeSelected(false);
       }
-      return "default";
+      return nextEnabled;
     });
+  }, []);
+  const switchSubmitMode = useCallback(() => {
+    setTodoModeSelected(false);
+    setPlanMode((enabled) => !enabled);
+  }, []);
+  const selectTodoMode = useCallback(() => {
+    if (!canUseTodoMode) return;
+    setPlanMode(false);
+    setTodoModeSelected(true);
   }, [canUseTodoMode]);
   const {
     globalMcpConfig,
@@ -301,7 +292,8 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       setIsCreatingTask(false);
       setDebouncedIsCreatingTask(false);
       // Reset submit mode after each submission
-      setSubmitMode("default");
+      setPlanMode(false);
+      setTodoModeSelected(false);
     },
     [
       input.text,
@@ -365,6 +357,9 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
         reviews={emptyReviews}
         onSwitchSubmitMode={switchSubmitMode}
         isPlanMode={planMode}
+        onSelectTodoMode={canUseTodoMode ? selectTodoMode : undefined}
+        onAttachFile={() => fileInputRef.current?.click()}
+        contextMenuSide="bottom"
       >
         {files.length > 0 && (
           <div className="px-3">
@@ -388,7 +383,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       />
 
       <div className="my-2 flex shrink-0 justify-between gap-5 overflow-x-hidden">
-        <div className="flex items-center gap-4 overflow-x-hidden truncate">
+        <div className="flex items-center gap-2 overflow-x-hidden truncate">
           <ModelSelect
             value={selectedModel || selectedModelFromStore}
             models={groupedModels}
@@ -399,6 +394,9 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
             reloadModels={reloadModels}
             triggerClassName="sidebar-model-select"
           />
+          {todoMode && (
+            <TodoModeBadge onRemove={() => setTodoModeSelected(false)} />
+          )}
         </div>
 
         <div className="mr-1 flex shrink-0 items-center gap-0.5">
@@ -416,28 +414,6 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
               onBaseBranchChange={setBaseBranch}
             />
           )}
-          <HoverCard>
-            <HoverCardTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => fileInputRef.current?.click()}
-                className="button-focus relative h-6 w-6 p-0"
-              >
-                <span className="size-4">
-                  <PaperclipIcon className="size-4" />
-                </span>
-              </Button>
-            </HoverCardTrigger>
-            <HoverCardContent
-              side="top"
-              align="start"
-              sideOffset={6}
-              className="!w-auto max-w-sm bg-background px-3 py-1.5 text-xs"
-            >
-              {t("chat.attachmentTooltip")}
-            </HoverCardContent>
-          </HoverCard>
           <SubmitDropdownButton
             isLoading={debouncedIsCreatingTask}
             disabled={!selectedModel || isUploadingAttachments}
@@ -448,9 +424,6 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
             resetMcpTools={resetMcpTools}
             isPlanMode={planMode}
             onTogglePlanMode={togglePlanMode}
-            isTodoMode={canUseTodoMode && todoMode}
-            showTodoMode={canUseTodoMode}
-            onToggleTodoMode={toggleTodoMode}
             onSwitchSubmitMode={switchSubmitMode}
           />
         </div>

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { QueuedMessage } from "../hooks/use-chat-submit";
+import { QueuedMessages } from "./queued-messages";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { count?: number }) =>
+      values?.count === undefined ? key : `${key}:${values.count}`,
+  }),
+}));
+
+describe("QueuedMessages", () => {
+  it("uses the todo icon for queued todo-mode messages", () => {
+    const { container } = render(
+      <QueuedMessages
+        messages={[
+          queuedMessage({ text: "regular queued message" }),
+          queuedMessage({ text: "todo queued message", isTodoMode: true }),
+        ]}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelectorAll(".lucide-list-end")).toHaveLength(1);
+    expect(container.querySelectorAll(".lucide-target")).toHaveLength(1);
+  });
+});
+
+function queuedMessage({
+  text,
+  isTodoMode = false,
+}: {
+  text: string;
+  isTodoMode?: boolean;
+}): QueuedMessage {
+  return {
+    text,
+    files: [],
+    reviews: [],
+    isTodoMode,
+  };
+}

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { parseTitle } from "@getpochi/common/message-utils";
-import { CornerDownRight, ListEnd, Trash2 } from "lucide-react";
+import { CornerDownRight, ListEnd, Target, Trash2 } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { QueuedMessage } from "../hooks/use-chat-submit";
@@ -19,7 +19,7 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
 }) => {
   const { t } = useTranslation();
   const renderMessages = useMemo(() => {
-    return messages.map(({ text, files, reviews }) => {
+    return messages.map(({ text, files, reviews, isTodoMode }) => {
       const title = text.trim() ? parseTitle(text) : t("chat.noMessage");
       const details = [
         files.length > 0 ? t("chat.fileCount", { count: files.length }) : "",
@@ -31,6 +31,7 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
       return {
         title,
         details: details.join(" · "),
+        isTodoMode,
       };
     });
   }, [messages, t]);
@@ -42,7 +43,11 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
           key={index}
           className="group flex h-6 items-center gap-2 text-muted-foreground"
         >
-          <ListEnd className="size-3.5 shrink-0 scale-x-[-1]" />
+          {message.isTodoMode ? (
+            <Target className="size-3.5 shrink-0" />
+          ) : (
+            <ListEnd className="size-3.5 shrink-0 scale-x-[-1]" />
+          )}
           <div className="flex min-w-0 flex-1 items-center gap-1.5">
             <p
               className="min-w-0 truncate text-sm"

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -234,6 +234,85 @@ describe("useChatSubmit", () => {
     expect(context.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("captures todo mode on queued submissions", async () => {
+    const context = setup({ isLoading: true, isTodoMode: true });
+
+    await act(async () => {
+      await context.hook.result.current.handleSubmit();
+    });
+
+    expect(context.queuedMessages).toEqual([
+      queuedMessage({ text: "follow up", isTodoMode: true }),
+    ]);
+  });
+
+  it("resets todo mode after queueing a todo submission", async () => {
+    const onTodoModeQueued = vi.fn();
+    const context = setup({
+      isLoading: true,
+      isTodoMode: true,
+      onTodoModeQueued,
+    });
+
+    await act(async () => {
+      await context.hook.result.current.handleSubmit();
+    });
+
+    expect(onTodoModeQueued).toHaveBeenCalledOnce();
+  });
+
+  it("uses queued todo mode when flushing queued messages", async () => {
+    const onBeforeSendText = vi.fn();
+    const context = setup({
+      isLoading: false,
+      isTodoMode: true,
+      onBeforeSendText,
+      queuedMessages: [
+        queuedMessage({ text: "regular queued message", isTodoMode: false }),
+        queuedMessage({ text: "todo queued message", isTodoMode: true }),
+      ],
+    });
+
+    await act(async () => {
+      await context.hook.result.current.handleSubmit(undefined, {
+        flushQueuedMessages: true,
+      });
+    });
+    expect(onBeforeSendText).not.toHaveBeenCalled();
+
+    context.hook.rerender();
+
+    await act(async () => {
+      await context.hook.result.current.handleSubmit(undefined, {
+        flushQueuedMessages: true,
+      });
+    });
+    expect(onBeforeSendText).toHaveBeenCalledWith("todo queued message");
+  });
+
+  it("does not apply queued todo mode when todo creation is disabled", async () => {
+    const onBeforeSendText = vi.fn();
+    const context = setup({
+      isLoading: false,
+      canCreateTodo: false,
+      onBeforeSendText,
+      queuedMessages: [
+        queuedMessage({ text: "todo queued message", isTodoMode: true }),
+      ],
+    });
+
+    await act(async () => {
+      await context.hook.result.current.handleSubmit(undefined, {
+        flushQueuedMessages: true,
+      });
+    });
+
+    expect(onBeforeSendText).not.toHaveBeenCalled();
+    expect(context.sendMessage).toHaveBeenCalledWith({
+      parts: ["text:todo queued message"],
+    });
+  });
+
   it("flushes queued files and reviews from the queued item", async () => {
     const file = new File(["image"], "queued.png", { type: "image/png" });
     const review = createReview("review-1");
@@ -279,6 +358,10 @@ function setup({
   queuedMessages: initialQueuedMessages = [],
   files = [],
   reviews = [],
+  isTodoMode = false,
+  canCreateTodo = true,
+  onTodoModeQueued,
+  onBeforeSendText,
   uploadFiles = vi.fn(() => Promise.resolve([])),
 }: {
   isLoading: boolean;
@@ -286,6 +369,10 @@ function setup({
   queuedMessages?: QueuedMessage[];
   files?: File[];
   reviews?: Review[];
+  isTodoMode?: boolean;
+  canCreateTodo?: boolean;
+  onTodoModeQueued?: () => void;
+  onBeforeSendText?: (text: string) => void;
   uploadFiles?: ReturnType<typeof vi.fn>;
 }) {
   let queuedMessages = initialQueuedMessages;
@@ -331,6 +418,10 @@ function setup({
       setQueuedMessages,
       reviews,
       taskId: "task-1",
+      isTodoMode,
+      canCreateTodo,
+      onTodoModeQueued,
+      onBeforeSendText,
     }),
   );
 
@@ -355,15 +446,18 @@ function queuedMessage({
   text,
   files = [],
   reviews = [],
+  isTodoMode = false,
 }: {
   text: string;
   files?: File[];
   reviews?: Review[];
+  isTodoMode?: boolean;
 }): QueuedMessage {
   return {
     text,
     files,
     reviews,
+    isTodoMode,
   };
 }
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -49,6 +49,11 @@ interface UseChatSubmitProps {
   setQueuedMessages: React.Dispatch<React.SetStateAction<QueuedMessage[]>>;
   reviews: Review[];
   taskId: string;
+  /**
+   * Invoked with the final submitted text right before the message is sent.
+   * Used e.g. to seed a todo from the message when todo mode is selected.
+   */
+  onBeforeSendText?: (text: string) => void;
 }
 
 export function useChatSubmit({
@@ -64,6 +69,7 @@ export function useChatSubmit({
   setQueuedMessages,
   reviews,
   taskId,
+  onBeforeSendText,
 }: UseChatSubmitProps) {
   const autoApproveGuard = useAutoApproveGuard();
   const { isExecuting } = useToolCallLifeCycle();
@@ -243,6 +249,10 @@ export function useChatSubmit({
         clearInput();
       }
 
+      if (text.length > 0) {
+        onBeforeSendText?.(text);
+      }
+
       if (messageFiles.length > 0) {
         try {
           logger.debug("Uploading files...");
@@ -310,6 +320,7 @@ export function useChatSubmit({
       isExecuting,
       queueCurrentInput,
       pendingApproval,
+      onBeforeSendText,
     ],
   );
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -30,6 +30,7 @@ export interface QueuedMessage {
   text: string;
   files: File[];
   reviews: Review[];
+  isTodoMode: boolean;
 }
 
 interface SubmitOptions {
@@ -49,6 +50,9 @@ interface UseChatSubmitProps {
   setQueuedMessages: React.Dispatch<React.SetStateAction<QueuedMessage[]>>;
   reviews: Review[];
   taskId: string;
+  isTodoMode?: boolean;
+  canCreateTodo?: boolean;
+  onTodoModeQueued?: () => void;
   /**
    * Invoked with the final submitted text right before the message is sent.
    * Used e.g. to seed a todo from the message when todo mode is selected.
@@ -69,6 +73,9 @@ export function useChatSubmit({
   setQueuedMessages,
   reviews,
   taskId,
+  isTodoMode = false,
+  canCreateTodo = true,
+  onTodoModeQueued,
   onBeforeSendText,
 }: UseChatSubmitProps) {
   const autoApproveGuard = useAutoApproveGuard();
@@ -125,6 +132,7 @@ export function useChatSubmit({
       text: input.text.trim(),
       files: [...files],
       reviews: [...reviews],
+      isTodoMode,
     };
 
     if (
@@ -136,7 +144,7 @@ export function useChatSubmit({
     }
 
     return currentMessage;
-  }, [files, input.text, reviews]);
+  }, [files, input.text, isTodoMode, reviews]);
 
   const clearCurrentMessage = useCallback(
     (currentMessage: QueuedMessage) => {
@@ -159,8 +167,16 @@ export function useChatSubmit({
 
     setQueuedMessages((prev) => [...prev, queuedMessage]);
     clearCurrentMessage(queuedMessage);
+    if (queuedMessage.isTodoMode) {
+      onTodoModeQueued?.();
+    }
     return true;
-  }, [clearCurrentMessage, createCurrentMessage, setQueuedMessages]);
+  }, [
+    clearCurrentMessage,
+    createCurrentMessage,
+    onTodoModeQueued,
+    setQueuedMessages,
+  ]);
 
   const queuePendingSteerInput = useCallback(() => {
     const queuedMessage = createCurrentMessage();
@@ -168,8 +184,11 @@ export function useChatSubmit({
 
     pendingSteerMessageRef.current = queuedMessage;
     clearCurrentMessage(queuedMessage);
+    if (queuedMessage.isTodoMode) {
+      onTodoModeQueued?.();
+    }
     return true;
-  }, [clearCurrentMessage, createCurrentMessage]);
+  }, [clearCurrentMessage, createCurrentMessage, onTodoModeQueued]);
 
   /**
    * Handles form submission, sending both the current input and any queued messages.
@@ -220,6 +239,8 @@ export function useChatSubmit({
       const text = queuedMessage?.text ?? content;
       const messageFiles = queuedMessage?.files ?? files;
       const messageReviews = queuedMessage?.reviews ?? reviews;
+      const shouldCreateTodo =
+        (queuedMessage?.isTodoMode ?? isTodoMode) && canCreateTodo;
 
       // Disallow empty submissions
       if (
@@ -249,7 +270,7 @@ export function useChatSubmit({
         clearInput();
       }
 
-      if (text.length > 0) {
+      if (text.length > 0 && shouldCreateTodo) {
         onBeforeSendText?.(text);
       }
 
@@ -321,6 +342,8 @@ export function useChatSubmit({
       queueCurrentInput,
       pendingApproval,
       onBeforeSendText,
+      isTodoMode,
+      canCreateTodo,
     ],
   );
 

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -452,7 +452,8 @@
     "filesDescription": "Search workspace files and folders with @",
     "attach": "Attach files",
     "attachDescription": "Upload images, PDFs, or videos from your computer",
-    "todoDescription": "Ask Pochi to keep working toward this todo"
+    "todoDescription": "Ask Pochi to keep working toward this todo",
+    "todoDisabledDescription": "Unavailable while this task already has active todos"
   },
   "mentionList": {
     "noResultsFound": "No results found",

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -443,6 +443,17 @@
     "cell": "Cell",
     "addContext": "Add Context"
   },
+  "todoModeBadge": {
+    "remove": "Remove todo mode"
+  },
+  "addContextMenu": {
+    "trigger": "Add",
+    "files": "Files and folders",
+    "filesDescription": "Search workspace files and folders with @",
+    "attach": "Attach files",
+    "attachDescription": "Upload images, PDFs, or videos from your computer",
+    "todoDescription": "Ask Pochi to keep working toward this todo"
+  },
   "mentionList": {
     "noResultsFound": "No results found",
     "typeToSearch": "Type to search...",

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -453,7 +453,7 @@
     "attach": "Attach files",
     "attachDescription": "Upload images, PDFs, or videos from your computer",
     "todoDescription": "Ask Pochi to keep working toward this todo",
-    "todoDisabledDescription": "Unavailable while this task already has active todos"
+    "todoDisabledDescription": "Finish the current todos before starting a new one"
   },
   "mentionList": {
     "noResultsFound": "No results found",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -437,6 +437,17 @@
     "cell": "セル",
     "addContext": "コンテキストを追加"
   },
+  "todoModeBadge": {
+    "remove": "Todoモードを削除"
+  },
+  "addContextMenu": {
+    "trigger": "追加",
+    "files": "ファイルとフォルダー",
+    "filesDescription": "@ でワークスペースのファイルとフォルダーを検索",
+    "attach": "ファイルを添付",
+    "attachDescription": "コンピューターから画像・PDF・動画をアップロード",
+    "todoDescription": "このTodoに向けてPochiが作業を続けます"
+  },
   "mentionList": {
     "noResultsFound": "結果が見つかりません",
     "typeToSearch": "入力して検索...",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -447,7 +447,7 @@
     "attach": "ファイルを添付",
     "attachDescription": "コンピューターから画像・PDF・動画をアップロード",
     "todoDescription": "このTodoに向けてPochiが作業を続けます",
-    "todoDisabledDescription": "このタスクには進行中のTodoがあるため利用できません"
+    "todoDisabledDescription": "現在のTodoを完了してから新しく開始できます"
   },
   "mentionList": {
     "noResultsFound": "結果が見つかりません",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -446,7 +446,8 @@
     "filesDescription": "@ でワークスペースのファイルとフォルダーを検索",
     "attach": "ファイルを添付",
     "attachDescription": "コンピューターから画像・PDF・動画をアップロード",
-    "todoDescription": "このTodoに向けてPochiが作業を続けます"
+    "todoDescription": "このTodoに向けてPochiが作業を続けます",
+    "todoDisabledDescription": "このタスクには進行中のTodoがあるため利用できません"
   },
   "mentionList": {
     "noResultsFound": "結果が見つかりません",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -445,7 +445,7 @@
     "attach": "파일 첨부",
     "attachDescription": "컴퓨터에서 이미지, PDF 또는 동영상 업로드",
     "todoDescription": "Pochi가 이 Todo를 계속 진행하도록 합니다",
-    "todoDisabledDescription": "이 작업에 이미 진행 중인 Todo가 있어 사용할 수 없습니다"
+    "todoDisabledDescription": "현재 Todo를 완료한 후 새로 시작할 수 있습니다"
   },
   "mentionList": {
     "noResultsFound": "결과를 찾을 수 없습니다",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -435,6 +435,17 @@
     "cell": "셀",
     "addContext": "컨텍스트 추가"
   },
+  "todoModeBadge": {
+    "remove": "Todo 모드 제거"
+  },
+  "addContextMenu": {
+    "trigger": "추가",
+    "files": "파일 및 폴더",
+    "filesDescription": "@로 작업 영역 파일 및 폴더 검색",
+    "attach": "파일 첨부",
+    "attachDescription": "컴퓨터에서 이미지, PDF 또는 동영상 업로드",
+    "todoDescription": "Pochi가 이 Todo를 계속 진행하도록 합니다"
+  },
   "mentionList": {
     "noResultsFound": "결과를 찾을 수 없습니다",
     "typeToSearch": "입력하여 검색...",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -444,7 +444,8 @@
     "filesDescription": "@로 작업 영역 파일 및 폴더 검색",
     "attach": "파일 첨부",
     "attachDescription": "컴퓨터에서 이미지, PDF 또는 동영상 업로드",
-    "todoDescription": "Pochi가 이 Todo를 계속 진행하도록 합니다"
+    "todoDescription": "Pochi가 이 Todo를 계속 진행하도록 합니다",
+    "todoDisabledDescription": "이 작업에 이미 진행 중인 Todo가 있어 사용할 수 없습니다"
   },
   "mentionList": {
     "noResultsFound": "결과를 찾을 수 없습니다",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -444,7 +444,8 @@
     "filesDescription": "使用 @ 搜索工作区文件和文件夹",
     "attach": "附加文件",
     "attachDescription": "从电脑上传图片、PDF 或视频",
-    "todoDescription": "让 Pochi 持续推进这个 Todo"
+    "todoDescription": "让 Pochi 持续推进这个 Todo",
+    "todoDisabledDescription": "当前任务已有进行中的 Todo，暂不可用"
   },
   "mentionList": {
     "noResultsFound": "未找到结果",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -435,6 +435,17 @@
     "cell": "单元格",
     "addContext": "添加上下文"
   },
+  "todoModeBadge": {
+    "remove": "移除 Todo 模式"
+  },
+  "addContextMenu": {
+    "trigger": "添加",
+    "files": "文件和文件夹",
+    "filesDescription": "使用 @ 搜索工作区文件和文件夹",
+    "attach": "附加文件",
+    "attachDescription": "从电脑上传图片、PDF 或视频",
+    "todoDescription": "让 Pochi 持续推进这个 Todo"
+  },
   "mentionList": {
     "noResultsFound": "未找到结果",
     "typeToSearch": "输入以搜索...",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -445,7 +445,7 @@
     "attach": "附加文件",
     "attachDescription": "从电脑上传图片、PDF 或视频",
     "todoDescription": "让 Pochi 持续推进这个 Todo",
-    "todoDisabledDescription": "当前任务已有进行中的 Todo，暂不可用"
+    "todoDisabledDescription": "完成当前 Todo 后才能开始新的"
   },
   "mentionList": {
     "noResultsFound": "未找到结果",

--- a/packages/vscode-webui/src/styles.css
+++ b/packages/vscode-webui/src/styles.css
@@ -205,6 +205,38 @@ code {
   animation: gradient-animation 1.4s linear infinite;
 }
 
+@keyframes todo-mode-badge-enter {
+  0% {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes todo-mode-badge-flash {
+  0% {
+    background-color: color-mix(in oklab, var(--primary) 35%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--primary) 30%, transparent);
+  }
+  100% {
+    background-color: transparent;
+    box-shadow: 0 0 0 2px transparent;
+  }
+}
+
+.todo-mode-badge-enter {
+  transform-origin: left center;
+  animation: todo-mode-badge-enter 260ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.todo-mode-badge-enter > div {
+  border-radius: 0.375rem;
+  animation: todo-mode-badge-flash 900ms ease-out 120ms both;
+}
+
 /* common classes */
 .text-success {
   @apply text-green-500 dark:text-green-700;


### PR DESCRIPTION
## Summary
- Add a new "Add Context" menu button to the prompt form toolbar, replacing the old, less discoverable buttons.
- Allow users to attach active selections, files, and toggle Todo mode or Plan mode directly from the context menu.
- Introduce nice UI transitions and badges (e.g., Todo Mode badge) to clearly indicate the current input state.

## Screen recording
https://jam.dev/c/ad6f7b51-74fe-41a0-8ab5-6fba3418752a

## Screenshot
<img width="680" height="392" alt="image" src="https://github.com/user-attachments/assets/4514c2b2-2cf3-41c8-a9c1-1295214d44c9" />

<img width="694" height="420" alt="image" src="https://github.com/user-attachments/assets/81659f5b-9d81-4025-837c-e27f5a1fb844" />

<img width="868" height="474" alt="image" src="https://github.com/user-attachments/assets/2f8c0cf8-c70d-48a5-95a8-0b74e1e4ffc8" />



## Test plan
- [ ] Verify that clicking the "Add Context" button opens a dropdown menu.
- [ ] Verify that selecting "Attach Active Selection" works and displays the active selection badge.
- [ ] Verify that toggling Todo mode via the context menu successfully updates the UI state (showing the todo mode badge with transition/flash) and submits in Todo mode.
- [ ] Verify that vitest tests pass for the new context menu and updated submit buttons.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-303305a8683f4eb094502fd2596e8583)