### PR TITLE
fix(common): disable tslog maskValuesOfKeys to prevent DOMException crash on Bun

### DIFF
--- a/packages/common/src/base/logger.ts
+++ b/packages/common/src/base/logger.ts
@@ -10,6 +10,14 @@ const isConsoleLogDisabled = () => {
 
 const mainLogger = new Logger({
   type: isVSCodeEnvironment() || isConsoleLogDisabled() ? "hidden" : "pretty",
+  // Disable tslog's value masking. Masking shallow-clones every logged
+  // argument via `Object.create(Object.getPrototypeOf(source))`, which turns a
+  // `DOMException` into a fake object carrying `DOMException.prototype` but that
+  // is not a real instance. Rendering that clone through `util.inspect` on Bun
+  // throws "The DOMException.name getter can only be used on instances of
+  // DOMException" and crashes the logger. We don't log secret-bearing keys, so
+  // dropping the default `["password"]` masking is safe here.
+  maskValuesOfKeys: [],
 });
 
 function stringToLogLevel(level: string) {


### PR DESCRIPTION
## Summary

- tslog's default value masking shallow-clones logged arguments via `Object.create(Object.getPrototypeOf(source))`, which turns a `DOMException` into a fake prototype-only object
- Rendering that clone through `util.inspect` on Bun throws `"The DOMException.name getter can only be used on instances of DOMException"` and crashes the logger
- Fix: set `maskValuesOfKeys: []` to disable the default `["password"]` masking — safe since we don't log secret-bearing keys

## Test plan

- [ ] Verify logger still works normally when logging plain objects and strings
- [ ] Verify no crash occurs when a `DOMException` is logged (e.g. network/abort errors)

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-dd15c606c5744d1d9e3ab6a6a02f8237)