### PR TITLE
fix(cli): return tool policy errors as tool result instead of early return

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@livestore/wa-sqlite": "catalog:",
         "@preact/signals-core": "^1.6.2",
         "@types/fluent-ffmpeg": "^2.1.28",
+        "@types/object-hash": "^3.0.6",
         "@types/semver": "^7.5.8",
         "@types/tabtab": "^3.0.4",
         "ai": "catalog:",
@@ -52,6 +53,7 @@
         "mdast": "^3.0.0",
         "mdast-util-gfm": "^3.1.0",
         "mdast-util-to-markdown": "^2.1.2",
+        "object-hash": "^3.0.0",
         "ora": "^8.2.0",
         "reconnecting-websocket": "^4.4.0",
         "remark": "^15.0.1",
@@ -280,7 +282,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.51.0-dev",
+      "version": "0.57.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -669,33 +669,38 @@ export class TaskRunner {
       `Found tool call: ${toolName} with args: ${JSON.stringify(toolCall.input)}`,
     );
 
+    let validateToolPolicyError: unknown;
     try {
       validateToolPolicy(toolName, toolCall.input, toolPolicies, {
         cwd: this.cwd,
       });
     } catch (error) {
-      return {
-        kind: "error",
-        error: toErrorMessage(error),
-      };
+      validateToolPolicyError = error;
     }
 
-    const resolvedInput = resolveToolCallArgs(
-      toolCall.input,
-      this.store.storeId,
-    );
+    let toolResult: unknown;
+    if (validateToolPolicyError) {
+      toolResult = {
+        error: toErrorMessage(validateToolPolicyError),
+      };
+    } else {
+      const resolvedInput = resolveToolCallArgs(
+        toolCall.input,
+        this.store.storeId,
+      );
 
-    let envs: Record<string, string> | undefined;
-    if (this.customAgent?.name === "browser") {
-      envs = this.toolCallOptions.browserSessionStore?.getAgentBrowserEnvs(
-        this.taskId,
+      let envs: Record<string, string> | undefined;
+      if (this.customAgent?.name === "browser") {
+        envs = this.toolCallOptions.browserSessionStore?.getAgentBrowserEnvs(
+          this.taskId,
+        );
+      }
+
+      toolResult = await this.executeToolCallItem(
+        { ...toolCall, input: resolvedInput } as ToolUIPart<UITools>,
+        envs,
       );
     }
-
-    const toolResult = await this.executeToolCallItem(
-      { ...toolCall, input: resolvedInput } as ToolUIPart<UITools>,
-      envs,
-    );
 
     const persistedToolResult = await maybePersistToolResult(
       toolName,


### PR DESCRIPTION
## Summary

- Previously, a `validateToolPolicy` error caused an early return with `{ kind: "error", error: ... }`, which bypassed `maybePersistToolResult`
- Refactored to capture the policy error and return it as `{ error: ... }` within the normal tool result flow, so persistence still occurs after a policy violation
- Also adds `object-hash` and `@types/object-hash` dependencies to `bun.lock`

## Test plan

- [ ] Verify that when a tool call violates a tool policy, the error is surfaced to the LLM as a tool result (not a hard error)
- [ ] Verify that `maybePersistToolResult` is still called after a policy violation
- [ ] Verify normal (non-policy-violating) tool calls still work as before

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ae6af7758a714b5aaa19269d0d9fd328)