### PR TITLE
fix(livekit): do not copy background tasks when forking

### DIFF
--- a/packages/livekit/src/chat/__tests__/fork-task-tools.test.ts
+++ b/packages/livekit/src/chat/__tests__/fork-task-tools.test.ts
@@ -152,6 +152,126 @@ describe("prepareForkTaskData", () => {
     expect(newSubTaskMessage?.taskId).toBe(newSubTask?.id);
   });
 
+  it("should not copy background tasks and their messages", () => {
+    const subTaskId = "sub-task-id";
+    const backgroundTaskId = "background-task-id";
+    const tasks = [
+      mockTask,
+      {
+        id: subTaskId,
+        parentId: oldTaskId,
+        status: "completed",
+        createdAt: new Date(),
+      },
+      {
+        // Background tasks are independent root tasks (no parentId).
+        id: backgroundTaskId,
+        background: true,
+        status: "completed",
+        createdAt: new Date(),
+      },
+    ] as any;
+
+    const subTaskMessage = {
+      id: "msg-sub",
+      taskId: subTaskId,
+      data: {
+        id: "msg-sub",
+        role: "user",
+        parts: [{ type: "text", text: "subtask message" }],
+      },
+    } as any;
+
+    const backgroundTaskMessage = {
+      id: "msg-background",
+      taskId: backgroundTaskId,
+      data: {
+        id: "msg-background",
+        role: "user",
+        parts: [{ type: "text", text: "background message" }],
+      },
+    } as any;
+
+    const messages = [...mockMessages, subTaskMessage, backgroundTaskMessage];
+
+    const result = prepareForkTaskData({
+      tasks,
+      messages,
+      files: [],
+      oldTaskId,
+      commitId,
+      messageId: undefined,
+      newTaskId,
+      newTaskTitle: "New Task",
+    });
+
+    // Only main task and normal subtask are copied, the background task is dropped.
+    expect(result.tasks).toHaveLength(2);
+    expect(
+      result.tasks.some((t: any) => t.id === backgroundTaskId),
+    ).toBe(false);
+
+    // Background task messages are not copied.
+    expect(
+      result.messages.some((m) => m.id === "msg-background"),
+    ).toBe(false);
+    // Normal subtask messages are still copied.
+    expect(result.messages.some((m) => m.id === "msg-sub")).toBe(true);
+  });
+
+  it("should not copy subtasks of background tasks", () => {
+    const backgroundTaskId = "background-task-id";
+    const backgroundSubTaskId = "background-sub-task-id";
+    const tasks = [
+      mockTask,
+      {
+        // Background tasks are independent root tasks (no parentId).
+        id: backgroundTaskId,
+        background: true,
+        status: "completed",
+        createdAt: new Date(),
+      },
+      {
+        // A subtask spawned by the background task should also be dropped,
+        // otherwise its parentId would reference a removed task.
+        id: backgroundSubTaskId,
+        parentId: backgroundTaskId,
+        status: "completed",
+        createdAt: new Date(),
+      },
+    ] as any;
+
+    const backgroundSubTaskMessage = {
+      id: "msg-background-sub",
+      taskId: backgroundSubTaskId,
+      data: {
+        id: "msg-background-sub",
+        role: "user",
+        parts: [{ type: "text", text: "background subtask message" }],
+      },
+    } as any;
+
+    const messages = [...mockMessages, backgroundSubTaskMessage];
+
+    const result = prepareForkTaskData({
+      tasks,
+      messages,
+      files: [],
+      oldTaskId,
+      commitId,
+      messageId: undefined,
+      newTaskId,
+      newTaskTitle: "New Task",
+    });
+
+    // Only the main task is copied.
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].id).toBe(newTaskId);
+    expect(
+      result.messages.some((m) => m.id === "msg-background-sub"),
+    ).toBe(false);
+  });
+
   it("should replace taskId in tool-newTask parts", () => {
     const subTaskId = "sub-task-id";
     const tasks = [

--- a/packages/livekit/src/chat/fork-task-tools.ts
+++ b/packages/livekit/src/chat/fork-task-tools.ts
@@ -33,9 +33,35 @@ export const prepareForkTaskData = ({
 }) => {
   const now = new Date();
 
+  // Background tasks (e.g. fork-agent memory jobs) should not be copied when
+  // forking. They are currently independent root tasks, but we also defensively
+  // exclude any subtasks they might spawn in the future so a copied subtask
+  // never ends up referencing a removed parent. The task being forked
+  // (oldTaskId) is always kept even if it is a background task.
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const isBackgroundDescendant = (task: (typeof tasks)[number]): boolean => {
+    const visited = new Set<string>();
+    let current: (typeof tasks)[number] | undefined = task;
+    while (current) {
+      if (current.id === oldTaskId) {
+        return false;
+      }
+      if (current.background) {
+        return true;
+      }
+      if (!current.parentId || visited.has(current.id)) {
+        break;
+      }
+      visited.add(current.id);
+      current = taskById.get(current.parentId);
+    }
+    return false;
+  };
+  const forkableTasks = tasks.filter((task) => !isBackgroundDescendant(task));
+
   const taskIdMap = new Map<string, string>();
   taskIdMap.set(oldTaskId, newTaskId);
-  for (const task of tasks) {
+  for (const task of forkableTasks) {
     if (!taskIdMap.has(task.id)) {
       taskIdMap.set(task.id, crypto.randomUUID());
     }
@@ -48,7 +74,7 @@ export const prepareForkTaskData = ({
     return newId;
   };
 
-  const newTasks = tasks.map((task) =>
+  const newTasks = forkableTasks.map((task) =>
     task.id === oldTaskId
       ? {
           id: newTaskId,
@@ -77,7 +103,8 @@ export const prepareForkTaskData = ({
   for (const message of messages) {
     if (message.taskId === oldTaskId) {
       mainTaskMessages.push(message as DBMessageShape);
-    } else {
+    } else if (taskIdMap.has(message.taskId)) {
+      // Skip messages that belong to tasks excluded from the fork (e.g. background tasks).
       subTaskMessages.push(message as DBMessageShape);
     }
   }


### PR DESCRIPTION
## Summary
- Fork previously copied **background tasks** (fork-agent memory jobs) into the newly forked task. This filters them out in `prepareForkTaskData`.
- Background tasks are independent root tasks, but we also defensively exclude any subtasks they might spawn in the future (via a `parentId` walk), so a copied subtask never references a removed parent.
- Messages belonging to excluded tasks are dropped (guarded by `taskIdMap.has(message.taskId)`); the forked task itself and its real subtasks are still copied.

## Test plan
- [x] `bun run test -- fork-task-tools` (11 tests pass), including new cases:
  - `should not copy background tasks and their messages`
  - `should not copy subtasks of background tasks`
- [x] `bun tsc` clean

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-15a39cffb7124c5d99d47751aaf98e3f)