### PR TITLE
fix(vscode-webui): shorten auto-approve toggle tooltips

### DIFF
--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -177,8 +177,8 @@
     "autoApprove": {
       "title": "Auto-Approve",
       "approvals": "Permissions",
-      "toolbarTooltipEnabled": "Auto-approve is enabled. Permission prompts will be approved automatically.",
-      "toolbarTooltipDisabled": "Auto-approve is disabled. Click to approve permission prompts automatically.",
+      "toolbarTooltipEnabled": "Auto-approve on. Click to turn off.",
+      "toolbarTooltipDisabled": "Auto-approve off. Click to turn on.",
       "disabled": "Disabled",
       "noActionsSelected": "No actions selected",
       "readFiles": "Read files",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -174,8 +174,8 @@
     "autoApprove": {
       "title": "自動承認",
       "approvals": "権限",
-      "toolbarTooltipEnabled": "自動承認は有効です。権限プロンプトは自動的に承認されます。",
-      "toolbarTooltipDisabled": "自動承認は無効です。クリックすると権限プロンプトを自動承認します。",
+      "toolbarTooltipEnabled": "自動承認オン。クリックでオフ。",
+      "toolbarTooltipDisabled": "自動承認オフ。クリックでオン。",
       "disabled": "無効",
       "noActionsSelected": "アクションが選択されていません",
       "readFiles": "ファイルを読む",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -173,8 +173,8 @@
     "autoApprove": {
       "title": "자동 승인",
       "approvals": "권한",
-      "toolbarTooltipEnabled": "자동 승인이 활성화되어 있습니다. 권한 요청은 자동으로 승인됩니다.",
-      "toolbarTooltipDisabled": "자동 승인이 비활성화되어 있습니다. 클릭하면 권한 요청을 자동으로 승인합니다.",
+      "toolbarTooltipEnabled": "자동 승인 켜짐. 클릭하면 끕니다.",
+      "toolbarTooltipDisabled": "자동 승인 꺼짐. 클릭하면 켭니다.",
       "disabled": "비활성화됨",
       "noActionsSelected": "선택된 작업 없음",
       "readFiles": "파일 읽기",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -173,8 +173,8 @@
     "autoApprove": {
       "title": "自动批准",
       "approvals": "权限",
-      "toolbarTooltipEnabled": "自动批准已开启。权限请求将自动通过。",
-      "toolbarTooltipDisabled": "自动批准已关闭。点击后将自动批准权限请求。",
+      "toolbarTooltipEnabled": "自动批准已开启。点击关闭。",
+      "toolbarTooltipDisabled": "自动批准已关闭。点击开启。",
       "disabled": "已禁用",
       "noActionsSelected": "未选择任何操作",
       "readFiles": "读取文件",


### PR DESCRIPTION
## Summary
- Shortened the tooltips for the auto-approve toggle button in English, Chinese, Japanese, and Korean.
- Made the tooltips more concise and action-oriented (e.g., "Auto-approve on. Click to turn off.").

## Test plan
- Verify tooltips for the auto-approve toggle button render correctly and are concise in the UI.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7b20f07d6cb5479ab6fc2debd4bc789d)