### PR TITLE
fix(livekit): compute context window usage from effective LLM messages

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -901,7 +901,7 @@ export class LiveChatKit<
     const status = toTaskStatus(message, finishReason);
 
     const contextWindowUsage = computeContextWindowUsage(
-      this.chat.messages,
+      formatters.llm(this.chat.messages),
       this.latestRequestSnapshot,
     );
 


### PR DESCRIPTION
## Summary
- `LiveChatKit.onFinish` fed `computeContextWindowUsage` the raw `this.chat.messages` transcript, but the request actually sends `formatters.llm(...)` — which drops pre-compact history (`extractCompactMessages`), strips tool-call metadata/transient data, and removes empty parts.
- As a result the context-window usage breakdown over-counted and diverged from what the model received, most dramatically after an auto/manual compaction where usage kept reporting the full pre-compact token count.
- Fixed by passing `formatters.llm(this.chat.messages)`, matching the effective message window already used by the auto-compact preflight and the `totalTokens` fallback in the same file.

## Test plan
- [x] `bun tsc` (packages/livekit) passes
- [x] `bun run test` (packages/livekit) — 90 tests pass
- [x] `biome check` clean on the modified file

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-64c023f4721d4d7dba2d9de6609992ef)