### PR TITLE
fix(vscode-webui): fix todo remaining in-progress when all todos are finished

### DIFF
--- a/packages/common/src/message-utils/__tests__/todo.test.ts
+++ b/packages/common/src/message-utils/__tests__/todo.test.ts
@@ -1,6 +1,6 @@
 import type { Todo } from "@getpochi/tools";
 import { describe, expect, it } from "vitest";
-import { areTodosFinished, hasActiveTodos, hasTodos } from "../todo";
+import { hasActiveTodos, hasTodos } from "../todo";
 
 describe("todo state helpers", () => {
   const todo = (status: Todo["status"]): Todo => ({
@@ -20,13 +20,5 @@ describe("todo state helpers", () => {
     expect(hasActiveTodos([todo("completed"), todo("cancelled")])).toBe(false);
     expect(hasActiveTodos([todo("pending")])).toBe(true);
     expect(hasActiveTodos([todo("in-progress")])).toBe(true);
-  });
-
-  it("detects finished todos without requiring them to be cleared", () => {
-    expect(areTodosFinished([])).toBe(false);
-    expect(areTodosFinished([todo("completed"), todo("cancelled")])).toBe(true);
-    expect(areTodosFinished([todo("completed"), todo("in-progress")])).toBe(
-      false,
-    );
   });
 });

--- a/packages/common/src/message-utils/index.ts
+++ b/packages/common/src/message-utils/index.ts
@@ -6,4 +6,4 @@ export {
   prepareLastMessageForRetry,
   fixCodeGenerationOutput,
 } from "./assistant-message";
-export { areTodosFinished, hasActiveTodos, hasTodos } from "./todo";
+export { hasActiveTodos, hasTodos } from "./todo";

--- a/packages/common/src/message-utils/todo.ts
+++ b/packages/common/src/message-utils/todo.ts
@@ -11,10 +11,3 @@ export function hasActiveTodos(todos?: readonly Todo[]): boolean {
     ) ?? false
   );
 }
-
-export function areTodosFinished(todos?: readonly Todo[]): boolean {
-  if (!todos?.length) return false;
-  return todos.every(
-    (todo) => todo.status === "completed" || todo.status === "cancelled",
-  );
-}

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -9,6 +9,7 @@ import { usePochiCredentials } from "@/lib/hooks/use-pochi-credentials";
 import { useTaskContextWindowUsage } from "@/lib/hooks/use-task-context-window-usage";
 import { useTaskMcpConfigOverride } from "@/lib/hooks/use-task-mcp-config-override";
 import { blobStore } from "@/lib/remote-blob-store";
+import { getInitialTodos } from "@/lib/todos-utils";
 import { useManageBrowserSession } from "@/lib/use-browser-session";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { cn } from "@/lib/utils";
@@ -103,6 +104,7 @@ function Chat({ user, uid, info }: ChatProps) {
   const subtask = useSubtaskInfo(uid, task?.parentId);
 
   const isSubTask = !!task?.parentId;
+  const messageRows = store.useQuery(catalog.queries.makeMessagesQuery(uid));
 
   // inherit autoApproveSettings from parent task
   useEffect(() => {
@@ -127,16 +129,16 @@ function Chat({ user, uid, info }: ChatProps) {
       : undefined;
     return resultSchema ? parseOutputSchema(resultSchema) : undefined;
   }, [customAgent?.isBuiltIn, customAgent?._internal?.resultSchema]);
-  const pendingTodos = isSubTask
-    ? subtask?.agent === constants.AttemptTodoCompletionAgentName
-      ? subtask.todos
-      : undefined
-    : info.type === "new-task"
-      ? info.todos
-      : undefined;
+  const initialTodos = getInitialTodos({
+    info,
+    isSubTask,
+    subtask,
+    task,
+    messageRows,
+  });
   const { todos, todosRef, updateTodos, updateTodoCompletion } = useTodos({
     persistedTodos: isSubTask ? undefined : task?.todos,
-    pendingTodos,
+    initialTodos,
     taskId: uid,
   });
   const autoApproveGuard = useAutoApproveGuard();
@@ -149,7 +151,6 @@ function Chat({ user, uid, info }: ChatProps) {
   } = useTaskMcpConfigOverride(uid);
 
   const { setContextWindowUsage } = useTaskContextWindowUsage(uid);
-
   const getters = useLiveChatKitGetters({
     todos: todosRef,
     todoModeActive: todoModeActiveRef,

--- a/packages/vscode-webui/src/features/todo/hooks/use-todos.test.tsx
+++ b/packages/vscode-webui/src/features/todo/hooks/use-todos.test.tsx
@@ -24,7 +24,7 @@ describe("useTodos", () => {
 
   it("updates local todos and ref without persistence when no task id", () => {
     const { result } = renderHook(() =>
-      useTodos({ pendingTodos: [activeTodo] }),
+      useTodos({ initialTodos: [activeTodo] }),
     );
     const nextTodos = [
       {
@@ -50,7 +50,7 @@ describe("useTodos", () => {
 
     const { result } = renderHook(() =>
       useTodos({
-        pendingTodos: [activeTodo],
+        initialTodos: [activeTodo],
         taskId: "task-1",
       }),
     );
@@ -75,10 +75,16 @@ describe("useTodos", () => {
       role: "assistant",
       parts: [],
     } as unknown as Message;
+    const resolvedTodos: Todo[] = [
+      {
+        ...activeTodo,
+        status: "completed",
+      },
+    ];
 
     const { result } = renderHook(() =>
       useTodos({
-        pendingTodos: [activeTodo],
+        initialTodos: [activeTodo],
         taskId: "task-1",
       }),
     );
@@ -86,20 +92,20 @@ describe("useTodos", () => {
     act(() =>
       result.current.updateTodoCompletion({
         message: completionMessage,
-        todos: [],
+        todos: resolvedTodos,
         status: "completed",
       }),
     );
 
-    expect(result.current.todos).toEqual([]);
-    expect(result.current.todosRef.current).toEqual([]);
+    expect(result.current.todos).toEqual(resolvedTodos);
+    expect(result.current.todosRef.current).toEqual(resolvedTodos);
     expect(storeCommitMock).toHaveBeenCalledTimes(1);
     expect(storeCommitMock.mock.calls[0]?.[0]).toMatchObject({
       name: "v1.AttemptTodoCompletionFinished",
       args: {
         id: "task-1",
         data: completionMessage,
-        todos: [],
+        todos: resolvedTodos,
         status: "completed",
       },
     });
@@ -138,7 +144,7 @@ describe("useTodos", () => {
     });
   });
 
-  it("does not restore pending todos after clearing resolved persisted todos", () => {
+  it("does not restore initial todos after clearing resolved persisted todos", () => {
     const resolvedTodos: Todo[] = [
       {
         ...activeTodo,
@@ -147,76 +153,101 @@ describe("useTodos", () => {
     ];
 
     const { result, rerender } = renderHook(
-      ({ persistedTodos }: { persistedTodos: readonly Todo[] }) =>
+      ({
+        persistedTodos,
+        initialTodos,
+      }: {
+        persistedTodos: readonly Todo[];
+        initialTodos?: readonly Todo[];
+      }) =>
         useTodos({
           persistedTodos,
-          pendingTodos: [activeTodo],
+          initialTodos,
           taskId: "task-1",
         }),
       {
         initialProps: {
           persistedTodos: resolvedTodos,
+          initialTodos: [activeTodo],
         },
       },
     );
 
     expect(result.current.todos).toEqual([]);
 
-    rerender({ persistedTodos: [] });
+    rerender({ persistedTodos: [], initialTodos: [activeTodo] });
 
     expect(result.current.todos).toEqual([]);
     expect(result.current.todosRef.current).toEqual([]);
   });
 
-  it("keeps explicit pending todos visible until they are persisted", () => {
-    const { result, rerender } = renderHook(
-      ({ persistedTodos }: { persistedTodos?: readonly Todo[] }) =>
-        useTodos({ persistedTodos, pendingTodos: [activeTodo] }),
+  it("does not restore initial todos after resolved completion todos are cleared", () => {
+    const completionMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [],
+    } as unknown as Message;
+    const resolvedTodos: Todo[] = [
       {
-        initialProps: {
-          persistedTodos: undefined as readonly Todo[] | undefined,
-        },
+        ...activeTodo,
+        status: "completed",
       },
-    );
+    ];
 
-    expect(result.current.todos).toEqual([activeTodo]);
-    expect(result.current.todosRef.current).toEqual([activeTodo]);
-
-    rerender({ persistedTodos: [] });
-
-    expect(result.current.todos).toEqual([activeTodo]);
-    expect(result.current.todosRef.current).toEqual([activeTodo]);
-  });
-
-  it("clears pending todos when persisted todos are empty and no pending source remains", () => {
     const { result, rerender } = renderHook(
       ({
         persistedTodos,
-        pendingTodos,
+        initialTodos,
       }: {
         persistedTodos?: readonly Todo[];
-        pendingTodos?: readonly Todo[];
-      }) => useTodos({ persistedTodos, pendingTodos }),
+        initialTodos?: readonly Todo[];
+      }) =>
+        useTodos({
+          persistedTodos,
+          initialTodos,
+          taskId: "task-1",
+        }),
       {
         initialProps: {
           persistedTodos: undefined as readonly Todo[] | undefined,
-          pendingTodos: [activeTodo] as readonly Todo[] | undefined,
+          initialTodos: [activeTodo] as readonly Todo[] | undefined,
         },
       },
     );
 
     expect(result.current.todos).toEqual([activeTodo]);
 
-    rerender({ persistedTodos: [], pendingTodos: undefined });
+    act(() =>
+      result.current.updateTodoCompletion({
+        message: completionMessage,
+        todos: resolvedTodos,
+        status: "completed",
+      }),
+    );
+
+    expect(result.current.todos).toEqual(resolvedTodos);
+
+    rerender({
+      persistedTodos: resolvedTodos,
+      initialTodos: [activeTodo],
+    });
+
+    expect(result.current.todos).toEqual([]);
+    expect(result.current.todosRef.current).toEqual([]);
+
+    rerender({
+      persistedTodos: [],
+      initialTodos: [activeTodo],
+    });
 
     expect(result.current.todos).toEqual([]);
     expect(result.current.todosRef.current).toEqual([]);
   });
 
-  it("does not restore consumed pending todos after deletion", () => {
+  it("keeps initial todos visible until they are persisted", () => {
     const { result, rerender } = renderHook(
       ({ persistedTodos }: { persistedTodos?: readonly Todo[] }) =>
-        useTodos({ persistedTodos, pendingTodos: [activeTodo] }),
+        useTodos({ persistedTodos, initialTodos: [activeTodo] }),
       {
         initialProps: {
           persistedTodos: undefined as readonly Todo[] | undefined,
@@ -224,11 +255,68 @@ describe("useTodos", () => {
       },
     );
 
-    rerender({ persistedTodos: [activeTodo] });
+    expect(result.current.todos).toEqual([activeTodo]);
+    expect(result.current.todosRef.current).toEqual([activeTodo]);
+
+    rerender({ persistedTodos: [] });
+
+    expect(result.current.todos).toEqual([activeTodo]);
+    expect(result.current.todosRef.current).toEqual([activeTodo]);
+  });
+
+  it("clears todos when persisted todos are empty and no initial source remains", () => {
+    const { result, rerender } = renderHook(
+      ({
+        persistedTodos,
+        initialTodos,
+      }: {
+        persistedTodos?: readonly Todo[];
+        initialTodos?: readonly Todo[];
+      }) => useTodos({ persistedTodos, initialTodos }),
+      {
+        initialProps: {
+          persistedTodos: undefined as readonly Todo[] | undefined,
+          initialTodos: [activeTodo] as readonly Todo[] | undefined,
+        },
+      },
+    );
+
+    expect(result.current.todos).toEqual([activeTodo]);
+
+    rerender({ persistedTodos: [], initialTodos: undefined });
+
+    expect(result.current.todos).toEqual([]);
+    expect(result.current.todosRef.current).toEqual([]);
+  });
+
+  it("keeps todos cleared after deletion even while the initial source remains", () => {
+    const { result, rerender } = renderHook(
+      ({
+        persistedTodos,
+        initialTodos,
+      }: {
+        persistedTodos?: readonly Todo[];
+        initialTodos?: readonly Todo[];
+      }) => useTodos({ persistedTodos, initialTodos }),
+      {
+        initialProps: {
+          persistedTodos: undefined as readonly Todo[] | undefined,
+          initialTodos: [activeTodo] as readonly Todo[] | undefined,
+        },
+      },
+    );
+
+    rerender({
+      persistedTodos: [activeTodo],
+      initialTodos: undefined,
+    });
     expect(result.current.todos).toEqual([activeTodo]);
 
     act(() => result.current.updateTodos([]));
-    rerender({ persistedTodos: [] });
+    rerender({
+      persistedTodos: [],
+      initialTodos: [activeTodo],
+    });
 
     expect(result.current.todos).toEqual([]);
     expect(result.current.todosRef.current).toEqual([]);

--- a/packages/vscode-webui/src/features/todo/hooks/use-todos.ts
+++ b/packages/vscode-webui/src/features/todo/hooks/use-todos.ts
@@ -11,19 +11,20 @@ export type TodoCompletionUpdate = {
 
 export function useTodos({
   persistedTodos,
-  pendingTodos,
+  initialTodos,
   taskId,
 }: {
   persistedTodos?: readonly Todo[];
-  pendingTodos?: readonly Todo[];
+  // Bootstrap todos from task creation or subtask metadata before persisted todos exist.
+  initialTodos?: readonly Todo[];
   taskId?: string;
 }) {
   const store = useDefaultStore();
   const todosRef = useRef<Todo[] | undefined>(undefined);
-  const consumedTodoIdsRef = useRef(new Set<string>());
-  const appliedPendingTodosRef = useRef(copyTodos(pendingTodos));
+  const appliedInitialTodosRef = useRef(copyTodos(initialTodos));
+  const consumedInitialTodosRef = useRef<Todo[] | undefined>(undefined);
   const [todos, setTodosImpl] = useState<Todo[]>(() => {
-    const nextTodos = getInitialTodos(persistedTodos, pendingTodos);
+    const nextTodos = getInitialTodoState(persistedTodos, initialTodos);
     todosRef.current = nextTodos;
     return nextTodos;
   });
@@ -32,14 +33,32 @@ export function useTodos({
     const snapshot = copyTodos(nextTodos);
     todosRef.current = snapshot;
     setTodosImpl((current) =>
-      areTodosEqual(current, snapshot) ? current : snapshot,
+      isTodoListEqual(current, snapshot) ? current : snapshot,
     );
     return snapshot;
+  }, []);
+
+  const markInitialTodosConsumed = useCallback(() => {
+    if (appliedInitialTodosRef.current.length > 0) {
+      consumedInitialTodosRef.current = copyTodos(
+        appliedInitialTodosRef.current,
+      );
+    }
+  }, []);
+
+  const isInitialTodosConsumed = useCallback((initialSnapshot: Todo[]) => {
+    return (
+      consumedInitialTodosRef.current !== undefined &&
+      isTodoListEqual(consumedInitialTodosRef.current, initialSnapshot)
+    );
   }, []);
 
   const updateTodos = useCallback(
     (nextTodos: Todo[]) => {
       const snapshot = setTodos(nextTodos);
+      if (snapshot.length === 0) {
+        markInitialTodosConsumed();
+      }
       if (!taskId) return;
       store.commit(
         catalog.events.updateTodos({
@@ -49,12 +68,15 @@ export function useTodos({
         }),
       );
     },
-    [setTodos, store, taskId],
+    [markInitialTodosConsumed, setTodos, store, taskId],
   );
 
   const updateTodoCompletion = useCallback(
     (update: TodoCompletionUpdate) => {
       const snapshot = setTodos(update.todos);
+      if (snapshot.length === 0 || isTodoListResolved(snapshot)) {
+        markInitialTodosConsumed();
+      }
       if (!taskId) return;
       store.commit(
         catalog.events.attemptTodoCompletionFinished({
@@ -66,21 +88,26 @@ export function useTodos({
         }),
       );
     },
-    [setTodos, store, taskId],
+    [markInitialTodosConsumed, setTodos, store, taskId],
   );
 
   useEffect(() => {
     if (persistedTodos === undefined) {
-      if (!pendingTodos?.length) {
-        appliedPendingTodosRef.current = [];
+      if (!initialTodos?.length) {
+        appliedInitialTodosRef.current = [];
         setTodos(copyTodos(todosRef.current));
         return;
       }
 
-      const pendingSnapshot = copyTodos(pendingTodos);
-      if (!areTodosEqual(appliedPendingTodosRef.current, pendingSnapshot)) {
-        appliedPendingTodosRef.current = pendingSnapshot;
-        setTodos(pendingSnapshot);
+      const initialSnapshot = copyTodos(initialTodos);
+      if (isInitialTodosConsumed(initialSnapshot)) {
+        setTodos(copyTodos(todosRef.current));
+        return;
+      }
+
+      if (!isTodoListEqual(appliedInitialTodosRef.current, initialSnapshot)) {
+        appliedInitialTodosRef.current = initialSnapshot;
+        setTodos(initialSnapshot);
         return;
       }
 
@@ -90,36 +117,35 @@ export function useTodos({
 
     if (persistedTodos.length > 0) {
       if (isTodoListResolved(persistedTodos)) {
-        for (const todo of persistedTodos) {
-          consumedTodoIdsRef.current.add(todo.id);
-        }
         updateTodos([]);
         return;
       }
 
-      const persistedTodoIds = new Set(persistedTodos.map((todo) => todo.id));
-      for (const todo of todosRef.current ?? []) {
-        if (persistedTodoIds.has(todo.id)) {
-          consumedTodoIdsRef.current.add(todo.id);
-        }
-      }
       setTodos(copyTodos(persistedTodos));
       return;
     }
 
-    if (!pendingTodos?.length) {
-      appliedPendingTodosRef.current = [];
+    if (!initialTodos?.length) {
+      appliedInitialTodosRef.current = [];
       setTodos([]);
       return;
     }
 
-    const pendingSnapshot = copyTodos(pendingTodos);
-    appliedPendingTodosRef.current = pendingSnapshot;
-    const unpersistedTodos = pendingSnapshot.filter(
-      (todo) => !consumedTodoIdsRef.current.has(todo.id),
-    );
-    setTodos(unpersistedTodos);
-  }, [persistedTodos, pendingTodos, setTodos, updateTodos]);
+    const initialSnapshot = copyTodos(initialTodos);
+    if (isInitialTodosConsumed(initialSnapshot)) {
+      setTodos([]);
+      return;
+    }
+
+    appliedInitialTodosRef.current = initialSnapshot;
+    setTodos(initialSnapshot);
+  }, [
+    persistedTodos,
+    initialTodos,
+    isInitialTodosConsumed,
+    setTodos,
+    updateTodos,
+  ]);
 
   return {
     todos,
@@ -133,7 +159,7 @@ function copyTodos(todos?: readonly Todo[]): Todo[] {
   return todos ? [...todos] : [];
 }
 
-function areTodosEqual(left: readonly Todo[], right: readonly Todo[]) {
+function isTodoListEqual(left: readonly Todo[], right: readonly Todo[]) {
   return (
     left.length === right.length &&
     left.every((todo, index) => {
@@ -149,21 +175,21 @@ function areTodosEqual(left: readonly Todo[], right: readonly Todo[]) {
   );
 }
 
-function getInitialTodos(
+function getInitialTodoState(
   persistedTodos: readonly Todo[] | undefined,
-  pendingTodos: readonly Todo[] | undefined,
+  initialTodos: readonly Todo[] | undefined,
 ): Todo[] {
   if (persistedTodos === undefined) {
-    return copyTodos(pendingTodos);
+    return copyTodos(initialTodos);
   }
 
   if (persistedTodos.length > 0 && isTodoListResolved(persistedTodos)) {
     return [];
   }
 
-  if (persistedTodos.length > 0 || !pendingTodos?.length) {
+  if (persistedTodos.length > 0 || !initialTodos?.length) {
     return copyTodos(persistedTodos);
   }
 
-  return copyTodos(pendingTodos);
+  return copyTodos(initialTodos);
 }

--- a/packages/vscode-webui/src/lib/__tests__/todos-utils.test.ts
+++ b/packages/vscode-webui/src/lib/__tests__/todos-utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
+import type { PochiTaskInfo } from "@getpochi/common/vscode-webui-bridge";
+import type { Message } from "@getpochi/livekit";
+import type { Todo } from "@getpochi/tools";
 import {
   getAttemptTodoCompletionSummary,
+  getInitialTodos,
   isAttemptTodoCompletionResolved,
 } from "../todos-utils";
 
@@ -17,6 +21,32 @@ function makeResolvedTodos(status: "completed" | "in-progress") {
 
 const completedTodos = makeResolvedTodos("completed");
 const inProgressTodos = makeResolvedTodos("in-progress");
+
+const activeTodo: Todo = {
+  id: "todo-1",
+  content: "Add one test",
+  status: "in-progress",
+  priority: "medium",
+};
+
+const newTaskInfo: PochiTaskInfo = {
+  uid: "task-1",
+  type: "new-task",
+  cwd: "/repo",
+  todos: [activeTodo],
+};
+
+const userMessage: Message = {
+  id: "user-1",
+  role: "user",
+  parts: [{ type: "text", text: "start" }],
+};
+
+const assistantMessage: Message = {
+  id: "assistant-1",
+  role: "assistant",
+  parts: [{ type: "text", text: "done" }],
+};
 
 describe("getAttemptTodoCompletionSummary", () => {
   it("returns summary from structured results", () => {
@@ -80,5 +110,64 @@ describe("isAttemptTodoCompletionResolved", () => {
 
   it("falls back to legacy success results", () => {
     expect(isAttemptTodoCompletionResolved({ success: false })).toBe(false);
+  });
+});
+
+describe("getInitialTodos", () => {
+  it("keeps new-task initial todos for a pristine task with only a user message", () => {
+    expect(
+      getInitialTodos({
+        info: newTaskInfo,
+        isSubTask: false,
+        task: {
+          todos: [],
+        },
+        messageRows: [{ data: userMessage }],
+      }),
+    ).toEqual([activeTodo]);
+  });
+
+  it("keeps new-task initial todos before the task exists", () => {
+    expect(
+      getInitialTodos({
+        info: newTaskInfo,
+        isSubTask: false,
+        messageRows: [],
+      }),
+    ).toEqual([activeTodo]);
+  });
+
+  it("drops new-task initial todos after the task has an assistant message", () => {
+    expect(
+      getInitialTodos({
+        info: newTaskInfo,
+        isSubTask: false,
+        task: {
+          todos: [],
+        },
+        messageRows: [{ data: userMessage }, { data: assistantMessage }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps attemptTodoCompletion subtask todos", () => {
+    expect(
+      getInitialTodos({
+        info: {
+          uid: "subtask-1",
+          type: "open-task",
+          cwd: "/repo",
+        },
+        isSubTask: true,
+        subtask: {
+          agent: "attemptTodoCompletion",
+          todos: [activeTodo],
+        },
+        task: {
+          todos: [],
+        },
+        messageRows: [{ data: assistantMessage }],
+      }),
+    ).toEqual([activeTodo]);
   });
 });

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.test.ts
@@ -53,7 +53,7 @@ describe("getTodoCompletionUpdate", () => {
     mocks.completeToolCalls = [];
   });
 
-  it("clears todos when attemptTodoCompletion completes all todos", () => {
+  it("returns resolved todos when attemptTodoCompletion completes all todos", () => {
     const resolvedTodos: Todo[] = [{ ...baseTodos[0], status: "completed" }];
     const update = getTodoCompletionUpdate({
       message: makeAttemptTodoCompletionMessage(),
@@ -69,7 +69,7 @@ describe("getTodoCompletionUpdate", () => {
     expect(update).toMatchObject({
       toolCallId: "tool-1",
       status: "completed",
-      todos: [],
+      todos: resolvedTodos,
     });
     expect(findToolPart(update?.message, "tool-1")).toMatchObject({
       state: "output-available",
@@ -92,7 +92,7 @@ describe("getTodoCompletionUpdate", () => {
     expect(update).toBeUndefined();
   });
 
-  it("clears todos when every todo is resolved", () => {
+  it("returns todos when every todo is resolved", () => {
     const resolvedTodos: Todo[] = [
       {
         id: "resolved-todo-1",
@@ -118,7 +118,7 @@ describe("getTodoCompletionUpdate", () => {
       },
     });
 
-    expect(update?.todos).toEqual([]);
+    expect(update?.todos).toEqual(resolvedTodos);
   });
 
   it("does not return a completion update when resolved todos still need work", () => {
@@ -148,37 +148,6 @@ describe("getTodoCompletionUpdate", () => {
     });
 
     expect(update).toBeUndefined();
-  });
-
-  it("does not return a completion update when resolved todos still need work", () => {
-    const update = getTodoCompletionUpdate({
-      message: makeAttemptTodoCompletionMessage(),
-      toolCallId: "tool-1",
-      output: {
-        result: {
-          summary: "More work remains.",
-          todos: baseTodos,
-        },
-      },
-    });
-
-    expect(update).toBeUndefined();
-  });
-
-  it("uses resolved todos without requiring one todo update", () => {
-    const resolvedTodos: Todo[] = [{ ...baseTodos[0], status: "completed" }];
-    const update = getTodoCompletionUpdate({
-      message: makeAttemptTodoCompletionMessage(),
-      toolCallId: "tool-1",
-      output: {
-        result: {
-          summary: "Done.",
-          todos: resolvedTodos,
-        },
-      },
-    });
-
-    expect(update?.todos).toEqual([]);
   });
 });
 
@@ -222,7 +191,7 @@ describe("useAddCompleteToolCalls", () => {
     await waitFor(() =>
       expect(updateTodoCompletion).toHaveBeenCalledWith(
         expect.objectContaining({
-          todos: [],
+          todos: resolvedTodos,
           status: "completed",
         }),
       ),

--- a/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-add-complete-tool-calls.ts
@@ -165,7 +165,7 @@ export function getTodoCompletionUpdate({
           : part,
       ),
     },
-    todos: [],
+    todos: parsedResult.data.todos,
     status: "completed",
     output,
   };

--- a/packages/vscode-webui/src/lib/todos-utils.ts
+++ b/packages/vscode-webui/src/lib/todos-utils.ts
@@ -1,6 +1,9 @@
+import { constants } from "@getpochi/common";
+import type { PochiTaskInfo } from "@getpochi/common/vscode-webui-bridge";
 import {
   ResolvedAttemptTodoCompletionResult,
   type ResolvedAttemptTodoCompletionResult as ResolvedAttemptTodoCompletionResultData,
+  type Todo,
   isTodoListResolved,
 } from "@getpochi/tools";
 
@@ -33,6 +36,44 @@ export function isAttemptTodoCompletionResolved(
     const resolved = isCandidateResolved(candidate);
     if (resolved !== undefined) return resolved;
   }
+}
+
+export function getInitialTodos({
+  info,
+  isSubTask,
+  subtask,
+  task,
+  messageRows,
+}: {
+  info: PochiTaskInfo;
+  isSubTask: boolean;
+  subtask?: { agent?: string; todos?: readonly Todo[] };
+  task?: { todos?: readonly Todo[] };
+  messageRows: readonly { data?: unknown }[];
+}): readonly Todo[] | undefined {
+  if (isSubTask) {
+    return subtask?.agent === constants.AttemptTodoCompletionAgentName
+      ? subtask.todos
+      : undefined;
+  }
+
+  if (info.type !== "new-task") return undefined;
+  if (hasAssistantMessage(messageRows)) return undefined;
+  if (!task) return info.todos;
+  if (task.todos && task.todos.length > 0) return undefined;
+  return info.todos;
+}
+
+function hasAssistantMessage(messageRows: readonly { data?: unknown }[]) {
+  return messageRows.some((row) => {
+    const data = row.data;
+    return (
+      typeof data === "object" &&
+      data !== null &&
+      "role" in data &&
+      data.role === "assistant"
+    );
+  });
 }
 
 function isCandidateResolved(candidate: unknown) {


### PR DESCRIPTION
## Summary
- Renamed `pendingTodos` to `initialTodos` and restricted its lifecycle to the pristine state before any assistant message or persisted todos using `getInitialTodos`, preventing resurrection of creation/initial todos.
- Updated `getTodoCompletionUpdate` to return the actual resolved todos on completion instead of an empty list, ensuring proper state propagation and persistence.
- Cleaned up `consumedTodoIdsRef` in favor of a `consumedInitialTodosRef` tracking snapshot, and updated all corresponding unit tests to align with the new lifecycle.

## Test plan
- Run unit tests in `packages/common` and `packages/vscode-webui` to verify that the `useTodos` hook, `getInitialTodos` helper, and completion update handler function correctly under various states.
- Verify that completed todo-mode tasks do not resurrect the initial/creation todos upon panel remount, webview reload, or task switching.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8e32617085bb41a6a32ad8b9d0a5ecfb)