### PR TITLE
feat(vscode-webui): add createPr action to attemptTodoCompletion view

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
+++ b/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
@@ -1,17 +1,9 @@
 import { CodeBlock, MessageMarkdown } from "@/components/message";
-import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { useSendMessage } from "@/features/chat";
-import { useCurrentWorkspace } from "@/lib/hooks/use-current-workspace";
-import { useWorktrees } from "@/lib/hooks/use-worktrees";
 import { isStaticToolUIPart } from "ai";
-import { Check, GitPullRequest } from "lucide-react";
+import { Check } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { CreatePrAction } from "./create-pr-action";
 import { getAttemptCompletionResultDisplay } from "./tool-result-display";
 import type { ToolProps } from "./types";
 
@@ -21,17 +13,6 @@ export const AttemptCompletionTool: React.FC<
   const { t } = useTranslation();
   const { result = "" } = toolCall.input || {};
   const resultContent = getAttemptCompletionResultDisplay(result);
-  const sendMessage = useSendMessage();
-
-  const { data: currentWorkspace } = useCurrentWorkspace();
-  const { worktrees } = useWorktrees();
-
-  const currentWorktree = useMemo(() => {
-    if (!worktrees || !currentWorkspace) return null;
-    return worktrees.find((wt) => wt.path === currentWorkspace.cwd);
-  }, [worktrees, currentWorkspace]);
-
-  const hasPR = !!currentWorktree?.data?.github?.pullRequest;
 
   const isLastPart = useMemo(() => {
     if (!messages || messages.length === 0) return false;
@@ -53,10 +34,6 @@ export const AttemptCompletionTool: React.FC<
     return null;
   }
 
-  const onClickCreatePR = () => {
-    sendMessage({ prompt: "Please create a PR for the changes above" });
-  };
-
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
@@ -64,23 +41,9 @@ export const AttemptCompletionTool: React.FC<
           <Check className="size-4" />
           {t("toolInvocation.taskCompleted")}
         </span>
-        {!!currentWorkspace && isLastPart && !isSubTask && (
+        {isLastPart && !isSubTask && (
           <div className="flex items-center gap-1">
-            {!hasPR && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-6 text-muted-foreground"
-                    onClick={onClickCreatePR}
-                  >
-                    <GitPullRequest className="size-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{t("worktree.createPr")}</TooltipContent>
-              </Tooltip>
-            )}
+            <CreatePrAction />
           </div>
         )}
       </div>

--- a/packages/vscode-webui/src/features/tools/components/create-pr-action.tsx
+++ b/packages/vscode-webui/src/features/tools/components/create-pr-action.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useSendMessage } from "@/features/chat";
+import { useCurrentWorkspace } from "@/lib/hooks/use-current-workspace";
+import { useWorktrees } from "@/lib/hooks/use-worktrees";
+import { GitPullRequest } from "lucide-react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * A "Create PR" action button. Renders nothing when there is no active
+ * workspace or when the current worktree already has an open pull request.
+ */
+export const CreatePrAction: React.FC = () => {
+  const { t } = useTranslation();
+  const sendMessage = useSendMessage();
+  const { data: currentWorkspace } = useCurrentWorkspace();
+  const { worktrees } = useWorktrees();
+
+  const currentWorktree = useMemo(() => {
+    if (!worktrees || !currentWorkspace) return null;
+    return worktrees.find((wt) => wt.path === currentWorkspace.cwd);
+  }, [worktrees, currentWorkspace]);
+
+  const hasPR = !!currentWorktree?.data?.github?.pullRequest;
+
+  if (!currentWorkspace || hasPR) {
+    return null;
+  }
+
+  const onClickCreatePR = () => {
+    sendMessage({ prompt: "Please create a PR for the changes above" });
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 text-muted-foreground"
+          onClick={onClickCreatePR}
+        >
+          <GitPullRequest className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{t("worktree.createPr")}</TooltipContent>
+    </Tooltip>
+  );
+};

--- a/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/attempt-todo-completion-view.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { isTodoListResolved } from "@getpochi/tools";
 import { useTranslation } from "react-i18next";
 import type { NewTaskToolViewProps } from ".";
+import { CreatePrAction } from "../create-pr-action";
 import { SubAgentView } from "./sub-agent-view";
 
 interface AttemptTodoCompletionViewProps extends NewTaskToolViewProps {
@@ -22,6 +23,8 @@ export function AttemptTodoCompletionView({
   isExecuting,
   taskSource,
   toolCallStatusRegistryRef,
+  isSubTask,
+  isLastPart,
 }: AttemptTodoCompletionViewProps) {
   const { t } = useTranslation();
   const result =
@@ -60,6 +63,11 @@ export function AttemptTodoCompletionView({
       assistantName="Todo"
       showToolCall={false}
       showTaskThread={showFooterTaskThread}
+      headerActions={
+        resolved && !isExecuting && !isSubTask && isLastPart ? (
+          <CreatePrAction />
+        ) : undefined
+      }
       headerContent={
         <span
           className={cn(


### PR DESCRIPTION
This refactor extracts the "Create PR" button logic into a reusable `CreatePrAction` component. It is now used in both the standard `AttemptCompletionTool` and the `AttemptTodoCompletionView` (the completion view for `newTask` sub-agents), ensuring a consistent experience for creating pull requests across different task types.

- Extracted `CreatePrAction` to `packages/vscode-webui/src/features/tools/components/create-pr-action.tsx`
- Replaced inline PR button logic in `AttemptCompletionTool` with `CreatePrAction`
- Added `CreatePrAction` to `AttemptTodoCompletionView` header actions

## Screenshot
<img width="958" height="372" alt="image" src="https://github.com/user-attachments/assets/2b4ab473-1887-4ec3-8276-363b80e8615f" />


🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7ddacbcf560b4435b30d9d4822069a3f)