### PR TITLE
feat(vscode-webui): show shortcut tooltip on todo mode hover

### DIFF
--- a/packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx
+++ b/packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { SubmitDropdownButton } from "../submit-dropdown-button";
 
 vi.mock("@/lib/hooks/use-mcp", () => ({
@@ -15,6 +15,14 @@ vi.mock("react-i18next", () => ({
     t: (key: string) => key,
   }),
 }));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
 
 const defaultProps = {
   onSubmit: vi.fn(),
@@ -51,5 +59,22 @@ describe("SubmitDropdownButton", () => {
     fireEvent.mouseEnter(screen.getByRole("button"));
 
     expect(screen.getByText("chat.todoModeLabel")).not.toBeNull();
+  });
+
+  it("shows the mode switch shortcut when hovering the todo mode toggle", async () => {
+    render(<SubmitDropdownButton {...defaultProps} showTodoMode />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    const todoModeItem = screen
+      .getByText("chat.todoModeLabel")
+      .closest("[role='menuitem']");
+    expect(todoModeItem).not.toBeNull();
+    fireEvent.pointerMove(todoModeItem as Element);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("chat.planModeToggleShortcutTooltip").length,
+      ).toBeGreaterThan(0);
+    });
   });
 });

--- a/packages/vscode-webui/src/components/submit-dropdown-button.tsx
+++ b/packages/vscode-webui/src/components/submit-dropdown-button.tsx
@@ -229,22 +229,31 @@ export function SubmitDropdownButton({
               </TooltipProvider>
 
               {showTodoMode && (
-                <DropdownMenuItem
-                  className="flex cursor-pointer items-center gap-2 px-2 py-1"
-                  onSelect={(e) => e.preventDefault()}
-                  onClick={() => onToggleTodoMode?.()}
-                >
-                  <Target className="size-3.5 transition-colors duration-200" />
-                  <span>{t("chat.todoModeLabel")}</span>
-                  <Switch
-                    checked={isTodoMode}
-                    className="ml-auto scale-75"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onToggleTodoMode?.();
-                    }}
-                  />
-                </DropdownMenuItem>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuItem
+                        className="flex cursor-pointer items-center gap-2 px-2 py-1"
+                        onSelect={(e) => e.preventDefault()}
+                        onClick={() => onToggleTodoMode?.()}
+                      >
+                        <Target className="size-3.5 transition-colors duration-200" />
+                        <span>{t("chat.todoModeLabel")}</span>
+                        <Switch
+                          checked={isTodoMode}
+                          className="ml-auto scale-75"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onToggleTodoMode?.();
+                          }}
+                        />
+                      </DropdownMenuItem>
+                    </TooltipTrigger>
+                    <TooltipContent side="left">
+                      <p>{t("chat.planModeToggleShortcutTooltip")}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               )}
 
               <DropdownMenuSeparator />


### PR DESCRIPTION
## Summary
- Add tooltip to the todo mode toggle item in the submit dropdown button to show the mode switch shortcut.
- Add corresponding unit tests to verify tooltip rendering on hover.

## Test plan
- Verified that all unit tests pass in `packages/vscode-webui/src/components/__tests__/submit-dropdown-button.test.tsx`.

## Screenshot
<img width="536" height="204" alt="image" src="https://github.com/user-attachments/assets/638668a1-72be-4ec0-9a37-a7a03ed88a9d" />


🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-c880cb2409dd4553a6622cecdb86763e)