### PR TITLE
style(vscode-webui): adjust queued messages and context panel layout

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -292,6 +292,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   const hasVisibleTodos = visibleTodos.length > 0;
   const hasVisibleChangedFiles =
     useTaskChangedFilesHelpers.visibleChangedFiles.length > 0;
+  const hasVisibleContextPanel = hasVisibleTodos || hasVisibleChangedFiles;
+  const hasQueuedMessages = queuedMessages.length > 0;
 
   return (
     <>
@@ -321,10 +323,22 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           />
         </div>
       </div>
-      {(hasVisibleTodos || hasVisibleChangedFiles) && (
+      {hasQueuedMessages && (
+        <QueuedMessages
+          messages={queuedMessages}
+          onRemove={(index) =>
+            setQueuedMessages((prev) => prev.filter((_, i) => i !== index))
+          }
+          onSteer={handleSteerQueuedMessage}
+        />
+      )}
+      {hasVisibleContextPanel && (
         <div
           className={cn(
             "mt-1.5 rounded-sm rounded-b-none border border-border border-b-0",
+            {
+              "mt-0": hasQueuedMessages,
+            },
           )}
         >
           {hasVisibleTodos && (
@@ -347,15 +361,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           />
         </div>
       )}
-      {queuedMessages.length > 0 && (
-        <QueuedMessages
-          messages={queuedMessages}
-          onRemove={(index) =>
-            setQueuedMessages((prev) => prev.filter((_, i) => i !== index))
-          }
-          onSteer={handleSteerQueuedMessage}
-        />
-      )}
       <div className="relative z-10">
         <ChatInputForm
           input={input}
@@ -373,10 +378,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           taskId={taskId}
           lastCheckpointHash={task?.lastCheckpointHash ?? undefined}
           className={cn({
-            "rounded-t-none":
-              hasVisibleTodos ||
-              hasVisibleChangedFiles ||
-              queuedMessages.length > 0,
+            "rounded-t-none": hasVisibleContextPanel || hasQueuedMessages,
           })}
         >
           {files.length > 0 && (


### PR DESCRIPTION
## Summary
- **Layout Adjustment**: Render the queued messages component above the context panel (todos / changed files) in the chat toolbar for a more logical visual hierarchy.
- **Styling Refinement**: Remove the top margin from the context panel when queued messages are present to ensure compact and clean spacing.
- **Form Styling Simplification**: Simplify the conditional styling for rounded corners on the chat input form container using helper variables.

<img width="700" height="346" alt="image" src="https://github.com/user-attachments/assets/5f95ab45-d553-4693-9319-a0e574e5f4d9" />


## Test plan
- [x] Verify the layout and spacing of the queued messages component and context panel in the chat toolbar.
- [x] Ensure that when both queued messages and context panel are visible, there is no double/excessive top margin.
- [x] Confirm that the chat input form's top rounded corners are correctly flattened when either queued messages or the context panel are visible.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7e713acee99a4cc3bfce052a1d749c86)