### PR TITLE
feat(vscode-webui): support steering queued messages with hidden pending state

### DIFF
--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -87,6 +87,89 @@ describe("useChatSubmit", () => {
     expect(chatStateMocks.autoApproveGuard.current).toBe("stop");
   });
 
+  it("does not interrupt Command+Enter when there is no current or queued message", async () => {
+    const context = setup({ isLoading: true, inputText: "" });
+
+    await act(async () => {
+      await context.hook.result.current.handleSteerSubmit();
+    });
+
+    expect(context.queuedMessages).toEqual([]);
+    expect(context.clearInput).not.toHaveBeenCalled();
+    expect(context.stopChat).not.toHaveBeenCalled();
+    expect(context.sendMessage).not.toHaveBeenCalled();
+    expect(chatStateMocks.autoApproveGuard.current).toBe("auto");
+  });
+
+  it("keeps the visible queue stable when Command+Enter interrupts with queued messages", async () => {
+    const firstQueuedMessage = queuedMessage({ text: "first queued message" });
+    const context = setup({
+      isLoading: true,
+      queuedMessages: [firstQueuedMessage],
+    });
+
+    await act(async () => {
+      await context.hook.result.current.handleSteerSubmit();
+    });
+
+    expect(context.queuedMessages).toEqual([firstQueuedMessage]);
+    expect(context.clearInput).toHaveBeenCalledOnce();
+    expect(context.stopChat).toHaveBeenCalledOnce();
+    expect(context.sendMessage).not.toHaveBeenCalled();
+    expect(chatStateMocks.autoApproveGuard.current).toBe("stop");
+
+    context.setIsLoading(false);
+    await act(async () => {
+      await context.hook.result.current.handleSubmit(undefined, {
+        flushQueuedMessages: true,
+      });
+    });
+
+    expect(context.queuedMessages).toEqual([firstQueuedMessage]);
+    expect(context.sendMessage).toHaveBeenNthCalledWith(1, {
+      parts: ["text:follow up"],
+    });
+
+    await act(async () => {
+      await context.hook.result.current.handleSubmit(undefined, {
+        flushQueuedMessages: true,
+      });
+    });
+
+    expect(context.queuedMessages).toEqual([]);
+    expect(context.sendMessage).toHaveBeenNthCalledWith(2, {
+      parts: ["text:first queued message"],
+    });
+  });
+
+  it("stores Command+Enter submissions as hidden pending messages while idle with queued messages", async () => {
+    const firstQueuedMessage = queuedMessage({ text: "first queued message" });
+    const context = setup({
+      isLoading: false,
+      queuedMessages: [firstQueuedMessage],
+    });
+
+    await act(async () => {
+      await context.hook.result.current.handleSteerSubmit();
+    });
+
+    expect(context.queuedMessages).toEqual([firstQueuedMessage]);
+    expect(context.clearInput).toHaveBeenCalledOnce();
+    expect(context.stopChat).not.toHaveBeenCalled();
+    expect(context.sendMessage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await context.hook.result.current.handleSubmit(undefined, {
+        flushQueuedMessages: true,
+      });
+    });
+
+    expect(context.queuedMessages).toEqual([firstQueuedMessage]);
+    expect(context.sendMessage).toHaveBeenCalledWith({
+      parts: ["text:follow up"],
+    });
+  });
+
   it("keeps adding Enter submissions when queued messages already exist", async () => {
     const context = setup({
       isLoading: false,
@@ -191,7 +274,7 @@ describe("useChatSubmit", () => {
 });
 
 function setup({
-  isLoading,
+  isLoading: initialIsLoading,
   inputText: initialInputText = " follow up ",
   queuedMessages: initialQueuedMessages = [],
   files = [],
@@ -206,6 +289,7 @@ function setup({
   uploadFiles?: ReturnType<typeof vi.fn>;
 }) {
   let queuedMessages = initialQueuedMessages;
+  let isLoading = initialIsLoading;
   const setQueuedMessages = vi.fn(
     (value: React.SetStateAction<QueuedMessage[]>) => {
       queuedMessages =
@@ -260,6 +344,10 @@ function setup({
     uploadFiles,
     sendMessage,
     stopChat,
+    setIsLoading(value: boolean) {
+      isLoading = value;
+      hook.rerender();
+    },
   };
 }
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -10,7 +10,7 @@ import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import { useUserEdits } from "@/lib/hooks/use-user-edits";
 import type { Review } from "@getpochi/common/vscode-webui-bridge";
 import type React from "react";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useAutoApproveGuard,
@@ -69,6 +69,7 @@ export function useChatSubmit({
   const { isExecuting } = useToolCallLifeCycle();
   const batchExecuteManager = useBatchExecuteManager();
   const { t } = useTranslation();
+  const pendingSteerMessageRef = useRef<QueuedMessage | undefined>(undefined);
 
   const abortExecutingToolCalls = useCallback(() => {
     batchExecuteManager.abort(taskId, "user-abort");
@@ -113,31 +114,56 @@ export function useChatSubmit({
     stopChat,
   ]);
 
-  const queueCurrentInput = useCallback(() => {
-    const queuedMessage: QueuedMessage = {
+  const createCurrentMessage = useCallback(() => {
+    const currentMessage: QueuedMessage = {
       text: input.text.trim(),
       files: [...files],
       reviews: [...reviews],
     };
 
     if (
-      queuedMessage.text.length === 0 &&
-      queuedMessage.files.length === 0 &&
-      queuedMessage.reviews.length === 0
+      currentMessage.text.length === 0 &&
+      currentMessage.files.length === 0 &&
+      currentMessage.reviews.length === 0
     ) {
-      return false;
+      return undefined;
     }
 
+    return currentMessage;
+  }, [files, input.text, reviews]);
+
+  const clearCurrentMessage = useCallback(
+    (currentMessage: QueuedMessage) => {
+      clearInput();
+      if (currentMessage.files.length > 0) {
+        clearFiles();
+      }
+      if (currentMessage.reviews.length > 0) {
+        vscodeHost.deleteReviews(
+          currentMessage.reviews.map((review) => review.id),
+        );
+      }
+    },
+    [clearFiles, clearInput],
+  );
+
+  const queueCurrentInput = useCallback(() => {
+    const queuedMessage = createCurrentMessage();
+    if (!queuedMessage) return false;
+
     setQueuedMessages((prev) => [...prev, queuedMessage]);
-    clearInput();
-    if (files.length > 0) {
-      clearFiles();
-    }
-    if (reviews.length > 0) {
-      vscodeHost.deleteReviews(reviews.map((review) => review.id));
-    }
+    clearCurrentMessage(queuedMessage);
     return true;
-  }, [clearFiles, clearInput, files, input.text, reviews, setQueuedMessages]);
+  }, [clearCurrentMessage, createCurrentMessage, setQueuedMessages]);
+
+  const queuePendingSteerInput = useCallback(() => {
+    const queuedMessage = createCurrentMessage();
+    if (!queuedMessage) return false;
+
+    pendingSteerMessageRef.current = queuedMessage;
+    clearCurrentMessage(queuedMessage);
+    return true;
+  }, [clearCurrentMessage, createCurrentMessage]);
 
   /**
    * Handles form submission, sending both the current input and any queued messages.
@@ -175,13 +201,16 @@ export function useChatSubmit({
       }
 
       const hasQueuedMessages = queuedMessages.length > 0;
-      const queuedMessage = options.flushQueuedMessages
-        ? queuedMessages[0]
-        : hasQueuedMessages
-          ? content.length > 0
-            ? undefined
-            : queuedMessages[0]
-          : undefined;
+      const pendingSteerMessage = options.flushQueuedMessages
+        ? pendingSteerMessageRef.current
+        : undefined;
+      const shouldUseQueuedMessage =
+        options.flushQueuedMessages ||
+        (hasQueuedMessages && !hasQueueableCurrentMessage);
+      const queuedMessage =
+        pendingSteerMessage ??
+        (shouldUseQueuedMessage ? queuedMessages[0] : undefined);
+      const hasPendingSteerMessage = !!pendingSteerMessage;
       const text = queuedMessage?.text ?? content;
       const messageFiles = queuedMessage?.files ?? files;
       const messageReviews = queuedMessage?.reviews ?? reviews;
@@ -205,7 +234,11 @@ export function useChatSubmit({
 
       // Send queued messages one at a time. The ready effect will flush the
       // next queued message after the current one finishes.
-      setQueuedMessages(hasQueuedMessages ? queuedMessages.slice(1) : []);
+      if (hasPendingSteerMessage) {
+        pendingSteerMessageRef.current = undefined;
+      } else {
+        setQueuedMessages(hasQueuedMessages ? queuedMessages.slice(1) : []);
+      }
       if (!options.flushQueuedMessages && content) {
         clearInput();
       }
@@ -288,14 +321,27 @@ export function useChatSubmit({
 
       if (blockingState.isBusy || isUploading) return;
 
-      if (isLoading || isExecuting) {
-        queueCurrentInput();
-        autoApproveGuard.current = "stop";
-        handleStop();
+      const hasVisibleQueue = queuedMessages.length > 0;
+      const isRunActive = isLoading || isExecuting;
+
+      if (!hasVisibleQueue && !isRunActive) {
+        await handleSubmit(e);
         return;
       }
 
-      await handleSubmit(e);
+      const didCaptureMessage = hasVisibleQueue
+        ? queuePendingSteerInput()
+        : queueCurrentInput();
+      const shouldInterrupt =
+        isRunActive && (hasVisibleQueue || didCaptureMessage);
+      const shouldPauseAutoApprove = didCaptureMessage || shouldInterrupt;
+      if (!shouldPauseAutoApprove) return;
+
+      autoApproveGuard.current = "stop";
+      if (shouldInterrupt) {
+        handleStop();
+        return;
+      }
     },
     [
       autoApproveGuard,
@@ -306,6 +352,8 @@ export function useChatSubmit({
       isLoading,
       isUploading,
       queueCurrentInput,
+      queuePendingSteerInput,
+      queuedMessages.length,
     ],
   );
 


### PR DESCRIPTION
## Summary
- **Hidden Pending State**: Introduced `pendingSteerMessageRef` to store Command+Enter submissions as hidden pending messages when a visible queue already exists, keeping the visible queue stable.
- **Refactored Helpers**: Refactored current message creation and clearing into clean, reusable `createCurrentMessage` and `clearCurrentMessage` helper functions.
- **Stable Interruption**: Prevented unnecessary interruptions when submitting via Command+Enter if there is no current or queued message.
- **Comprehensive Tests**: Added robust unit tests to verify that Command+Enter inputs are correctly stored as hidden pending messages, visible queue stability is maintained, and idle/active states behave as expected.

## Test plan
- Run unit tests for `useChatSubmit` to verify that Command+Enter inputs (text, files, and reviews) are correctly handled as pending steer messages, the visible queue remains stable, and idle/active states function correctly:
  ```bash
  bun --cwd packages/vscode-webui vitest --run src/features/chat/hooks/use-chat-submit.test.tsx
  ```
- Run type checks and biome check to ensure no regression or formatting issues:
  ```bash
  bun check
  bun tsc
  ```

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-eff06f163d444da8b252b2d1d7215845)