### PR TITLE
fix(livekit): keep user-edits badge after read-only trailing commands

### DIFF
--- a/packages/livekit/src/chat/__tests__/clean-checkpoint.test.ts
+++ b/packages/livekit/src/chat/__tests__/clean-checkpoint.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "../../types";
+import { getCleanCheckpoint } from "../live-chat-kit";
+
+const checkpoint = (commit: string): Message["parts"][number] =>
+  ({
+    type: "data-checkpoint",
+    data: { commit },
+  }) as Message["parts"][number];
+
+const stepStart = (): Message["parts"][number] =>
+  ({ type: "step-start" }) as Message["parts"][number];
+
+const writeTool = (path: string): Message["parts"][number] =>
+  ({
+    type: "tool-writeToFile",
+    toolCallId: `write-${path}`,
+    state: "output-available",
+    input: { path, content: "" },
+    output: { success: true },
+  }) as Message["parts"][number];
+
+const executeTool = (command: string): Message["parts"][number] =>
+  ({
+    type: "tool-executeCommand",
+    toolCallId: `cmd-${command}`,
+    state: "output-available",
+    input: { command },
+    output: { output: "", isTruncated: false },
+  }) as Message["parts"][number];
+
+const attemptCompletionTool = (): Message["parts"][number] =>
+  ({
+    type: "tool-attemptCompletion",
+    toolCallId: "attempt-1",
+    state: "input-available",
+    input: { result: "done" },
+  }) as Message["parts"][number];
+
+const assistant = (parts: Message["parts"]): Message =>
+  ({ id: "assistant-1", role: "assistant", parts }) as Message;
+
+const user = (commit: string): Message =>
+  ({
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "hi" }, checkpoint(commit)],
+  }) as Message;
+
+describe("getCleanCheckpoint", () => {
+  it("returns the last checkpoint when the task ends on a write", () => {
+    // "add 123 to readme" then attemptCompletion.
+    const messages = [
+      user("c0"),
+      assistant([
+        stepStart(),
+        writeTool("readme.md"),
+        checkpoint("c1"),
+        stepStart(),
+        attemptCompletionTool(),
+      ]),
+    ];
+
+    expect(getCleanCheckpoint(messages)).toBe("c1");
+  });
+
+  it("ignores a trailing read-only command that made no file changes", () => {
+    // "add 123 to readme and then echo 'sdfg'": the echo is read-only, so no
+    // checkpoint is appended after it, but the tree still matches c1.
+    const messages = [
+      user("c0"),
+      assistant([
+        stepStart(),
+        writeTool("readme.md"),
+        checkpoint("c1"),
+        stepStart(),
+        executeTool("echo 'sdfg'"),
+        stepStart(),
+        attemptCompletionTool(),
+      ]),
+    ];
+
+    expect(getCleanCheckpoint(messages)).toBe("c1");
+  });
+
+  it("returns the last checkpoint when the task is only a read-only command", () => {
+    const messages = [
+      user("c0"),
+      assistant([stepStart(), executeTool("ls -la"), checkpoint("c0")]),
+    ];
+
+    expect(getCleanCheckpoint(messages)).toBe("c0");
+  });
+
+  it("returns undefined when a file-writing command is the final action", () => {
+    // A command that redirects output to a file is not read-only, so with no
+    // checkpoint captured after it the tree is considered dirty.
+    const messages = [
+      user("c0"),
+      assistant([
+        stepStart(),
+        writeTool("readme.md"),
+        checkpoint("c1"),
+        stepStart(),
+        executeTool("echo x >> readme.md"),
+      ]),
+    ];
+
+    expect(getCleanCheckpoint(messages)).toBeUndefined();
+  });
+
+  it("returns undefined when a write is the final action with no checkpoint after it", () => {
+    const messages = [
+      user("c0"),
+      assistant([stepStart(), writeTool("readme.md")]),
+    ];
+
+    expect(getCleanCheckpoint(messages)).toBeUndefined();
+  });
+
+  it("returns undefined when there is no checkpoint at all", () => {
+    const messages = [assistant([stepStart(), attemptCompletionTool()])];
+
+    expect(getCleanCheckpoint(messages)).toBeUndefined();
+  });
+});

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -13,6 +13,7 @@ import {
   type CustomAgent,
   ToolsByPermission,
   getToolCallCancelErrorMessage,
+  isReadonlyToolCall,
   isUserInputToolPart,
 } from "@getpochi/tools";
 import { Duration } from "@livestore/utils/effect";
@@ -20,6 +21,7 @@ import {
   type ChatInit,
   type ChatOnErrorCallback,
   type ChatOnFinishCallback,
+  getToolName,
   isToolUIPart,
 } from "ai";
 import type z from "zod";
@@ -1066,15 +1068,30 @@ export class LiveChatKit<
 }
 
 // clean checkpoint means after this checkpoint there are no write or execute toolcalls that may cause file edits
-const getCleanCheckpoint = (messages: Message[]) => {
+/**
+ * Whether a message part is a tool call that may have modified files, i.e. a
+ * write tool or a non-read-only execute tool. A read-only command (e.g. `echo`
+ * or `ls`) does not dirty the working tree relative to the last checkpoint, so
+ * it must not invalidate it.
+ */
+const isDirtyingToolPart = (part: Message["parts"][number]): boolean => {
+  if (!isToolUIPart(part)) {
+    return false;
+  }
+  const toolName = getToolName(part);
+  if (
+    !ToolsByPermission.write.includes(toolName) &&
+    !ToolsByPermission.execute.includes(toolName)
+  ) {
+    return false;
+  }
+  return !isReadonlyToolCall(toolName, part.input);
+};
+
+export const getCleanCheckpoint = (messages: Message[]) => {
   const lastPart = messages
     .flatMap((m) => m.parts)
-    .filter(
-      (p) =>
-        p.type === "data-checkpoint" ||
-        ToolsByPermission.write.some((tool) => p.type === `tool-${tool}`) ||
-        ToolsByPermission.execute.some((tool) => p.type === `tool-${tool}`),
-    )
+    .filter((p) => p.type === "data-checkpoint" || isDirtyingToolPart(p))
     .at(-1);
 
   if (lastPart?.type === "data-checkpoint") {


### PR DESCRIPTION
## Summary
- Fixes the user-edits badge disappearing when a task ends on a read-only command (e.g. `add 123 to readme and then echo 'sdfg'`), while it worked when the task ended on a write.
- Root cause: when a trailing command makes no file changes, `saveCheckpoint` returns `null` and no `data-checkpoint` part is appended after the `executeCommand`. `getCleanCheckpoint` then saw the trailing execute tool and returned `undefined`, clearing the badge — even though the working tree still matched the last real checkpoint.
- Fix: `getCleanCheckpoint` now uses `isReadonlyToolCall` (from `@getpochi/tools`) to only treat **write** tools and **non-read-only** execute commands as dirtying the working tree. A read-only command (`echo`, `ls`, `cat`, `git status`, …) no longer invalidates the last checkpoint. This is done without mutating messages, so no duplicate/extra checkpoints appear in the UI.
- Tool-name extraction uses the AI SDK's `isToolUIPart` / `getToolName` helpers.

## Test plan
- [x] `bun run test -- clean-checkpoint` (new unit test, 6 cases: trailing write, trailing read-only command, read-only-only task, file-writing command as final action, trailing write with no checkpoint, no checkpoint at all)
- [x] `bunx tsc --noEmit` in `packages/livekit`
- [x] `biome check`
- [ ] Manual: create a task with `add 123 to readme and then echo 'sdfg'`, edit another file, confirm the user edit shows in the task input.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9cbce02b7c14469d8b275827708e3193)