### PR TITLE
fix(tools): allow askFollowupQuestion in todo mode

### DIFF
--- a/packages/common/src/base/prompts/system.ts
+++ b/packages/common/src/base/prompts/system.ts
@@ -113,7 +113,6 @@ Use normal tools to make concrete progress toward completing the todos. Do not s
 
 When you believe the todos may be complete or should stop, call attemptCompletion. In todo mode, attemptCompletion is the completion checkpoint and may be audited before automatic continuation stops. If the completion audit is not accepted, you will receive a reason and should continue working from that feedback.
 
-Do not call askFollowupQuestion when active todos are present.
 `;
   return prompt;
 }

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -209,7 +209,6 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       skills,
       attemptCompletionSchema: this.attemptCompletionSchema,
       mcpTools,
-      todoModeEnabled,
     });
     if (tools.readFile) {
       tools.readFile = handleReadFileOutput(this.blobStore, tools.readFile);

--- a/packages/tools/src/__test__/select-agent-tools.test.ts
+++ b/packages/tools/src/__test__/select-agent-tools.test.ts
@@ -24,8 +24,6 @@ const ClientToolNames = [
 
 const RequiredAgentToolNames = ["attemptCompletion", "useSkill"].sort();
 
-const TodoModeRequiredAgentToolNames = ["attemptCompletion", "useSkill"].sort();
-
 function createAgent(overrides: Partial<CustomAgent> = {}): CustomAgent {
   return {
     name: "test-agent",
@@ -307,39 +305,16 @@ describe("selectAgentTools", () => {
     );
   });
 
-  it("uses todo mode tools when active todos are present", () => {
-    const tools = selectAgentTools({
-      isSubTask: false,
-      todoModeEnabled: true,
-    });
-
-    expect(toolNames(tools)).toContain("attemptCompletion");
-    expect(toolNames(tools)).toContain("useSkill");
-    expect(tools).not.toHaveProperty("todoWrite");
-    expect(tools).not.toHaveProperty("askFollowupQuestion");
-  });
-
-  it("does not use todo mode tools for subtasks", () => {
-    const tools = selectAgentTools({
-      isSubTask: true,
-      todoModeEnabled: true,
-    });
-
-    expect(toolNames(tools)).toContain("attemptCompletion");
-    expect(toolNames(tools)).toContain("useSkill");
-  });
-
-  it("uses todo mode required tools for filtered agents", () => {
+  it("always injects required tools even when agent allowList omits them", () => {
     const tools = selectAgentTools({
       agent: createAgent({
-        tools: ["readFile", "attemptCompletion", "askFollowupQuestion"],
+        tools: ["readFile"],
       }),
       isSubTask: false,
-      todoModeEnabled: true,
     });
 
     expect(toolNames(tools)).toEqual(
-      [...TodoModeRequiredAgentToolNames, "readFile"].sort(),
+      [...RequiredAgentToolNames, "readFile"].sort(),
     );
   });
 });

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -132,7 +132,6 @@ export interface CreateClientToolOptions {
   contentType?: string[];
   attemptCompletionSchema?: z.ZodType;
   agent?: CustomAgent;
-  todoModeEnabled?: boolean;
 }
 
 const HiddenNewTaskAgentNames = new Set(["attemptTodoCompletion"]);
@@ -191,23 +190,12 @@ type SelectAgentToolsOptions = {
 
 const RequiredAgentTools = ["attemptCompletion", "useSkill"];
 
-function isTodoModeToolSelectionEnabled(
-  todoModeEnabled: boolean | undefined,
-  isSubTask: boolean,
-): boolean {
-  return !!todoModeEnabled && !isSubTask;
-}
-
 function isAgentToolDisabled(
   agentName: string,
   toolName: string,
   isSubTask: boolean,
-  todoModeEnabled?: boolean,
 ): boolean {
   if (isSubTask && toolName === "newTask") return true;
-  if (todoModeEnabled) {
-    return toolName === "askFollowupQuestion";
-  }
 
   const canAskFollowupQuestion =
     agentName === "planner" || agentName === "guide";
@@ -217,7 +205,6 @@ function isAgentToolDisabled(
 function getAgentToolAllowList(
   agent: CustomAgent | undefined,
   isSubTask: boolean,
-  todoModeEnabled?: boolean,
 ): Set<string> | undefined {
   /**
    * if no agent or no tools specified, we don't filter any tools.
@@ -231,7 +218,7 @@ function getAgentToolAllowList(
 
   for (const tool of agent.tools) {
     const { name } = parseToolSpec(tool);
-    if (isAgentToolDisabled(agent.name, name, isSubTask, todoModeEnabled)) {
+    if (isAgentToolDisabled(agent.name, name, isSubTask)) {
       continue;
     }
     if (RequiredAgentTools.includes(name)) continue;
@@ -260,26 +247,12 @@ export const selectAgentTools = (
   options: SelectAgentToolsOptions,
 ): AgentTools => {
   const { agent, mcpTools, isSubTask, ...toolOptions } = options;
-  const todoModeEnabled = isTodoModeToolSelectionEnabled(
-    options.todoModeEnabled,
-    options.isSubTask,
-  );
-  const allowList = getAgentToolAllowList(
-    agent,
-    options.isSubTask,
-    todoModeEnabled,
-  );
+  const allowList = getAgentToolAllowList(agent, options.isSubTask);
 
-  let avaliableTools: AgentTools = {
+  const avaliableTools: AgentTools = {
     ...createClientTools(toolOptions),
     ...(mcpTools ?? {}),
   };
-
-  if (todoModeEnabled) {
-    const { askFollowupQuestion: _askFollowupQuestion, ...rest } =
-      avaliableTools;
-    avaliableTools = rest;
-  }
 
   if (agent?.name === "reviewer") {
     avaliableTools.createReview = createReview;


### PR DESCRIPTION
## Summary
* Remove restriction that filters out `askFollowupQuestion` when todo mode is enabled.
* Allow agents to ask questions to gather additional information / clarify requirements during todo execution.
* Update related test suite to verify the expected tool names are correctly returned.

## Screenshot
<img width="838" height="832" alt="image" src="https://github.com/user-attachments/assets/316ab4c4-772a-4f17-94fe-a33189e71cba" />


## Test plan
* Run unit tests: `bun run test packages/tools/src/__test__/select-agent-tools.test.ts`
* Verify that type check and lint pass successfully.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0c51a31ffbe845f583627c6d1e2cc5a1)