### PR TITLE
fix(vscode-webui): open sidebar new tasks in pinned mode

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -195,18 +195,21 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
         }
       }
 
-      vscodeHost.openTaskInPanel({
-        type: "new-task",
-        cwd: worktree && typeof worktree === "object" ? worktree.path : cwd,
-        prompt: content,
-        todos,
-        files: uploadedFiles,
-        activeSelection: activeSelection ?? undefined,
-        mcpConfigOverride:
-          Object.keys(mcpConfigOverride).length > 0
-            ? mcpConfigOverride
-            : globalMcpConfig,
-      });
+      vscodeHost.openTaskInPanel(
+        {
+          type: "new-task",
+          cwd: worktree && typeof worktree === "object" ? worktree.path : cwd,
+          prompt: content,
+          todos,
+          files: uploadedFiles,
+          activeSelection: activeSelection ?? undefined,
+          mcpConfigOverride:
+            Object.keys(mcpConfigOverride).length > 0
+              ? mcpConfigOverride
+              : globalMcpConfig,
+        },
+        { preview: false },
+      );
 
       // Clear files if they were uploaded
       if (uploadedFiles && uploadedFiles.length > 0) {


### PR DESCRIPTION
## Summary
- New tasks created from the sidebar were opening as preview (transient) editor tabs because `openTaskInPanel` was called without a `preview` option, which defaults to preview mode when the Pochi layout is enabled (`openTaskInColumn`: `preview: options?.preview ?? true`).
- Pass `preview: false` from `create-task-input.tsx` so the task tab is pinned immediately instead of entering preview mode.
- The existing `use-keep-task-editor` fallback (converting preview → pinned on status change) is unaffected.

## Test plan
- [ ] Enable Pochi layout, create a new task from the sidebar, and verify the task tab opens pinned (not italic/transient) and is not replaced when opening another tab.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d366b580d2694f64a4bab67056a3f555)