### PR TITLE
fix(common): keep task memory section content on its own paragraph

### DIFF
--- a/packages/common/src/base/prompts/__tests__/__snapshots__/task-memory.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/task-memory.test.ts.snap
@@ -49,6 +49,7 @@ CRITICAL RULES:
 - NEVER modify, delete, or add section headers (the lines starting with '#')
 - NEVER modify or delete the italic _section description_ lines
 - ONLY update the actual content that appears BELOW the italic _section descriptions_ within each section
+- ALWAYS leave a blank line between the italic _section description_ and the content you add below it, so the content renders as its own paragraph instead of being joined onto the description line
 - Do NOT add any new sections or information outside the existing structure
 - Do NOT reference this note-taking process anywhere in the notes
 - Skip updating a section if there are no substantial new insights to add — leave it blank

--- a/packages/common/src/base/prompts/task-memory.ts
+++ b/packages/common/src/base/prompts/task-memory.ts
@@ -67,6 +67,7 @@ CRITICAL RULES:
 - NEVER modify, delete, or add section headers (the lines starting with '#')
 - NEVER modify or delete the italic _section description_ lines
 - ONLY update the actual content that appears BELOW the italic _section descriptions_ within each section
+- ALWAYS leave a blank line between the italic _section description_ and the content you add below it, so the content renders as its own paragraph instead of being joined onto the description line
 - Do NOT add any new sections or information outside the existing structure
 - Do NOT reference this note-taking process anywhere in the notes
 - Skip updating a section if there are no substantial new insights to add — leave it blank


### PR DESCRIPTION
## Summary
- Add a CRITICAL RULE to the task-memory extraction directive requiring a blank line between each section's italic `_description_` and the content written below it.
- Without the blank line, markdown collapses the soft line break so content (most visibly the Session Title) renders joined onto the description line — e.g. "A short 5-10 word title Investigate frontend detecting two trajectories via API".
- Updated the extraction directive snapshot accordingly.

## Test plan
- [x] `bun run test -- task-memory` in `packages/common` (4 tests pass, snapshot updated)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-481fed0503654bb7a2af163e733fdf3e)