### PR TITLE
feat(livekit): add effectiveContextWindow to cap auto-compaction earlier

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -81,6 +81,10 @@
                       "description": "Context window size for the model",
                       "type": "number"
                     },
+                    "effectiveContextWindow": {
+                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
+                      "type": "number"
+                    },
                     "useToolCallMiddleware": {
                       "description": "Whether to use tool call middleware",
                       "type": "boolean"
@@ -139,6 +143,10 @@
                     },
                     "contextWindow": {
                       "description": "Context window size for the model",
+                      "type": "number"
+                    },
+                    "effectiveContextWindow": {
+                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
                       "type": "number"
                     },
                     "useToolCallMiddleware": {
@@ -202,6 +210,10 @@
                       "description": "Context window size for the model",
                       "type": "number"
                     },
+                    "effectiveContextWindow": {
+                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
+                      "type": "number"
+                    },
                     "useToolCallMiddleware": {
                       "description": "Whether to use tool call middleware",
                       "type": "boolean"
@@ -261,6 +273,10 @@
                     },
                     "contextWindow": {
                       "description": "Context window size for the model",
+                      "type": "number"
+                    },
+                    "effectiveContextWindow": {
+                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
                       "type": "number"
                     },
                     "useToolCallMiddleware": {
@@ -391,6 +407,10 @@
                     },
                     "contextWindow": {
                       "description": "Context window size for the model",
+                      "type": "number"
+                    },
+                    "effectiveContextWindow": {
+                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
                       "type": "number"
                     },
                     "useToolCallMiddleware": {

--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -81,10 +81,6 @@
                       "description": "Context window size for the model",
                       "type": "number"
                     },
-                    "effectiveContextWindow": {
-                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
-                      "type": "number"
-                    },
                     "useToolCallMiddleware": {
                       "description": "Whether to use tool call middleware",
                       "type": "boolean"
@@ -143,10 +139,6 @@
                     },
                     "contextWindow": {
                       "description": "Context window size for the model",
-                      "type": "number"
-                    },
-                    "effectiveContextWindow": {
-                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
                       "type": "number"
                     },
                     "useToolCallMiddleware": {
@@ -210,10 +202,6 @@
                       "description": "Context window size for the model",
                       "type": "number"
                     },
-                    "effectiveContextWindow": {
-                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
-                      "type": "number"
-                    },
                     "useToolCallMiddleware": {
                       "description": "Whether to use tool call middleware",
                       "type": "boolean"
@@ -273,10 +261,6 @@
                     },
                     "contextWindow": {
                       "description": "Context window size for the model",
-                      "type": "number"
-                    },
-                    "effectiveContextWindow": {
-                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
                       "type": "number"
                     },
                     "useToolCallMiddleware": {
@@ -407,10 +391,6 @@
                     },
                     "contextWindow": {
                       "description": "Context window size for the model",
-                      "type": "number"
-                    },
-                    "effectiveContextWindow": {
-                      "description": "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
                       "type": "number"
                     },
                     "useToolCallMiddleware": {
@@ -571,6 +551,10 @@
         }
       },
       "additionalProperties": false
+    },
+    "effectiveContextWindow": {
+      "description": "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 200000.",
+      "type": "number"
     }
   },
   "additionalProperties": false

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -656,7 +656,7 @@ async function createLLMConfigWithVendors(
       id: `${vendorId}/${modelId}`,
       type: "vendor",
       contextWindow: options.contextWindow,
-      effectiveContextWindow: options.effectiveContextWindow,
+      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
       useToolCallMiddleware: options.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {
@@ -680,7 +680,7 @@ async function createLLMConfigWithPochi(
       id: `${vendorId}/${model}`,
       type: "vendor",
       contextWindow: pochiModelOptions.contextWindow,
-      effectiveContextWindow: pochiModelOptions.effectiveContextWindow,
+      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
       useToolCallMiddleware: pochiModelOptions.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {
@@ -718,7 +718,7 @@ async function createLLMConfigWithProviders(
       apiKey: modelProvider.apiKey,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: modelSetting.effectiveContextWindow,
+      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       contentType: modelSetting.contentType,
@@ -733,7 +733,7 @@ async function createLLMConfigWithProviders(
       vertex: modelProvider.vertex,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: modelSetting.effectiveContextWindow,
+      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       useToolCallMiddleware: modelSetting.useToolCallMiddleware,
@@ -755,7 +755,7 @@ async function createLLMConfigWithProviders(
       apiKey: modelProvider.apiKey,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: modelSetting.effectiveContextWindow,
+      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       useToolCallMiddleware: modelSetting.useToolCallMiddleware,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -656,6 +656,7 @@ async function createLLMConfigWithVendors(
       id: `${vendorId}/${modelId}`,
       type: "vendor",
       contextWindow: options.contextWindow,
+      effectiveContextWindow: options.effectiveContextWindow,
       useToolCallMiddleware: options.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {
@@ -679,6 +680,7 @@ async function createLLMConfigWithPochi(
       id: `${vendorId}/${model}`,
       type: "vendor",
       contextWindow: pochiModelOptions.contextWindow,
+      effectiveContextWindow: pochiModelOptions.effectiveContextWindow,
       useToolCallMiddleware: pochiModelOptions.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {
@@ -716,6 +718,7 @@ async function createLLMConfigWithProviders(
       apiKey: modelProvider.apiKey,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
+      effectiveContextWindow: modelSetting.effectiveContextWindow,
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       contentType: modelSetting.contentType,
@@ -730,6 +733,7 @@ async function createLLMConfigWithProviders(
       vertex: modelProvider.vertex,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
+      effectiveContextWindow: modelSetting.effectiveContextWindow,
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       useToolCallMiddleware: modelSetting.useToolCallMiddleware,
@@ -751,6 +755,7 @@ async function createLLMConfigWithProviders(
       apiKey: modelProvider.apiKey,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
+      effectiveContextWindow: modelSetting.effectiveContextWindow,
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       useToolCallMiddleware: modelSetting.useToolCallMiddleware,

--- a/packages/common/src/configuration/model.ts
+++ b/packages/common/src/configuration/model.ts
@@ -22,6 +22,12 @@ const BaseModelSettings = z.object({
         .number()
         .optional()
         .describe("Context window size for the model"),
+      effectiveContextWindow: z
+        .number()
+        .optional()
+        .describe(
+          "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
+        ),
       useToolCallMiddleware: z
         .boolean()
         .optional()

--- a/packages/common/src/configuration/model.ts
+++ b/packages/common/src/configuration/model.ts
@@ -22,12 +22,6 @@ const BaseModelSettings = z.object({
         .number()
         .optional()
         .describe("Context window size for the model"),
-      effectiveContextWindow: z
-        .number()
-        .optional()
-        .describe(
-          "Context window size used for auto-compaction; set below contextWindow when the model degrades before its declared limit",
-        ),
       useToolCallMiddleware: z
         .boolean()
         .optional()

--- a/packages/common/src/configuration/types.ts
+++ b/packages/common/src/configuration/types.ts
@@ -42,5 +42,11 @@ export function makePochiConfig(strict = false) {
     providers: looseRecord(CustomModelSetting, strict).optional(),
     mcp: looseRecord(McpServerConfig, strict).optional(),
     browserAgentSettings: BrowserAgentSettingsConfig.optional(),
+    effectiveContextWindow: z
+      .number()
+      .optional()
+      .describe(
+        "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 200000.",
+      ),
   });
 }

--- a/packages/common/src/vendor/types.ts
+++ b/packages/common/src/vendor/types.ts
@@ -3,6 +3,7 @@ import z from "zod";
 export const ModelOptions = z.object({
   label: z.string().optional(),
   contextWindow: z.number().optional(),
+  effectiveContextWindow: z.number().optional(),
   useToolCallMiddleware: z.boolean().optional(),
   contentType: z.array(z.string()).optional(),
 });

--- a/packages/common/src/vendor/types.ts
+++ b/packages/common/src/vendor/types.ts
@@ -3,7 +3,6 @@ import z from "zod";
 export const ModelOptions = z.object({
   label: z.string().optional(),
   contextWindow: z.number().optional(),
-  effectiveContextWindow: z.number().optional(),
   useToolCallMiddleware: z.boolean().optional(),
   contentType: z.array(z.string()).optional(),
 });

--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -432,6 +432,8 @@ const VSCodeHostStub = {
       setAutoMemoryEnabled: (_enabled: boolean) => Promise.resolve(),
     };
   },
+  readEffectiveContextWindow: async (): Promise<number | undefined> =>
+    undefined,
   readAutoMemoryState: async (
     _taskId: string,
   ): Promise<{

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -462,6 +462,13 @@ export interface VSCodeHostApi {
     setAutoMemoryEnabled: (enabled: boolean) => Promise<void>;
   }>;
 
+  /**
+   * Read the global effective context window (in tokens) used to cap
+   * auto-compaction. Returns undefined when not configured, in which case the
+   * built-in default is used.
+   */
+  readEffectiveContextWindow(): Promise<number | undefined>;
+
   readAutoMemoryState(taskId: string): Promise<{
     value: ThreadSignalSerialization<AutoMemoryTaskState | undefined>;
     setAutoMemoryState: (state: AutoMemoryTaskState) => Promise<void>;

--- a/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
+++ b/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import type { Message, RequestData, Task } from "../../types";
 import {
   AutoCompactBufferTokens,
+  AutoCompactRatio,
+  DefaultEffectiveContextWindow,
   MaxSummaryOutputTokens,
   findAutoCompactAttachIndex,
   getAutoCompactThreshold,
@@ -62,12 +64,34 @@ const openaiLlm = (contextWindow: number): RequestData["llm"] =>
   }) as RequestData["llm"];
 
 describe("getAutoCompactThreshold", () => {
-  it("subtracts summary reserve + buffer from the context window", () => {
+  it("subtracts summary reserve + buffer from small context windows", () => {
     expect(getAutoCompactThreshold(100_000)).toBe(
       100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
     );
-    expect(getAutoCompactThreshold(200_000)).toBe(
-      200_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
+  });
+
+  it("caps the threshold at AutoCompactRatio of the window when the absolute buffer is proportionally small", () => {
+    expect(getAutoCompactThreshold(200_000)).toBe(200_000 * AutoCompactRatio);
+  });
+
+  it("caps very large declared windows at DefaultEffectiveContextWindow", () => {
+    expect(getAutoCompactThreshold(1_000_000)).toBe(
+      DefaultEffectiveContextWindow * AutoCompactRatio,
+    );
+  });
+
+  it("uses an explicit effectiveContextWindow instead of the default cap", () => {
+    expect(getAutoCompactThreshold(1_000_000, 400_000)).toBe(
+      400_000 * AutoCompactRatio,
+    );
+    expect(getAutoCompactThreshold(1_000_000, 100_000)).toBe(
+      100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
+    );
+  });
+
+  it("never lets effectiveContextWindow exceed the declared window", () => {
+    expect(getAutoCompactThreshold(100_000, 400_000)).toBe(
+      100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
     );
   });
 
@@ -181,6 +205,30 @@ describe("shouldAutoCompact", () => {
         messages,
         llm: vendorLlm,
         task: task(constants.CompactTaskMinTokens * 2),
+      }),
+    ).toBe(false);
+  });
+
+  it("respects an explicit effectiveContextWindow on the llm", () => {
+    const messages = [assistantMessage(), userMessage()];
+    const llm = {
+      ...openaiLlm(1_000_000),
+      effectiveContextWindow: 100_000,
+    } as RequestData["llm"];
+
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm,
+        task: task(getAutoCompactThreshold(1_000_000, 100_000)),
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm,
+        task: task(getAutoCompactThreshold(1_000_000, 100_000) - 1),
       }),
     ).toBe(false);
   });

--- a/packages/livekit/src/chat/auto-compact-policy.ts
+++ b/packages/livekit/src/chat/auto-compact-policy.ts
@@ -6,17 +6,44 @@ export const MaxSummaryOutputTokens = 20_000;
 
 export const AutoCompactBufferTokens = 13_000;
 
+// The absolute buffer alone kicks in far too late on large context windows,
+// so the threshold is also capped at this fraction of the effective window.
+export const AutoCompactRatio = 0.8;
+
+// Most models degrade on agentic tasks well before very large declared
+// windows are exhausted. When a model does not declare an explicit
+// effectiveContextWindow, cap the window used for auto-compaction here.
+export const DefaultEffectiveContextWindow = 200_000;
+
 export const MaxConsecutiveAutoCompactFailures = 3;
 
-export function getAutoCompactThreshold(contextWindow: number): number {
-  const effective = Math.max(contextWindow - MaxSummaryOutputTokens, 0);
-  return Math.max(effective - AutoCompactBufferTokens, 0);
+export function getAutoCompactThreshold(
+  contextWindow: number,
+  effectiveContextWindow?: number,
+): number {
+  const window = Math.min(
+    effectiveContextWindow || DefaultEffectiveContextWindow,
+    contextWindow,
+  );
+  const byBuffer = window - MaxSummaryOutputTokens - AutoCompactBufferTokens;
+  const byRatio = Math.floor(window * AutoCompactRatio);
+  return Math.max(Math.min(byBuffer, byRatio), 0);
 }
 
-function resolveContextWindow(llm: RequestData["llm"] | undefined): number {
+function resolveContextWindow(llm: RequestData["llm"] | undefined): {
+  contextWindow: number;
+  effectiveContextWindow?: number;
+} {
   const declared =
     llm && "contextWindow" in llm ? llm.contextWindow : undefined;
-  return declared || constants.DefaultContextWindow;
+  const effective =
+    llm && "effectiveContextWindow" in llm
+      ? llm.effectiveContextWindow
+      : undefined;
+  return {
+    contextWindow: declared || constants.DefaultContextWindow,
+    effectiveContextWindow: effective,
+  };
 }
 
 export function shouldAutoCompact({
@@ -50,8 +77,10 @@ export function shouldAutoCompact({
   );
   if (totalTokens < constants.CompactTaskMinTokens) return false;
 
-  const contextWindow = resolveContextWindow(llm);
-  if (totalTokens < getAutoCompactThreshold(contextWindow)) {
+  const { contextWindow, effectiveContextWindow } = resolveContextWindow(llm);
+  if (
+    totalTokens < getAutoCompactThreshold(contextWindow, effectiveContextWindow)
+  ) {
     return false;
   }
 

--- a/packages/livekit/src/chat/auto-compact-policy.ts
+++ b/packages/livekit/src/chat/auto-compact-policy.ts
@@ -11,8 +11,8 @@ export const AutoCompactBufferTokens = 13_000;
 export const AutoCompactRatio = 0.8;
 
 // Most models degrade on agentic tasks well before very large declared
-// windows are exhausted. When a model does not declare an explicit
-// effectiveContextWindow, cap the window used for auto-compaction here.
+// windows are exhausted. When no effectiveContextWindow is configured, cap
+// the window used for auto-compaction here.
 export const DefaultEffectiveContextWindow = 200_000;
 
 export const MaxConsecutiveAutoCompactFailures = 3;

--- a/packages/livekit/src/index.ts
+++ b/packages/livekit/src/index.ts
@@ -8,6 +8,7 @@ export {
   type LiveChatKitProjectMemoryOptions,
   type LiveChatKitTaskMemoryOptions,
 } from "./chat/live-chat-kit";
+export { getAutoCompactThreshold } from "./chat/auto-compact-policy";
 export type { AutoMemoryManager } from "@getpochi/common";
 export type { RunningTaskAdaptor } from "./background-task/task-executor/task-executor";
 export type LLMRequestData = RequestData["llm"];

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -51,7 +51,7 @@ const RequestData = z.object({
         .number()
         .optional()
         .describe(
-          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
         ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
@@ -74,7 +74,7 @@ const RequestData = z.object({
         .number()
         .optional()
         .describe(
-          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
         ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
@@ -97,7 +97,7 @@ const RequestData = z.object({
         .number()
         .optional()
         .describe(
-          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
         ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
@@ -119,7 +119,7 @@ const RequestData = z.object({
         .number()
         .optional()
         .describe(
-          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
         ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
@@ -141,7 +141,7 @@ const RequestData = z.object({
         .number()
         .optional()
         .describe(
-          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
         ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
@@ -164,7 +164,7 @@ const RequestData = z.object({
         .number()
         .optional()
         .describe(
-          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
         ),
       useToolCallMiddleware: z
         .boolean()

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -47,6 +47,12 @@ const RequestData = z.object({
       baseURL: z.string().optional(),
       apiKey: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
+      effectiveContextWindow: z
+        .number()
+        .optional()
+        .describe(
+          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+        ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -64,6 +70,12 @@ const RequestData = z.object({
       baseURL: z.string().optional(),
       apiKey: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
+      effectiveContextWindow: z
+        .number()
+        .optional()
+        .describe(
+          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+        ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -81,6 +93,12 @@ const RequestData = z.object({
       baseURL: z.string().optional(),
       apiKey: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
+      effectiveContextWindow: z
+        .number()
+        .optional()
+        .describe(
+          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+        ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -97,6 +115,12 @@ const RequestData = z.object({
       modelId: z.string(),
       vertex: GoogleVertexModel,
       contextWindow: z.number().describe("Context window of the model."),
+      effectiveContextWindow: z
+        .number()
+        .optional()
+        .describe(
+          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+        ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -113,6 +137,12 @@ const RequestData = z.object({
       modelId: z.string(),
       apiKey: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
+      effectiveContextWindow: z
+        .number()
+        .optional()
+        .describe(
+          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+        ),
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -130,6 +160,12 @@ const RequestData = z.object({
         .number()
         .optional()
         .describe("Context window of the model."),
+      effectiveContextWindow: z
+        .number()
+        .optional()
+        .describe(
+          "Effective context window used for auto-compaction; overrides the default cap derived from contextWindow.",
+        ),
       useToolCallMiddleware: z
         .boolean()
         .optional()

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -13,6 +13,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useAutoMemoryEnabled } from "@/lib/hooks/use-auto-memory-enabled";
+import { useEffectiveContextWindow } from "@/lib/hooks/use-effective-context-window";
 import { useRules } from "@/lib/hooks/use-rules";
 import { useTaskContextWindowUsage } from "@/lib/hooks/use-task-context-window-usage";
 import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
@@ -89,9 +90,10 @@ export function TokenUsage({
   const contextWindow =
     selectedModel.options.contextWindow || constants.DefaultContextWindow;
   const percentage = Math.ceil((totalTokens / contextWindow) * 100);
+  const effectiveContextWindow = useEffectiveContextWindow();
   const autoCompactThreshold = getAutoCompactThreshold(
     contextWindow,
-    selectedModel.options.effectiveContextWindow,
+    effectiveContextWindow,
   );
   const autoCompactPct = (autoCompactThreshold / contextWindow) * 100;
   const [isOpen, setIsOpen] = useState(false);

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -19,6 +19,7 @@ import { useTaskMemoryState } from "@/lib/hooks/use-task-memory-state";
 import { vscodeAutoMemoryManager, vscodeHost } from "@/lib/vscode";
 import { constants, TaskMemoryFileUri } from "@getpochi/common";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
+import { getAutoCompactThreshold } from "@getpochi/livekit";
 import { useQuery } from "@tanstack/react-query";
 import { CircleAlert, Loader2 } from "lucide-react";
 import { useState } from "react";
@@ -88,6 +89,11 @@ export function TokenUsage({
   const contextWindow =
     selectedModel.options.contextWindow || constants.DefaultContextWindow;
   const percentage = Math.ceil((totalTokens / contextWindow) * 100);
+  const autoCompactThreshold = getAutoCompactThreshold(
+    contextWindow,
+    selectedModel.options.effectiveContextWindow,
+  );
+  const autoCompactPct = (autoCompactThreshold / contextWindow) * 100;
   const [isOpen, setIsOpen] = useState(false);
   const [isPinned, setIsPinned] = useState(false);
 
@@ -237,7 +243,30 @@ export function TokenUsage({
                 {percentage}%
               </span>
             </div>
-            <Progress value={percentage} className="mb-3" />
+            <div className="relative mb-3">
+              <Progress value={percentage} />
+              {autoCompactThreshold > 0 && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div
+                        className="group -translate-x-1/2 -inset-y-0.5 absolute flex w-3 cursor-default justify-center"
+                        style={{ left: `${autoCompactPct}%` }}
+                      >
+                        <div className="h-full w-[3px] rounded-full bg-muted-foreground/60 transition-all duration-150 group-hover:scale-x-125 group-hover:bg-foreground/90" />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>
+                        {t("tokenUsage.autoCompactAt", {
+                          tokens: formatTokens(autoCompactThreshold),
+                        })}
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
+            </div>
 
             <div className="mt-1 flex flex-col gap-y-3">
               {showSystemSection && (

--- a/packages/vscode-webui/src/features/chat/lib/display-model-to-llm.ts
+++ b/packages/vscode-webui/src/features/chat/lib/display-model-to-llm.ts
@@ -17,6 +17,7 @@ export function displayModelToLLM(model: DisplayModel): LLMRequestData {
       id: model.id,
       type: "vendor",
       contextWindow: model.options.contextWindow,
+      effectiveContextWindow: model.options.effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       getModel: () =>
         createModel(model.vendorId, {
@@ -38,6 +39,7 @@ export function displayModelToLLM(model: DisplayModel): LLMRequestData {
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
+      effectiveContextWindow: model.options.effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };
@@ -53,6 +55,7 @@ export function displayModelToLLM(model: DisplayModel): LLMRequestData {
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
+      effectiveContextWindow: model.options.effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };
@@ -74,6 +77,7 @@ export function displayModelToLLM(model: DisplayModel): LLMRequestData {
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
+      effectiveContextWindow: model.options.effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };

--- a/packages/vscode-webui/src/features/chat/lib/display-model-to-llm.ts
+++ b/packages/vscode-webui/src/features/chat/lib/display-model-to-llm.ts
@@ -11,13 +11,16 @@ import { createModel } from "@getpochi/common/vendor/edge";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
 import type { LLMRequestData } from "@getpochi/livekit";
 
-export function displayModelToLLM(model: DisplayModel): LLMRequestData {
+export function displayModelToLLM(
+  model: DisplayModel,
+  effectiveContextWindow?: number,
+): LLMRequestData {
   if (model.type === "vendor") {
     return {
       id: model.id,
       type: "vendor",
       contextWindow: model.options.contextWindow,
-      effectiveContextWindow: model.options.effectiveContextWindow,
+      effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       getModel: () =>
         createModel(model.vendorId, {
@@ -39,7 +42,7 @@ export function displayModelToLLM(model: DisplayModel): LLMRequestData {
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: model.options.effectiveContextWindow,
+      effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };
@@ -55,7 +58,7 @@ export function displayModelToLLM(model: DisplayModel): LLMRequestData {
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: model.options.effectiveContextWindow,
+      effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };
@@ -77,7 +80,7 @@ export function displayModelToLLM(model: DisplayModel): LLMRequestData {
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: model.options.effectiveContextWindow,
+      effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -1,6 +1,7 @@
 import { useSelectedModels } from "@/features/settings";
 import { useAutoMemoryEnabled } from "@/lib/hooks/use-auto-memory-enabled";
 import { useCustomAgents } from "@/lib/hooks/use-custom-agents";
+import { useEffectiveContextWindow } from "@/lib/hooks/use-effective-context-window";
 import { useLatest } from "@/lib/hooks/use-latest";
 import { useMcp } from "@/lib/hooks/use-mcp";
 import { useSkills } from "@/lib/hooks/use-skills";
@@ -139,11 +140,12 @@ function useLLM({
   modelOverride?: DisplayModel;
 }): React.RefObject<LLMRequestData> {
   const { selectedModel } = useSelectedModels({ isSubTask });
+  const effectiveContextWindow = useEffectiveContextWindow();
 
   const model = modelOverride || selectedModel;
   const llmFromSelectedModel = ((): LLMRequestData => {
     if (!model) return undefined as never;
-    return displayModelToLLM(model);
+    return displayModelToLLM(model, effectiveContextWindow);
   })();
 
   return useLatest(llmFromSelectedModel);

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -63,6 +63,7 @@
     "contextWindow": "Context Window",
     "newTaskWithSummary": "New Task with Summary",
     "compactTask": "Compact Task",
+    "autoCompactAt": "Auto-compact triggers at ~{{tokens}} tokens",
     "minTokensRequired": "At least {{minTokens}} tokens are required to compact the conversation",
     "defaultContextWindowWarning": "The context window value is a default and may not be accurate for your custom model. For precise token management, please adjust it in the settings according to your model provider's documentation.",
     "tokensUsed": "{{used}} / {{total}} tokens",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -63,6 +63,7 @@
     "ofUsed": "{{total}} のうち {{used}} 使用済み",
     "newTaskWithSummary": "新しいタスクと要約",
     "compactTask": "タスクを圧縮",
+    "autoCompactAt": "約 {{tokens}} tokens で自動圧縮されます",
     "minTokensRequired": "会話を圧縮するには少なくとも {{minTokens}} tokens が必要です",
     "defaultContextWindowWarning": "コンテキストウィンドウの値はデフォルトであり、カスタムモデルには正確でない場合があります。正確な token 管理のために、モデルプロバイダーのドキュメントに従って設定で調整してください。",
     "tokensUsed": "{{used}} / {{total}} tokens",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -62,6 +62,7 @@
     "ofUsed": "{{total}} 중 {{used}} 사용됨",
     "newTaskWithSummary": "새 작업 및 요약",
     "compactTask": "작업 압축",
+    "autoCompactAt": "약 {{tokens}} tokens에서 자동 압축됩니다",
     "minTokensRequired": "대화를 압축하려면 최소 {{minTokens}} tokens 이상 필요합니다",
     "defaultContextWindowWarning": "컨텍스트 창 값은 기본값이며 사용자 지정 모델에 대해 정확하지 않을 수 있습니다. 정확한 token 관리를 위해 모델 공급자의 설명서에 따라 설정에서 조정하십시오.",
     "tokensUsed": "{{used}} / {{total}} tokens",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -62,6 +62,7 @@
     "ofUsed": "已使用 {{used}} / {{total}}",
     "newTaskWithSummary": "新建任务并生成摘要",
     "compactTask": "压缩任务",
+    "autoCompactAt": "达到约 {{tokens}} tokens 时将自动压缩",
     "minTokensRequired": "至少需要 {{minTokens}} 个 token 才能压缩对话",
     "defaultContextWindowWarning": "上下文窗口值是默认值，对于您的自定义模型可能不准确。为了精确的 token 管理，请根据您的模型提供商的文档在设置中进行调整。",
     "tokensUsed": "已使用 {{used}} / {{total}} tokens",

--- a/packages/vscode-webui/src/lib/hooks/use-effective-context-window.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-effective-context-window.ts
@@ -1,0 +1,17 @@
+import { vscodeHost } from "@/lib/vscode";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Reads the global effective context window (in tokens) used to cap
+ * auto-compaction. Returns undefined when not configured, in which case the
+ * built-in default is used.
+ */
+export const useEffectiveContextWindow = (): number | undefined => {
+  const { data } = useQuery({
+    queryKey: ["effectiveContextWindow"],
+    queryFn: () => vscodeHost.readEffectiveContextWindow(),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  return data ?? undefined;
+};

--- a/packages/vscode-webui/src/lib/vscode-running-task-adaptor.ts
+++ b/packages/vscode-webui/src/lib/vscode-running-task-adaptor.ts
@@ -31,6 +31,7 @@ export class VscodeRunningTaskAdaptor implements RunningTaskAdaptor {
   };
   private customAgents: CustomAgentFile[] = [];
   private skills: SkillFile[] = [];
+  private effectiveContextWindow: number | undefined = undefined;
   private autoMemoryCache: Promise<AutoMemoryContext | undefined> | null = null;
   private readonly unsubscribers: Array<() => void> = [];
   private readonly ready: Promise<void>;
@@ -115,7 +116,12 @@ export class VscodeRunningTaskAdaptor implements RunningTaskAdaptor {
       this.initMcpStatus(),
       this.initCustomAgents(),
       this.initSkills(),
+      this.initEffectiveContextWindow(),
     ]);
+  }
+
+  private async initEffectiveContextWindow() {
+    this.effectiveContextWindow = await vscodeHost.readEffectiveContextWindow();
   }
 
   private async initModelList() {
@@ -183,7 +189,9 @@ export class VscodeRunningTaskAdaptor implements RunningTaskAdaptor {
       resolveModelFromId(selectedModelId, this.modelList) ??
       this.modelList.at(0);
 
-    return selectedModel ? displayModelToLLM(selectedModel) : undefined;
+    return selectedModel
+      ? displayModelToLLM(selectedModel, this.effectiveContextWindow)
+      : undefined;
   }
 
   private getAutoMemory() {

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -132,6 +132,7 @@ function createVSCodeHost(): VSCodeHostApi {
         "readAutoMemory",
         "readAutoMemoryEnabled",
         "readAutoMemoryState",
+        "readEffectiveContextWindow",
         "readBackgroundTaskState",
         "readTaskArchived",
         "readTaskPinned",

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1410,6 +1410,10 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     };
   };
 
+  readEffectiveContextWindow = async (): Promise<number | undefined> => {
+    return pochiConfig.value.effectiveContextWindow;
+  };
+
   readAutoMemoryState = async (
     taskId: string,
   ): Promise<{


### PR DESCRIPTION
## Summary
- Add an optional `effectiveContextWindow` model setting (config schema, vendor types, livekit `RequestData`) that controls the window used for auto-compaction, independent of the declared `contextWindow`.
- Rework `getAutoCompactThreshold` to accept an optional `effectiveContextWindow`, cap very large declared windows at a `DefaultEffectiveContextWindow` (200k), and clamp via an `AutoCompactRatio` (0.8) so compaction fires before large windows are exhausted (where models tend to degrade).
- Thread `effectiveContextWindow` through the CLI and webui `displayModelToLLM` paths, and render the auto-compact threshold as a marker/tooltip on the token-usage progress bar (localized en/jp/ko/zh).

## Test plan
- [ ] `bun run test` in `packages/livekit` (auto-compact-policy tests cover default cap, explicit override, ratio cap, and the never-exceed-declared invariant)
- [ ] Verify the auto-compact marker renders at the correct position with tooltip in the token-usage popover

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7e4192f8a3e6495d9e4f8dca906f7ef0)