### PR TITLE
feat: track and display execution duration per task step

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -216,6 +216,217 @@ describe('formatters', () => {
       ]);
     });
 
+    describe('message metadata merging', () => {
+      it('should merge assistant metadata when combining consecutive assistant messages', () => {
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'First' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 10,
+              finishReason: 'stop',
+              totalStreamingDuration: 100,
+              totalToolsExecutionDuration: 50,
+            },
+          },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Second' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 20,
+              finishReason: 'stop',
+              totalStreamingDuration: 200,
+              totalToolsExecutionDuration: 75,
+            },
+          },
+        ];
+
+        const formatted = formatters.ui(clone(messages));
+        expect(formatted).toHaveLength(1);
+        const merged = formatted[0].metadata as any;
+        expect(merged.kind).toBe('assistant');
+        expect(merged.totalTokens).toBe(20); // last value wins for non-summed fields
+        expect(merged.totalStreamingDuration).toBe(300); // 100 + 200
+        expect(merged.totalToolsExecutionDuration).toBe(125); // 50 + 75
+      });
+
+      it('should sum totalStreamingDuration when only one side has the value', () => {
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'First' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 10,
+              finishReason: 'stop',
+              totalStreamingDuration: 150,
+            },
+          },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Second' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 20,
+              finishReason: 'stop',
+              // totalStreamingDuration intentionally absent
+            },
+          },
+        ];
+
+        const formatted = formatters.ui(clone(messages));
+        expect(formatted).toHaveLength(1);
+        const merged = formatted[0].metadata as any;
+        expect(merged.totalStreamingDuration).toBe(150); // 150 + 0
+      });
+
+      it('should sum totalToolsExecutionDuration when only the second message has the value', () => {
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'First' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 10,
+              finishReason: 'stop',
+              // totalToolsExecutionDuration intentionally absent
+            },
+          },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Second' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 20,
+              finishReason: 'stop',
+              totalToolsExecutionDuration: 80,
+            },
+          },
+        ];
+
+        const formatted = formatters.ui(clone(messages));
+        expect(formatted).toHaveLength(1);
+        const merged = formatted[0].metadata as any;
+        expect(merged.totalToolsExecutionDuration).toBe(80); // 0 + 80
+      });
+
+      it('should leave duration fields undefined when neither message has them', () => {
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'First' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 5,
+              finishReason: 'stop',
+            },
+          },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Second' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 15,
+              finishReason: 'stop',
+            },
+          },
+        ];
+
+        const formatted = formatters.ui(clone(messages));
+        expect(formatted).toHaveLength(1);
+        const merged = formatted[0].metadata as any;
+        expect(merged.totalStreamingDuration).toBeUndefined();
+        expect(merged.totalToolsExecutionDuration).toBeUndefined();
+      });
+
+      it('should use the metadata from the only message that has it', () => {
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'First' }],
+            // no metadata
+          },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Second' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 30,
+              finishReason: 'length',
+              totalStreamingDuration: 500,
+            },
+          },
+        ];
+
+        const formatted = formatters.ui(clone(messages));
+        expect(formatted).toHaveLength(1);
+        const merged = formatted[0].metadata as any;
+        expect(merged.kind).toBe('assistant');
+        expect(merged.totalTokens).toBe(30);
+        expect(merged.totalStreamingDuration).toBe(500);
+      });
+
+      it('should accumulate durations correctly across three consecutive assistant messages', () => {
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'First' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 10,
+              finishReason: 'stop',
+              totalStreamingDuration: 100,
+              totalToolsExecutionDuration: 10,
+            },
+          },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Second' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 20,
+              finishReason: 'stop',
+              totalStreamingDuration: 200,
+              totalToolsExecutionDuration: 20,
+            },
+          },
+          {
+            id: 'assistant-3',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Third' }],
+            metadata: {
+              kind: 'assistant',
+              totalTokens: 30,
+              finishReason: 'stop',
+              totalStreamingDuration: 300,
+              totalToolsExecutionDuration: 30,
+            },
+          },
+        ];
+
+        const formatted = formatters.ui(clone(messages));
+        expect(formatted).toHaveLength(1);
+        expect(formatted[0].id).toBe('assistant-3');
+        const merged = formatted[0].metadata as any;
+        expect(merged.totalStreamingDuration).toBe(600); // 100 + 200 + 300
+        expect(merged.totalToolsExecutionDuration).toBe(60); // 10 + 20 + 30
+      });
+    });
+
     it('should hide deprecated todoWrite tool calls', () => {
       const messages: UIMessage[] = [
         {

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -12,6 +12,7 @@ import {
 } from "ai";
 import { clone } from "remeda";
 import { AttemptTodoCompletionAgentName, KnownTags } from "./constants";
+import type { MessageMetadata } from "./message";
 import { prompts } from "./prompts";
 
 function resolvePendingToolCalls(
@@ -124,6 +125,39 @@ function isCompactOnlyUserMessage(message: UIMessage): boolean {
   );
 }
 
+type AssistantMessageMetadata = Extract<MessageMetadata, { kind: "assistant" }>;
+
+function isAssistantMetadata(m: unknown): m is AssistantMessageMetadata {
+  return (
+    typeof m === "object" &&
+    m !== null &&
+    (m as { kind?: string }).kind === "assistant"
+  );
+}
+
+function mergeAssistantMetadata(
+  a: AssistantMessageMetadata | undefined,
+  b: AssistantMessageMetadata | undefined,
+): AssistantMessageMetadata | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return {
+    ...a,
+    ...b,
+    totalStreamingDuration:
+      a?.totalStreamingDuration !== undefined ||
+      b?.totalStreamingDuration !== undefined
+        ? (a?.totalStreamingDuration ?? 0) + (b?.totalStreamingDuration ?? 0)
+        : undefined,
+    totalToolsExecutionDuration:
+      a?.totalToolsExecutionDuration !== undefined ||
+      b?.totalToolsExecutionDuration !== undefined
+        ? (a?.totalToolsExecutionDuration ?? 0) +
+          (b?.totalToolsExecutionDuration ?? 0)
+        : undefined,
+  };
+}
+
 function combineConsecutiveAssistantMessages(
   messages: UIMessage[],
 ): UIMessage[] {
@@ -157,6 +191,20 @@ function combineConsecutiveAssistantMessages(
     // and prepending the earlier message's parts.
     if (message.role === "assistant" && prev?.role === "assistant") {
       message.parts.unshift(...prev.parts);
+
+      const prevMessageMetadata = isAssistantMetadata(prev.metadata)
+        ? prev.metadata
+        : undefined;
+      const messageMetadata = isAssistantMetadata(message.metadata)
+        ? message.metadata
+        : undefined;
+      if (prevMessageMetadata || messageMetadata) {
+        message.metadata = mergeAssistantMetadata(
+          prevMessageMetadata,
+          messageMetadata,
+        );
+      }
+
       result[result.length - 1] = message;
       continue;
     }

--- a/packages/common/src/base/message.ts
+++ b/packages/common/src/base/message.ts
@@ -8,6 +8,8 @@ export const MessageMetadata = z.discriminatedUnion("kind", [
     finishReason: z.custom<FinishReason>(),
     startedAt: z.coerce.date().optional(),
     finishedAt: z.coerce.date().optional(),
+    totalStreamingDuration: z.number().optional(),
+    totalToolsExecutionDuration: z.number().optional(),
   }),
   z.object({
     kind: z.literal("user"),

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -280,6 +280,14 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
         originalMessages: preparedMessages,
         messageMetadata: ({ part }) => {
           if (part.type === "finish") {
+            const now = new Date();
+            const duration = now.getTime() - requestStartedAt.getTime();
+            const lastMessage = preparedMessages[preparedMessages.length - 1];
+            const lastMessageMetadata =
+              lastMessage?.role === "assistant" &&
+              lastMessage.metadata?.kind === "assistant"
+                ? lastMessage.metadata
+                : undefined;
             return {
               kind: "assistant",
               // The client only consumes the aggregated total token count here.
@@ -288,7 +296,9 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
                 part.totalUsage.totalTokens || estimateTotalTokens(llmMessages),
               finishReason: part.finishReason,
               startedAt: requestStartedAt,
-              finishedAt: new Date(),
+              finishedAt: now,
+              totalStreamingDuration:
+                (lastMessageMetadata?.totalStreamingDuration ?? 0) + duration,
             } satisfies MessageMetadata;
           }
         },

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -377,6 +377,9 @@ export class LiveChatKit<
   private readonly pendingMemoryOperations = new Set<Promise<void>>();
   private latestRequestSnapshot: FinishedRequestSnapshot | undefined;
   private backgroundTasksStarted = false;
+  private currentToolsExecution:
+    | { messageId: string; startedAt: Date }
+    | undefined = undefined;
 
   onStreamStart?: (
     data: Pick<Task, "id" | "cwd"> & {
@@ -774,6 +777,60 @@ export class LiveChatKit<
     );
   };
 
+  /**
+   * Mark the start of a tool-calls execution.
+   */
+  markStartToolsExecution = () => {
+    const messages = this.messages;
+    const lastMessage = messages[messages.length - 1];
+    if (
+      lastMessage?.role === "assistant" &&
+      lastMessage.parts.some(
+        (p) =>
+          "toolCallId" in p && p.toolCallId && p.state === "input-available",
+      )
+    ) {
+      this.currentToolsExecution = {
+        messageId: lastMessage.id,
+        startedAt: new Date(),
+      };
+    }
+  };
+
+  /**
+   * Mark the end of a tool-calls execution.
+   */
+  markEndToolsExecution = () => {
+    const toolsExecution = this.currentToolsExecution;
+    this.currentToolsExecution = undefined;
+    if (toolsExecution) {
+      const duration = Date.now() - toolsExecution.startedAt.getTime();
+      const messageToUpdate = this.messages.find(
+        (m) => m.id === toolsExecution.messageId,
+      );
+      if (messageToUpdate) {
+        const updatedMessages = this.messages.map((m) => {
+          if (m.id === toolsExecution.messageId) {
+            return {
+              ...m,
+              metadata: {
+                ...m.metadata,
+                totalToolsExecutionDuration:
+                  m.metadata?.kind === "assistant" &&
+                  m.metadata.totalToolsExecutionDuration !== undefined
+                    ? m.metadata.totalToolsExecutionDuration + duration
+                    : duration,
+              },
+            };
+          }
+          return m;
+        });
+        this.store.commit(events.updateMessages({ messages: updatedMessages }));
+        this.chat.messages = this.messages;
+      }
+    }
+  };
+
   fork = (
     sourceStore: LiveKitStore,
     forkTaskParams: {
@@ -907,11 +964,27 @@ export class LiveChatKit<
       this.latestRequestSnapshot,
     );
 
+    const metadataToMerge = this.messages.find(
+      (m) => m.id === message.id,
+    )?.metadata;
+    const messageWithMergedMetadata = metadataToMerge
+      ? {
+          ...message,
+          metadata: {
+            ...metadataToMerge,
+            ...message.metadata,
+          },
+        }
+      : message;
+
     let duration = undefined;
-    if (message.metadata.finishedAt && message.metadata.startedAt) {
+    if (
+      messageWithMergedMetadata.metadata?.kind === "assistant" &&
+      messageWithMergedMetadata.metadata.totalStreamingDuration !== undefined
+    ) {
       duration = Duration.millis(
-        message.metadata.finishedAt.getTime() -
-          message.metadata.startedAt.getTime(),
+        messageWithMergedMetadata.metadata.totalStreamingDuration +
+          (messageWithMergedMetadata.metadata.totalToolsExecutionDuration ?? 0),
       );
     }
 
@@ -919,7 +992,7 @@ export class LiveChatKit<
       events.chatStreamFinished({
         id: this.taskId,
         status,
-        data: message,
+        data: messageWithMergedMetadata,
         totalTokens: message.metadata.totalTokens,
         updatedAt: new Date(),
         duration,
@@ -1034,15 +1107,32 @@ export class LiveChatKit<
       this.chat.messages = [...this.chat.messages.slice(0, -1), lastMessage];
     }
 
+    let lastMessageWithMergedMetadata = lastMessage;
+    if (lastMessage) {
+      const metadataToMerge = this.messages.find(
+        (m) => m.id === lastMessage.id,
+      )?.metadata;
+      if (metadataToMerge) {
+        lastMessageWithMergedMetadata = {
+          ...lastMessage,
+          metadata: {
+            ...metadataToMerge,
+            ...lastMessage.metadata,
+          },
+        };
+      }
+    }
+
     let duration = undefined;
     if (
-      lastMessage?.metadata?.kind === "assistant" &&
-      lastMessage.metadata.finishedAt &&
-      lastMessage.metadata.startedAt
+      lastMessageWithMergedMetadata?.metadata?.kind === "assistant" &&
+      lastMessageWithMergedMetadata.metadata.totalStreamingDuration !==
+        undefined
     ) {
       duration = Duration.millis(
-        lastMessage.metadata.finishedAt.getTime() -
-          lastMessage.metadata.startedAt.getTime(),
+        lastMessageWithMergedMetadata.metadata.totalStreamingDuration +
+          (lastMessageWithMergedMetadata.metadata.totalToolsExecutionDuration ??
+            0),
       );
     }
 
@@ -1050,7 +1140,7 @@ export class LiveChatKit<
       events.chatStreamFailed({
         id: this.taskId,
         error: toTaskError(error),
-        data: lastMessage,
+        data: lastMessageWithMergedMetadata,
         updatedAt: new Date(),
         duration,
         lastCheckpointHash: getCleanCheckpoint(this.chat.messages),

--- a/packages/livekit/src/livestore/types.ts
+++ b/packages/livekit/src/livestore/types.ts
@@ -12,6 +12,12 @@ export const DBMessage = Schema.Struct({
   id: Schema.String,
   role: Schema.Literal("user", "assistant", "system"),
   parts: Schema.Array(DBUIPart),
+  metadata: Schema.optional(
+    Schema.Record({
+      key: Schema.String,
+      value: Schema.Any,
+    }),
+  ),
 });
 
 export const Todo = Schema.Struct({

--- a/packages/vscode-webui/src/components/checkpoint-ui.tsx
+++ b/packages/vscode-webui/src/components/checkpoint-ui.tsx
@@ -12,7 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 import { useIsDevMode } from "@/features/settings";
-import { cn } from "@/lib/utils";
+import { cn, formatExecutionDuration } from "@/lib/utils";
 import { prompts } from "@getpochi/common";
 import type { DataParts } from "@getpochi/livekit";
 import type { TextUIPart } from "ai";
@@ -31,6 +31,7 @@ export const CheckpointUI: React.FC<{
   isRestored?: boolean;
   compactPart?: TextUIPart;
   compactMessageId?: string;
+  executionDuration?: number;
 }> = ({
   checkpoint,
   isLoading,
@@ -41,6 +42,7 @@ export const CheckpointUI: React.FC<{
   isRestored,
   compactPart,
   compactMessageId,
+  executionDuration,
 }) => {
   const { t } = useTranslation();
   const [isDevMode] = useIsDevMode();
@@ -172,9 +174,9 @@ export const CheckpointUI: React.FC<{
   };
 
   /**
-   * Return the icon on unhover state
+   * Return the label for normal (non-hover) state
    */
-  const getIcon = () => {
+  const getNormalStateLabel = () => {
     if (isPending) {
       return <Loader2 className="size-3 animate-spin" />;
     }
@@ -189,6 +191,12 @@ export const CheckpointUI: React.FC<{
     if (compactPart) {
       return <SquareChartGantt className="size-3" />;
     }
+    if (executionDuration) {
+      const label = t("messageList.completedIn", {
+        duration: formatExecutionDuration(executionDuration),
+      });
+      return <span>{label}</span>;
+    }
     return <GitCommitHorizontal className="size-5" />;
   };
 
@@ -201,7 +209,8 @@ export const CheckpointUI: React.FC<{
     >
       <div
         className={cn(
-          "-translate-x-1/2 -top-1 group absolute left-1/2 mx-auto flex min-h-5 w-full max-w-[72px] select-none items-center hover:max-w-full",
+          "-translate-x-1/2 -top-1 group absolute left-1/2 mx-auto flex min-h-5 w-full select-none items-center hover:max-w-full",
+          executionDuration && !compactPart ? "max-w-[140px]" : "max-w-[72px]",
           isLoading && "pointer-events-none",
           className,
         )}
@@ -298,9 +307,10 @@ export const CheckpointUI: React.FC<{
             className={cn(
               "group-hover:hidden",
               isRestored && "text-primary/60",
+              executionDuration && !compactPart && "px-2 text-xs",
             )}
           >
-            {getIcon()}
+            {getNormalStateLabel()}
           </span>
         </span>
         <Border

--- a/packages/vscode-webui/src/components/message/__stories__/message-list.stories.tsx
+++ b/packages/vscode-webui/src/components/message/__stories__/message-list.stories.tsx
@@ -17,6 +17,8 @@ const messages1: Message[] = [
       kind: "assistant",
       totalTokens: 46401,
       finishReason: "tool-calls",
+      totalStreamingDuration: 5_000,
+      totalToolsExecutionDuration: 5_000,
     },
     role: "assistant",
     parts: [
@@ -264,6 +266,7 @@ export const Messages1: Story = {
     },
     isLoading: false,
     sendMessage: async () => null,
+    showLastStepDuration: true,
   },
   parameters: {
     backgrounds: { disable: true },

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -1,5 +1,6 @@
 import { Loader2, UserIcon } from "lucide-react";
 import type React from "react";
+import { useTranslation } from "react-i18next";
 
 import { ReasoningPartUI } from "@/components/reasoning-part.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -12,7 +13,7 @@ import {
 import { ToolInvocationPart } from "@/features/tools";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { useLatestCheckpoint } from "@/lib/hooks/use-latest-checkpoint";
-import { cn } from "@/lib/utils";
+import { cn, formatExecutionDuration } from "@/lib/utils";
 import { isVSCodeEnvironment } from "@/lib/vscode";
 import { prompts } from "@getpochi/common";
 import type { ActiveSelection } from "@getpochi/common/vscode-webui-bridge";
@@ -55,6 +56,7 @@ export const MessageList: React.FC<{
   hideUserEditsActions?: boolean;
   repairMermaid?: MermaidContext["repairMermaid"];
   repairingChart?: string | null;
+  showLastStepDuration?: boolean;
 }> = ({
   messages: renderMessages,
   isLoading,
@@ -71,6 +73,7 @@ export const MessageList: React.FC<{
   hideUserEditsActions,
   repairMermaid,
   repairingChart,
+  showLastStepDuration,
 }) => {
   const [debouncedIsLoading, setDebouncedIsLoading] = useDebounceState(
     isLoading,
@@ -186,7 +189,7 @@ export const MessageList: React.FC<{
                 <UserAttachments message={m} />
                 <UserActiveSelections message={m} />
               </div>
-              {messageIndex < renderMessages.length - 1 && (
+              {messageIndex < renderMessages.length - 1 ? (
                 <SeparatorWithCheckpoint
                   messageIndex={messageIndex}
                   message={m}
@@ -197,6 +200,13 @@ export const MessageList: React.FC<{
                   latestCheckpoint={latestCheckpoint}
                   lastCheckpointInMessage={lastCheckpointInMessage}
                 />
+              ) : (
+                showLastStepDuration &&
+                !(isLoading || isExecuting) && (
+                  <OptionalSeparatorWithExecutionDuration
+                    duration={computeExecutionDuration(m)}
+                  />
+                )
               )}
             </div>
           ))}
@@ -459,6 +469,7 @@ const SeparatorWithCheckpoint: React.FC<{
 
   const compactPart = findCompactPart(checkpointMessage);
   const lastPart = checkpointMessage.parts.at(-1);
+  const executionDuration = computeExecutionDuration(message);
 
   if (
     lastPart &&
@@ -480,6 +491,7 @@ const SeparatorWithCheckpoint: React.FC<{
           }
           compactPart={compactPart}
           compactMessageId={checkpointMessage.id}
+          executionDuration={executionDuration}
         />
       </div>
     );
@@ -496,7 +508,30 @@ const SeparatorWithCheckpoint: React.FC<{
     );
   }
 
+  if (executionDuration) {
+    return (
+      <OptionalSeparatorWithExecutionDuration duration={executionDuration} />
+    );
+  }
+
   return sep;
+};
+
+const OptionalSeparatorWithExecutionDuration: React.FC<{
+  duration: number | undefined;
+}> = ({ duration }) => {
+  const { t } = useTranslation();
+  if (duration == null) return null;
+  const label = t("messageList.completedIn", {
+    duration: formatExecutionDuration(duration),
+  });
+  return (
+    <div className="mt-1 mb-2 flex items-center gap-2 text-muted-foreground/60 text-xs">
+      <div className="flex-1 border-border border-t" />
+      <span>{label}</span>
+      <div className="flex-1 border-border border-t" />
+    </div>
+  );
 };
 
 export interface ToolCallCheckpoint {
@@ -589,4 +624,12 @@ function buildUserEditsCheckpoints(messages: Message[]) {
   }
 
   return userEditsCheckpoints;
+}
+
+function computeExecutionDuration(message: Message) {
+  return message.metadata?.kind === "assistant" &&
+    message.metadata.totalStreamingDuration !== undefined
+    ? message.metadata.totalStreamingDuration +
+        (message.metadata.totalToolsExecutionDuration ?? 0)
+    : undefined;
 }

--- a/packages/vscode-webui/src/features/approval/components/approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/approval-button.tsx
@@ -15,6 +15,8 @@ interface ApprovalButtonProps {
   isSubTask: boolean;
   task?: Task;
   subtask?: SubtaskInfo;
+  onToolsExecutionStarted?: () => void;
+  onToolsExecutionEnded?: () => void;
 }
 
 export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
@@ -24,6 +26,8 @@ export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
   retry,
   isSubTask,
   subtask,
+  onToolsExecutionStarted,
+  onToolsExecutionEnded,
 }) => {
   const shouldShowApprovalButton = pendingApproval && allowAddToolResult;
 
@@ -51,6 +55,8 @@ export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
           isSubTask={isSubTask}
           parentUid={task?.parentId ?? undefined}
           subtask={subtask}
+          onToolsExecutionStarted={onToolsExecutionStarted}
+          onToolsExecutionEnded={onToolsExecutionEnded}
         />
       )}
     </div>

--- a/packages/vscode-webui/src/features/approval/components/tool-call-approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/tool-call-approval-button.tsx
@@ -31,6 +31,8 @@ interface ToolCallApprovalButtonProps {
   taskId?: string;
   parentUid?: string;
   subtask?: SubtaskInfo;
+  onToolsExecutionStarted?: () => void;
+  onToolsExecutionEnded?: () => void;
 }
 
 // Component
@@ -40,6 +42,8 @@ export const ToolCallApprovalButton: React.FC<ToolCallApprovalButtonProps> = ({
   isSubTask,
   parentUid,
   subtask,
+  onToolsExecutionStarted,
+  onToolsExecutionEnded,
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -163,7 +167,13 @@ export const ToolCallApprovalButton: React.FC<ToolCallApprovalButtonProps> = ({
     }
 
     if (taskId) {
-      batchExecuteManager.processQueue(taskId);
+      const promise = batchExecuteManager.processQueue(taskId);
+      if (promise) {
+        onToolsExecutionStarted?.();
+        promise.catch(/*ignore*/).then(() => {
+          onToolsExecutionEnded?.();
+        });
+      }
     }
   }, [
     tools,
@@ -177,6 +187,8 @@ export const ToolCallApprovalButton: React.FC<ToolCallApprovalButtonProps> = ({
     builtinSubAgentInfo,
     toolPolicies,
     batchExecuteManager,
+    onToolsExecutionStarted,
+    onToolsExecutionEnded,
   ]);
 
   const onReject = useCallback(() => {

--- a/packages/vscode-webui/src/features/chat/components/chat-area.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.tsx
@@ -17,6 +17,7 @@ interface ChatAreaProps {
   isSubTask?: boolean;
   repairMermaid?: MermaidContext["repairMermaid"];
   repairingChart?: string | null;
+  showLastStepDuration?: boolean;
 }
 
 export function ChatArea({
@@ -31,6 +32,7 @@ export function ChatArea({
   isSubTask,
   repairMermaid,
   repairingChart,
+  showLastStepDuration,
 }: ChatAreaProps) {
   const resourceUri = useResourceURI();
   return (
@@ -54,6 +56,7 @@ export function ChatArea({
         isSubTask={isSubTask}
         repairMermaid={repairMermaid}
         repairingChart={repairingChart}
+        showLastStepDuration={showLastStepDuration}
       />
     </>
   );

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -87,6 +87,8 @@ interface ChatToolbarProps {
   isRepairingMermaid?: boolean;
   mcpConfigOverride?: McpConfigOverride;
   getSystemPrompt?: () => string | undefined;
+  onToolsExecutionStarted?: () => void;
+  onToolsExecutionEnded?: () => void;
 }
 
 export const ChatToolbar: React.FC<ChatToolbarProps> = ({
@@ -109,6 +111,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   isRepairingMermaid = false,
   mcpConfigOverride,
   getSystemPrompt,
+  onToolsExecutionStarted,
+  onToolsExecutionEnded,
 }) => {
   const { t } = useTranslation();
 
@@ -311,6 +315,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             isSubTask={isSubTask}
             task={task}
             subtask={subtask}
+            onToolsExecutionStarted={onToolsExecutionStarted}
+            onToolsExecutionEnded={onToolsExecutionEnded}
           />
           {showRenderWidgetFixButton ? (
             <div className="flex select-none gap-3 [&>button]:flex-1 [&>button]:rounded-sm">

--- a/packages/vscode-webui/src/features/chat/lib/batch-execute-manager.ts
+++ b/packages/vscode-webui/src/features/chat/lib/batch-execute-manager.ts
@@ -26,7 +26,7 @@ export class BatchExecuteManager {
 
   /** Start processing the queue for `taskId`. */
   processQueue(taskId: string) {
-    this.queues.get(taskId)?.start();
+    return this.queues.get(taskId)?.start();
   }
 
   /** Abort queued tool calls for `taskId` by clearing pending items that have not started yet. */

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -460,6 +460,7 @@ function Chat({ user, uid, info }: ChatProps) {
         isSubTask={isSubTask}
         repairMermaid={repairMermaid}
         repairingChart={repairingChart}
+        showLastStepDuration={task?.status === "completed"}
       />
       <div className={ChatToolbarContainerClassName}>
         <ChatToolbar
@@ -482,6 +483,8 @@ function Chat({ user, uid, info }: ChatProps) {
           isRepairingMermaid={!!repairingChart}
           mcpConfigOverride={mcpConfigOverride}
           getSystemPrompt={() => chatKit.latestSystemPrompt}
+          onToolsExecutionStarted={chatKit.markStartToolsExecution}
+          onToolsExecutionEnded={chatKit.markEndToolsExecution}
         />
       </div>
       <BackgroundTaskDebugPanel />

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -429,7 +429,8 @@
     "disableLineWrap": "Disable Line Wrap"
   },
   "messageList": {
-    "compactedConversationTooltip": "Conversation has been compacted from this point onward to reduce token usage"
+    "compactedConversationTooltip": "Conversation has been compacted from this point onward to reduce token usage",
+    "completedIn": "Completed in {{duration}}"
   },
   "markdown": {
     "codeOmitted": "... {{language}} code omitted ( {{bytes}} bytes ) ..."

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -423,7 +423,8 @@
     "disableLineWrap": "折り返しを無効にする"
   },
   "messageList": {
-    "compactedConversationTooltip": "トークン使用量を削減するため、この時点から会話が圧縮されています"
+    "compactedConversationTooltip": "トークン使用量を削減するため、この時点から会話が圧縮されています",
+    "completedIn": "{{duration}} で完了"
   },
   "markdown": {
     "codeOmitted": "... {{language}} コードが省略されました ( {{bytes}} バイト ) ..."

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -421,7 +421,8 @@
     "disableLineWrap": "줄 바꿈 비활성화"
   },
   "messageList": {
-    "compactedConversationTooltip": "토큰 사용량을 줄이기 위해 이 지점부터 대화가 압축되었습니다"
+    "compactedConversationTooltip": "토큰 사용량을 줄이기 위해 이 지점부터 대화가 압축되었습니다",
+    "completedIn": "{{duration}} 만에 완료"
   },
   "markdown": {
     "codeOmitted": "... {{language}} 코드 생략됨 ( {{bytes}} 바이트 ) ..."

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -421,7 +421,8 @@
     "disableLineWrap": "禁用自动换行"
   },
   "messageList": {
-    "compactedConversationTooltip": "从此处开始，对话已被压缩以减少令牌使用量"
+    "compactedConversationTooltip": "从此处开始，对话已被压缩以减少令牌使用量",
+    "completedIn": "完成于 {{duration}}"
   },
   "markdown": {
     "codeOmitted": "... {{language}} 代码已省略 ( {{bytes}} 字节 ) ..."

--- a/packages/vscode-webui/src/lib/utils.ts
+++ b/packages/vscode-webui/src/lib/utils.ts
@@ -6,3 +6,18 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const tw = String.raw;
+
+export function formatExecutionDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}h ${String(minutes).padStart(2, "0")}m ${String(seconds).padStart(2, "0")}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+  }
+  return `${seconds}s`;
+}


### PR DESCRIPTION
## Summary

- Add `totalStreamingDuration` and `totalToolsExecutionDuration` fields to `MessageMetadata` (assistant kind) to accumulate durations across multiple LLM requests within a task step
- Track streaming duration in `FlexibleChatTransport` per request, and tools execution duration in `LiveChatKit` via `markStartToolsExecution`/`markEndToolsExecution` callbacks wired to the approval button lifecycle
- Display **"Completed in \<duration\>"** label on checkpoint separators between steps and at the end of completed tasks; falls back to just the commit icon when no duration is available
- Add `formatExecutionDuration` utility (ms → `Xs`, `Xm XXs`, `Xh XXm XXs`)
- i18n: add `messageList.completedIn` key for en / zh / jp / ko

## Test plan

- [ ] Start a task with multiple tool-call steps and verify each checkpoint separator shows the correct duration
- [ ] Verify the final "Completed in …" label appears at the bottom of a completed task
- [ ] Verify no duration label appears while the task is still loading / executing
- [ ] Verify the duration accumulates correctly across retries (multiple consecutive assistant messages merged)
- [ ] Verify i18n strings render correctly in en, zh, jp, ko locales

🤖 Generated with [Pochi](https://app.getpochi.com) | [Task](https://app.getpochi.com/share/p-8f76a0e325e245468083d67f46a0b4f1)


---

Preview:

<img width="1833" height="3006" alt="Screenshot from 2026-07-13 08-10-46" src="https://github.com/user-attachments/assets/07fdc703-7b9a-426d-b580-2bfbf8bf792d" />

