### PR TITLE
feat(common): surface skill file path in useSkill tool result

### DIFF
--- a/packages/common/src/base/prompts/__tests__/skill.test.ts
+++ b/packages/common/src/base/prompts/__tests__/skill.test.ts
@@ -1,0 +1,38 @@
+import type { Skill } from "@getpochi/tools";
+import { describe, expect, it } from "vitest";
+import { createUseSkillResult } from "../skill";
+
+const baseSkill: Skill = {
+  name: "demo-skill",
+  description: "A demo skill",
+  filePath: ".pochi/skills/demo-skill/SKILL.md",
+  instructions: "Do the thing.",
+};
+
+describe("createUseSkillResult", () => {
+  it("prepends the skill file path to the result", () => {
+    const result = createUseSkillResult(baseSkill);
+    expect(result).toContain(
+      "Skill location: .pochi/skills/demo-skill/SKILL.md",
+    );
+    expect(result).toContain("Do the thing.");
+  });
+
+  it("keeps tool restriction instructions alongside the path", () => {
+    const result = createUseSkillResult({
+      ...baseSkill,
+      allowedTools: "readFile writeToFile",
+    });
+    expect(result).toContain("Skill location:");
+    expect(result).toContain(
+      "This skill is restricted to use only the following tools: readFile writeToFile",
+    );
+    expect(result).toContain("Do the thing.");
+  });
+
+  it("omits the location line when no file path is available", () => {
+    const result = createUseSkillResult({ ...baseSkill, filePath: "" });
+    expect(result).not.toContain("Skill location:");
+    expect(result).toBe("Do the thing.");
+  });
+});

--- a/packages/common/src/base/prompts/skill.ts
+++ b/packages/common/src/base/prompts/skill.ts
@@ -26,5 +26,14 @@ You must ONLY use these approved tools when executing this skill. Do not use any
 ${prompt}`;
   }
 
+  // Surface the skill's file path so the model can resolve sibling resources
+  // (scripts/, references/, assets/) relative to the skill's directory.
+  if (skill.filePath?.trim()) {
+    prompt = `Skill location: ${skill.filePath.trim()}
+Use the directory containing this file as the base directory for resolving any relative resource paths referenced in the instructions below.
+
+${prompt}`;
+  }
+
   return prompt;
 }


### PR DESCRIPTION
## Summary
- Surfaces the skill's file path in the `useSkill` tool result prompt text.
- Encourages the agent/model to resolve relative resource paths (such as `scripts/`, `references/`, `assets/`) relative to the skill's directory.
- Adds comprehensive test coverage for `createUseSkillResult` to verify path inclusion and correct fallback behavior.

## Test plan
- Run unit tests: `bun run test -- src/base/prompts/__tests__/skill.test.ts` (verified passing).
- Run typechecking and lint checks.

### Context / Background
Here is the error/issue showing why this is needed (before this change, the agent tried to read `pochi://skills/developer-updates/references/FORMAT.md` but didn't have the resolved path context):

![Pasted screenshot of the error](https://pochi-file-uploads.getpochi.com/blob-1783903543549.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260713%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260713T004544Z&X-Amz-Expires=561600&X-Amz-Signature=9cbb522918f26cf944184671cf61d06217a62ede0dc2fada2738a7c5069844a9&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a54b33c248d440c6bb95d72fc689a7ac)