### PR TITLE
fix(vscode-webui): process sub-task tool call results through processContentOutput

### DIFF
--- a/packages/vscode-webui/src/features/chat/lib/__tests__/batched-tool-call-adapters.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/batched-tool-call-adapters.test.ts
@@ -1,0 +1,122 @@
+import { blobStore } from "@/lib/remote-blob-store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSubtaskBatchedToolCall } from "../batched-tool-call-adapters";
+
+const executeToolCall = vi.fn();
+vi.mock("@/lib/vscode", () => ({
+  vscodeHost: {
+    executeToolCall: (...args: unknown[]) => executeToolCall(...args),
+  },
+}));
+
+vi.mock("@/lib/remote-blob-store", () => ({
+  blobStore: {
+    protocol: "https:",
+    put: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+const processContentOutput = vi.fn();
+vi.mock("@getpochi/livekit", () => ({
+  processContentOutput: (...args: unknown[]) => processContentOutput(...args),
+}));
+
+vi.mock("@quilted/threads", () => ({
+  ThreadAbortSignal: {
+    serialize: vi.fn(() => ({})),
+  },
+}));
+
+function makeToolCallStatusRegistry() {
+  return { set: vi.fn() } as unknown as Parameters<
+    typeof createSubtaskBatchedToolCall
+  >[0]["toolCallStatusRegistry"];
+}
+
+describe("createSubtaskBatchedToolCall", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // By default, pass the raw result through unchanged.
+    processContentOutput.mockImplementation(async (_blobStore, result) => result);
+  });
+
+  it("routes media readFile output through processContentOutput before adding tool output (regression)", async () => {
+    // Regression: sub-agent readFile results with base64 media data must be
+    // processed via processContentOutput into a blob url, otherwise the
+    // downstream toModelOutput fails with "Failed to load media.".
+    const rawResult = {
+      type: "media",
+      data: btoa("fake-image-bytes"),
+      mimeType: "image/png",
+    };
+    const processedResult = {
+      type: "media",
+      data: "https://blob.example/generated-blob",
+      mimeType: "image/png",
+    };
+    executeToolCall.mockResolvedValue(rawResult);
+    processContentOutput.mockResolvedValue(processedResult);
+
+    const addToolOutput = vi.fn();
+    const abortSignal = new AbortController().signal;
+
+    const batched = createSubtaskBatchedToolCall({
+      toolCall: {
+        toolName: "readFile",
+        toolCallId: "tool-call-1",
+        input: { path: "image.png" },
+      } as never,
+      uid: "subtask-1",
+      storeId: "store-1",
+      abortSignal,
+      contentType: ["image/png"],
+      addToolOutput,
+      toolCallStatusRegistry: makeToolCallStatusRegistry(),
+    });
+
+    const result = await batched.run();
+
+    expect(result).toEqual({ kind: "success" });
+    expect(processContentOutput).toHaveBeenCalledWith(
+      blobStore,
+      rawResult,
+      abortSignal,
+    );
+    expect(addToolOutput).toHaveBeenCalledWith({
+      tool: "readFile",
+      toolCallId: "tool-call-1",
+      output: processedResult,
+    });
+  });
+
+  it("still stores non-media results after processing", async () => {
+    const textResult = { content: "hello world", isTruncated: false };
+    executeToolCall.mockResolvedValue(textResult);
+
+    const addToolOutput = vi.fn();
+
+    const batched = createSubtaskBatchedToolCall({
+      toolCall: {
+        toolName: "readFile",
+        toolCallId: "tool-call-2",
+        input: { path: "notes.txt" },
+      } as never,
+      uid: "subtask-1",
+      storeId: "store-1",
+      abortSignal: new AbortController().signal,
+      addToolOutput,
+      toolCallStatusRegistry: makeToolCallStatusRegistry(),
+    });
+
+    const result = await batched.run();
+
+    expect(result).toEqual({ kind: "success" });
+    expect(processContentOutput).toHaveBeenCalledOnce();
+    expect(addToolOutput).toHaveBeenCalledWith({
+      tool: "readFile",
+      toolCallId: "tool-call-2",
+      output: textResult,
+    });
+  });
+});

--- a/packages/vscode-webui/src/features/chat/lib/batched-tool-call-adapters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/batched-tool-call-adapters.ts
@@ -1,3 +1,4 @@
+import { blobStore } from "@/lib/remote-blob-store";
 import {
   getToolCallErrorMessage,
   getToolResultError,
@@ -8,6 +9,7 @@ import type {
   BuiltinSubAgentInfo,
   ExecuteCommandResult,
 } from "@getpochi/common/vscode-webui-bridge";
+import { processContentOutput } from "@getpochi/livekit";
 import type { useLiveChatKit } from "@getpochi/livekit/react";
 import type {
   BatchedToolCall,
@@ -240,13 +242,19 @@ export function createSubtaskBatchedToolCall({
           isExecuting: false,
         });
 
+        const processedResult = await processContentOutput(
+          blobStore,
+          result,
+          abortSignal,
+        );
+
         addToolOutput({
           tool: toolCall.toolName,
           toolCallId: toolCall.toolCallId,
-          output: result,
+          output: processedResult,
         });
 
-        const error = getToolResultError(result);
+        const error = getToolResultError(processedResult);
         if (error) {
           return {
             kind: "error",


### PR DESCRIPTION
## Summary
- Run sub-task tool call results through `processContentOutput` before adding them to tool output in `createSubtaskBatchedToolCall`.
- This ensures that image/media outputs from tools like `readFile` run by sub-agents (e.g. browser, explore) are correctly processed into blob store URLs instead of remaining as raw base64 data, preventing "Failed to load media" errors downstream.

## Test plan
- Verify that using the browser agent or explore agent to read an image file via `readFile` correctly displays the image inside the webview instead of failing with "Failed to load media.".

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ef0bb989351445c58a6d53f7e1820db8)