### PR TITLE
fix(vscode): support pochi:// virtual paths in applyDiff

### DIFF
--- a/packages/vscode/src/tools/apply-diff.ts
+++ b/packages/vscode/src/tools/apply-diff.ts
@@ -3,6 +3,7 @@ import { getLogger } from "@/lib/logger";
 import { writeTextDocument } from "@/lib/write-text-document";
 import { parseDiffAndApply } from "@getpochi/common/diff-utils";
 import {
+  isVirtualPath,
   validateTextFile,
   withFileStateCacheGuard,
 } from "@getpochi/common/tool-utils";
@@ -24,8 +25,13 @@ export const applyDiff: ToolFunctionType<ClientTools["applyDiff"]> = async (
     getMtime: getVscodeFileMtime,
     operation: "editing",
     doWork: async (resolvedPath) => {
-      const fileUri = vscode.Uri.file(resolvedPath);
-      await ensureFileDirectoryExists(fileUri);
+      const isVirtual = isVirtualPath(resolvedPath);
+      const fileUri = isVirtual
+        ? vscode.Uri.parse(resolvedPath)
+        : vscode.Uri.file(resolvedPath);
+      if (!isVirtual) {
+        await ensureFileDirectoryExists(fileUri);
+      }
 
       const fileBuffer = await vscode.workspace.fs.readFile(fileUri);
       validateTextFile(fileBuffer);


### PR DESCRIPTION
## Summary
- Fixes `applyDiff` tool in VSCode so it handles `pochi://` URIs correctly.
- Parses virtual paths with `vscode.Uri.parse` and skips unconditional local directory creation.

## Test plan
- Verified that `applyDiff` on `pochi://-/plan.md` no longer throws `EROFS: read-only file system, mkdir '/pochi:'`.
- Ran `bun tsc` inside `packages/vscode` to ensure types compile cleanly.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-efdaf41027a942d196e45474f7372d7d)