### PR TITLE
feat(vscode): support reading output of any currently-opened user terminal

### DIFF
--- a/packages/common/src/base/environment.ts
+++ b/packages/common/src/base/environment.ts
@@ -59,7 +59,7 @@ export const Environment = z.object({
               .string()
               .optional()
               .describe(
-                "The ID of the background job associated with the terminal.",
+                'A stable id for the terminal. Pass it to `readBackgroundJobOutput` to read the terminal\'s most recent command output. Ids prefixed with "bgjob-" are Pochi-started background jobs and can also be killed with `killBackgroundJob`; ids prefixed with "term-" are user-opened terminals and are read-only.',
               ),
           }),
         )

--- a/packages/common/src/base/prompts/__tests__/__snapshots__/prompt.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/prompt.test.ts.snap
@@ -20,9 +20,12 @@ tsconfig.json
 package.json
 
 # Opened Terminals in Editor
+You can read a terminal's most recent command output by calling \`readBackgroundJobOutput\` with its id.
+- Ids prefixed with "bgjob-" are Pochi-started background jobs (can be read and killed with \`killBackgroundJob\`).
+- Ids prefixed with "term-" are user-opened terminals (read-only; cannot be killed).
 * Terminal 1 (selected)
   Terminal 2
-  Terminal 3 (background job: job-id-1)
+  Terminal 3 (id: job-id-1)
 
 # GIT STATUS
 Origin: https://github.com/username/repo.git

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -155,10 +155,12 @@ function getVisibleTerminals(workspace: Environment["workspace"]) {
   if (terminals.length === 0) {
     return "";
   }
-  return `# Opened Terminals in Editor\n${terminals
+  const header =
+    '# Opened Terminals in Editor\nYou can read a terminal\'s most recent command output by calling `readBackgroundJobOutput` with its id.\n- Ids prefixed with "bgjob-" are Pochi-started background jobs (can be read and killed with `killBackgroundJob`).\n- Ids prefixed with "term-" are user-opened terminals (read-only; cannot be killed).';
+  return `${header}\n${terminals
     .map(
       (t) =>
-        `${t.isActive ? "* " : "  "}${t.name}${t.isActive ? " (selected)" : ""}${t.backgroundJobId ? ` (background job: ${t.backgroundJobId})` : ""}`,
+        `${t.isActive ? "* " : "  "}${t.name}${t.isActive ? " (selected)" : ""}${t.backgroundJobId ? ` (id: ${t.backgroundJobId})` : ""}`,
     )
     .join("\n")}`;
 }

--- a/packages/vscode-webui/src/features/tools/components/read-background-job-output.tsx
+++ b/packages/vscode-webui/src/features/tools/components/read-background-job-output.tsx
@@ -9,13 +9,16 @@ export const ReadBackgroundJobOutputTool: React.FC<
   ToolProps<"readBackgroundJobOutput">
 > = ({ tool, isExecuting }) => {
   const { t } = useTranslation();
-  const { regex } = tool.input || {};
-  const backgroundJobId =
-    tool.state !== "input-streaming" ? tool.input?.backgroundJobId : undefined;
+  const { backgroundJobId, regex } = tool.input || {};
+  const isUserTerminal = backgroundJobId?.startsWith("term-");
   const title = (
     <>
       <StatusIcon isExecuting={isExecuting} tool={tool} />
-      <span className="ml-2">{t("toolInvocation.readBackground")}</span>
+      <span className="ml-2">
+        {isUserTerminal
+          ? t("toolInvocation.readTerminal")
+          : t("toolInvocation.readBackground")}
+      </span>
       {regex && (
         <>
           {" "}
@@ -26,13 +29,16 @@ export const ReadBackgroundJobOutputTool: React.FC<
     </>
   );
 
+  const finalJobId =
+    tool.state !== "input-streaming" ? backgroundJobId : undefined;
+
   return (
     <ExpandableToolContainer
       title={title}
       detail={
-        backgroundJobId ? (
+        finalJobId ? (
           <BackgroundJobPanel
-            backgroundJobId={backgroundJobId}
+            backgroundJobId={finalJobId}
             output={tool.output?.output}
           />
         ) : null

--- a/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
@@ -220,10 +220,15 @@ const ReadBackgroundJobTool = ({
   tool,
 }: ToolCallLiteViewProps<"readBackgroundJobOutput">) => {
   const { t } = useTranslation();
-  const { regex } = tool.input || {};
+  const { backgroundJobId, regex } = tool.input || {};
+  const isUserTerminal = backgroundJobId?.startsWith("term-");
   return (
     <>
-      <span className="ml-2">{t("toolInvocation.readBackground")}</span>
+      <span className="ml-2">
+        {isUserTerminal
+          ? t("toolInvocation.readTerminal")
+          : t("toolInvocation.readBackground")}
+      </span>
       {regex && (
         <>
           {" "}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -352,6 +352,7 @@
     "result_one": "{{count}} result",
     "result_other": "{{count}} results",
     "readBackground": "Reading background job output",
+    "readTerminal": "Reading terminal output",
     "withRegexFilter": "with regex filter",
     "backgroundExecute": "I will execute the following command in the background",
     "backgroundExecuting": "Executing command in background",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -348,6 +348,7 @@
     "result_one": "{{count}}件の結果",
     "result_other": "{{count}}件の結果",
     "readBackground": "バックグラウンドジョブ出力を読み込み中",
+    "readTerminal": "ターミナル出力を読み込み中",
     "withRegexFilter": "正規表現フィルター付き",
     "backgroundExecute": "以下のコマンドをバックグラウンドで実行します",
     "backgroundExecuting": "バックグラウンドでコマンドを実行中",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -346,6 +346,7 @@
     "result_one": "{{count}}개 결과",
     "result_other": "{{count}}개 결과",
     "readBackground": "백그라운드 작업 출력 읽는 중",
+    "readTerminal": "터미널 출력 읽는 중",
     "withRegexFilter": "정규식 필터 사용",
     "backgroundExecute": "다음 명령을 백그라운드에서 실행합니다",
     "backgroundExecuting": "백그라운드에서 명령 실행 중",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -346,6 +346,7 @@
     "result_one": "{{count}}个结果",
     "result_other": "{{count}}个结果",
     "readBackground": "正在读取后台任务输出",
+    "readTerminal": "正在读取终端输出",
     "withRegexFilter": "使用正则表达式过滤器",
     "backgroundExecute": "我将在后台执行以下命令",
     "backgroundExecuting": "正在后台执行命令",

--- a/packages/vscode/src/integrations/terminal/terminal-state.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-state.ts
@@ -1,30 +1,60 @@
+import { randomUUID } from "node:crypto";
+import { getLogger } from "@/lib/logger";
 import { signal } from "@preact/signals-core";
 import { injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
+import { OutputManager } from "./output";
 import { TerminalJob } from "./terminal-job";
+import { ExecutionError } from "./utils";
+
+const logger = getLogger("TerminalState");
+
 export interface TerminalInfo {
   name: string;
   isActive: boolean;
+  /**
+   * A stable id for the terminal that can be passed to `readBackgroundJobOutput`.
+   *
+   * The prefix encodes the terminal's origin:
+   * - `bgjob-` — a Pochi-started background job. Can be read and killed.
+   * - `term-`  — a user-opened terminal. Read-only; `killBackgroundJob` refuses
+   *   these because they are not tracked by the `TerminalJob` registry.
+   */
   backgroundJobId?: string;
 }
 
 @injectable()
 @singleton()
 export class TerminalState implements vscode.Disposable {
-  // Signal containing the current active terminals
-  visibleTerminals = signal(listVisibleTerminals());
-
   private disposables: vscode.Disposable[] = [];
 
+  /**
+   * Stable ids assigned to regular (non-background-job) terminals so their
+   * shell execution output can be captured and read.
+   */
+  private readonly terminalIds = new WeakMap<vscode.Terminal, string>();
+
+  /**
+   * Maps an in-flight shell execution to the OutputManager collecting its
+   * output, so it can be finalized when the execution ends.
+   */
+  private readonly runningExecutions = new Map<
+    vscode.TerminalShellExecution,
+    OutputManager
+  >();
+
+  // Signal containing the current active terminals
+  visibleTerminals = signal<TerminalInfo[]>([]);
+
   constructor() {
+    this.visibleTerminals.value = this.listVisibleTerminals();
     this.setupEventListeners();
   }
 
   public openBackgroundJobTerminal(backgroundJobId: string) {
-    const terminal = vscode.window.terminals.find((t) => {
-      const job = TerminalJob.get(t);
-      return job?.id === backgroundJobId;
-    });
+    const terminal = vscode.window.terminals.find(
+      (t) => this.getTerminalId(t) === backgroundJobId,
+    );
     if (!terminal) return;
     terminal.show();
   }
@@ -40,17 +70,118 @@ export class TerminalState implements vscode.Disposable {
       vscode.window.onDidOpenTerminal(this.onTerminalChanged),
     );
     this.disposables.push(
-      vscode.window.onDidCloseTerminal(this.onTerminalChanged),
+      vscode.window.onDidCloseTerminal(this.onTerminalClosed),
     );
     this.disposables.push(TerminalJob.onDidDispose(this.onTerminalChanged));
+
+    // Capture output from shell executions in regular terminals so the model
+    // can read them via `readBackgroundJobOutput`. Background job terminals
+    // capture their own output and are skipped here.
+    this.disposables.push(
+      vscode.window.onDidStartTerminalShellExecution(
+        this.onShellExecutionStart,
+      ),
+    );
+    this.disposables.push(
+      vscode.window.onDidEndTerminalShellExecution(this.onShellExecutionEnd),
+    );
   }
 
   /**
    * Update the active terminals signal when terminals change
    */
   private onTerminalChanged = () => {
-    this.visibleTerminals.value = listVisibleTerminals();
+    this.visibleTerminals.value = this.listVisibleTerminals();
   };
+
+  private onTerminalClosed = (terminal: vscode.Terminal) => {
+    const id = this.terminalIds.get(terminal);
+    if (id) {
+      OutputManager.delete(id);
+    }
+    this.onTerminalChanged();
+  };
+
+  private onShellExecutionStart = (
+    event: vscode.TerminalShellExecutionStartEvent,
+  ) => {
+    // Background job terminals are handled by their own TerminalJob.
+    if (TerminalJob.get(event.terminal)) {
+      return;
+    }
+
+    const id = this.getTerminalId(event.terminal);
+    // Start a fresh capture for this execution so a read returns the output of
+    // the most recent command run in the terminal.
+    const outputManager = OutputManager.create({
+      id,
+      command: event.execution.commandLine.value,
+    });
+    this.runningExecutions.set(event.execution, outputManager);
+    this.captureExecutionOutput(event.execution, outputManager);
+    // Reflect the newly readable terminal in the environment.
+    this.onTerminalChanged();
+  };
+
+  private onShellExecutionEnd = (
+    event: vscode.TerminalShellExecutionEndEvent,
+  ) => {
+    const outputManager = this.runningExecutions.get(event.execution);
+    if (!outputManager) return;
+    this.runningExecutions.delete(event.execution);
+
+    const error =
+      event.exitCode === undefined || event.exitCode === 0
+        ? undefined
+        : ExecutionError.create(`Command exited with code ${event.exitCode}.`);
+    outputManager.finalize(error);
+  };
+
+  private async captureExecutionOutput(
+    execution: vscode.TerminalShellExecution,
+    outputManager: OutputManager,
+  ): Promise<void> {
+    try {
+      for await (const chunk of execution.read()) {
+        outputManager.addChunk(chunk);
+      }
+    } catch (error) {
+      logger.debug(`Failed to read terminal shell execution output: ${error}`);
+    }
+  }
+
+  /**
+   * Resolves a stable id for a terminal. Background job terminals use their job
+   * id; regular terminals are assigned a `bgjob-` id lazily.
+   */
+  private getTerminalId(terminal: vscode.Terminal): string {
+    const job = TerminalJob.get(terminal);
+    if (job) return job.id;
+
+    let id = this.terminalIds.get(terminal);
+    if (!id) {
+      // `term-` distinguishes user-opened terminals from Pochi background jobs
+      // (`bgjob-`), which cannot be killed via `killBackgroundJob`.
+      id = `term-${randomUUID()}`;
+      this.terminalIds.set(terminal, id);
+    }
+    return id;
+  }
+
+  private listVisibleTerminals(): TerminalInfo[] {
+    return vscode.window.terminals
+      .filter((t) => {
+        if ("hideFromUser" in t.creationOptions) {
+          return !t.creationOptions.hideFromUser;
+        }
+        return true;
+      })
+      .map((t) => ({
+        name: t.name || "Unnamed Terminal",
+        isActive: t === vscode.window.activeTerminal,
+        backgroundJobId: this.getTerminalId(t),
+      }));
+  }
 
   /**
    * Release all resources held by this class
@@ -61,19 +192,4 @@ export class TerminalState implements vscode.Disposable {
     }
     this.disposables = [];
   }
-}
-
-function listVisibleTerminals(): TerminalInfo[] {
-  return vscode.window.terminals
-    .filter((t) => {
-      if ("hideFromUser" in t.creationOptions) {
-        return !t.creationOptions.hideFromUser;
-      }
-      return true;
-    })
-    .map((t) => ({
-      name: t.name || "Unnamed Terminal",
-      isActive: t === vscode.window.activeTerminal,
-      backgroundJobId: TerminalJob.get(t)?.id,
-    }));
 }

--- a/packages/vscode/src/tools/__test__/read-background-job-output.test.ts
+++ b/packages/vscode/src/tools/__test__/read-background-job-output.test.ts
@@ -1,0 +1,83 @@
+import * as assert from "node:assert";
+import { afterEach, describe, it } from "mocha";
+import { OutputManager } from "../../integrations/terminal/output";
+
+/**
+ * `readBackgroundJobOutput` resolves output through the shared `OutputManager`
+ * registry keyed by a terminal id. Background jobs and (newly) user-opened
+ * terminals both register their output here, which is what allows the model to
+ * read any terminal by id. These tests cover that registry contract directly
+ * (importing the tool itself pulls in the webview/layout module chain, which is
+ * not available in the unit test host).
+ */
+describe("OutputManager registry (readBackgroundJobOutput backing store)", () => {
+  const createdIds: string[] = [];
+
+  const track = (id: string) => {
+    createdIds.push(id);
+    return id;
+  };
+
+  afterEach(() => {
+    for (const id of createdIds) {
+      OutputManager.delete(id);
+    }
+    createdIds.length = 0;
+  });
+
+  it("captures and returns output for a background job id", () => {
+    const id = track("bgjob-read-test");
+    const manager = OutputManager.create({ id, command: "echo hello" });
+    manager.addChunk("hello world\n");
+    manager.finalize();
+
+    const found = OutputManager.get(id);
+    assert.ok(found, "manager should be retrievable by id");
+
+    const result = found.readOutput();
+    assert.ok(
+      result.output.includes("hello world"),
+      `expected captured output, got: ${JSON.stringify(result)}`,
+    );
+    assert.strictEqual(result.status, "completed");
+  });
+
+  it("captures and returns output for a user-opened terminal id (term- prefix)", () => {
+    const id = track("term-read-test");
+    const manager = OutputManager.create({ id, command: "ls" });
+    manager.addChunk("file-a file-b\n");
+    manager.finalize();
+
+    const result = OutputManager.get(id)?.readOutput();
+    assert.ok(result?.output.includes("file-a"), "expected captured output");
+  });
+
+  it("returns only new output since the last read", () => {
+    const id = track("bgjob-incremental");
+    const manager = OutputManager.create({ id, command: "run" });
+
+    manager.addChunk("first\n");
+    assert.ok(manager.readOutput().output.includes("first"));
+
+    manager.addChunk("second\n");
+    const second = manager.readOutput();
+    assert.ok(second.output.includes("second"));
+    assert.ok(
+      !second.output.includes("first"),
+      "already-read output should not be returned again",
+    );
+  });
+
+  it("is unresolvable once deleted (e.g. terminal closed)", () => {
+    const id = "bgjob-closed-terminal";
+    OutputManager.create({ id, command: "ls" });
+    assert.ok(OutputManager.get(id));
+
+    OutputManager.delete(id);
+    assert.strictEqual(
+      OutputManager.get(id),
+      undefined,
+      "a closed terminal's output should no longer be readable",
+    );
+  });
+});

--- a/packages/vscode/src/tools/kill-background-job.ts
+++ b/packages/vscode/src/tools/kill-background-job.ts
@@ -6,6 +6,11 @@ export const killBackgroundJob: ToolFunctionType<
 > = async ({ backgroundJobId }) => {
   const job = TerminalJob.get(backgroundJobId);
   if (!job) {
+    if (backgroundJobId.startsWith("term-")) {
+      throw new Error(
+        `"${backgroundJobId}" is a user-opened terminal and cannot be killed. Only terminals started by startBackgroundJob (ids prefixed with "bgjob-") can be killed.`,
+      );
+    }
     throw new Error(`Background job with ID "${backgroundJobId}" not found.`);
   }
 

--- a/packages/vscode/src/tools/read-background-job-output.ts
+++ b/packages/vscode/src/tools/read-background-job-output.ts
@@ -20,8 +20,13 @@ export const readBackgroundJobOutput: ToolFunctionType<
     };
   }
 
-  if (backgroundJobId.startsWith("bgjob-")) {
-    throw new Error(`Background job with ID "${backgroundJobId}" not found.`);
+  if (
+    backgroundJobId.startsWith("bgjob-") ||
+    backgroundJobId.startsWith("term-")
+  ) {
+    throw new Error(
+      `No output available for terminal/background job "${backgroundJobId}". It may have been closed, no command has run in it yet, or shell integration is not active for it.`,
+    );
   }
 
   const taskOutput = await readTaskOutput(backgroundJobId);


### PR DESCRIPTION
## Summary
- **Lazily assign stable ids with `term-` prefix** to user-opened terminals, keeping them distinct from Pochi-started background jobs (which use `bgjob-`).
- **Global shell-execution capture**: Capture output from user-opened terminals using the global `onDidStartTerminalShellExecution` event, pumping output into the existing `OutputManager` registry while skipping background-job terminals.
- **Environment prompt**: Surface the new terminal IDs and add hints so the model knows it can call `readBackgroundJobOutput` with the terminal's ID.
- **Safety invariant**: Ensure `killBackgroundJob` only resolves `bgjob-` IDs, preventing user-opened terminals from ever being killed.

## Test plan
- Added unit tests in `packages/vscode/src/tools/__test__/read-background-job-output.test.ts` to verify `OutputManager` registry reads, incremental reads, and deletion on terminal close.
- Verified snapshot test in `packages/common/src/base/prompts/__tests__/prompt.test.ts` passes after formatting updates.
- Verified typechecks (`bun tsc`) and format checks run clean.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4b808fa581444d4ca83ff628519e5274)