### PR TITLE
fix(common): keep last message id when merging consecutive assistant messages

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -80,6 +80,41 @@ describe('formatters', () => {
       expect(assistantMessages[0].parts).toHaveLength(4); // reasoning, text, tool1, tool2
     });
 
+    it('should keep the last message id when combining consecutive assistant messages', () => {
+      const formatted = formatters.ui(clone(baseMessages));
+      const assistantMessages = formatted.filter((m) => m.role === 'assistant');
+      expect(assistantMessages).toHaveLength(1);
+      // The surviving message must carry the id of the last (most recent)
+      // assistant message so that fork truncation and checkpoint tracking
+      // reference the correct DB record.
+      expect(assistantMessages[0].id).toBe('assistant-2');
+    });
+
+    it('should keep the last message id when combining three or more consecutive assistant messages', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-a',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'first' }],
+        },
+        {
+          id: 'assistant-b',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'second' }],
+        },
+        {
+          id: 'assistant-c',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'third' }],
+        },
+      ];
+      const formatted = formatters.ui(clone(messages));
+      expect(formatted).toHaveLength(1);
+      expect(formatted[0].id).toBe('assistant-c');
+      const textParts = formatted[0].parts.filter((p) => p.type === 'text');
+      expect(textParts.map((p) => (p as any).text)).toEqual(['first', 'second', 'third']);
+    });
+
     it('should remove empty reasoning parts with provider metadata', () => {
       const messages: UIMessage[] = [
         {

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -132,8 +132,8 @@ function combineConsecutiveAssistantMessages(
       messages[i].role === "assistant" &&
       messages[i + 1].role === "assistant"
     ) {
-      messages[i].parts.push(...messages[i + 1].parts);
-      messages.splice(i + 1, 1);
+      messages[i + 1].parts.unshift(...messages[i].parts);
+      messages.splice(i, 1);
       i--;
     }
   }
@@ -168,8 +168,8 @@ function combineConsecutiveAssistantMessages(
       messages[i].role === "assistant" &&
       messages[i + 1].role === "assistant"
     ) {
-      messages[i].parts.push(...messages[i + 1].parts);
-      messages.splice(i + 1, 1);
+      messages[i + 1].parts.unshift(...messages[i].parts);
+      messages.splice(i, 1);
       i--;
     }
   }


### PR DESCRIPTION
## Summary

- When combining consecutive assistant messages in `combineConsecutiveAssistantMessages`, the **last** (most recent) message's `id` now survives the merge instead of the first's. Part order is preserved correctly via `unshift`.
- This ensures `truncateMessages` in `fork-task-tools.ts` receives the correct DB message `id` for fork checkpoint truncation, and that `pendingMessageId` tracking in the CLI renderer is anchored to the most recently created assistant message.
- Adds two unit tests that lock in the surviving-id semantics for the two-message and three-or-more-message cases.

## Test plan

- [x] Run `bun run test` in `packages/common` — all 546 tests pass including the 2 new ones
- [ ] Verify fork-from-checkpoint flow works end-to-end in the UI

🤖 Generated with [Pochi](https://app.getpochi.com/share/p-e0adc33981354c6f888d1d43b122bc8a) | [Task](https://app.getpochi.com/share/p-e0adc33981354c6f888d1d43b122bc8a)