### PR TITLE
feat(memory): keep extracting project memory when injection is disabled

### DIFF
--- a/packages/common/src/base/memory.ts
+++ b/packages/common/src/base/memory.ts
@@ -61,8 +61,9 @@ export interface AutoMemoryReadContextOptions {
   ensure?: boolean;
   /**
    * When true, bypass the user's Project Memory enabled preference and
-   * return the context regardless. Used by UI surfaces that need to
-   * surface the memory index file even when the feature is disabled.
+   * return the context regardless. Used by UI surfaces that need to surface
+   * the memory index file, and by background extraction which keeps running
+   * even when memory injection is disabled.
    */
   force?: boolean;
 }

--- a/packages/livekit/src/background-task/memory/__tests__/adaptors.test.ts
+++ b/packages/livekit/src/background-task/memory/__tests__/adaptors.test.ts
@@ -268,6 +268,49 @@ describe("auto-memory adaptor", () => {
     });
   });
 
+  it("reads context with force so extraction runs while injection is disabled", async () => {
+    const store = new FakeStore([
+      makeTask({
+        id: "parent",
+        status: "completed",
+        background: false,
+        title: "Build shared runner",
+      }),
+    ]);
+    // Simulate the host gating injection: readContext only resolves when the
+    // caller explicitly bypasses the enabled preference via `force`.
+    const readContext = vi.fn(
+      async (cwdOrOptions?: string | { force?: boolean }) => {
+        const force =
+          typeof cwdOrOptions === "object" ? cwdOrOptions?.force : false;
+        return force ? autoMemoryContext : undefined;
+      },
+    );
+    const manager = makeAutoMemoryManager({ readContext });
+    const adaptor = new AutoMemoryAdaptor({
+      store: store as unknown as LiveKitStore,
+      backgroundTask: createTestBackgroundTask({
+        store: store as unknown as LiveKitStore,
+        stateStore: new BackgroundTaskStateStore(),
+      }),
+      parentTaskId: "parent",
+      parentCwd: "/repo",
+      manager,
+    });
+
+    await expect(
+      adaptor.update({
+        messages: makeParentMessages(),
+        status: "completed",
+      }),
+    ).resolves.toBe(true);
+
+    expect(readContext).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/repo", force: true }),
+    );
+    expect(store.backgroundTasks()).toHaveLength(1);
+  });
+
   it("records direct memory writes without starting extraction", async () => {
     const store = new FakeStore([
       makeTask({

--- a/packages/livekit/src/background-task/memory/auto-memory.ts
+++ b/packages/livekit/src/background-task/memory/auto-memory.ts
@@ -441,7 +441,12 @@ export class AutoMemoryAdaptor {
 
     try {
       const parentCwd = this.getParentCwd();
-      const context = await this.options.manager.readContext(parentCwd);
+      // Extraction keeps running even when Project Memory injection is
+      // disabled, so bypass the enabled preference when reading context.
+      const context = await this.options.manager.readContext({
+        cwd: parentCwd,
+        force: true,
+      });
       if (!context) return false;
 
       const state = this.getState();

--- a/packages/vscode/src/lib/auto-memory.ts
+++ b/packages/vscode/src/lib/auto-memory.ts
@@ -60,7 +60,8 @@ export class AutoMemoryManager extends BaseAutoMemoryManager {
     updatedAt?: number;
     transcript: string;
   }) {
-    if (!this.isEnabled()) return undefined;
+    // Extraction keeps running even when injection is disabled, so this is
+    // intentionally not gated by the Project Memory enabled preference.
     return this.writeTaskTranscript({
       taskId: options.taskId,
       cwd: options.cwd ?? this.cwd,
@@ -76,8 +77,8 @@ export class AutoMemoryManager extends BaseAutoMemoryManager {
     sessionUpdatedAts?: readonly number[];
     currentTranscript?: AutoMemoryDreamCandidate;
   }) {
-    if (!this.isEnabled()) return undefined;
-
+    // Dreaming is part of extraction and keeps running even when injection is
+    // disabled, so it is intentionally not gated by the enabled preference.
     const cwd = options.cwd ?? this.cwd;
     const candidates = [
       ...(await this.collectDreamCandidates(cwd)),


### PR DESCRIPTION
## Summary
- Decouple Project Memory **extraction** from the enabled preference: disabling Project Memory now only stops **prompt injection**, while background extraction, transcript writing, and dreaming keep running (VS Code only).
- The extraction adaptor reads context with `force: true` so it bypasses the enabled preference.
- The extraction-only host methods (`writeHostTaskTranscript`, `beginHostDreamRun`) no longer gate on the enabled preference. `readHostContext` keeps its gate so injection callers (webui getters, `VscodeRunningTaskAdaptor`) stay disabled — no memory injection leaks into background tasks when disabled.

## Why
The enabled gate previously blocked both injection and extraction. Users disabling Project Memory to save context window still want Pochi to keep learning in the background. This makes the toggle mean "don't inject memory into my prompt" while extraction continues.

## Test plan
- [x] `bun tsc` clean in `packages/livekit` and `packages/vscode`
- [x] `bun run test` for `adaptors.test.ts` (added regression test asserting extraction reads context with `force: true`) and `live-chat-kit-memory.test.ts`
- [x] Biome check clean on edited files

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5e10e398b85849499ae59806721747b1)