### PR TITLE
fix(vscode): keep background job terminal linked after command finishes

### DIFF
--- a/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
@@ -1,0 +1,186 @@
+import * as assert from "node:assert";
+import { describe, it } from "mocha";
+import proxyquire from "proxyquire";
+
+interface Disposable {
+  dispose(): void;
+}
+
+class TestEventEmitter<T> {
+  private listeners: Array<((event: T) => void) | undefined> = [];
+
+  readonly event = (listener: (event: T) => void): Disposable => {
+    const index = this.listeners.length;
+    this.listeners.push(listener);
+
+    return {
+      dispose: () => {
+        this.listeners[index] = undefined;
+      },
+    };
+  };
+
+  fire(event: T): void {
+    const listenerCount = this.listeners.length;
+    for (let i = 0; i < listenerCount; i++) {
+      this.listeners[i]?.(event);
+    }
+  }
+}
+
+class TestExecutionError extends Error {
+  static create(message: string): TestExecutionError {
+    return new TestExecutionError(message);
+  }
+
+  static createAbortError(): TestExecutionError {
+    return new TestExecutionError("Background job aborted.");
+  }
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function createHarness() {
+  const closeEmitter = new TestEventEmitter<FakeTerminal>();
+  const shellIntegrationEmitter = new TestEventEmitter<{
+    terminal: FakeTerminal;
+    shellIntegration: FakeShellIntegration;
+  }>();
+  const executionEndEmitter = new TestEventEmitter<{
+    execution: FakeExecution;
+    exitCode: number | undefined;
+  }>();
+  const execution: FakeExecution = {
+    async *read() {},
+  };
+  const shellIntegration: FakeShellIntegration = {
+    executeCommand: () => execution,
+  };
+  const terminal: FakeTerminal = {
+    shellIntegration,
+    show: () => {},
+    dispose: () => closeEmitter.fire(terminal),
+  };
+  const finalizeCalls: Array<TestExecutionError | undefined> = [];
+  const outputManager = {
+    output: { value: undefined },
+    addChunk: () => {},
+    finalize: (error?: TestExecutionError) => finalizeCalls.push(error),
+  };
+
+  const vscode = {
+    EventEmitter: TestEventEmitter,
+    ThemeIcon: class {
+      constructor(readonly id: string) {}
+    },
+    window: {
+      onDidCloseTerminal: closeEmitter.event,
+      onDidChangeTerminalShellIntegration: shellIntegrationEmitter.event,
+      onDidEndTerminalShellExecution: executionEndEmitter.event,
+    },
+  };
+
+  const { TerminalJob } = proxyquire
+    .noCallThru()
+    .noPreserveCache()
+    .load("../terminal-job", {
+      vscode,
+      "../layout": {
+        createTerminal: () => terminal,
+      },
+      "@/lib/logger": {
+        getLogger: () => ({
+          debug: () => {},
+          info: () => {},
+        }),
+      },
+      "@getpochi/common/env-utils": {
+        getTerminalEnv: () => ({}),
+      },
+      "@getpochi/common/tool-utils": {
+        getShellPath: () => "/bin/sh",
+      },
+      "./output": {
+        OutputManager: {
+          create: () => outputManager,
+        },
+      },
+      "./utils": {
+        ExecutionError: TestExecutionError,
+      },
+    }) as typeof import("../terminal-job");
+
+  const job = TerminalJob.create({
+    name: "test job",
+    command: "sleep 10",
+    cwd: "/tmp",
+  });
+
+  return {
+    TerminalJob,
+    closeEmitter,
+    execution,
+    executionEndEmitter,
+    finalizeCalls,
+    job,
+    terminal,
+  };
+}
+
+interface FakeExecution {
+  read(): AsyncIterable<string>;
+}
+
+interface FakeShellIntegration {
+  executeCommand(command: string): FakeExecution;
+}
+
+interface FakeTerminal {
+  shellIntegration: FakeShellIntegration;
+  show(): void;
+  dispose(): void;
+}
+
+describe("TerminalJob", () => {
+  it("keeps a completed job registered until its terminal closes", async () => {
+    const {
+      TerminalJob,
+      execution,
+      executionEndEmitter,
+      finalizeCalls,
+      job,
+      terminal,
+    } = createHarness();
+
+    await flushPromises();
+    executionEndEmitter.fire({ execution, exitCode: 0 });
+    await flushPromises();
+
+    assert.strictEqual(finalizeCalls.length, 1);
+    assert.strictEqual(finalizeCalls[0], undefined);
+    assert.strictEqual(TerminalJob.get(job.id), job);
+
+    terminal.dispose();
+    await flushPromises();
+
+    assert.strictEqual(TerminalJob.get(job.id), undefined);
+    assert.strictEqual(finalizeCalls.length, 1);
+  });
+
+  it("finalizes a running job when its terminal closes", async () => {
+    const { TerminalJob, finalizeCalls, job, terminal } = createHarness();
+
+    await flushPromises();
+    terminal.dispose();
+    await flushPromises();
+
+    assert.strictEqual(TerminalJob.get(job.id), undefined);
+    assert.strictEqual(finalizeCalls.length, 1);
+    assert.match(
+      finalizeCalls[0]?.message ?? "",
+      /user closed terminal/,
+    );
+  });
+});

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -36,8 +36,10 @@ export class TerminalJob implements vscode.Disposable {
   static readonly onDidDispose = TerminalJob.onDidDisposeEmitter.event;
 
   private readonly terminal: vscode.Terminal;
+  private readonly terminalClosed: Promise<never>;
   private disposables: vscode.Disposable[] = [];
   private closeListener: vscode.Disposable | undefined;
+  private rejectTerminalClosed: ((error: ExecutionError) => void) | undefined;
   private disposed = false;
   private shellIntegration: vscode.TerminalShellIntegration | undefined;
   private execution: vscode.TerminalShellExecution | undefined;
@@ -73,12 +75,22 @@ export class TerminalJob implements vscode.Disposable {
       isTransient: false,
     });
 
+    this.terminalClosed = new Promise<never>((_, reject) => {
+      this.rejectTerminalClosed = reject;
+    });
+
     // Keep the job registered (and thus its terminal <-> backgroundJobId
     // association) alive as long as the terminal is open, so the UI can keep
     // highlighting the active terminal and jump to it even after the command
     // has finished executing.
     this.closeListener = vscode.window.onDidCloseTerminal((terminal) => {
       if (terminal === this.terminal) {
+        this.rejectTerminalClosed?.(
+          ExecutionError.create(
+            "Background job finished as user closed terminal.",
+          ),
+        );
+        this.rejectTerminalClosed = undefined;
         this.dispose();
       }
     });
@@ -93,20 +105,24 @@ export class TerminalJob implements vscode.Disposable {
   }
 
   async execute(): Promise<void> {
-    // Wait for shell integration if not available
-    const shellIntegration = await this.waitForShellIntegration();
-
-    this.execution = shellIntegration.executeCommand(this.config.command);
-    logger.debug(
-      `Executed command in terminal "${this.config.name}": ${this.config.command}`,
-    );
-    this.processOutputStream(this.execution.read());
-
     let executionError: ExecutionError | undefined;
     try {
+      // Wait for shell integration if not available
+      const shellIntegration = await Promise.race([
+        this.waitForShellIntegration(),
+        this.terminalClosed,
+      ]);
+
+      this.execution = shellIntegration.executeCommand(this.config.command);
+      logger.debug(
+        `Executed command in terminal "${this.config.name}": ${this.config.command}`,
+      );
+      this.processOutputStream(this.execution.read());
+
       await Promise.race([
         this.waitForExecutionFinish(),
         this.createAbortPromise(),
+        this.terminalClosed,
       ]);
     } catch (error) {
       if (error instanceof ExecutionError) {
@@ -246,19 +262,6 @@ export class TerminalJob implements vscode.Disposable {
 
   private waitForExecutionFinish(): Promise<void> {
     return new Promise((resolve, reject) => {
-      // Listen for terminal close events
-      this.disposables.push(
-        vscode.window.onDidCloseTerminal((terminal) => {
-          if (terminal === this.terminal) {
-            reject(
-              ExecutionError.create(
-                "Background job finished as user closed terminal.",
-              ),
-            );
-          }
-        }),
-      );
-
       // Listen for shell execution end.
       this.disposables.push(
         vscode.window.onDidEndTerminalShellExecution((event) => {

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -37,6 +37,8 @@ export class TerminalJob implements vscode.Disposable {
 
   private readonly terminal: vscode.Terminal;
   private disposables: vscode.Disposable[] = [];
+  private closeListener: vscode.Disposable | undefined;
+  private disposed = false;
   private shellIntegration: vscode.TerminalShellIntegration | undefined;
   private execution: vscode.TerminalShellExecution | undefined;
   private outputManager: OutputManager;
@@ -69,6 +71,16 @@ export class TerminalJob implements vscode.Disposable {
       iconPath: new vscode.ThemeIcon("piano"),
       hideFromUser: false,
       isTransient: false,
+    });
+
+    // Keep the job registered (and thus its terminal <-> backgroundJobId
+    // association) alive as long as the terminal is open, so the UI can keep
+    // highlighting the active terminal and jump to it even after the command
+    // has finished executing.
+    this.closeListener = vscode.window.onDidCloseTerminal((terminal) => {
+      if (terminal === this.terminal) {
+        this.dispose();
+      }
     });
 
     this.terminal.show();
@@ -106,8 +118,21 @@ export class TerminalJob implements vscode.Disposable {
       }
     } finally {
       this.outputManager.finalize(executionError);
-      this.dispose();
+      // Only tear down the execution-scoped listeners here. The job itself
+      // stays registered until the terminal is closed (see closeListener),
+      // so the UI can still highlight and reopen the terminal.
+      this.cleanupExecution();
     }
+  }
+
+  /**
+   * Dispose of the execution-scoped listeners while keeping the job registered.
+   */
+  private cleanupExecution(): void {
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+    this.disposables = [];
   }
 
   /**
@@ -168,12 +193,18 @@ export class TerminalJob implements vscode.Disposable {
    * Dispose of the terminal and clean up resources
    */
   dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+
     TerminalJob.jobs.delete(this.id);
     TerminalJob.onDidDisposeEmitter.fire(this);
-    for (const d of this.disposables) {
-      d.dispose();
-    }
-    this.disposables = [];
+
+    this.closeListener?.dispose();
+    this.closeListener = undefined;
+
+    this.cleanupExecution();
 
     logger.debug(`Disposed terminal job "${this.config.name}"`);
   }


### PR DESCRIPTION
## Summary
- Fixes a bug where a background job's terminal lost its active highlight and could no longer be reopened via its label after the command finished running.
- Root cause: `TerminalJob.dispose()` ran in the `execute()` `finally` block when the command completed, removing the job from the registry even though the terminal was still open. Since `listVisibleTerminals()` derives `backgroundJobId` from `TerminalJob.get(t)?.id`, the still-open terminal lost its `backgroundJobId`, breaking the webui's `isActive` highlight and `openBackgroundJobTerminal` jump.
- Fix: keep the job registered as long as the terminal is open. A persistent `onDidCloseTerminal` listener now disposes the job only when the terminal is actually closed; execution-scoped listeners are torn down separately via `cleanupExecution()`. `dispose()` is made idempotent.

## Test plan
- [ ] Start a background job; confirm the terminal label (e.g. `%1`) is highlighted as active.
- [ ] Read the job output after the command finishes; confirm the label stays highlighted.
- [ ] Click the label after completion; confirm it jumps to the correct terminal.
- [ ] Close the terminal; confirm the job is disposed and removed from the visible terminals.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-935280b491454edfbe3b816fea791e27)