### PR TITLE
fix: guard rapid background job output reads

### DIFF
--- a/packages/cli/src/lib/__tests__/background-job-manager.test.ts
+++ b/packages/cli/src/lib/__tests__/background-job-manager.test.ts
@@ -36,6 +36,20 @@ describe("BackgroundJobManager", () => {
     expect(result2?.output).toBe("");
   });
 
+  it("should guide agents away from rapid empty reads", () => {
+    const manager = new BackgroundJobManager();
+    const id = manager.start("sleep 10", ".");
+
+    const firstResult = manager.readOutput(id);
+    expect(firstResult?.output).toBe("");
+
+    expect(() => manager.readOutput(id)).toThrow(
+      /executeCommand to run `sleep 1`/,
+    );
+
+    manager.kill(id);
+  });
+
   it("should wait for all jobs to complete", async () => {
     const manager = new BackgroundJobManager();
     manager.start("sleep 0.1", ".");

--- a/packages/cli/src/lib/background-job-manager.ts
+++ b/packages/cli/src/lib/background-job-manager.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import * as crypto from "node:crypto";
+import { assertBackgroundJobReadInterval } from "@getpochi/common";
 import { getTerminalEnv } from "@getpochi/common/env-utils";
 import { getShellPath } from "@getpochi/common/tool-utils";
 
@@ -10,6 +11,7 @@ export interface BackgroundJob {
   output: string;
   startTime: number;
   status: "running" | "completed";
+  lastReadAt?: number;
 }
 
 export class BackgroundJobManager {
@@ -78,6 +80,14 @@ export class BackgroundJobManager {
       return null;
     }
 
+    const now = Date.now();
+    const previousReadAt = job.lastReadAt;
+    assertBackgroundJobReadInterval({
+      now,
+      previousReadAt,
+      status: job.status,
+    });
+
     let outputToReturn = job.output;
 
     if (regex) {
@@ -87,6 +97,7 @@ export class BackgroundJobManager {
     }
 
     job.output = ""; // Clear buffer
+    job.lastReadAt = now;
 
     return {
       output: outputToReturn,

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -7,7 +7,11 @@ export {
   formatters,
   type LLMFormatterOptions,
 } from "./formatters";
-export { prompts, parseEnvironmentInfo } from "./prompts";
+export {
+  assertBackgroundJobReadInterval,
+  prompts,
+  parseEnvironmentInfo,
+} from "./prompts";
 
 export { SocialLinks } from "./social";
 export * as constants from "./constants";

--- a/packages/common/src/base/prompts/__tests__/background-job.test.ts
+++ b/packages/common/src/base/prompts/__tests__/background-job.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { assertBackgroundJobReadInterval } from "../background-job";
+
+describe("background job prompt helpers", () => {
+  it("throws when a running background job output is read too soon", () => {
+    expect(() =>
+      assertBackgroundJobReadInterval({
+        now: 1500,
+        previousReadAt: 1000,
+        status: "running",
+      }),
+    ).toThrow(/executeCommand to run `sleep 1`/);
+  });
+
+  it("allows the first read", () => {
+    expect(() =>
+      assertBackgroundJobReadInterval({
+        now: 1000,
+        status: "running",
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows reads after the threshold", () => {
+    expect(() =>
+      assertBackgroundJobReadInterval({
+        now: 2000,
+        previousReadAt: 1000,
+        status: "running",
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows non-running background jobs", () => {
+    expect(() =>
+      assertBackgroundJobReadInterval({
+        now: 1500,
+        previousReadAt: 1000,
+        status: "completed",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/common/src/base/prompts/background-job.ts
+++ b/packages/common/src/base/prompts/background-job.ts
@@ -1,0 +1,23 @@
+type BackgroundJobReadStatus = "idle" | "running" | "completed";
+
+const BackgroundJobRapidReadThresholdMs = 1000;
+const BackgroundJobRapidReadError =
+  "Output has not changed since the last read. The previous read was less than 1 second ago; consider waiting about a second, for example by using executeCommand to run `sleep 1`, before reading again.";
+
+export function assertBackgroundJobReadInterval({
+  now = Date.now(),
+  previousReadAt,
+  status,
+}: {
+  now?: number;
+  previousReadAt?: number;
+  status: BackgroundJobReadStatus;
+}) {
+  if (
+    status === "running" &&
+    previousReadAt !== undefined &&
+    now - previousReadAt < BackgroundJobRapidReadThresholdMs
+  ) {
+    throw new Error(BackgroundJobRapidReadError);
+  }
+}

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -1,5 +1,6 @@
 import { renderActiveSelection } from "./active-selection";
 import { buildAttemptTodoCompletionPrompt } from "./attempt-todo-completion";
+export { assertBackgroundJobReadInterval } from "./background-job";
 import {
   buildAutoMemoryDreamDirective,
   buildAutoMemoryDynamicPrompt,

--- a/packages/vscode/src/integrations/terminal/__test__/output.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/output.test.ts
@@ -1,7 +1,52 @@
-import * as assert from "assert";
-import { describe, it, beforeEach } from "mocha";
-import { OutputTruncator } from "../output";
 import { MaxTerminalOutputSize } from "@getpochi/common/tool-utils";
+import * as assert from "assert";
+import { beforeEach, describe, it } from "mocha";
+import { OutputManager, OutputTruncator } from "../output";
+
+describe("OutputManager", () => {
+  it("throws when a running job is read repeatedly without new output", () => {
+    const manager = OutputManager.create({
+      id: "rapid-read-test",
+      command: "bun run dev",
+    });
+
+    manager.addChunk("Starting development server...\n");
+
+    const firstRead = manager.readOutput();
+    assert.strictEqual(firstRead.output, "Starting development server...\n");
+    assert.strictEqual(firstRead.error, undefined);
+
+    assert.throws(
+      () => manager.readOutput(),
+      /executeCommand to run `sleep 1`/,
+    );
+
+    OutputManager.delete("rapid-read-test");
+  });
+
+  it("preserves new output when a rapid read is rejected", () => {
+    const manager = OutputManager.create({
+      id: "rapid-read-with-output-test",
+      command: "bun run dev",
+    });
+
+    manager.addChunk("Starting development server...\n");
+    manager.readOutput();
+    manager.addChunk("Ready\n");
+
+    assert.throws(
+      () => manager.readOutput(),
+      /executeCommand to run `sleep 1`/,
+    );
+
+    (manager as unknown as { lastReadAt: number }).lastReadAt = Date.now() - 1000;
+    const secondRead = manager.readOutput();
+    assert.strictEqual(secondRead.output, "Ready\n");
+    assert.strictEqual(secondRead.error, undefined);
+
+    OutputManager.delete("rapid-read-with-output-test");
+  });
+});
 
 describe("OutputTruncator", () => {
   let truncator: OutputTruncator;

--- a/packages/vscode/src/integrations/terminal/output.ts
+++ b/packages/vscode/src/integrations/terminal/output.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "@/lib/logger";
+import { assertBackgroundJobReadInterval } from "@getpochi/common";
 import { MaxTerminalOutputSize } from "@getpochi/common/tool-utils";
 import type { ExecuteCommandResult } from "@getpochi/common/vscode-webui-bridge";
 import { signal } from "@preact/signals-core";
@@ -132,6 +133,7 @@ export class OutputManager {
   private chunks: string[] = [];
   private truncator = new OutputTruncator();
   private lastReadLength = 0; // tracks byte length, not character length
+  private lastReadAt = 0;
 
   private constructor(options: OutputManagerOptions) {
     this.id = options.id;
@@ -164,6 +166,13 @@ export class OutputManager {
   } {
     const currentOutput = this.output.value.content;
     const currentOutputBytes = Buffer.byteLength(currentOutput, "utf8");
+    const now = Date.now();
+    const previousReadAt = this.lastReadAt === 0 ? undefined : this.lastReadAt;
+    assertBackgroundJobReadInterval({
+      now,
+      previousReadAt,
+      status: this.output.value.status,
+    });
 
     // Get the substring based on byte position
     let newOutput = "";
@@ -178,6 +187,7 @@ export class OutputManager {
     }
 
     this.lastReadLength = currentOutputBytes;
+    this.lastReadAt = now;
 
     if (regex) {
       /**
@@ -199,6 +209,7 @@ export class OutputManager {
 
       newOutput = filteredParts.join("");
     }
+
     return {
       output: newOutput,
       isTruncated: this.output.value.isTruncated ?? false,

--- a/packages/vscode/src/tools/__test__/read-background-job-output.test.ts
+++ b/packages/vscode/src/tools/__test__/read-background-job-output.test.ts
@@ -60,6 +60,9 @@ describe("OutputManager registry (readBackgroundJobOutput backing store)", () =>
     assert.ok(manager.readOutput().output.includes("first"));
 
     manager.addChunk("second\n");
+    // Simulate time passing so the rapid-read guard does not reject the read
+    (manager as unknown as { lastReadAt: number }).lastReadAt =
+      Date.now() - 1000;
     const second = manager.readOutput();
     assert.ok(second.output.includes("second"));
     assert.ok(


### PR DESCRIPTION
## Summary
- Add a shared rapid-read guard for background job output polling.
- Reuse the guard in CLI and VS Code terminal output handling to reject reads within 1 second.
- Add common, CLI, and VS Code coverage for the rapid-read behavior.

## Test plan
- `bun check`
- `bun tsc`
- `packages/common`: `bun vitest --run src/base/prompts/__tests__/background-job.test.ts`
- `packages/cli`: `bun vitest --run src/lib/__tests__/background-job-manager.test.ts`
- `packages/vscode`: `bun run test`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d4a693a2e6dd4b309fc9d3d937a2edb2)