### PR TITLE
fix(vscode): shorten background job terminal titles

### DIFF
--- a/packages/vscode/src/lib/__test__/background-job-terminal-name.test.ts
+++ b/packages/vscode/src/lib/__test__/background-job-terminal-name.test.ts
@@ -1,0 +1,34 @@
+import * as assert from "node:assert";
+import { describe, it } from "mocha";
+import { getBackgroundJobTerminalName } from "../background-job-terminal-name";
+
+describe("getBackgroundJobTerminalName", () => {
+  it("uses a concise command title", () => {
+    assert.strictEqual(getBackgroundJobTerminalName("bun test"), "bun test");
+  });
+
+  it("strips leading inline environment assignments", () => {
+    assert.strictEqual(
+      getBackgroundJobTerminalName(
+        'GEMINI_MSRL_PROJECT_ID=ollie-rl GEMINI_MSRL_BASE_URL="https://example.com" bun run dev',
+      ),
+      "bun run dev",
+    );
+  });
+
+  it("handles quoted environment values with spaces", () => {
+    assert.strictEqual(
+      getBackgroundJobTerminalName('OP_NAME="projects/ollie rl/locations/us" python server.py'),
+      "python server.py",
+    );
+  });
+
+  it("clips long commands to the maximum terminal title length", () => {
+    assert.strictEqual(
+      getBackgroundJobTerminalName(
+        "bun run very-long-background-command-name-that-would-overflow-terminal-tabs -- --watch --verbose",
+      ),
+      "bun run very-long-backg…",
+    );
+  });
+});

--- a/packages/vscode/src/lib/background-job-terminal-name.ts
+++ b/packages/vscode/src/lib/background-job-terminal-name.ts
@@ -1,0 +1,84 @@
+const MaxTerminalNameLength = 24;
+
+/**
+ * Creates a concise, stable terminal tab label for background jobs.
+ *
+ * Long commands often begin with inline environment variables. Showing those in
+ * the terminal title makes VS Code tabs unreadable, so strip only leading env
+ * assignments and keep the actual command visible.
+ */
+export function getBackgroundJobTerminalName(command: string): string {
+  const title =
+    stripLeadingEnvAssignments(command).replace(/\s+/g, " ").trim() ||
+    "Background Job";
+
+  if (title.length <= MaxTerminalNameLength) {
+    return title;
+  }
+
+  return `${title.slice(0, MaxTerminalNameLength - 1)}…`;
+}
+
+function stripLeadingEnvAssignments(command: string): string {
+  const trimmedCommand = command.trim();
+  let remainingCommand = trimmedCommand;
+
+  while (remainingCommand) {
+    const token = readShellToken(remainingCommand);
+
+    if (!token || !isEnvAssignment(token.value)) {
+      break;
+    }
+
+    remainingCommand = remainingCommand.slice(token.end).trimStart();
+  }
+
+  return remainingCommand || trimmedCommand;
+}
+
+function readShellToken(
+  input: string,
+): { value: string; end: number } | undefined {
+  if (!input) {
+    return undefined;
+  }
+
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      return { value: input.slice(0, index), end: index };
+    }
+  }
+
+  return { value: input, end: input.length };
+}
+
+function isEnvAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}

--- a/packages/vscode/src/tools/start-background-job.ts
+++ b/packages/vscode/src/tools/start-background-job.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import { getViewColumnForTerminal } from "@/integrations/layout";
 import { TerminalJob } from "@/integrations/terminal/terminal-job";
+import { getBackgroundJobTerminalName } from "@/lib/background-job-terminal-name";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 
 export const startBackgroundJob: ToolFunctionType<
@@ -20,7 +21,7 @@ export const startBackgroundJob: ToolFunctionType<
   const location = viewColumn ? { viewColumn } : undefined;
 
   const job = TerminalJob.create({
-    name: command,
+    name: getBackgroundJobTerminalName(command),
     command,
     cwd,
     location,


### PR DESCRIPTION
## Summary
- Generate concise terminal names for VS Code background jobs instead of using the full command.
- Strip leading inline environment assignments and clip long commands to keep terminal tabs readable.
- Add unit coverage for env-prefixed commands, quoted env values, and long command clipping.

## Test plan
- `cd packages/vscode && bun run test`
- `cd packages/vscode && bun tsc`
- `bun check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-565feeb1f36549dab0df46055a993736)