### PR TITLE
fix(common): stream ripgrep search output

### DIFF
--- a/packages/common/src/tool-utils/__tests__/ripgrep.test.ts
+++ b/packages/common/src/tool-utils/__tests__/ripgrep.test.ts
@@ -1,21 +1,84 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { execAsyncMock } = vi.hoisted(() => {
-  return { execAsyncMock: vi.fn() };
+const { spawnMock } = vi.hoisted(() => {
+  return { spawnMock: vi.fn() };
 });
 
-vi.mock("node:util", () => ({
-  promisify: vi.fn().mockReturnValue(execAsyncMock),
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
 }));
 
 import { searchFilesWithRipgrep } from "../ripgrep";
+
+class MockChildProcess extends EventEmitter {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  killed = false;
+  closed = false;
+
+  kill = vi.fn(() => {
+    this.killed = true;
+    this.close(null, "SIGTERM");
+    return true;
+  });
+
+  close(code: number | null, signal: NodeJS.Signals | null) {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    queueMicrotask(() => this.emit("close", code, signal));
+  }
+}
+
+function mockSpawnResult({
+  stdout = "",
+  stderr = "",
+  code = 0,
+  error,
+}: {
+  stdout?: string | string[];
+  stderr?: string;
+  code?: number;
+  error?: Error;
+}) {
+  const child = new MockChildProcess();
+  spawnMock.mockReturnValueOnce(child);
+
+  queueMicrotask(() => {
+    if (error) {
+      child.emit("error", error);
+      return;
+    }
+
+    if (stderr) {
+      child.stderr.write(stderr);
+      child.stderr.end();
+    }
+
+    const chunks = Array.isArray(stdout) ? stdout : [stdout];
+    for (const chunk of chunks) {
+      if (child.killed) {
+        break;
+      }
+      child.stdout.write(chunk);
+    }
+    child.stdout.end();
+    child.close(code, null);
+  });
+
+  return child;
+}
 
 describe("searchFilesWithRipgrep", () => {
   const rgPath = "/usr/bin/rg";
   const workspacePath = "/workspace";
 
   beforeEach(() => {
-    execAsyncMock.mockClear();
+    spawnMock.mockClear();
   });
 
   afterEach(() => {
@@ -44,7 +107,7 @@ describe("searchFilesWithRipgrep", () => {
       .map((o) => JSON.stringify(o))
       .join("\n");
 
-    execAsyncMock.mockResolvedValue({ stdout: mockRgOutput, stderr: "" });
+    mockSpawnResult({ stdout: mockRgOutput });
 
     const result = await searchFilesWithRipgrep(
       ".",
@@ -66,14 +129,23 @@ describe("searchFilesWithRipgrep", () => {
       },
     ]);
     expect(result.isTruncated).toBe(false);
-    expect(execAsyncMock).toHaveBeenCalledWith(
-      `"/usr/bin/rg" --json --case-sensitive --binary --sortr modified 'hello' '/workspace'`,
-      expect.any(Object),
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/usr/bin/rg",
+      [
+        "--json",
+        "--case-sensitive",
+        "--binary",
+        "--sortr",
+        "modified",
+        "hello",
+        "/workspace",
+      ],
+      { signal: undefined },
     );
   });
 
   it("should return an empty array when no matches are found", async () => {
-    execAsyncMock.mockRejectedValue({ code: 1, stdout: "", stderr: "" });
+    mockSpawnResult({ code: 1 });
 
     const result = await searchFilesWithRipgrep(
       ".",
@@ -87,7 +159,7 @@ describe("searchFilesWithRipgrep", () => {
   });
 
   it("should include filePattern in the command when provided", async () => {
-    execAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+    mockSpawnResult({ stdout: "" });
 
     await searchFilesWithRipgrep(
       ".",
@@ -97,13 +169,24 @@ describe("searchFilesWithRipgrep", () => {
       "**/*.ts",
     );
 
-    expect(execAsyncMock).toHaveBeenCalledWith(
-      `"/usr/bin/rg" --json --case-sensitive --binary --sortr modified --glob '**/*.ts' 'hello' '/workspace'`,
-      expect.any(Object),
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/usr/bin/rg",
+      [
+        "--json",
+        "--case-sensitive",
+        "--binary",
+        "--sortr",
+        "modified",
+        "--glob",
+        "**/*.ts",
+        "hello",
+        "/workspace",
+      ],
+      { signal: undefined },
     );
   });
 
-  it("should truncate results if matches exceed MaxRipgrepItems", async () => {
+  it("should stop rg as soon as the global match limit is exceeded", async () => {
     const mockRgOutput = Array.from({ length: 501 }, (_, i) => ({
       type: "match",
       data: {
@@ -115,7 +198,7 @@ describe("searchFilesWithRipgrep", () => {
       .map((o) => JSON.stringify(o))
       .join("\n");
 
-    execAsyncMock.mockResolvedValue({ stdout: mockRgOutput, stderr: "" });
+    const child = mockSpawnResult({ stdout: mockRgOutput });
 
     const result = await searchFilesWithRipgrep(
       ".",
@@ -126,23 +209,20 @@ describe("searchFilesWithRipgrep", () => {
 
     expect(result.matches.length).toBe(500);
     expect(result.isTruncated).toBe(true);
+    expect(child.kill).toHaveBeenCalled();
   });
 
   it("should throw an error when rg fails with code > 1", async () => {
-    const mockError = {
-      code: 2,
-      stderr: "A critical error occurred",
-    };
-    execAsyncMock.mockRejectedValue(mockError);
+    mockSpawnResult({ code: 2, stderr: "A critical error occurred" });
 
     await expect(
       searchFilesWithRipgrep(".", "error", rgPath, workspacePath),
-    ).rejects.toThrow(`rg command failed with code 2: A critical error occurred`);
+    ).rejects.toThrow("rg command failed with code 2: A critical error occurred");
   });
 
   it("should handle JSON parsing errors gracefully", async () => {
     const mockRgOutput =
-      'invalid-json\n' +
+      "invalid-json\n" +
       JSON.stringify({
         type: "match",
         data: {
@@ -152,7 +232,7 @@ describe("searchFilesWithRipgrep", () => {
         },
       });
 
-    execAsyncMock.mockResolvedValue({ stdout: mockRgOutput, stderr: "" });
+    mockSpawnResult({ stdout: mockRgOutput });
 
     const result = await searchFilesWithRipgrep(
       ".",
@@ -165,7 +245,7 @@ describe("searchFilesWithRipgrep", () => {
     expect(result.matches[0].file).toBe("src/app.ts");
   });
 
-  it("should handle exit code 1 with stdout", async () => {
+  it("should process stdout when rg exits with code 1", async () => {
     const mockRgOutput = JSON.stringify({
       type: "match",
       data: {
@@ -174,12 +254,12 @@ describe("searchFilesWithRipgrep", () => {
         line_number: 5,
       },
     });
-    const mockError = {
+
+    mockSpawnResult({
       code: 1,
       stdout: mockRgOutput,
       stderr: "A non-fatal error occurred",
-    };
-    execAsyncMock.mockRejectedValue(mockError);
+    });
 
     const result = await searchFilesWithRipgrep(
       ".",
@@ -188,14 +268,18 @@ describe("searchFilesWithRipgrep", () => {
       workspacePath,
     );
 
-    // The current implementation does not process stdout on error, so matches will be empty
-    // This test just ensures the function doesn't crash and handles the error path correctly.
-    expect(result.matches).toEqual([]);
+    expect(result.matches).toEqual([
+      {
+        file: "src/app.ts",
+        line: 5,
+        context: "console.log('hello');",
+      },
+    ]);
   });
 
   it("should rethrow an unexpected error", async () => {
     const unexpectedError = new Error("Unexpected error");
-    execAsyncMock.mockRejectedValue(unexpectedError);
+    mockSpawnResult({ error: unexpectedError });
 
     await expect(
       searchFilesWithRipgrep(".", "error", rgPath, workspacePath),

--- a/packages/common/src/tool-utils/ripgrep.ts
+++ b/packages/common/src/tool-utils/ripgrep.ts
@@ -1,10 +1,7 @@
-import { exec } from "node:child_process";
+import { spawn } from "node:child_process";
 import { relative, resolve } from "node:path";
-import { promisify } from "node:util";
 import { getLogger } from "../base";
 import { MaxRipgrepItems } from "./limits";
-
-const execAsync = promisify(exec);
 
 const logger = getLogger("RipgrepUtils");
 
@@ -55,11 +52,30 @@ interface RipgrepOutput {
     | RipgrepSummaryData;
 }
 
-// Define a type for the error caught from execAsync
-interface ExecError extends Error {
-  code?: number;
-  stdout?: string;
-  stderr?: string;
+type RipgrepMatch = { file: string; line: number; context: string };
+
+function parseRipgrepLine(
+  line: string,
+  workspacePath: string,
+): RipgrepMatch | undefined {
+  try {
+    const output = JSON.parse(line) as RipgrepOutput;
+
+    if (output.type !== "match") {
+      return undefined;
+    }
+
+    const matchData = output.data as RipgrepMatchData;
+    return {
+      file: relative(workspacePath, matchData.path.text),
+      line: matchData.line_number,
+      // rg includes the newline in lines.text, trim it
+      context: matchData.lines.text.replace(/\r?\n$/, ""),
+    };
+  } catch (parseError) {
+    logger.error(`Failed to parse rg JSON output line: ${line}`, parseError);
+    return undefined;
+  }
 }
 
 export async function searchFilesWithRipgrep(
@@ -70,109 +86,107 @@ export async function searchFilesWithRipgrep(
   filePattern?: string,
   abortSignal?: AbortSignal,
 ): Promise<{
-  matches: { file: string; line: number; context: string }[];
+  matches: RipgrepMatch[];
   isTruncated: boolean;
 }> {
   logger.debug("searchFiles", path, regex, filePattern);
-  const matches: { file: string; line: number; context: string }[] = [];
+  const matches: RipgrepMatch[] = [];
+  let isTruncated = false;
 
-  // Construct the rg command
-  // Use single quotes to wrap regex and path to handle potential spaces or special characters
-  // Escape single quotes within the regex itself if necessary (though rg might handle this)
-  // Using --multiline to ensure regex can span multiple lines if needed, though the output format focuses on single line matches
-  // Using --fixed-strings might be safer if the input 'regex' isn't meant to be a regex, but the param name suggests it is.
-  // Added --case-sensitive based on original implementation's RegExp usage (default is case-sensitive)
-  // Added --binary to skip binary files, similar to the original file-type check
-  // Need to quote rgPath in case env.appRoot contains spaces
-  let command = `"${rgPath.replace(/"/g, '\\"')}" --json --case-sensitive --binary --sortr modified `; // Quote rgPath
+  const args = [
+    "--json",
+    "--case-sensitive",
+    "--binary",
+    "--sortr",
+    "modified",
+  ];
 
   if (filePattern) {
-    // Add glob pattern. Ensure it's properly quoted.
-    command += `--glob '${filePattern.replace(/'/g, "'\\''")}' `; // Escape single quotes in pattern
+    args.push("--glob", filePattern);
   }
 
-  const absPath = resolve(workspacePath, path.replace(/'/g, "'\\''"));
-  // Add regex and path. Ensure they are properly quoted.
-  command += `'${regex.replace(/'/g, "'\\''")}' '${absPath}'`;
-  logger.debug("command", command);
+  const absPath = resolve(workspacePath, path);
+  args.push(regex, absPath);
+  logger.debug("command", rgPath, args);
 
-  try {
-    const { stdout, stderr } = await execAsync(command, {
-      // Set a reasonable maxBuffer size in case of large output
-      // Consider streaming if output can be extremely large
-      maxBuffer: 1024 * 1024 * 10, // 10M
-      signal: abortSignal, // Pass the abort signal
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn(rgPath, args, { signal: abortSignal });
+    let pendingStdout = "";
+    let stderr = "";
+    let stoppedAfterLimit = false;
+
+    const stopAfterLimit = () => {
+      stoppedAfterLimit = true;
+      child.kill();
+    };
+
+    const processLine = (line: string) => {
+      if (!line) {
+        return;
+      }
+
+      const match = parseRipgrepLine(line, workspacePath);
+      if (!match) {
+        return;
+      }
+
+      matches.push(match);
+      if (matches.length > MaxRipgrepItems) {
+        isTruncated = true;
+        stopAfterLimit();
+      }
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      pendingStdout += chunk;
+      const lines = pendingStdout.split("\n");
+      pendingStdout = lines.pop() ?? "";
+
+      for (const line of lines) {
+        processLine(line);
+        if (stoppedAfterLimit) {
+          return;
+        }
+      }
     });
 
-    if (stderr) {
-      logger.warn("rg command stderr: ", stderr.slice(0, 1000)); // Log first 1000 chars of stderr
-    }
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr = (stderr + chunk).slice(-10_000);
+    });
 
-    // rg --json outputs newline-separated JSON objects
-    const outputLines = stdout.trim().split("\n");
+    child.on("error", (error) => {
+      rejectPromise(error);
+    });
 
-    for (const line of outputLines) {
-      try {
-        const output = JSON.parse(line) as RipgrepOutput;
-
-        if (output.type === "match") {
-          const matchData = output.data as RipgrepMatchData;
-          matches.push({
-            file: relative(workspacePath, matchData.path.text),
-            line: matchData.line_number,
-            // rg includes the newline in lines.text, trim it
-            context: matchData.lines.text.replace(/\r?\n$/, ""),
-          });
-        }
-      } catch (parseError) {
-        logger.error(
-          `Failed to parse rg JSON output line: ${line}`,
-          parseError,
-        );
-        // Continue processing other lines
+    child.on("close", (code, signal) => {
+      if (!stoppedAfterLimit && pendingStdout) {
+        processLine(pendingStdout);
       }
-    }
-    // biome-ignore lint/suspicious/noExplicitAny: exception catch has to be any
-  } catch (error: any) {
-    if (!(error satisfies ExecError)) {
-      logger.error("rg command error: ", error);
-      throw error;
-    }
 
-    // Handle errors, e.g., rg not found, command execution failure
-    // error.code === 1 often means rg found matches but encountered non-fatal errors (like permission denied on a dir)
-    // error.code > 1 usually indicates a more serious issue.
-    // rg exits with 0 if matches are found, 1 if no matches are found, >1 for errors.
-    // The original function returns empty matches if none found, so exit code 1 is not an error here.
-    if (error.code && error.code > 1) {
-      // Rethrow or handle more specific errors if needed
-      // Include stderr in the error message for better debugging
-      throw new Error(
-        `rg command failed with code ${error.code}: ${error.stderr || error.message}`,
+      if (stderr) {
+        logger.warn("rg command stderr: ", stderr.slice(0, 1000));
+      }
+
+      // rg exits with 0 if matches are found, 1 if no matches are found, >1 for errors.
+      if (stoppedAfterLimit || code === 0 || code === 1) {
+        resolvePromise();
+        return;
+      }
+
+      rejectPromise(
+        new Error(
+          `rg command failed with code ${code ?? `signal ${signal}`}: ${
+            stderr || "Unknown error"
+          }`,
+        ),
       );
-    }
-    if (!error.code && error.stderr) {
-      // Log stderr even if code is 0 (e.g., warnings)
-      logger.warn(`rg command stderr (exit code 0): ${error.stderr}`);
-    } else if (error.code === 1 && !error.stdout && !error.stderr) {
-      // Exit code 1 and no output means no matches found, which is not an error for this function.
-      // console.log("rg command finished with exit code 1 (no matches found).");
-    } else if (error.code === 1 && error.stdout) {
-      // Exit code 1 but there was output (matches were found, but maybe some errors occurred)
-      // We already processed stdout, so just log stderr if present
-      if (error.stderr) {
-        logger.warn(`rg command stderr (exit code 1): ${error.stderr}`);
-      }
-    } else {
-      // Other unexpected errors
-      logger.error("Error executing rg command: ", error);
-      throw error; // Rethrow unexpected errors
-    }
-    // If error.code is 1 (no matches), we fall through and return the empty matches array, which is correct.
-  }
+    });
+  });
 
   return {
     matches: matches.slice(0, MaxRipgrepItems),
-    isTruncated: matches.length > MaxRipgrepItems,
+    isTruncated,
   };
 }


### PR DESCRIPTION
## Summary
- Stream `rg --json` output for `searchFiles` instead of collecting all stdout through `exec`.
- Stop the ripgrep process once `MaxRipgrepItems` is exceeded so the result limit is applied before stdout can overflow.
- Update ripgrep tool tests to cover spawn-based streaming, early termination, and exit-code handling.

## Test plan
- `bun vitest --run packages/common/src/tool-utils/__tests__/ripgrep.test.ts`
- `bun check`
- `bun tsc`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1ba6fca388c142ccbc1c006a53a44a29)