### PR TITLE
fix(common): avoid stale OpenAI item references

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -338,6 +338,7 @@ describe('formatters', () => {
         {
           id: 'assistant-1',
           role: 'assistant',
+          metadata: { kind: 'assistant' },
           parts: [
             {
               type: 'reasoning',
@@ -350,11 +351,84 @@ describe('formatters', () => {
               providerMetadata: { openai: { itemId: 'msg_abc123' } },
             },
           ],
-        },
+        } as UIMessage,
       ];
       const formatted = formatters.llm(clone(messages));
       const assistantMsg = formatted.find((m) => m.id === 'assistant-1');
       expect(assistantMsg?.parts.some((p) => p.type === 'reasoning')).toBe(true);
+    });
+
+    it('should strip OpenAI item references from unfinished assistant messages', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: '',
+              providerMetadata: {
+                openai: {
+                  itemId: 'rs_interrupted',
+                  reasoningEncryptedContent: 'encrypted-reasoning',
+                },
+              },
+              providerOptions: {
+                openai: {
+                  itemId: 'rs_interrupted',
+                  reasoningEncryptedContent: 'encrypted-reasoning',
+                },
+              },
+            },
+            {
+              type: 'text',
+              text: 'Response',
+              providerMetadata: { openai: { itemId: 'msg_interrupted' } },
+            },
+          ],
+        } as UIMessage,
+      ];
+
+      const formatted = formatters.llm(clone(messages));
+      const reasoningPart = formatted[0].parts.find(
+        (part) => part.type === 'reasoning',
+      ) as any;
+      const textPart = formatted[0].parts.find(
+        (part) => part.type === 'text',
+      ) as any;
+
+      expect(reasoningPart.providerMetadata.openai).toEqual({
+        reasoningEncryptedContent: 'encrypted-reasoning',
+      });
+      expect(reasoningPart.providerOptions.openai).toEqual({
+        reasoningEncryptedContent: 'encrypted-reasoning',
+      });
+      expect(textPart.providerMetadata).toBeUndefined();
+    });
+
+    it('should keep OpenAI reasoning item references for finished assistant messages', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          metadata: { kind: 'assistant' },
+          parts: [
+            {
+              type: 'reasoning',
+              text: '',
+              providerMetadata: { openai: { itemId: 'rs_finished' } },
+            },
+            { type: 'text', text: 'Response' },
+          ],
+        } as UIMessage,
+      ];
+
+      const formatted = formatters.llm(clone(messages));
+      const reasoningPart = formatted[0].parts.find(
+        (part) => part.type === 'reasoning',
+      ) as any;
+
+      expect(reasoningPart.providerMetadata.openai.itemId).toBe('rs_finished');
     });
 
     it('should keep only messages from the latest compact block onward', () => {

--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -431,6 +431,82 @@ describe('formatters', () => {
       expect(reasoningPart.providerMetadata.openai.itemId).toBe('rs_finished');
     });
 
+    it('should strip OpenAI item references from unfinished tool call parts', () => {
+      const toolPart = createToolPart('testTool', 'input-available', {
+        arg: 1,
+      });
+      toolPart.callProviderMetadata = {
+        openai: { itemId: 'fc_interrupted' },
+        google: { thoughtSignature: 'signature-1' },
+      };
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [toolPart],
+        } as UIMessage,
+      ];
+
+      const formatted = formatters.llm(clone(messages));
+      const formattedToolPart = formatted[0].parts[0] as any;
+
+      expect(formattedToolPart.callProviderMetadata).toEqual({
+        google: { thoughtSignature: 'signature-1' },
+      });
+      expect(formattedToolPart.callProviderMetadata.openai).toBeUndefined();
+    });
+
+    it('should keep OpenAI item references for finished tool call parts', () => {
+      const toolPart = createToolPart('testTool', 'input-available', {
+        arg: 1,
+      });
+      toolPart.callProviderMetadata = {
+        openai: { itemId: 'fc_finished' },
+      };
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          metadata: { kind: 'assistant' },
+          parts: [toolPart],
+        } as UIMessage,
+      ];
+
+      const formatted = formatters.llm(clone(messages));
+      const formattedToolPart = formatted[0].parts[0] as any;
+
+      expect(formattedToolPart.callProviderMetadata.openai.itemId).toBe(
+        'fc_finished',
+      );
+    });
+
+    it('should strip OpenAI item references from unfinished provider-executed tool results', () => {
+      const toolPart = createToolPart(
+        'testTool',
+        'output-available',
+        { arg: 1 },
+        { result: 'ok' },
+      );
+      toolPart.providerExecuted = true;
+      toolPart.resultProviderMetadata = {
+        openai: { itemId: 'fc_result_interrupted', customField: 'preserved' },
+      };
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [toolPart],
+        } as UIMessage,
+      ];
+
+      const formatted = formatters.llm(clone(messages));
+      const formattedToolPart = formatted[0].parts[0] as any;
+
+      expect(formattedToolPart.resultProviderMetadata).toEqual({
+        openai: { customField: 'preserved' },
+      });
+    });
+
     it('should keep only messages from the latest compact block onward', () => {
       const messages: UIMessage[] = [
         {

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -464,6 +464,13 @@ type ProviderMetadataMap = Record<string, Record<string, unknown>>;
 type PartWithProviderMetadata = UIMessage["parts"][number] & {
   providerMetadata?: ProviderMetadataMap;
   providerOptions?: ProviderMetadataMap;
+  // Tool-call parts carry their provider metadata (e.g. OpenAI itemId) here.
+  // The SDK maps it back to providerOptions when converting to model messages.
+  callProviderMetadata?: ProviderMetadataMap;
+  // Provider-executed tool results carry their metadata here; the SDK maps it
+  // into the tool-result providerOptions. Kept for defense-in-depth in case
+  // provider-executed OpenAI tools are ever enabled.
+  resultProviderMetadata?: ProviderMetadataMap;
 };
 
 function removeOpenAIItemId(
@@ -509,10 +516,18 @@ function removeUnstableOpenAIItemReferences(
       const providerOptions = removeOpenAIItemId(
         partWithMetadata.providerOptions,
       );
+      const callProviderMetadata = removeOpenAIItemId(
+        partWithMetadata.callProviderMetadata,
+      );
+      const resultProviderMetadata = removeOpenAIItemId(
+        partWithMetadata.resultProviderMetadata,
+      );
 
       if (
         providerMetadata === partWithMetadata.providerMetadata &&
-        providerOptions === partWithMetadata.providerOptions
+        providerOptions === partWithMetadata.providerOptions &&
+        callProviderMetadata === partWithMetadata.callProviderMetadata &&
+        resultProviderMetadata === partWithMetadata.resultProviderMetadata
       ) {
         return part;
       }
@@ -520,12 +535,16 @@ function removeUnstableOpenAIItemReferences(
       const {
         providerMetadata: _providerMetadata,
         providerOptions: _providerOptions,
+        callProviderMetadata: _callProviderMetadata,
+        resultProviderMetadata: _resultProviderMetadata,
         ...partWithoutOpenAIItemIds
       } = partWithMetadata;
       return {
         ...partWithoutOpenAIItemIds,
         ...(providerMetadata ? { providerMetadata } : {}),
         ...(providerOptions ? { providerOptions } : {}),
+        ...(callProviderMetadata ? { callProviderMetadata } : {}),
+        ...(resultProviderMetadata ? { resultProviderMetadata } : {}),
       } as UIMessage["parts"][number];
     });
     return message;

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -459,6 +459,79 @@ function extractCompactMessages(messages: UIMessage[]) {
   return messages;
 }
 
+type ProviderMetadataMap = Record<string, Record<string, unknown>>;
+
+type PartWithProviderMetadata = UIMessage["parts"][number] & {
+  providerMetadata?: ProviderMetadataMap;
+  providerOptions?: ProviderMetadataMap;
+};
+
+function removeOpenAIItemId(
+  metadata: ProviderMetadataMap | undefined,
+): ProviderMetadataMap | undefined {
+  if (!metadata?.openai || !("itemId" in metadata.openai)) {
+    return metadata;
+  }
+
+  const { itemId: _itemId, ...openaiWithoutItemId } = metadata.openai;
+  const { openai: _openai, ...metadataWithoutOpenAI } = metadata;
+  const nextMetadata =
+    Object.keys(openaiWithoutItemId).length > 0
+      ? { ...metadataWithoutOpenAI, openai: openaiWithoutItemId }
+      : metadataWithoutOpenAI;
+
+  return Object.keys(nextMetadata).length > 0 ? nextMetadata : undefined;
+}
+
+function isUnfinishedAssistantMessage(message: UIMessage): boolean {
+  if (message.role !== "assistant") return false;
+
+  const metadata = (message as UIMessage & { metadata?: { kind?: unknown } })
+    .metadata;
+  return metadata?.kind !== "assistant";
+}
+
+function removeUnstableOpenAIItemReferences(
+  messages: UIMessage[],
+): UIMessage[] {
+  // OpenAI Responses item references can point at output items that were never
+  // committed server-side when a stream was interrupted or failed. Remove only
+  // the fragile item id for unfinished messages and keep other metadata such as
+  // reasoningEncryptedContent so the SDK can resend the reasoning payload.
+  return messages.map((message) => {
+    if (!isUnfinishedAssistantMessage(message)) return message;
+
+    message.parts = message.parts.map((part) => {
+      const partWithMetadata = part as PartWithProviderMetadata;
+      const providerMetadata = removeOpenAIItemId(
+        partWithMetadata.providerMetadata,
+      );
+      const providerOptions = removeOpenAIItemId(
+        partWithMetadata.providerOptions,
+      );
+
+      if (
+        providerMetadata === partWithMetadata.providerMetadata &&
+        providerOptions === partWithMetadata.providerOptions
+      ) {
+        return part;
+      }
+
+      const {
+        providerMetadata: _providerMetadata,
+        providerOptions: _providerOptions,
+        ...partWithoutOpenAIItemIds
+      } = partWithMetadata;
+      return {
+        ...partWithoutOpenAIItemIds,
+        ...(providerMetadata ? { providerMetadata } : {}),
+        ...(providerOptions ? { providerOptions } : {}),
+      } as UIMessage["parts"][number];
+    });
+    return message;
+  });
+}
+
 function removeEmptyTextParts(messages: UIMessage[]) {
   return messages.map((message) => {
     message.parts = message.parts.filter((part) => {
@@ -467,7 +540,7 @@ function removeEmptyTextParts(messages: UIMessage[]) {
       }
       if (part.type === "reasoning") {
         // Keep reasoning parts that have providerMetadata (e.g. OpenAI itemId),
-        // because they need to be included as item_reference in subsequent API calls,
+        // because they need to be included in subsequent API calls,
         // even if their text content is empty.
         if (
           part.providerMetadata &&
@@ -641,6 +714,7 @@ function removeDeprecatedTodoWriteToolCalls(
 }
 
 const LLMFormatOps: FormatOp[] = [
+  removeUnstableOpenAIItemReferences,
   removeEmptyTextParts,
   removeEmptyMessages,
   refineDetectedNewPromblems,


### PR DESCRIPTION
## Summary
- Strip OpenAI `itemId` metadata from unfinished assistant messages before LLM requests to avoid stale Responses `item_reference` lookups after interruptions.
- Preserve recoverable metadata such as `reasoningEncryptedContent` and keep item references for completed assistant messages.
- Add formatter tests for interrupted vs completed OpenAI metadata handling.

## Test plan
- `bun run test src/base/__tests__/formatters.test.ts` from `packages/common`
- `bun tsc` from `packages/common`
- `bun check` from repo root

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fe615a4a22b14174bbf63d4d191f7849)