### PR TITLE
feat(share): show last step duration on share page

### DIFF
--- a/packages/livekit/src/index.ts
+++ b/packages/livekit/src/index.ts
@@ -33,3 +33,4 @@ export type {
   BackgroundJobStatus,
   TaskStatusLike,
 } from "./task-utils";
+export { toTaskStatus } from "./task";

--- a/packages/vscode-webui/src/features/share/page.tsx
+++ b/packages/vscode-webui/src/features/share/page.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { formatters } from "@getpochi/common";
 import { type ResizeEvent, ShareEvent } from "@getpochi/common/share-utils";
 import type { Message } from "@getpochi/livekit";
+import { toTaskStatus } from "@getpochi/livekit";
 import { createChannel } from "bidc";
 import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -156,6 +157,17 @@ export function SharePage() {
 
   const todos = shareData?.todos ?? [];
 
+  const lastMessage = (messages as Message[])[messages.length - 1];
+  const lastMessageFinishReason =
+    lastMessage?.metadata?.kind === "assistant"
+      ? lastMessage.metadata.finishReason
+      : undefined;
+  const showLastStepDuration =
+    !!lastMessage &&
+    !isLoading &&
+    !error &&
+    toTaskStatus(lastMessage, lastMessageFinishReason) === "completed";
+
   return (
     <VSCodeWebProvider>
       <ChatContextProvider>
@@ -184,6 +196,7 @@ export function SharePage() {
                     messages={renderMessages}
                     isLoading={isLoading}
                     hideUserEditsActions
+                    showLastStepDuration={showLastStepDuration}
                   />
                   <ErrorMessageView error={error ?? undefined} />
                 </div>


### PR DESCRIPTION
## Summary

- Exports `toTaskStatus` from `@getpochi/livekit` so it can be consumed by consumers outside the package
- Uses `toTaskStatus` in the share page to detect when the last task step has completed
- Passes `showLastStepDuration` to `TaskThread`, making the share page consistent with the chat page behaviour introduced in #1775

## Test plan

- [ ] Open a shared task URL and verify the last step duration is shown when the task is completed
- [ ] Verify no duration is shown when the task is still loading or has errored

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7316021e1e2d4df1872e2e727375335b)