### PR TITLE
fix(cli): track tools execution duration in task runner

### DIFF
--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -654,7 +654,10 @@ export class TaskRunner {
       },
       { once: true },
     );
+
+    this.chatKit.markStartToolsExecution();
     await queue.start();
+    this.chatKit.markEndToolsExecution();
 
     logger.trace("All tool calls processed in the last message.");
     return "next" as const;


### PR DESCRIPTION
## Summary

- Wrap `queue.start()` with `markStartToolsExecution()` / `markEndToolsExecution()` in the CLI `TaskRunner`
- Ensures tool execution duration is properly tracked in the CLI, consistent with the webui which already instruments these calls via `onToolsExecutionStarted` / `onToolsExecutionEnded` props

## Test plan

- [ ] Run a CLI task and verify tool execution timing is reported correctly

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e71c2ed759c74ebe9b6a50051428369d)