### PR TITLE
fix(tools): clarify pochi:// schema is only for built-in skill resources

### DIFF
--- a/packages/tools/src/use-skill.ts
+++ b/packages/tools/src/use-skill.ts
@@ -74,10 +74,10 @@ Important:
 - Only use skills listed in "Available skills" below
 - Check compatibility requirements before using a skill - ensure the skill is compatible with the current OS/environment
 - After calling this tool, follow the returned instructions step by step
-- The skill file location is shown in the [Location: filepath] section of each skill listing below - use it to decide how to resolve any resource files (e.g. a \`references/<name>.md\` reference in the instructions) the skill mentions:
-  * Built-in skills (shipped with Pochi; [Location] lives inside the extension's bundled \`assets/skills/...\`): address resources with the \`pochi://\` schema, i.e. \`pochi://skills/<skill-name>/<resource-path>\` (e.g. \`pochi://skills/<skill-name>/references/<name>.md\`)
-  * Project/user skills ([Location] is a workspace or home path such as \`.pochi/skills/...\` or \`~/.pochi/skills/...\`): resolve resources as normal filesystem paths relative to the [Location] directory
-- NEVER use the \`pochi://\` schema for a project/user skill - \`pochi://skills/...\` resolves ONLY to built-in skills
+- Resolve resource files (e.g. a \`references/<name>.md\` referenced in the instructions) based on the skill's [Location]:
+  * Built-in skills (provided by Pochi): address resources with the \`pochi://\` schema, e.g. \`pochi://skills/<skill-name>/references/<name>.md\`
+  * Project/user skills: resolve resources as filesystem paths relative to the [Location] directory
+- NEVER use the \`pochi://\` schema for a project/user skill; \`pochi://skills/...\` resolves ONLY to built-in skills
 - Proactively explore the skill directory for optional resources that enhance task completion:
   * scripts/ - executable code that agents can run (Python, Bash, JavaScript, etc.)
   * references/ - on-demand documentation (REFERENCE.md, FORMS.md, domain-specific files)

--- a/packages/tools/src/use-skill.ts
+++ b/packages/tools/src/use-skill.ts
@@ -74,8 +74,10 @@ Important:
 - Only use skills listed in "Available skills" below
 - Check compatibility requirements before using a skill - ensure the skill is compatible with the current OS/environment
 - After calling this tool, follow the returned instructions step by step
-- The skill file location is shown in the [Location: filepath] section of each skill listing below - use this information to understand where the skill is defined
-- Use the directory containing the skill's source file as the base directory for resolving any resource files mentioned in the instructions
+- The skill file location is shown in the [Location: filepath] section of each skill listing below - use it to decide how to resolve any resource files (e.g. a \`references/<name>.md\` reference in the instructions) the skill mentions:
+  * Built-in skills (shipped with Pochi; [Location] lives inside the extension's bundled \`assets/skills/...\`): address resources with the \`pochi://\` schema, i.e. \`pochi://skills/<skill-name>/<resource-path>\` (e.g. \`pochi://skills/<skill-name>/references/<name>.md\`)
+  * Project/user skills ([Location] is a workspace or home path such as \`.pochi/skills/...\` or \`~/.pochi/skills/...\`): resolve resources as normal filesystem paths relative to the [Location] directory
+- NEVER use the \`pochi://\` schema for a project/user skill - \`pochi://skills/...\` resolves ONLY to built-in skills
 - Proactively explore the skill directory for optional resources that enhance task completion:
   * scripts/ - executable code that agents can run (Python, Bash, JavaScript, etc.)
   * references/ - on-demand documentation (REFERENCE.md, FORMS.md, domain-specific files)


### PR DESCRIPTION
## Summary
- The model was applying the built-in `pochi://skills/...` schema to project/user skills, whose resources actually live on the real filesystem.
- Reworked the `useSkill` tool guidance so resource paths are resolved based on the skill's `[Location]`:
  - Built-in skills (bundled under the extension's `assets/skills/...`) → address resources via the `pochi://skills/<skill-name>/...` schema.
  - Project/user skills (`.pochi/skills/...` or `~/.pochi/skills/...`) → resolve resources as filesystem paths relative to `[Location]`.
- Added an explicit rule: never use the `pochi://` schema for project/user skills.

This is a prompt-only change (no runtime/path-processing logic).

## Test plan
- [x] `bunx @biomejs/biome check packages/tools/src/use-skill.ts`
- [x] `bun run test` in `packages/tools` (116 passing)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-554581143bd2498d8492f9646725a967)