### PR TITLE
chore(vscode): bump version to 0.59.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.57.0-dev",
+  "version": "0.59.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump the `pochi` VS Code extension version from `0.57.0-dev` to `0.59.0-dev`.

## Test plan
- [ ] CI passes

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-cc8c779d703849e4a932b2e1c7df318f)