### PR TITLE
feat(livekit): add MiniMax as a new LLM provider

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -422,6 +422,67 @@
               "kind"
             ],
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Display name of the provider, e.g., \"OpenAI\", \"Anthropic\", etc.",
+                "type": "string"
+              },
+              "models": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "Display name of the model, e.g., \"GPT-4o\"",
+                      "type": "string"
+                    },
+                    "maxTokens": {
+                      "description": "Maximum number of generated tokens for the model",
+                      "type": "number"
+                    },
+                    "contextWindow": {
+                      "description": "Context window size for the model",
+                      "type": "number"
+                    },
+                    "useToolCallMiddleware": {
+                      "description": "Whether to use tool call middleware",
+                      "type": "boolean"
+                    },
+                    "contentType": {
+                      "description": "The supported mime types model can handle",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "baseURL": {
+                "description": "Base URL for the model provider's API, e.g., \"https://api.openai.com/v1\"",
+                "type": "string"
+              },
+              "apiKey": {
+                "description": "API key for the model provider, if required.",
+                "type": "string"
+              },
+              "kind": {
+                "type": "string",
+                "const": "minimax"
+              }
+            },
+            "required": [
+              "models",
+              "kind"
+            ],
+            "additionalProperties": false
           }
         ]
       }

--- a/bun.lock
+++ b/bun.lock
@@ -168,6 +168,7 @@
         "ai": "catalog:",
         "react": "catalog:",
         "remeda": "catalog:",
+        "vercel-minimax-ai-provider": "^0.0.2",
         "zod": "catalog:",
       },
     },
@@ -4421,6 +4422,8 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
+    "vercel-minimax-ai-provider": ["vercel-minimax-ai-provider@0.0.2", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.6", "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.4" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-h9QzLL7RBmOreqWfr2fcoFVNTJgusENJVagVm8vAi+DBfd+1t+sVJZ/hAhKrtuCKCrm33BlOSWVdJehQFju5jQ=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
@@ -5419,6 +5422,12 @@
 
     "unbzip2-stream/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
+    "vercel-minimax-ai-provider/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.6", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@ai-sdk/provider-utils": "4.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ns5OOPHXbODzitvqCySnAFZCAm9ldpx+fdbC0c/f9QwX5b4MQtQJIQ0xZyKm+tB/ynBoeV6zhtyWDXjYeVEWIw=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/provider": ["@ai-sdk/provider@3.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.4", "", { "dependencies": { "@ai-sdk/provider": "3.0.2", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VxhX0B/dWGbpNHxrKCWUAJKXIXV015J4e7qYjdIU9lLWeptk0KMLGcqkB4wFxff5Njqur8dt8wRi1MN9lZtDqg=="],
+
     "vite/esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
 
     "vite/postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
@@ -6137,6 +6146,12 @@
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg=="],
 
+    "vercel-minimax-ai-provider/@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@3.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2lR4w7mr9XrydzxBSjir4N6YMGdXD+Np1Sh0RXABh7tWdNFFwIeRI1Q+SaYZMbfL8Pg8RRLcrxQm51yxTLhokg=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.3", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Vo2p61dDld8Dy/O66zKQpE4nqHojiEEYEjZcSbICjE7h8Z6QmHzBfd+ss/paIDdyXyS0yHmC1GoRYYKo89cqZQ=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "vite-node/vite/esbuild": ["esbuild@0.25.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.1", "@esbuild/android-arm": "0.25.1", "@esbuild/android-arm64": "0.25.1", "@esbuild/android-x64": "0.25.1", "@esbuild/darwin-arm64": "0.25.1", "@esbuild/darwin-x64": "0.25.1", "@esbuild/freebsd-arm64": "0.25.1", "@esbuild/freebsd-x64": "0.25.1", "@esbuild/linux-arm": "0.25.1", "@esbuild/linux-arm64": "0.25.1", "@esbuild/linux-ia32": "0.25.1", "@esbuild/linux-loong64": "0.25.1", "@esbuild/linux-mips64el": "0.25.1", "@esbuild/linux-ppc64": "0.25.1", "@esbuild/linux-riscv64": "0.25.1", "@esbuild/linux-s390x": "0.25.1", "@esbuild/linux-x64": "0.25.1", "@esbuild/netbsd-arm64": "0.25.1", "@esbuild/netbsd-x64": "0.25.1", "@esbuild/openbsd-arm64": "0.25.1", "@esbuild/openbsd-x64": "0.25.1", "@esbuild/sunos-x64": "0.25.1", "@esbuild/win32-arm64": "0.25.1", "@esbuild/win32-ia32": "0.25.1", "@esbuild/win32-x64": "0.25.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ=="],
 
     "vite-node/vite/postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
@@ -6502,6 +6517,8 @@
     "shiki/@shikijs/engine-javascript/oniguruma-to-es/regex": ["regex@6.0.1", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA=="],
 
     "shiki/@shikijs/engine-javascript/oniguruma-to-es/regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/anthropic/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ=="],
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -745,7 +745,8 @@ async function createLLMConfigWithProviders(
     modelProvider.kind === undefined ||
     modelProvider.kind === "openai" ||
     modelProvider.kind === "openai-responses" ||
-    modelProvider.kind === "anthropic"
+    modelProvider.kind === "anthropic" ||
+    modelProvider.kind === "minimax"
   ) {
     return {
       id: `${providerId}/${modelId}`,

--- a/packages/common/src/configuration/model.ts
+++ b/packages/common/src/configuration/model.ts
@@ -59,6 +59,10 @@ const AnthropicModelSettings = ExtendedModelSettings.extend({
   kind: z.literal("anthropic"),
 });
 
+const MiniMaxModelSettings = ExtendedModelSettings.extend({
+  kind: z.literal("minimax"),
+});
+
 export const GoogleVertexModel = z
   .discriminatedUnion("type", [
     z.object({
@@ -121,6 +125,7 @@ export const CustomModelSetting = z.discriminatedUnion("kind", [
   AnthropicModelSettings,
   GoogleVertexTuningModelSettings,
   AiGatewayModelSettings,
+  MiniMaxModelSettings,
 ]);
 
 /**

--- a/packages/livekit/package.json
+++ b/packages/livekit/package.json
@@ -29,6 +29,7 @@
     "ai": "catalog:",
     "react": "catalog:",
     "remeda": "catalog:",
+    "vercel-minimax-ai-provider": "^0.0.2",
     "zod": "catalog:"
   }
 }

--- a/packages/livekit/src/chat/models/index.ts
+++ b/packages/livekit/src/chat/models/index.ts
@@ -2,6 +2,7 @@ import type { RequestData } from "../../types";
 import { createAiGatewayModel } from "./ai-gateway";
 import { createAnthropicModel } from "./anthropic";
 import { createGoogleVertexTuningModel } from "./google-vertex-tuning";
+import { createMiniMaxModel } from "./minimax";
 import { createOpenAIModel } from "./openai";
 import { createOpenAIResponsesModel } from "./openai-responses";
 
@@ -28,6 +29,10 @@ export function createModel({ llm }: { llm: RequestData["llm"] }) {
 
   if (llm.type === "openai-responses") {
     return createOpenAIResponsesModel(llm);
+  }
+
+  if (llm.type === "minimax") {
+    return createMiniMaxModel(llm);
   }
 
   assertUnreachable(llm);

--- a/packages/livekit/src/chat/models/minimax.ts
+++ b/packages/livekit/src/chat/models/minimax.ts
@@ -1,0 +1,32 @@
+import { createMinimax } from "vercel-minimax-ai-provider";
+
+import { fetchWithCorsProxy } from "@getpochi/common/fetch-utils";
+import { wrapLanguageModel } from "ai";
+import type { RequestData } from "../../types";
+
+export function createMiniMaxModel(
+  llm: Extract<RequestData["llm"], { type: "minimax" }>,
+) {
+  const minimax = createMinimax({
+    baseURL: llm.baseURL,
+    apiKey: llm.apiKey,
+    fetch: fetchWithCorsProxy,
+  });
+
+  return wrapLanguageModel({
+    model: minimax(llm.modelId),
+    middleware: {
+      specificationVersion: "v3",
+      async transformParams({ params }) {
+        params.maxOutputTokens = llm.maxOutputTokens;
+        params.providerOptions = {
+          // createMinimax uses the Anthropic messages protocol under the hood
+          anthropic: {
+            thinking: { type: "enabled" },
+          },
+        };
+        return params;
+      },
+    },
+  });
+}

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -155,6 +155,23 @@ const RequestData = z.object({
     }),
     z.object({
       id: z.string(),
+      type: z.literal("minimax"),
+      modelId: z.string(),
+      baseURL: z.string().optional(),
+      apiKey: z.string().optional(),
+      contextWindow: z.number().describe("Context window of the model."),
+      maxOutputTokens: z.number().describe("Max output tokens of the model."),
+      useToolCallMiddleware: z
+        .boolean()
+        .optional()
+        .describe("Whether to use tool call middleware"),
+      contentType: z
+        .array(z.string())
+        .optional()
+        .describe("The supported mime types model can handle"),
+    }),
+    z.object({
+      id: z.string(),
       type: z.literal("vendor"),
       contextWindow: z
         .number()

--- a/packages/vscode-webui/src/features/chat/lib/display-model-to-llm.ts
+++ b/packages/vscode-webui/src/features/chat/lib/display-model-to-llm.ts
@@ -68,7 +68,8 @@ export function displayModelToLLM(
     provider.kind === undefined ||
     provider.kind === "openai" ||
     provider.kind === "anthropic" ||
-    provider.kind === "openai-responses"
+    provider.kind === "openai-responses" ||
+    provider.kind === "minimax"
   ) {
     return {
       id: model.id,


### PR DESCRIPTION
## Summary

- Adds `vercel-minimax-ai-provider` as a dependency in `packages/livekit`
- Implements `createMiniMaxModel` in `packages/livekit/src/chat/models/minimax.ts` following the same pattern as other providers (OpenAI, Anthropic, etc.)
- Registers the `minimax` kind in `CustomModelSetting` config schema and `RequestData` types
- Wires `minimax` into the `createModel` factory and `displayModelToLLM` mapping
- Updates `assets/config.schema.json` with the full MiniMax provider schema definition

## Test plan

- [ ] Configure a MiniMax provider entry in `.pochi/config.jsonc` with `kind: "minimax"`, `apiKey`, and at least one model
- [ ] Verify the model appears in the model selector
- [ ] Send a chat message and confirm the MiniMax API is called correctly
- [ ] Verify tool-call middleware path works when `useToolCallMiddleware: true` is set

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b3da1ff0763146bca05e2ea53b4c8b9d)