### PR TITLE
fix(livekit): use effectiveContextWindow as the auto-compaction trigger point

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -614,7 +614,7 @@
       "additionalProperties": false
     },
     "effectiveContextWindow": {
-      "description": "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 160000.",
+      "description": "Token count at which auto-compaction triggers, even when the model declares a larger context window (models tend to degrade earlier on agentic tasks). Models whose real context window is smaller trigger earlier to leave room for the summary. Defaults to 160000.",
       "type": "number"
     }
   },

--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -614,7 +614,7 @@
       "additionalProperties": false
     },
     "effectiveContextWindow": {
-      "description": "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 200000.",
+      "description": "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 160000.",
       "type": "number"
     }
   },

--- a/bun.lock
+++ b/bun.lock
@@ -283,7 +283,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.57.0-dev",
+      "version": "0.59.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/common/src/configuration/types.ts
+++ b/packages/common/src/configuration/types.ts
@@ -46,7 +46,7 @@ export function makePochiConfig(strict = false) {
       .number()
       .optional()
       .describe(
-        "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 200000.",
+        "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 160000.",
       ),
   });
 }

--- a/packages/common/src/configuration/types.ts
+++ b/packages/common/src/configuration/types.ts
@@ -46,7 +46,7 @@ export function makePochiConfig(strict = false) {
       .number()
       .optional()
       .describe(
-        "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 160000.",
+        "Token count at which auto-compaction triggers, even when the model declares a larger context window (models tend to degrade earlier on agentic tasks). Models whose real context window is smaller trigger earlier to leave room for the summary. Defaults to 160000.",
       ),
   });
 }

--- a/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
+++ b/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
@@ -63,15 +63,13 @@ const openaiLlm = (contextWindow: number): RequestData["llm"] =>
   }) as RequestData["llm"];
 
 describe("getAutoCompactThreshold", () => {
-  it("caps large declared windows at DefaultEffectiveContextWindow", () => {
+  it("triggers at DefaultEffectiveContextWindow for large declared windows", () => {
     expect(getAutoCompactThreshold(1_000_000)).toBe(
-      DefaultEffectiveContextWindow -
-        MaxSummaryOutputTokens -
-        AutoCompactBufferTokens,
+      DefaultEffectiveContextWindow,
     );
   });
 
-  it("subtracts summary reserve + buffer when the context window is smaller than the effective cap", () => {
+  it("subtracts summary reserve + buffer when the context window is smaller than the effective window", () => {
     expect(getAutoCompactThreshold(100_000)).toBe(
       100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
     );
@@ -80,13 +78,9 @@ describe("getAutoCompactThreshold", () => {
     );
   });
 
-  it("uses an explicit effectiveContextWindow instead of the default cap", () => {
-    expect(getAutoCompactThreshold(1_000_000, 400_000)).toBe(
-      400_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
-    );
-    expect(getAutoCompactThreshold(1_000_000, 100_000)).toBe(
-      100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
-    );
+  it("uses an explicit effectiveContextWindow as the trigger point", () => {
+    expect(getAutoCompactThreshold(1_000_000, 400_000)).toBe(400_000);
+    expect(getAutoCompactThreshold(1_000_000, 100_000)).toBe(100_000);
   });
 
   it("never lets effectiveContextWindow exceed the declared window", () => {

--- a/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
+++ b/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import type { Message, RequestData, Task } from "../../types";
 import {
   AutoCompactBufferTokens,
-  AutoCompactRatio,
   DefaultEffectiveContextWindow,
   MaxSummaryOutputTokens,
   findAutoCompactAttachIndex,
@@ -64,25 +63,26 @@ const openaiLlm = (contextWindow: number): RequestData["llm"] =>
   }) as RequestData["llm"];
 
 describe("getAutoCompactThreshold", () => {
-  it("subtracts summary reserve + buffer from small context windows", () => {
-    expect(getAutoCompactThreshold(100_000)).toBe(
-      100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
+  it("caps large declared windows at DefaultEffectiveContextWindow", () => {
+    expect(getAutoCompactThreshold(1_000_000)).toBe(
+      DefaultEffectiveContextWindow -
+        MaxSummaryOutputTokens -
+        AutoCompactBufferTokens,
     );
   });
 
-  it("caps the threshold at AutoCompactRatio of the window when the absolute buffer is proportionally small", () => {
-    expect(getAutoCompactThreshold(200_000)).toBe(200_000 * AutoCompactRatio);
-  });
-
-  it("caps very large declared windows at DefaultEffectiveContextWindow", () => {
-    expect(getAutoCompactThreshold(1_000_000)).toBe(
-      DefaultEffectiveContextWindow * AutoCompactRatio,
+  it("subtracts summary reserve + buffer when the context window is smaller than the effective cap", () => {
+    expect(getAutoCompactThreshold(100_000)).toBe(
+      100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
+    );
+    expect(getAutoCompactThreshold(40_000)).toBe(
+      40_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
     );
   });
 
   it("uses an explicit effectiveContextWindow instead of the default cap", () => {
     expect(getAutoCompactThreshold(1_000_000, 400_000)).toBe(
-      400_000 * AutoCompactRatio,
+      400_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
     );
     expect(getAutoCompactThreshold(1_000_000, 100_000)).toBe(
       100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
@@ -191,7 +191,7 @@ describe("shouldAutoCompact", () => {
     ).toBe(false);
   });
 
-  it("uses an explicit vendor contextWindow when one is provided", () => {
+  it("caps an explicit vendor contextWindow at the default effective window", () => {
     const messages = [assistantMessage(), userMessage()];
     const vendorLlm = {
       id: "vendor-cli",
@@ -199,14 +199,23 @@ describe("shouldAutoCompact", () => {
       contextWindow: 1_000_000,
       getModel: () => ({}) as never,
     } as RequestData["llm"];
+    const threshold = getAutoCompactThreshold(1_000_000);
 
     expect(
       shouldAutoCompact({
         messages,
         llm: vendorLlm,
-        task: task(constants.CompactTaskMinTokens * 2),
+        task: task(threshold - 1),
       }),
     ).toBe(false);
+
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: vendorLlm,
+        task: task(threshold),
+      }),
+    ).toBe(true);
   });
 
   it("respects an explicit effectiveContextWindow on the llm", () => {
@@ -233,13 +242,19 @@ describe("shouldAutoCompact", () => {
     ).toBe(false);
   });
 
-  it("does not trigger when totalTokens is below the buffer-based threshold", () => {
+  it("does not trigger when totalTokens is below the effective threshold", () => {
     const messages = [assistantMessage(), userMessage()];
+    const llm = {
+      ...openaiLlm(1_000_000),
+      effectiveContextWindow: 100_000,
+    } as RequestData["llm"];
+    const threshold = getAutoCompactThreshold(1_000_000, 100_000);
+
     expect(
       shouldAutoCompact({
         messages,
-        llm: openaiLlm(1_000_000),
-        task: task(minTokens + 1),
+        llm,
+        task: task(threshold - 1),
       }),
     ).toBe(false);
   });

--- a/packages/livekit/src/chat/auto-compact-policy.ts
+++ b/packages/livekit/src/chat/auto-compact-policy.ts
@@ -7,8 +7,8 @@ export const MaxSummaryOutputTokens = 20_000;
 export const AutoCompactBufferTokens = 13_000;
 
 // Most models degrade on agentic tasks well before very large declared
-// windows are exhausted. When no effectiveContextWindow is configured, cap
-// auto-compaction at this token count.
+// windows are exhausted. When no effectiveContextWindow is configured,
+// auto-compaction triggers at this token count.
 export const DefaultEffectiveContextWindow = 160_000;
 
 export const MaxConsecutiveAutoCompactFailures = 3;
@@ -17,11 +17,13 @@ export function getAutoCompactThreshold(
   contextWindow: number,
   effectiveContextWindow?: number,
 ): number {
-  const window = Math.min(
-    effectiveContextWindow ?? DefaultEffectiveContextWindow,
-    contextWindow,
-  );
-  return Math.max(window - MaxSummaryOutputTokens - AutoCompactBufferTokens, 0);
+  // The effective window is the point where auto-compaction triggers. When the
+  // model's real context window is too small to hold that point plus the
+  // summary output, back off so the compaction request itself doesn't overflow.
+  const triggerPoint = effectiveContextWindow ?? DefaultEffectiveContextWindow;
+  const bufferLimit =
+    contextWindow - MaxSummaryOutputTokens - AutoCompactBufferTokens;
+  return Math.max(Math.min(triggerPoint, bufferLimit), 0);
 }
 
 function resolveContextWindow(llm: RequestData["llm"] | undefined): {

--- a/packages/livekit/src/chat/auto-compact-policy.ts
+++ b/packages/livekit/src/chat/auto-compact-policy.ts
@@ -6,14 +6,10 @@ export const MaxSummaryOutputTokens = 20_000;
 
 export const AutoCompactBufferTokens = 13_000;
 
-// The absolute buffer alone kicks in far too late on large context windows,
-// so the threshold is also capped at this fraction of the effective window.
-export const AutoCompactRatio = 0.8;
-
 // Most models degrade on agentic tasks well before very large declared
 // windows are exhausted. When no effectiveContextWindow is configured, cap
-// the window used for auto-compaction here.
-export const DefaultEffectiveContextWindow = 200_000;
+// auto-compaction at this token count.
+export const DefaultEffectiveContextWindow = 160_000;
 
 export const MaxConsecutiveAutoCompactFailures = 3;
 
@@ -22,12 +18,10 @@ export function getAutoCompactThreshold(
   effectiveContextWindow?: number,
 ): number {
   const window = Math.min(
-    effectiveContextWindow || DefaultEffectiveContextWindow,
+    effectiveContextWindow ?? DefaultEffectiveContextWindow,
     contextWindow,
   );
-  const byBuffer = window - MaxSummaryOutputTokens - AutoCompactBufferTokens;
-  const byRatio = Math.floor(window * AutoCompactRatio);
-  return Math.max(Math.min(byBuffer, byRatio), 0);
+  return Math.max(window - MaxSummaryOutputTokens - AutoCompactBufferTokens, 0);
 }
 
 function resolveContextWindow(llm: RequestData["llm"] | undefined): {


### PR DESCRIPTION
## Summary
- Treat `effectiveContextWindow` (or the 160k default) as the token count at which auto-compaction triggers, instead of a ratio/buffer-derived cap. This makes the setting directly configurable — the value you set is the trigger point.
- The summary reserve + buffer now only apply as a fallback when the model's real context window is too small to hold the trigger point plus the summary output, so the compaction request itself never overflows.
- Lower the default effective window to 160k and update the config schema descriptions.

## Behavior
| Model | Trigger point |
|---|---|
| 200k / 1M declared, default | 160k |
| config `effectiveContextWindow: 400k` on a 1M model | 400k |
| 128k (qwen-code) | 95k (buffer-protected) |
| 100k fallback / BYOK | 67k (buffer-protected) |

## Test plan
- [x] bun vitest --run packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
- [x] bun check

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8eb5494eed914380957090bef44aef86)