### PR TITLE
fix(common): merge consecutive reasoning parts for UI

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -90,6 +90,71 @@ describe('formatters', () => {
       expect(assistantMessages[0].id).toBe('assistant-2');
     });
 
+    it('should combine consecutive reasoning parts', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            { type: 'reasoning', text: 'First reasoning paragraph.' },
+            {
+              type: 'reasoning',
+              text: 'Second reasoning paragraph.',
+              providerMetadata: { openai: { itemId: 'rs_abc123' } },
+            },
+            { type: 'text', text: 'Done' },
+            { type: 'reasoning', text: 'Third reasoning paragraph.' },
+            { type: 'reasoning', text: 'Fourth reasoning paragraph.' },
+          ],
+        },
+      ];
+
+      const formatted = formatters.ui(clone(messages));
+
+      expect(formatted[0].parts).toHaveLength(3);
+      expect(formatted[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'First reasoning paragraph.\nSecond reasoning paragraph.',
+        providerMetadata: { openai: { itemId: 'rs_abc123' } },
+      });
+      expect(formatted[0].parts[1]).toEqual({ type: 'text', text: 'Done' });
+      expect(formatted[0].parts[2]).toEqual({
+        type: 'reasoning',
+        text: 'Third reasoning paragraph.\nFourth reasoning paragraph.',
+      });
+    });
+
+    it('should use the latest reasoning state when combining consecutive reasoning parts', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Finished reasoning paragraph.',
+              state: 'done',
+            },
+            {
+              type: 'reasoning',
+              text: 'Streaming reasoning paragraph.',
+              state: 'streaming',
+            },
+          ],
+        },
+      ];
+
+      const formatted = formatters.ui(clone(messages));
+
+      expect(formatted[0].parts).toEqual([
+        {
+          type: 'reasoning',
+          text: 'Finished reasoning paragraph.\nStreaming reasoning paragraph.',
+          state: 'streaming',
+        },
+      ]);
+    });
+
     it('should keep the last message id when combining three or more consecutive assistant messages', () => {
       const messages: UIMessage[] = [
         {

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -215,6 +215,49 @@ function combineConsecutiveAssistantMessages(
   return result;
 }
 
+function combineConsecutiveReasoningParts(messages: UIMessage[]): UIMessage[] {
+  return messages.map((message) => {
+    const parts: UIMessage["parts"] = [];
+
+    for (const part of message.parts) {
+      const prev = parts.at(-1);
+      if (part.type === "reasoning" && prev?.type === "reasoning") {
+        // This merge is only for UI rendering. A shallow merge may overwrite
+        // nested providerMetadata from earlier reasoning parts, but losing that
+        // metadata here is acceptable because LLM/storage formatting does not
+        // use this UI-only operation.
+        const providerMetadata =
+          prev.providerMetadata || part.providerMetadata
+            ? {
+                ...prev.providerMetadata,
+                ...part.providerMetadata,
+              }
+            : undefined;
+        const {
+          providerMetadata: _providerMetadata,
+          state: _state,
+          ...prevPart
+        } = prev;
+
+        parts[parts.length - 1] = {
+          ...prevPart,
+          text: `${prev.text}\n${part.text}`,
+          ...(part.state ? { state: part.state } : {}),
+          ...(providerMetadata ? { providerMetadata } : {}),
+        };
+        continue;
+      }
+
+      parts.push(part);
+    }
+
+    return {
+      ...message,
+      parts,
+    };
+  });
+}
+
 function removeEmptyMessages(messages: UIMessage[]): UIMessage[] {
   return messages.filter((message) => message.parts.length > 0);
 }
@@ -793,6 +836,7 @@ const UIFormatOps = [
   resolvePendingToolCalls,
   removeSystemReminder,
   combineConsecutiveAssistantMessages,
+  combineConsecutiveReasoningParts,
 ];
 const ShareUIFormatOps = [...UIFormatOps, resolvePendingToolCallsForShareUI];
 const StorageFormatOps = [


### PR DESCRIPTION
## Summary
- Combine consecutive reasoning parts during UI formatting so adjacent thinking blocks render as one block.
- Preserve newline-separated paragraphs and keep the latest reasoning state for streaming updates.
- Cover paragraph merging and `done` -> `streaming` state behavior with formatter tests.

## Test plan
- `bun vitest --run src/base/__tests__/formatters.test.ts` from `packages/common`
- `bun tsc` from `packages/common`
- `bun check` from repo root

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-58035fd22fcd4761ad4baeb45d01b0b7)