### PR TITLE
feat(tools): make executeCommand default timeout configurable

### DIFF
--- a/packages/cli/src/tools/execute-command.ts
+++ b/packages/cli/src/tools/execute-command.ts
@@ -10,7 +10,11 @@ import {
   fixExecuteCommandOutput,
   getShellPath,
 } from "@getpochi/common/tool-utils";
-import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
+import {
+  type ClientTools,
+  ExecuteCommandDefaultTimeoutSec,
+  type ToolFunctionType,
+} from "@getpochi/tools";
 
 export class ExecuteCommandError extends Error {
   public code: number;
@@ -38,7 +42,7 @@ export class ExecuteCommandError extends Error {
 export const executeCommand =
   (): ToolFunctionType<ClientTools["executeCommand"]> =>
   async (
-    { command, cwd = ".", timeout = 120 },
+    { command, cwd = ".", timeout = ExecuteCommandDefaultTimeoutSec },
     { abortSignal, cwd: workspaceDir, envs },
   ) => {
     if (!command) {

--- a/packages/tools/src/execute-command.ts
+++ b/packages/tools/src/execute-command.ts
@@ -1,6 +1,31 @@
 import { z } from "zod";
 import { defineClientTool } from "./types";
 
+function resolveExecuteCommandDefaultTimeoutSec(): number {
+  const fallback = 60;
+  const envValue =
+    typeof process !== "undefined"
+      ? process.env.POCHI_EXECUTE_COMMAND_TIMEOUT_SEC
+      : undefined;
+
+  if (!envValue) {
+    return fallback;
+  }
+
+  const parsed = Number(envValue);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Default timeout (in seconds) for the `executeCommand` tool, used when the
+ * model does not specify a `timeout` for a given command.
+ *
+ * Can be overridden via the `POCHI_EXECUTE_COMMAND_TIMEOUT_SEC` environment
+ * variable.
+ */
+export const ExecuteCommandDefaultTimeoutSec =
+  resolveExecuteCommandDefaultTimeoutSec();
+
 const toolDef = {
   description:
     `Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
@@ -25,7 +50,7 @@ Before executing the command, please follow these steps:
 
 Usage notes:
 - The command argument is required.
-- You can specify an optional timeout in seconds (up to 300s / 5 minutes). If not specified, commands will timeout after 60s (1 minute).
+- You can specify an optional timeout in seconds (up to 300s). If not specified, commands will timeout after ${ExecuteCommandDefaultTimeoutSec}s.
 - If the output exceeds 30000 characters, output will be truncated before being returned to you.
 - When issuing multiple commands:
   - If the commands are independent and can run in parallel, make multiple executeCommand tool calls in a single message. For example, if you need to run "git status" and "git diff", send a single message with two executeCommand tool calls in parallel.
@@ -145,7 +170,7 @@ Important:
       .max(60 * 5)
       .optional()
       .describe(
-        "Optional timeout in seconds, max 300 seconds. By default the timeout is 120 seconds.",
+        `Optional timeout in seconds, max 300 seconds. By default the timeout is ${ExecuteCommandDefaultTimeoutSec} seconds.`,
       ),
   }),
   outputSchema: z.object({

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,6 +1,7 @@
 export { McpTool } from "./mcp-tools";
 import { ToolsByPermission } from "./constants";
 export { ToolsByPermission, MaxToolCallConcurrency } from "./constants";
+export { ExecuteCommandDefaultTimeoutSec } from "./execute-command";
 import {
   type Tool,
   type UIDataTypes,

--- a/packages/vscode/src/tools/execute-command.ts
+++ b/packages/vscode/src/tools/execute-command.ts
@@ -6,7 +6,11 @@ import {
   maybePersistToolResult,
 } from "@getpochi/common/tool-utils";
 import type { ExecuteCommandResult } from "@getpochi/common/vscode-webui-bridge";
-import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
+import {
+  type ClientTools,
+  ExecuteCommandDefaultTimeoutSec,
+  type ToolFunctionType,
+} from "@getpochi/tools";
 import { signal } from "@preact/signals-core";
 import {
   ThreadSignal,
@@ -31,10 +35,9 @@ type CompletedCommandOutput = {
 export const executeCommand: ToolFunctionType<
   ClientTools["executeCommand"]
 > = async (
-  { command, cwd = ".", timeout },
+  { command, cwd = ".", timeout = ExecuteCommandDefaultTimeoutSec },
   { abortSignal, cwd: workspaceDir, envs, toolCallId, taskId },
 ) => {
-  const defaultTimeout = 120;
   if (!command) {
     throw new Error("Command is required to execute.");
   }
@@ -94,7 +97,7 @@ export const executeCommand: ToolFunctionType<
     executeCommandImpl({
       command,
       cwd,
-      timeout: timeout ?? defaultTimeout,
+      timeout,
       abortSignal,
       envs,
       onData: (data) => {


### PR DESCRIPTION
## Summary
- Introduce `ExecuteCommandDefaultTimeoutSec` (default `60`s) in `packages/tools/src/execute-command.ts`, overridable via the `POCHI_EXECUTE_COMMAND_TIMEOUT_SEC` environment variable.
- Update the `executeCommand` tool prompt and `timeout` schema description to reflect the actual configured default instead of hardcoded/inconsistent values (60s vs 120s).
- Export `ExecuteCommandDefaultTimeoutSec` from `@getpochi/tools` and use it as the default timeout in both the VS Code (`packages/vscode/src/tools/execute-command.ts`) and CLI (`packages/cli/src/tools/execute-command.ts`) implementations, replacing the previously hardcoded `120`.

## Test plan
- [x] `bun tsc` (root + `packages/vscode`) — no type errors
- [x] `bun check` — biome/ast-grep/i18n checks pass
- [x] `packages/tools` vitest suite — 116 tests passed
- [x] `packages/cli` vitest suite (execute-command) — 112 tests passed
- [x] `packages/vscode` mocha suite — 177 tests passed

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-001d536aa8234b59a47f56c93e170565)