### PR TITLE
fix(common): strip streaming OpenAI item refs from finished messages

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -707,6 +707,53 @@ describe('formatters', () => {
       expect(reasoningPart.providerMetadata.openai.itemId).toBe('rs_finished');
     });
 
+    it('should strip a streaming reasoning item from every part of a finished message', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          metadata: { kind: 'assistant' },
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Committed reasoning',
+              state: 'done',
+              providerMetadata: {
+                openai: { itemId: 'rs_committed' },
+              },
+            },
+            {
+              type: 'reasoning',
+              text: 'Finished summary part',
+              state: 'done',
+              providerOptions: {
+                openai: { itemId: 'rs_interrupted' },
+              },
+            },
+            {
+              type: 'reasoning',
+              text: 'Streaming summary part',
+              state: 'streaming',
+              providerMetadata: {
+                openai: { itemId: 'rs_interrupted' },
+              },
+            },
+            { type: 'text', text: 'Response' },
+          ],
+        } as UIMessage,
+      ];
+
+      const formatted = formatters.llm(clone(messages));
+      const [committedPart, finishedPart, streamingPart] = formatted[0]
+        .parts as any[];
+
+      expect(committedPart.providerMetadata.openai.itemId).toBe(
+        'rs_committed',
+      );
+      expect(finishedPart.providerOptions).toBeUndefined();
+      expect(streamingPart.providerMetadata).toBeUndefined();
+    });
+
     it('should strip OpenAI item references from unfinished tool call parts', () => {
       const toolPart = createToolPart('testTool', 'input-available', {
         arg: 1,

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -554,10 +554,36 @@ type PartWithProviderMetadata = UIMessage["parts"][number] & {
   resultProviderMetadata?: ProviderMetadataMap;
 };
 
+const ProviderMetadataFields = [
+  "providerMetadata",
+  "providerOptions",
+  "callProviderMetadata",
+  "resultProviderMetadata",
+] as const;
+
+function getOpenAIItemIds(part: UIMessage["parts"][number]): string[] {
+  const partWithMetadata = part as PartWithProviderMetadata;
+  const itemIds = new Set<string>();
+
+  for (const field of ProviderMetadataFields) {
+    const itemId = partWithMetadata[field]?.openai?.itemId;
+    if (typeof itemId === "string") itemIds.add(itemId);
+  }
+
+  return [...itemIds];
+}
+
 function removeOpenAIItemId(
   metadata: ProviderMetadataMap | undefined,
+  unstableItemIds?: ReadonlySet<string>,
 ): ProviderMetadataMap | undefined {
-  if (!metadata?.openai || !("itemId" in metadata.openai)) {
+  const itemId = metadata?.openai?.itemId;
+  if (
+    !metadata?.openai ||
+    !("itemId" in metadata.openai) ||
+    (unstableItemIds &&
+      (typeof itemId !== "string" || !unstableItemIds.has(itemId)))
+  ) {
     return metadata;
   }
 
@@ -579,29 +605,55 @@ function isUnfinishedAssistantMessage(message: UIMessage): boolean {
   return metadata?.kind !== "assistant";
 }
 
+function isStreamingPart(part: UIMessage["parts"][number]): boolean {
+  if (part.type === "text" || part.type === "reasoning") {
+    return part.state === "streaming";
+  }
+
+  return "state" in part && part.state === "input-streaming";
+}
+
 function removeUnstableOpenAIItemReferences(
   messages: UIMessage[],
 ): UIMessage[] {
   // OpenAI Responses item references can point at output items that were never
-  // committed server-side when a stream was interrupted or failed. Remove only
-  // the fragile item id for unfinished messages and keep other metadata such as
-  // reasoningEncryptedContent so the SDK can resend the reasoning payload.
+  // committed server-side when a stream was interrupted or failed. Keep other
+  // metadata such as reasoningEncryptedContent so the SDK can resend it.
   return messages.map((message) => {
-    if (!isUnfinishedAssistantMessage(message)) return message;
+    if (message.role !== "assistant") return message;
+
+    const stripAllItemIds = isUnfinishedAssistantMessage(message);
+    // The SDK reuses the previous assistant message while continuing a task,
+    // so message-level completion metadata may be stale. A streaming part is
+    // authoritative; remove its id everywhere because one OpenAI reasoning
+    // item can be split into several UI parts that all share the same id.
+    const unstableItemIds = stripAllItemIds
+      ? undefined
+      : new Set(
+          message.parts
+            .filter(isStreamingPart)
+            .flatMap((part) => getOpenAIItemIds(part)),
+        );
+
+    if (!stripAllItemIds && unstableItemIds?.size === 0) return message;
 
     message.parts = message.parts.map((part) => {
       const partWithMetadata = part as PartWithProviderMetadata;
       const providerMetadata = removeOpenAIItemId(
         partWithMetadata.providerMetadata,
+        unstableItemIds,
       );
       const providerOptions = removeOpenAIItemId(
         partWithMetadata.providerOptions,
+        unstableItemIds,
       );
       const callProviderMetadata = removeOpenAIItemId(
         partWithMetadata.callProviderMetadata,
+        unstableItemIds,
       );
       const resultProviderMetadata = removeOpenAIItemId(
         partWithMetadata.resultProviderMetadata,
+        unstableItemIds,
       );
 
       if (


### PR DESCRIPTION
## Summary
- A single OpenAI Responses reasoning item can be split across several UI parts that all share the same `itemId`. When a stream is interrupted, the message-level completion metadata may be stale (the SDK reuses the previous assistant message while continuing a task), so the previous unfinished-message heuristic could miss references that later 404 as "item not found".
- Now, for finished assistant messages, we treat any streaming part as authoritative: collect the unstable `itemId`s from streaming parts and remove them from every part that references them, across all four metadata fields (`providerMetadata`, `providerOptions`, `callProviderMetadata`, `resultProviderMetadata`), while preserving `reasoningEncryptedContent` so the SDK can resend the reasoning payload.
- Added `getOpenAIItemIds` / `isStreamingPart` helpers and a regression test covering a finished message whose committed reasoning is kept while the interrupted/streaming item id is stripped from every part.

## Test plan
- [ ] `bun run test` in `packages/common`
- [ ] Verify no more OpenAI "item not found" errors when continuing an interrupted Responses task

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-55e4a74d289942549912ca0d0f8ed9d1)