### PR TITLE
fix(livekit): strip OpenAI item refs from failed steps

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -707,13 +707,14 @@ describe('formatters', () => {
       expect(reasoningPart.providerMetadata.openai.itemId).toBe('rs_finished');
     });
 
-    it('should strip a streaming reasoning item from every part of a finished message', () => {
+    it('should strip every OpenAI item reference from the step containing a streaming part', () => {
       const messages: UIMessage[] = [
         {
           id: 'assistant-1',
           role: 'assistant',
           metadata: { kind: 'assistant' },
           parts: [
+            { type: 'step-start' },
             {
               type: 'reasoning',
               text: 'Committed reasoning',
@@ -722,12 +723,16 @@ describe('formatters', () => {
                 openai: { itemId: 'rs_committed' },
               },
             },
+            { type: 'step-start' },
             {
               type: 'reasoning',
               text: 'Finished summary part',
               state: 'done',
               providerOptions: {
-                openai: { itemId: 'rs_interrupted' },
+                openai: {
+                  itemId: 'rs_done_but_uncommitted',
+                  reasoningEncryptedContent: 'encrypted-reasoning',
+                },
               },
             },
             {
@@ -735,7 +740,7 @@ describe('formatters', () => {
               text: 'Streaming summary part',
               state: 'streaming',
               providerMetadata: {
-                openai: { itemId: 'rs_interrupted' },
+                openai: { itemId: 'rs_streaming' },
               },
             },
             { type: 'text', text: 'Response' },
@@ -744,13 +749,15 @@ describe('formatters', () => {
       ];
 
       const formatted = formatters.llm(clone(messages));
-      const [committedPart, finishedPart, streamingPart] = formatted[0]
+      const [, committedPart, , finishedPart, streamingPart] = formatted[0]
         .parts as any[];
 
       expect(committedPart.providerMetadata.openai.itemId).toBe(
         'rs_committed',
       );
-      expect(finishedPart.providerOptions).toBeUndefined();
+      expect(finishedPart.providerOptions.openai).toEqual({
+        reasoningEncryptedContent: 'encrypted-reasoning',
+      });
       expect(streamingPart.providerMetadata).toBeUndefined();
     });
 

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -11,6 +11,7 @@ import {
   isStaticToolUIPart,
 } from "ai";
 import { clone } from "remeda";
+import { stripOpenAIItemReferencesFromLastStep } from "../message-utils/openai-item-references";
 import { AttemptTodoCompletionAgentName, KnownTags } from "./constants";
 import type { MessageMetadata } from "./message";
 import { prompts } from "./prompts";
@@ -540,63 +541,6 @@ function extractCompactMessages(messages: UIMessage[]) {
   return messages;
 }
 
-type ProviderMetadataMap = Record<string, Record<string, unknown>>;
-
-type PartWithProviderMetadata = UIMessage["parts"][number] & {
-  providerMetadata?: ProviderMetadataMap;
-  providerOptions?: ProviderMetadataMap;
-  // Tool-call parts carry their provider metadata (e.g. OpenAI itemId) here.
-  // The SDK maps it back to providerOptions when converting to model messages.
-  callProviderMetadata?: ProviderMetadataMap;
-  // Provider-executed tool results carry their metadata here; the SDK maps it
-  // into the tool-result providerOptions. Kept for defense-in-depth in case
-  // provider-executed OpenAI tools are ever enabled.
-  resultProviderMetadata?: ProviderMetadataMap;
-};
-
-const ProviderMetadataFields = [
-  "providerMetadata",
-  "providerOptions",
-  "callProviderMetadata",
-  "resultProviderMetadata",
-] as const;
-
-function getOpenAIItemIds(part: UIMessage["parts"][number]): string[] {
-  const partWithMetadata = part as PartWithProviderMetadata;
-  const itemIds = new Set<string>();
-
-  for (const field of ProviderMetadataFields) {
-    const itemId = partWithMetadata[field]?.openai?.itemId;
-    if (typeof itemId === "string") itemIds.add(itemId);
-  }
-
-  return [...itemIds];
-}
-
-function removeOpenAIItemId(
-  metadata: ProviderMetadataMap | undefined,
-  unstableItemIds?: ReadonlySet<string>,
-): ProviderMetadataMap | undefined {
-  const itemId = metadata?.openai?.itemId;
-  if (
-    !metadata?.openai ||
-    !("itemId" in metadata.openai) ||
-    (unstableItemIds &&
-      (typeof itemId !== "string" || !unstableItemIds.has(itemId)))
-  ) {
-    return metadata;
-  }
-
-  const { itemId: _itemId, ...openaiWithoutItemId } = metadata.openai;
-  const { openai: _openai, ...metadataWithoutOpenAI } = metadata;
-  const nextMetadata =
-    Object.keys(openaiWithoutItemId).length > 0
-      ? { ...metadataWithoutOpenAI, openai: openaiWithoutItemId }
-      : metadataWithoutOpenAI;
-
-  return Object.keys(nextMetadata).length > 0 ? nextMetadata : undefined;
-}
-
 function isUnfinishedAssistantMessage(message: UIMessage): boolean {
   if (message.role !== "assistant") return false;
 
@@ -622,65 +566,17 @@ function removeUnstableOpenAIItemReferences(
   return messages.map((message) => {
     if (message.role !== "assistant") return message;
 
-    const stripAllItemIds = isUnfinishedAssistantMessage(message);
-    // The SDK reuses the previous assistant message while continuing a task,
-    // so message-level completion metadata may be stale. A streaming part is
-    // authoritative; remove its id everywhere because one OpenAI reasoning
-    // item can be split into several UI parts that all share the same id.
-    const unstableItemIds = stripAllItemIds
-      ? undefined
-      : new Set(
-          message.parts
-            .filter(isStreamingPart)
-            .flatMap((part) => getOpenAIItemIds(part)),
-        );
+    // Completion metadata can be stale after a failed stream. If any part is
+    // still streaming, the latest step is the current LLM call. Strip every
+    // item id in that step: a "done" reasoning part only means that part's
+    // stream ended, not that the containing OpenAI response was committed.
+    const shouldStripLastStep =
+      isUnfinishedAssistantMessage(message) ||
+      message.parts.some(isStreamingPart);
 
-    if (!stripAllItemIds && unstableItemIds?.size === 0) return message;
-
-    message.parts = message.parts.map((part) => {
-      const partWithMetadata = part as PartWithProviderMetadata;
-      const providerMetadata = removeOpenAIItemId(
-        partWithMetadata.providerMetadata,
-        unstableItemIds,
-      );
-      const providerOptions = removeOpenAIItemId(
-        partWithMetadata.providerOptions,
-        unstableItemIds,
-      );
-      const callProviderMetadata = removeOpenAIItemId(
-        partWithMetadata.callProviderMetadata,
-        unstableItemIds,
-      );
-      const resultProviderMetadata = removeOpenAIItemId(
-        partWithMetadata.resultProviderMetadata,
-        unstableItemIds,
-      );
-
-      if (
-        providerMetadata === partWithMetadata.providerMetadata &&
-        providerOptions === partWithMetadata.providerOptions &&
-        callProviderMetadata === partWithMetadata.callProviderMetadata &&
-        resultProviderMetadata === partWithMetadata.resultProviderMetadata
-      ) {
-        return part;
-      }
-
-      const {
-        providerMetadata: _providerMetadata,
-        providerOptions: _providerOptions,
-        callProviderMetadata: _callProviderMetadata,
-        resultProviderMetadata: _resultProviderMetadata,
-        ...partWithoutOpenAIItemIds
-      } = partWithMetadata;
-      return {
-        ...partWithoutOpenAIItemIds,
-        ...(providerMetadata ? { providerMetadata } : {}),
-        ...(providerOptions ? { providerOptions } : {}),
-        ...(callProviderMetadata ? { callProviderMetadata } : {}),
-        ...(resultProviderMetadata ? { resultProviderMetadata } : {}),
-      } as UIMessage["parts"][number];
-    });
-    return message;
+    return shouldStripLastStep
+      ? stripOpenAIItemReferencesFromLastStep(message)
+      : message;
   });
 }
 

--- a/packages/common/src/message-utils/index.ts
+++ b/packages/common/src/message-utils/index.ts
@@ -6,4 +6,5 @@ export {
   prepareLastMessageForRetry,
   fixCodeGenerationOutput,
 } from "./assistant-message";
+export { stripOpenAIItemReferencesFromLastStep } from "./openai-item-references";
 export { hasActiveTodos, hasTodos } from "./todo";

--- a/packages/common/src/message-utils/openai-item-references.ts
+++ b/packages/common/src/message-utils/openai-item-references.ts
@@ -1,0 +1,93 @@
+import type { UIMessage } from "ai";
+
+type ProviderMetadataMap = Record<string, Record<string, unknown>>;
+
+type PartWithProviderMetadata = UIMessage["parts"][number] & {
+  providerMetadata?: ProviderMetadataMap;
+  providerOptions?: ProviderMetadataMap;
+  // Tool-call parts carry their provider metadata (e.g. OpenAI itemId) here.
+  // The SDK maps it back to providerOptions when converting to model messages.
+  callProviderMetadata?: ProviderMetadataMap;
+  // Provider-executed tool results carry their metadata here; the SDK maps it
+  // into the tool-result providerOptions.
+  resultProviderMetadata?: ProviderMetadataMap;
+};
+
+function removeOpenAIItemId(
+  metadata: ProviderMetadataMap | undefined,
+): ProviderMetadataMap | undefined {
+  if (!metadata?.openai || !("itemId" in metadata.openai)) {
+    return metadata;
+  }
+
+  const { itemId: _itemId, ...openaiWithoutItemId } = metadata.openai;
+  const { openai: _openai, ...metadataWithoutOpenAI } = metadata;
+  const nextMetadata =
+    Object.keys(openaiWithoutItemId).length > 0
+      ? { ...metadataWithoutOpenAI, openai: openaiWithoutItemId }
+      : metadataWithoutOpenAI;
+
+  return Object.keys(nextMetadata).length > 0 ? nextMetadata : undefined;
+}
+
+/**
+ * Removes OpenAI Responses item references emitted by the latest LLM call.
+ *
+ * A failed or interrupted stream can expose item ids before OpenAI commits the
+ * response. Keep all other provider metadata, especially encrypted reasoning,
+ * so the next request can resend the content without referencing the item id.
+ */
+export function stripOpenAIItemReferencesFromLastStep<T extends UIMessage>(
+  message: T,
+): T {
+  if (message.role !== "assistant") return message;
+
+  const lastStepStartIndex = message.parts.findLastIndex(
+    (part) => part.type === "step-start",
+  );
+  let changed = false;
+  const parts = message.parts.map((part, index) => {
+    if (index <= lastStepStartIndex) return part;
+
+    const partWithMetadata = part as PartWithProviderMetadata;
+    const providerMetadata = removeOpenAIItemId(
+      partWithMetadata.providerMetadata,
+    );
+    const providerOptions = removeOpenAIItemId(
+      partWithMetadata.providerOptions,
+    );
+    const callProviderMetadata = removeOpenAIItemId(
+      partWithMetadata.callProviderMetadata,
+    );
+    const resultProviderMetadata = removeOpenAIItemId(
+      partWithMetadata.resultProviderMetadata,
+    );
+
+    if (
+      providerMetadata === partWithMetadata.providerMetadata &&
+      providerOptions === partWithMetadata.providerOptions &&
+      callProviderMetadata === partWithMetadata.callProviderMetadata &&
+      resultProviderMetadata === partWithMetadata.resultProviderMetadata
+    ) {
+      return part;
+    }
+
+    changed = true;
+    const {
+      providerMetadata: _providerMetadata,
+      providerOptions: _providerOptions,
+      callProviderMetadata: _callProviderMetadata,
+      resultProviderMetadata: _resultProviderMetadata,
+      ...partWithoutOpenAIItemIds
+    } = partWithMetadata;
+    return {
+      ...partWithoutOpenAIItemIds,
+      ...(providerMetadata ? { providerMetadata } : {}),
+      ...(providerOptions ? { providerOptions } : {}),
+      ...(callProviderMetadata ? { callProviderMetadata } : {}),
+      ...(resultProviderMetadata ? { resultProviderMetadata } : {}),
+    } as UIMessage["parts"][number];
+  });
+
+  return changed ? ({ ...message, parts } as T) : message;
+}

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -87,6 +87,78 @@ describe("LiveChatKit memory lifecycle", () => {
     });
   });
 
+  it("strips OpenAI item references from the failed step before saving", () => {
+    const store = new FakeStore([
+      makeTask({
+        id: "parent",
+        status: "pending-model",
+        background: false,
+      }),
+    ]);
+    const chatKit = new LiveChatKit<FakeChat>({
+      taskId: "parent",
+      store: store as unknown as LiveKitStore,
+      blobStore: {} as BlobStore,
+      chatClass: FakeChat,
+      getters: {
+        getLLM: () => ({ id: "test-model" }) as never,
+      },
+    });
+    const message = {
+      id: "assistant-1",
+      role: "assistant",
+      metadata: { kind: "assistant" },
+      parts: [
+        { type: "step-start" },
+        {
+          type: "reasoning",
+          text: "Committed reasoning",
+          state: "done",
+          providerMetadata: { openai: { itemId: "rs_committed" } },
+        },
+        { type: "step-start" },
+        {
+          type: "reasoning",
+          text: "Done part from failed response",
+          state: "done",
+          providerMetadata: {
+            openai: {
+              itemId: "rs_done_but_uncommitted",
+              reasoningEncryptedContent: "encrypted-reasoning",
+            },
+          },
+        },
+        {
+          type: "text",
+          text: "Partial response",
+          state: "done",
+          providerMetadata: {
+            openai: { itemId: "msg_uncommitted" },
+            google: { custom: "preserved" },
+          },
+        },
+      ],
+    } as Message;
+    chatKit.chat.messages = [userMessage(), message];
+
+    chatKit.chat.fail(new Error("network error"));
+
+    for (const failedMessage of [
+      chatKit.chat.messages.at(-1),
+      store.taskMessages("parent").at(-1),
+    ]) {
+      expect((failedMessage?.parts[1] as any).providerMetadata).toEqual({
+        openai: { itemId: "rs_committed" },
+      });
+      expect((failedMessage?.parts[3] as any).providerMetadata).toEqual({
+        openai: { reasoningEncryptedContent: "encrypted-reasoning" },
+      });
+      expect((failedMessage?.parts[4] as any).providerMetadata).toEqual({
+        google: { custom: "preserved" },
+      });
+    }
+  });
+
   it.each([
     ["tool-attemptCompletion", "completion-1", { result: "Done." }],
     [

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -7,7 +7,10 @@ import type {
   TaskMemoryState,
 } from "@getpochi/common";
 import { formatters, getLogger, isForkAgentUseCase } from "@getpochi/common";
-import { hasActiveTodos } from "@getpochi/common/message-utils";
+import {
+  hasActiveTodos,
+  stripOpenAIItemReferencesFromLastStep,
+} from "@getpochi/common/message-utils";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import {
   type CustomAgent,
@@ -79,7 +82,7 @@ function normalizeFailedStreamMessage(
   }
 
   const errorText = getFailedToolCallErrorText(error);
-  return {
+  const normalizedMessage = {
     ...message,
     parts: message.parts.map((part) => {
       if (!isToolUIPart(part)) {
@@ -110,6 +113,8 @@ function normalizeFailedStreamMessage(
       } as unknown as typeof part;
     }),
   };
+
+  return stripOpenAIItemReferencesFromLastStep(normalizedMessage);
 }
 
 function getFailedToolCallErrorText(error: unknown): string {


### PR DESCRIPTION
## Summary
- extract OpenAI item-reference stripping into a reusable message utility scoped to the latest LLM step
- sanitize failed stream messages before updating chat state and persisting them
- preserve committed-step references and non-item provider metadata, including encrypted reasoning

## Test plan
- [x] `bun run test` in `packages/common`
- [x] `bun run test` in `packages/livekit`
- [x] `bun check`
- [x] `bun tsc`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-459502ad62684df89510f80dde2b829a)