### PR TITLE
fix(common): bound search file results by size

### DIFF
--- a/packages/common/src/tool-utils/__tests__/ripgrep.test.ts
+++ b/packages/common/src/tool-utils/__tests__/ripgrep.test.ts
@@ -10,6 +10,7 @@ vi.mock("node:child_process", () => ({
   spawn: spawnMock,
 }));
 
+import { MaxRipgrepCharLength } from "../limits";
 import { searchFilesWithRipgrep } from "../ripgrep";
 
 class MockChildProcess extends EventEmitter {
@@ -209,6 +210,65 @@ describe("searchFilesWithRipgrep", () => {
 
     expect(result.matches.length).toBe(500);
     expect(result.isTruncated).toBe(true);
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it("should truncate a single oversized match to the character limit", async () => {
+    const context = `${"start".repeat(4_000)}${"end".repeat(4_000)}`;
+    const mockRgOutput = JSON.stringify({
+      type: "match",
+      data: {
+        path: { text: "/workspace/generated.js" },
+        lines: { text: `${context}\n` },
+        line_number: 1,
+      },
+    });
+    const child = mockSpawnResult({ stdout: mockRgOutput });
+
+    const result = await searchFilesWithRipgrep(
+      ".",
+      "hello",
+      rgPath,
+      workspacePath,
+    );
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].context).toContain("... [truncated] ...");
+    expect(result.matches[0].context).toMatch(/^start/);
+    expect(result.matches[0].context).toMatch(/end$/);
+    expect(result.isTruncated).toBe(true);
+    expect(JSON.stringify(result).length).toBeLessThanOrEqual(
+      MaxRipgrepCharLength,
+    );
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it("should stop when multiple matches reach the character limit", async () => {
+    const mockRgOutput = Array.from({ length: 10 }, (_, i) => ({
+      type: "match",
+      data: {
+        path: { text: `/workspace/file${i}.ts` },
+        lines: { text: `${"content".repeat(1_000)}\n` },
+        line_number: i + 1,
+      },
+    }))
+      .map((o) => JSON.stringify(o))
+      .join("\n");
+    const child = mockSpawnResult({ stdout: mockRgOutput });
+
+    const result = await searchFilesWithRipgrep(
+      ".",
+      "hello",
+      rgPath,
+      workspacePath,
+    );
+
+    expect(result.matches.length).toBeLessThan(10);
+    expect(result.matches.at(-1)?.context).toContain("... [truncated] ...");
+    expect(result.isTruncated).toBe(true);
+    expect(JSON.stringify(result).length).toBeLessThanOrEqual(
+      MaxRipgrepCharLength,
+    );
     expect(child.kill).toHaveBeenCalled();
   });
 

--- a/packages/common/src/tool-utils/limits.ts
+++ b/packages/common/src/tool-utils/limits.ts
@@ -1,4 +1,5 @@
 export const MaxRipgrepItems = 500;
+export const MaxRipgrepCharLength = 30_000;
 export const MaxListFileItems = 1500;
 export const MaxListFileCharLength = 30_000;
 export const MaxGlobFileItems = 500;

--- a/packages/common/src/tool-utils/ripgrep.ts
+++ b/packages/common/src/tool-utils/ripgrep.ts
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
 import { relative, resolve } from "node:path";
 import { getLogger } from "../base";
-import { MaxRipgrepItems } from "./limits";
+import { MaxRipgrepCharLength, MaxRipgrepItems } from "./limits";
 
 const logger = getLogger("RipgrepUtils");
+const TruncatedContextMarker = "\n... [truncated] ...\n";
 
 // Define an interface for the relevant parts of the rg JSON output
 interface RipgrepMatchData {
@@ -54,6 +55,40 @@ interface RipgrepOutput {
 
 type RipgrepMatch = { file: string; line: number; context: string };
 
+function fitMatchWithinSerializedLength(
+  match: RipgrepMatch,
+  maxSerializedLength: number,
+): RipgrepMatch | undefined {
+  if (JSON.stringify(match).length <= maxSerializedLength) {
+    return match;
+  }
+
+  let low = 0;
+  let high = match.context.length;
+  let fittedMatch: RipgrepMatch | undefined;
+
+  while (low <= high) {
+    const retainedChars = Math.floor((low + high) / 2);
+    const firstPartLength = Math.ceil(retainedChars / 2);
+    const lastPartLength = Math.floor(retainedChars / 2);
+    const candidate: RipgrepMatch = {
+      ...match,
+      context: `${match.context.slice(0, firstPartLength)}${TruncatedContextMarker}${match.context.slice(
+        match.context.length - lastPartLength,
+      )}`,
+    };
+
+    if (JSON.stringify(candidate).length <= maxSerializedLength) {
+      fittedMatch = candidate;
+      low = retainedChars + 1;
+    } else {
+      high = retainedChars - 1;
+    }
+  }
+
+  return fittedMatch;
+}
+
 function parseRipgrepLine(
   line: string,
   workspacePath: string,
@@ -92,6 +127,10 @@ export async function searchFilesWithRipgrep(
   logger.debug("searchFiles", path, regex, filePattern);
   const matches: RipgrepMatch[] = [];
   let isTruncated = false;
+  let serializedLength = JSON.stringify({
+    matches: [],
+    isTruncated: false,
+  }).length;
 
   const args = [
     "--json",
@@ -130,8 +169,28 @@ export async function searchFilesWithRipgrep(
         return;
       }
 
-      matches.push(match);
-      if (matches.length > MaxRipgrepItems) {
+      if (matches.length >= MaxRipgrepItems) {
+        isTruncated = true;
+        stopAfterLimit();
+        return;
+      }
+
+      const separatorLength = matches.length > 0 ? 1 : 0;
+      const remainingLength =
+        MaxRipgrepCharLength - serializedLength - separatorLength;
+      const fittedMatch = fitMatchWithinSerializedLength(
+        match,
+        remainingLength,
+      );
+      if (!fittedMatch) {
+        isTruncated = true;
+        stopAfterLimit();
+        return;
+      }
+
+      matches.push(fittedMatch);
+      serializedLength += separatorLength + JSON.stringify(fittedMatch).length;
+      if (fittedMatch !== match) {
         isTruncated = true;
         stopAfterLimit();
       }
@@ -186,7 +245,7 @@ export async function searchFilesWithRipgrep(
   });
 
   return {
-    matches: matches.slice(0, MaxRipgrepItems),
+    matches,
     isTruncated,
   };
 }


### PR DESCRIPTION
## Summary
- cap serialized `searchFiles` results at 30,000 characters in addition to the existing match-count limit
- preserve useful head and tail context when a single match exceeds the remaining result budget
- stop ripgrep immediately at either limit and cover single-match and aggregate overflow cases

## Test plan
- [x] Run `bun run test` in `packages/common` (566 tests)
- [x] Run `bun run tsc` in `packages/common`
- [x] Run `bun check` from the repository root

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-6cfb48ada5f54a89a53a22a3cafc38d5)