### PR TITLE
test(vscode): verify test user model access

### DIFF
--- a/packages/vscode/tests/specs/plain-workspace/test-user-model-access.test.ts
+++ b/packages/vscode/tests/specs/plain-workspace/test-user-model-access.test.ts
@@ -3,7 +3,7 @@ import type { Workbench } from "wdio-vscode-service";
 import { PochiSidebar } from "../../pageobjects/pochi-sidebar";
 import { PochiPanel } from "../../pageobjects/pochi-panel";
 
-describe("Freebie User Swift Model Tests", () => {
+describe("Test User Model Access Tests", () => {
   let workbench: Workbench;
 
   beforeEach(async () => {
@@ -73,7 +73,7 @@ describe("Freebie User Swift Model Tests", () => {
 
     // Wait for the task to appear in the sidebar task list
     await sidebar.waitForTaskToAppear(60000);
-    
+
     // Switch back to main content
     await sidebar.close();
 
@@ -110,7 +110,7 @@ describe("Freebie User Swift Model Tests", () => {
     await panel.close();
   });
 
-  it("should not see super models for freebie user", async () => {
+  it("should see Super models for the test user", async () => {
     const sidebar = new PochiSidebar();
     await sidebar.open();
 
@@ -143,7 +143,7 @@ describe("Freebie User Swift Model Tests", () => {
       }
     }
 
-    expect(superHeader).toBeUndefined();
+    expect(superHeader).toBeDefined();
     await sidebar.close();
   });
 });


### PR DESCRIPTION
## Summary
- rename the freebie Swift model E2E spec to cover test-user model access
- verify that test users can access both Swift and Super model groups

## Test plan
- [ ] `bun turbo test:integration --filter=pochi -- --spec \"./tests/specs/plain-workspace/test-user-model-access.test.ts\"` (3 of 4 WDIO workers pass; one worker consistently fails during webview startup before reaching the assertions)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7e4ecb97416c459cb19986495af427b2)