### PR TITLE
fix(livekit): simplify auto-compaction and trace aborts

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -614,7 +614,7 @@
       "additionalProperties": false
     },
     "effectiveContextWindow": {
-      "description": "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 200000.",
+      "description": "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 160000.",
       "type": "number"
     }
   },

--- a/packages/common/src/configuration/types.ts
+++ b/packages/common/src/configuration/types.ts
@@ -46,7 +46,7 @@ export function makePochiConfig(strict = false) {
       .number()
       .optional()
       .describe(
-        "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 200000.",
+        "Effective context window (in tokens) used to cap auto-compaction. Auto-compaction triggers before this many tokens even when the model declares a larger context window, since models tend to degrade earlier. Defaults to 160000.",
       ),
   });
 }

--- a/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
+++ b/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import type { Message, RequestData, Task } from "../../types";
 import {
   AutoCompactBufferTokens,
-  AutoCompactRatio,
   DefaultEffectiveContextWindow,
   MaxSummaryOutputTokens,
   findAutoCompactAttachIndex,
@@ -64,25 +63,26 @@ const openaiLlm = (contextWindow: number): RequestData["llm"] =>
   }) as RequestData["llm"];
 
 describe("getAutoCompactThreshold", () => {
-  it("subtracts summary reserve + buffer from small context windows", () => {
-    expect(getAutoCompactThreshold(100_000)).toBe(
-      100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
+  it("caps large declared windows at DefaultEffectiveContextWindow", () => {
+    expect(getAutoCompactThreshold(1_000_000)).toBe(
+      DefaultEffectiveContextWindow -
+        MaxSummaryOutputTokens -
+        AutoCompactBufferTokens,
     );
   });
 
-  it("caps the threshold at AutoCompactRatio of the window when the absolute buffer is proportionally small", () => {
-    expect(getAutoCompactThreshold(200_000)).toBe(200_000 * AutoCompactRatio);
-  });
-
-  it("caps very large declared windows at DefaultEffectiveContextWindow", () => {
-    expect(getAutoCompactThreshold(1_000_000)).toBe(
-      DefaultEffectiveContextWindow * AutoCompactRatio,
+  it("subtracts summary reserve + buffer when the context window is smaller than the effective cap", () => {
+    expect(getAutoCompactThreshold(100_000)).toBe(
+      100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
+    );
+    expect(getAutoCompactThreshold(40_000)).toBe(
+      40_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
     );
   });
 
   it("uses an explicit effectiveContextWindow instead of the default cap", () => {
     expect(getAutoCompactThreshold(1_000_000, 400_000)).toBe(
-      400_000 * AutoCompactRatio,
+      400_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
     );
     expect(getAutoCompactThreshold(1_000_000, 100_000)).toBe(
       100_000 - MaxSummaryOutputTokens - AutoCompactBufferTokens,
@@ -191,7 +191,7 @@ describe("shouldAutoCompact", () => {
     ).toBe(false);
   });
 
-  it("uses an explicit vendor contextWindow when one is provided", () => {
+  it("caps an explicit vendor contextWindow at the default effective window", () => {
     const messages = [assistantMessage(), userMessage()];
     const vendorLlm = {
       id: "vendor-cli",
@@ -199,14 +199,23 @@ describe("shouldAutoCompact", () => {
       contextWindow: 1_000_000,
       getModel: () => ({}) as never,
     } as RequestData["llm"];
+    const threshold = getAutoCompactThreshold(1_000_000);
 
     expect(
       shouldAutoCompact({
         messages,
         llm: vendorLlm,
-        task: task(constants.CompactTaskMinTokens * 2),
+        task: task(threshold - 1),
       }),
     ).toBe(false);
+
+    expect(
+      shouldAutoCompact({
+        messages,
+        llm: vendorLlm,
+        task: task(threshold),
+      }),
+    ).toBe(true);
   });
 
   it("respects an explicit effectiveContextWindow on the llm", () => {
@@ -233,13 +242,19 @@ describe("shouldAutoCompact", () => {
     ).toBe(false);
   });
 
-  it("does not trigger when totalTokens is below the buffer-based threshold", () => {
+  it("does not trigger when totalTokens is below the effective threshold", () => {
     const messages = [assistantMessage(), userMessage()];
+    const llm = {
+      ...openaiLlm(1_000_000),
+      effectiveContextWindow: 100_000,
+    } as RequestData["llm"];
+    const threshold = getAutoCompactThreshold(1_000_000, 100_000);
+
     expect(
       shouldAutoCompact({
         messages,
-        llm: openaiLlm(1_000_000),
-        task: task(minTokens + 1),
+        llm,
+        task: task(threshold - 1),
       }),
     ).toBe(false);
   });

--- a/packages/livekit/src/chat/auto-compact-policy.ts
+++ b/packages/livekit/src/chat/auto-compact-policy.ts
@@ -6,14 +6,10 @@ export const MaxSummaryOutputTokens = 20_000;
 
 export const AutoCompactBufferTokens = 13_000;
 
-// The absolute buffer alone kicks in far too late on large context windows,
-// so the threshold is also capped at this fraction of the effective window.
-export const AutoCompactRatio = 0.8;
-
 // Most models degrade on agentic tasks well before very large declared
 // windows are exhausted. When no effectiveContextWindow is configured, cap
-// the window used for auto-compaction here.
-export const DefaultEffectiveContextWindow = 200_000;
+// auto-compaction at this token count.
+export const DefaultEffectiveContextWindow = 160_000;
 
 export const MaxConsecutiveAutoCompactFailures = 3;
 
@@ -22,12 +18,10 @@ export function getAutoCompactThreshold(
   effectiveContextWindow?: number,
 ): number {
   const window = Math.min(
-    effectiveContextWindow || DefaultEffectiveContextWindow,
+    effectiveContextWindow ?? DefaultEffectiveContextWindow,
     contextWindow,
   );
-  const byBuffer = window - MaxSummaryOutputTokens - AutoCompactBufferTokens;
-  const byRatio = Math.floor(window * AutoCompactRatio);
-  return Math.max(Math.min(byBuffer, byRatio), 0);
+  return Math.max(window - MaxSummaryOutputTokens - AutoCompactBufferTokens, 0);
 }
 
 function resolveContextWindow(llm: RequestData["llm"] | undefined): {

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -535,6 +535,10 @@ export class LiveChatKit<
     abortSignal?.addEventListener(
       "abort",
       () => {
+        logger.warn("Chat abort signal received; stopping transport", {
+          abortOrigin: "external-abort-signal",
+          taskId: this.taskId,
+        });
         this.chat.stop();
       },
       { once: true },
@@ -930,6 +934,11 @@ export class LiveChatKit<
     abortError.name = "AbortError";
 
     if (isAbort) {
+      logger.warn("Provider reported chat transport abort", {
+        abortOrigin: "provider-isAbort",
+        taskId: this.taskId,
+        assistantMessageId: originalMessage.id,
+      });
       return this.onError(abortError);
     }
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-abort-before-navigation.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-abort-before-navigation.ts
@@ -1,17 +1,29 @@
+import { getLogger } from "@getpochi/common";
 import { useRouter } from "@tanstack/react-router";
 import { useEffect } from "react";
 
-export function useAbortBeforeNavigation(abortController: AbortController) {
+const logger = getLogger("useAbortBeforeNavigation");
+
+export function useAbortBeforeNavigation(
+  abortController: AbortController,
+  taskId: string,
+): void {
   const router = useRouter();
   useEffect(() => {
-    // Subscribe to the 'onBeforeLoad' event
-    const unsubscribe = router.subscribe("onBeforeLoad", () => {
+    const unsubscribe = router.subscribe("onBeforeLoad", (event) => {
+      logger.warn("Router navigation requested chat abort", {
+        abortOrigin: "router-navigation",
+        taskId,
+        signalAlreadyAborted: abortController.signal.aborted,
+        fromPathname: event.fromLocation?.pathname,
+        toPathname: event.toLocation.pathname,
+        pathChanged: event.pathChanged,
+        hrefChanged: event.hrefChanged,
+        hashChanged: event.hashChanged,
+      });
       abortController.abort();
     });
 
-    // Clean up the subscription when the component unmounts
-    return () => {
-      unsubscribe();
-    };
-  }, [abortController, router]);
+    return unsubscribe;
+  }, [abortController, router, taskId]);
 }

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -97,7 +97,7 @@ function Chat({ user, uid, info }: ChatProps) {
   };
 
   const chatAbortController = useChatAbortController();
-  useAbortBeforeNavigation(chatAbortController.current);
+  useAbortBeforeNavigation(chatAbortController.current, uid);
 
   const task = store.useQuery(catalog.queries.makeTaskQuery(uid));
   useKeepTaskEditor(task);


### PR DESCRIPTION
## Summary
- simplify the auto-compaction threshold to use a 160k effective context cap minus summary and buffer reserves
- add correlated task, router, and transport diagnostics for unexpected chat aborts
- distinguish external navigation-driven cancellation from provider-reported abort completion in logs

## Test plan
- [x] Run `bun check`
- [x] Run `bun tsc`
- [x] Run LiveKit unit tests (`101 passed`)
- [x] Run VS Code webview unit tests (`287 passed`)
- [ ] Reproduce extension startup and verify router/transport abort logs include matching task IDs

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-017917a243d049ae932b019a620ac99c)