### PR TITLE
chore(chat): add abort logging

### DIFF
--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -535,6 +535,10 @@ export class LiveChatKit<
     abortSignal?.addEventListener(
       "abort",
       () => {
+        logger.warn("Chat abort signal received; stopping transport", {
+          abortOrigin: "external-abort-signal",
+          taskId: this.taskId,
+        });
         this.chat.stop();
       },
       { once: true },
@@ -930,6 +934,11 @@ export class LiveChatKit<
     abortError.name = "AbortError";
 
     if (isAbort) {
+      logger.warn("Provider reported chat transport abort", {
+        abortOrigin: "provider-isAbort",
+        taskId: this.taskId,
+        assistantMessageId: originalMessage.id,
+      });
       return this.onError(abortError);
     }
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-abort-before-navigation.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-abort-before-navigation.ts
@@ -1,17 +1,29 @@
+import { getLogger } from "@getpochi/common";
 import { useRouter } from "@tanstack/react-router";
 import { useEffect } from "react";
 
-export function useAbortBeforeNavigation(abortController: AbortController) {
+const logger = getLogger("useAbortBeforeNavigation");
+
+export function useAbortBeforeNavigation(
+  abortController: AbortController,
+  taskId: string,
+): void {
   const router = useRouter();
   useEffect(() => {
-    // Subscribe to the 'onBeforeLoad' event
-    const unsubscribe = router.subscribe("onBeforeLoad", () => {
+    const unsubscribe = router.subscribe("onBeforeLoad", (event) => {
+      logger.warn("Router navigation requested chat abort", {
+        abortOrigin: "router-navigation",
+        taskId,
+        signalAlreadyAborted: abortController.signal.aborted,
+        fromPathname: event.fromLocation?.pathname,
+        toPathname: event.toLocation.pathname,
+        pathChanged: event.pathChanged,
+        hrefChanged: event.hrefChanged,
+        hashChanged: event.hashChanged,
+      });
       abortController.abort();
     });
 
-    // Clean up the subscription when the component unmounts
-    return () => {
-      unsubscribe();
-    };
-  }, [abortController, router]);
+    return unsubscribe;
+  }, [abortController, router, taskId]);
 }

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -97,7 +97,7 @@ function Chat({ user, uid, info }: ChatProps) {
   };
 
   const chatAbortController = useChatAbortController();
-  useAbortBeforeNavigation(chatAbortController.current);
+  useAbortBeforeNavigation(chatAbortController.current, uid);
 
   const task = store.useQuery(catalog.queries.makeTaskQuery(uid));
   useKeepTaskEditor(task);


### PR DESCRIPTION
## Summary
- log router navigation details when a chat abort is requested
- attach task and message context to LiveKit transport abort logs
- pass the task ID into the navigation abort hook for end-to-end correlation

## Test plan
- [ ] Verify navigating away from an active chat logs the route transition and task ID
- [ ] Verify external and provider transport aborts log their origin and task context

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-cb49aae7e0b7457cab6694ac7bc122ed)