### PR TITLE
fix(livekit): increase stream chunk timeout to 30s

### DIFF
--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -256,8 +256,9 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       tools,
       maxRetries: 0,
       timeout: {
-        // Abort if no chunk is received within 15s to prevent indefinitely stalled streams.
-        chunkMs: 15_000,
+        // Abort if no new chunk is received within 30s to prevent indefinitely stalled streams.
+        // See https://ai-sdk.dev/docs/ai-sdk-core/settings#timeout
+        chunkMs: 30_000,
       },
       // error log is handled in live chat kit.
       onError: () => {},


### PR DESCRIPTION
## Summary
- Increase the `streamText` `timeout.chunkMs` from 15s to 30s to reduce false aborts on slower model responses
- Add a link to the AI SDK docs for the `timeout` option and clarify the comment

## Test plan
- [ ] N/A (comment/config change only)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-35305c7d807845a58fac95bbf11d96b0)