### PR TITLE
chore(vscode): turn off editor predictions

### DIFF
--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -10,7 +10,6 @@
     "vscode",
     "cli",
     "---Features---",
-    "tab-completion",
     "reviews",
     "edits",
     "auto-compact",

--- a/packages/docs/content/docs/tab-completion.mdx
+++ b/packages/docs/content/docs/tab-completion.mdx
@@ -6,6 +6,8 @@ icon: "Code"
 
 # Tab Completion
 
+> **Unavailable:** Tab Completion and Next Edit Suggestions are turned off in current releases. Pochi does not provide editor predictions or display the associated status bar indicator. The documentation below is retained for reference.
+
 **Tab Completion** is Pochi's in-editor inline code completion feature that provides AI-powered suggestions as you type, helping you write code faster and more efficiently.
 
 Pochi uses a state-of-the-art model that adapts to your coding patterns in real time,

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -401,37 +401,37 @@
       {
         "command": "pochi.tabCompletion.reveal",
         "key": "tab",
-        "when": "editorTextFocus && pochiTabCompletionState === 'scrollIndicatorVisible'"
+        "when": "pochiEditorPredictionsAvailable && editorTextFocus && pochiTabCompletionState === 'scrollIndicatorVisible'"
       },
       {
         "command": "pochi.tabCompletion.accept",
         "key": "tab",
-        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible'"
+        "when": "pochiEditorPredictionsAvailable && editorTextFocus && pochiTabCompletionState === 'diffVisible'"
       },
       {
         "command": "pochi.tabCompletion.reject",
         "key": "escape",
-        "when": "editorTextFocus && (pochiTabCompletionState || inlineSuggestionVisible)"
+        "when": "pochiEditorPredictionsAvailable && editorTextFocus && (pochiTabCompletionState || inlineSuggestionVisible)"
       },
       {
         "command": "pochi.tabCompletion.nextChoice",
         "key": "alt+]",
-        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible'"
+        "when": "pochiEditorPredictionsAvailable && editorTextFocus && pochiTabCompletionState === 'diffVisible'"
       },
       {
         "command": "pochi.tabCompletion.prevChoice",
         "key": "alt+[",
-        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible'"
+        "when": "pochiEditorPredictionsAvailable && editorTextFocus && pochiTabCompletionState === 'diffVisible'"
       },
       {
         "command": "pochi.tabCompletion.nextChoice",
         "key": "right",
-        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible' && pochiTabCompletionHasMultipleChoices"
+        "when": "pochiEditorPredictionsAvailable && editorTextFocus && pochiTabCompletionState === 'diffVisible' && pochiTabCompletionHasMultipleChoices"
       },
       {
         "command": "pochi.tabCompletion.prevChoice",
         "key": "left",
-        "when": "editorTextFocus && pochiTabCompletionState === 'diffVisible' && pochiTabCompletionHasMultipleChoices"
+        "when": "pochiEditorPredictionsAvailable && editorTextFocus && pochiTabCompletionState === 'diffVisible' && pochiTabCompletionHasMultipleChoices"
       },
       {
         "command": "pochi.applyPochiLayoutWithCycleFocus",
@@ -503,6 +503,7 @@
               "tabCompletion": {
                 "type": "object",
                 "default": {},
+                "description": "Tab Completion and Next Edit Suggestions are currently unavailable. These settings are retained for compatibility but are ignored.",
                 "additionalProperties": false,
                 "properties": {
                   "disabled": {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -38,6 +38,10 @@ import { PochiTaskEditorProvider } from "./integrations/webview/webview-panel";
 import { type AuthClient, createAuthClient } from "./lib/auth-client";
 import "./lib/file-logger";
 import { createBrowserSessionStore } from "./integrations/browser";
+import {
+  EditorPredictionsAvailable,
+  EditorPredictionsAvailableContextKey,
+} from "./lib/feature-availability";
 import { getLogger } from "./lib/logger";
 import { PostInstallActions } from "./lib/post-install-actions";
 import { WorkspaceScope } from "./lib/workspace-scoped";
@@ -50,6 +54,12 @@ const logger = getLogger("Extension");
 export async function activate(context: vscode.ExtensionContext) {
   const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri;
   const cwd = workspaceUri?.fsPath;
+
+  await vscode.commands.executeCommand(
+    "setContext",
+    EditorPredictionsAvailableContextKey,
+    EditorPredictionsAvailable,
+  );
 
   // Container will dispose all the registered instances when itself is disposed
   context.subscriptions.push(container);
@@ -79,7 +89,9 @@ export async function activate(context: vscode.ExtensionContext) {
     useFactory: instanceCachingFactory(createBrowserSessionStore),
   });
   container.resolve(PochiWebviewSidebar);
-  container.resolve(StatusBarItem);
+  if (EditorPredictionsAvailable) {
+    container.resolve(StatusBarItem);
+  }
   container.resolve(PochiAuthenticationProvider);
   container.resolve(RagdollUriHandler);
   container.resolve(CommandManager);
@@ -89,7 +101,9 @@ export async function activate(context: vscode.ExtensionContext) {
   container.resolve(WorktreeManager);
   container.resolve(ReviewController);
   container.resolve(PochiFileSystemProvider);
-  container.resolve(TabCompletionManager);
+  if (EditorPredictionsAvailable) {
+    container.resolve(TabCompletionManager);
+  }
   container.resolve(LayoutManager);
 }
 

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -4,6 +4,7 @@ import type { AuthClient } from "@/lib/auth-client";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { AuthEvents } from "@/lib/auth-events";
 import { getWorkspaceRulesFileUri } from "@/lib/env";
+import { EditorPredictionsAvailable } from "@/lib/feature-availability";
 import { getLogger, showOutputPanel } from "@/lib/logger";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { NewProjectRegistry, prepareProject } from "@/lib/new-project";
@@ -11,7 +12,6 @@ import { NewProjectRegistry, prepareProject } from "@/lib/new-project";
 import { PostHog } from "@/lib/posthog";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { WorkspaceScope } from "@/lib/workspace-scoped";
-// biome-ignore lint/style/useImportType: needed for dependency injection
 import {
   type OnDidAcceptInlineCompletionItemParams,
   TabCompletionManager,
@@ -28,7 +28,7 @@ import { McpHub } from "@getpochi/common/mcp-utils";
 import { getVendor } from "@getpochi/common/vendor";
 import type { PochiTaskParams } from "@getpochi/common/vscode-webui-bridge";
 import { getServerBaseUrl } from "@getpochi/common/vscode-webui-bridge";
-import { inject, injectable, singleton } from "tsyringe";
+import { container, inject, injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { type PochiAdvanceSettings, PochiConfiguration } from "./configuration";
@@ -69,13 +69,15 @@ export class CommandManager implements vscode.Disposable {
     private readonly mcpHub: McpHub,
     private readonly pochiConfiguration: PochiConfiguration,
     private readonly posthog: PostHog,
-    private readonly tabCompletionManager: TabCompletionManager,
     private readonly worktreeManager: WorktreeManager,
     private readonly worktreeInfoProvider: GitWorktreeInfoProvider,
     private readonly reviewController: ReviewController,
     private readonly layoutManager: LayoutManager,
   ) {
     this.registerCommands();
+    if (EditorPredictionsAvailable) {
+      this.disposables.push(...this.registerEditorPredictionCommands());
+    }
   }
 
   private async prepareProjectAndOpenTask(
@@ -448,94 +450,6 @@ export class CommandManager implements vscode.Disposable {
         }
       }),
 
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.onDidAccept",
-        async (params: OnDidAcceptInlineCompletionItemParams) => {
-          this.posthog.capture("acceptCodeCompletion");
-          this.tabCompletionManager.handleDidAcceptInlineCompletion(params);
-        },
-      ),
-
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.resolveConflicts",
-        async () => {
-          const githubCopilotCodeCompletionEnabled =
-            this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value;
-          if (!githubCopilotCodeCompletionEnabled) {
-            return;
-          }
-          const selection = await vscode.window.showWarningMessage(
-            "Pochi Tab Completion is unavailable due to conflict with **GitHub Copilot Code Completion**. You can disable conflicting features to use Pochi Tab Completion.",
-            "Disable Conflicting Features",
-            "Disable Pochi Tab Completion",
-          );
-          if (selection === "Disable Conflicting Features") {
-            this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value = false;
-          } else if (selection === "Disable Pochi Tab Completion") {
-            vscode.commands.executeCommand(
-              "pochi.tabCompletion.toggleEnabled",
-              false,
-            );
-          }
-        },
-      ),
-
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.toggleEnabled",
-        async (enabled?: boolean | undefined) => {
-          const current = this.pochiConfiguration.advancedSettings.value;
-          const disabled =
-            enabled === undefined ? !current.tabCompletion?.disabled : !enabled;
-          const newSettings = {
-            ...current,
-            tabCompletion: {
-              ...current.tabCompletion,
-              disabled,
-            },
-          };
-          this.pochiConfiguration.advancedSettings.value = newSettings;
-        },
-      ),
-
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.toggleLanguageEnabled",
-        async (language?: string | undefined) => {
-          const languageId =
-            language ?? vscode.window.activeTextEditor?.document.languageId;
-
-          if (!languageId) {
-            return;
-          }
-
-          const current = this.pochiConfiguration.advancedSettings.value;
-          let newSettings: PochiAdvanceSettings;
-          if (current.tabCompletion?.disabledLanguages?.includes(languageId)) {
-            newSettings = {
-              ...current,
-              tabCompletion: {
-                ...current.tabCompletion,
-                disabledLanguages:
-                  current.tabCompletion.disabledLanguages.filter(
-                    (lang) => lang !== languageId,
-                  ),
-              },
-            };
-          } else {
-            newSettings = {
-              ...current,
-              tabCompletion: {
-                ...current.tabCompletion,
-                disabledLanguages: [
-                  ...(current.tabCompletion?.disabledLanguages ?? []),
-                  languageId,
-                ],
-              },
-            };
-          }
-          this.pochiConfiguration.advancedSettings.value = newSettings;
-        },
-      ),
-
       vscode.commands.registerCommand("pochi.openFileFromDiff", async () => {
         const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
         logger.debug("openFileFromDiff", { activeTab });
@@ -593,41 +507,6 @@ export class CommandManager implements vscode.Disposable {
             type: "new-task",
             cwd,
           });
-        },
-      ),
-
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.reveal",
-        async () => {
-          this.tabCompletionManager.reveal();
-        },
-      ),
-
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.accept",
-        async () => {
-          this.tabCompletionManager.accept();
-        },
-      ),
-
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.reject",
-        async () => {
-          this.tabCompletionManager.reject();
-        },
-      ),
-
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.nextChoice",
-        async () => {
-          this.tabCompletionManager.nextChoice();
-        },
-      ),
-
-      vscode.commands.registerCommand(
-        "pochi.tabCompletion.prevChoice",
-        async () => {
-          this.tabCompletionManager.prevChoice();
         },
       ),
 
@@ -763,6 +642,118 @@ export class CommandManager implements vscode.Disposable {
         },
       ),
     );
+  }
+
+  private registerEditorPredictionCommands(): vscode.Disposable[] {
+    const tabCompletionManager = container.resolve(TabCompletionManager);
+    return [
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.onDidAccept",
+        async (params: OnDidAcceptInlineCompletionItemParams) => {
+          this.posthog.capture("acceptCodeCompletion");
+          tabCompletionManager.handleDidAcceptInlineCompletion(params);
+        },
+      ),
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.resolveConflicts",
+        async () => {
+          const githubCopilotCodeCompletionEnabled =
+            this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value;
+          if (!githubCopilotCodeCompletionEnabled) return;
+
+          const selection = await vscode.window.showWarningMessage(
+            "Pochi Tab Completion is unavailable due to conflict with **GitHub Copilot Code Completion**. You can disable conflicting features to use Pochi Tab Completion.",
+            "Disable Conflicting Features",
+            "Disable Pochi Tab Completion",
+          );
+          if (selection === "Disable Conflicting Features") {
+            this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value = false;
+          } else if (selection === "Disable Pochi Tab Completion") {
+            vscode.commands.executeCommand(
+              "pochi.tabCompletion.toggleEnabled",
+              false,
+            );
+          }
+        },
+      ),
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.toggleEnabled",
+        async (enabled?: boolean | undefined) => {
+          const current = this.pochiConfiguration.advancedSettings.value;
+          const disabled =
+            enabled === undefined ? !current.tabCompletion?.disabled : !enabled;
+          this.pochiConfiguration.advancedSettings.value = {
+            ...current,
+            tabCompletion: { ...current.tabCompletion, disabled },
+          };
+        },
+      ),
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.toggleLanguageEnabled",
+        async (language?: string | undefined) => {
+          const languageId =
+            language ?? vscode.window.activeTextEditor?.document.languageId;
+          if (!languageId) return;
+
+          const current = this.pochiConfiguration.advancedSettings.value;
+          let newSettings: PochiAdvanceSettings;
+          if (current.tabCompletion?.disabledLanguages?.includes(languageId)) {
+            newSettings = {
+              ...current,
+              tabCompletion: {
+                ...current.tabCompletion,
+                disabledLanguages:
+                  current.tabCompletion.disabledLanguages.filter(
+                    (lang) => lang !== languageId,
+                  ),
+              },
+            };
+          } else {
+            newSettings = {
+              ...current,
+              tabCompletion: {
+                ...current.tabCompletion,
+                disabledLanguages: [
+                  ...(current.tabCompletion?.disabledLanguages ?? []),
+                  languageId,
+                ],
+              },
+            };
+          }
+          this.pochiConfiguration.advancedSettings.value = newSettings;
+        },
+      ),
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.reveal",
+        async () => {
+          tabCompletionManager.reveal();
+        },
+      ),
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.accept",
+        async () => {
+          tabCompletionManager.accept();
+        },
+      ),
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.reject",
+        async () => {
+          tabCompletionManager.reject();
+        },
+      ),
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.nextChoice",
+        async () => {
+          tabCompletionManager.nextChoice();
+        },
+      ),
+      vscode.commands.registerCommand(
+        "pochi.tabCompletion.prevChoice",
+        async () => {
+          tabCompletionManager.prevChoice();
+        },
+      ),
+    ];
   }
 
   private async ensureDefaultCustomModelSettings() {

--- a/packages/vscode/src/lib/__test__/feature-availability.test.ts
+++ b/packages/vscode/src/lib/__test__/feature-availability.test.ts
@@ -1,0 +1,9 @@
+import * as assert from "node:assert";
+import { describe, it } from "mocha";
+import { EditorPredictionsAvailable } from "../feature-availability";
+
+describe("editor prediction availability", () => {
+  it("keeps editor predictions unavailable", () => {
+    assert.strictEqual(EditorPredictionsAvailable, false);
+  });
+});

--- a/packages/vscode/src/lib/feature-availability.ts
+++ b/packages/vscode/src/lib/feature-availability.ts
@@ -1,0 +1,10 @@
+/**
+ * Whether editor predictions are available in this release.
+ *
+ * This controls the complete editor-prediction subsystem, including FIM tab
+ * completion, all NES providers, their commands, and the shared status bar UI.
+ */
+export const EditorPredictionsAvailable = false;
+
+export const EditorPredictionsAvailableContextKey =
+  "pochiEditorPredictionsAvailable";


### PR DESCRIPTION
## Summary
- disable FIM tab completion and next edit suggestions at the extension composition boundary
- prevent prediction commands and the shared status bar item from activating while retaining their implementation and guarded keybindings
- mark editor predictions unavailable in settings and current documentation

> [!IMPORTANT]
> This PR should be merged only after the 0.60 release.

## Test plan
- [x] `bun run check`
- [x] `bun run tsc` in `packages/vscode`
- [x] `bun run test` in `packages/vscode` (178 passing)
- [x] `bun run build` in `packages/vscode`
- [ ] Integration tests (deferred)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b9b41816b3704501b0a53259a825977b)