### PR TITLE
feat(config): reactive effectiveContextWindow with 64K minimum

### DIFF
--- a/assets/config.schema.json
+++ b/assets/config.schema.json
@@ -614,7 +614,7 @@
       "additionalProperties": false
     },
     "effectiveContextWindow": {
-      "description": "Token count at which auto-compaction triggers, even when the model declares a larger context window (models tend to degrade earlier on agentic tasks). Models whose real context window is smaller trigger earlier to leave room for the summary. Defaults to 160000.",
+      "description": "Token count at which auto-compaction triggers, even when the model declares a larger context window (models tend to degrade earlier on agentic tasks). Models whose real context window is smaller trigger earlier to leave room for the summary. Minimum 64000, defaults to 160000.",
       "type": "number"
     }
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -656,7 +656,7 @@ async function createLLMConfigWithVendors(
       id: `${vendorId}/${modelId}`,
       type: "vendor",
       contextWindow: options.contextWindow,
-      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
+
       useToolCallMiddleware: options.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {
@@ -680,7 +680,7 @@ async function createLLMConfigWithPochi(
       id: `${vendorId}/${model}`,
       type: "vendor",
       contextWindow: pochiModelOptions.contextWindow,
-      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
+
       useToolCallMiddleware: pochiModelOptions.useToolCallMiddleware,
       getModel: () =>
         createModel(vendorId, {
@@ -718,7 +718,7 @@ async function createLLMConfigWithProviders(
       apiKey: modelProvider.apiKey,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
+
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       contentType: modelSetting.contentType,
@@ -733,7 +733,7 @@ async function createLLMConfigWithProviders(
       vertex: modelProvider.vertex,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
+
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       useToolCallMiddleware: modelSetting.useToolCallMiddleware,
@@ -756,7 +756,7 @@ async function createLLMConfigWithProviders(
       apiKey: modelProvider.apiKey,
       contextWindow:
         modelSetting.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow: pochiConfig.value.effectiveContextWindow,
+
       maxOutputTokens:
         modelSetting.maxTokens ?? constants.DefaultMaxOutputTokens,
       useToolCallMiddleware: modelSetting.useToolCallMiddleware,

--- a/packages/cli/src/running-task-adaptor.ts
+++ b/packages/cli/src/running-task-adaptor.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@getpochi/common";
 import { AutoMemoryManager } from "@getpochi/common/auto-memory/node";
+import { pochiConfig } from "@getpochi/common/configuration";
 import type { McpHub } from "@getpochi/common/mcp-utils";
 import {
   FileStateCache,
@@ -83,6 +84,7 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
   getRequestGetters(context: { taskId: string; cwd: string | undefined }) {
     return {
       getLLM: () => this.llm,
+      getEffectiveContextWindow: () => pochiConfig.value.effectiveContextWindow,
       getEnvironment: async () =>
         readEnvironment({ cwd: context.cwd ?? this.cwd }),
       ...(this.projectMemoryEnabled

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -8,6 +8,7 @@ import {
   toErrorMessage,
 } from "@getpochi/common";
 import type { BrowserSessionStore } from "@getpochi/common/browser";
+import { pochiConfig } from "@getpochi/common/configuration";
 import type { McpHub } from "@getpochi/common/mcp-utils";
 import {
   isAssistantMessageWithEmptyParts,
@@ -309,6 +310,8 @@ export class TaskRunner {
 
       getters: {
         getLLM: () => options.llm,
+        getEffectiveContextWindow: () =>
+          pochiConfig.value.effectiveContextWindow,
         getEnvironment: async () => ({
           ...(await readEnvironment({
             cwd: options.cwd,

--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -11,6 +11,9 @@ export const CompactTaskMinTokens = 50_000;
 export const DefaultContextWindow = 100_000;
 export const DefaultMaxOutputTokens = 4096;
 
+export const DefaultEffectiveContextWindow = 160_000;
+export const MinEffectiveContextWindow = 64_000;
+
 export const StreamingUpdateThrottleMs = 100;
 
 export const AttemptTodoCompletionAgentName = "attemptTodoCompletion";

--- a/packages/common/src/configuration/__tests__/types.test.ts
+++ b/packages/common/src/configuration/__tests__/types.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MinEffectiveContextWindow } from "../../base/constants";
 import { PochiConfig, makePochiConfig } from "../types";
 
 describe("PochiConfig types", () => {
@@ -89,6 +90,26 @@ describe("PochiConfig types", () => {
         $schema: "custom-schema-url",
       });
       expect(config.$schema).toBe("custom-schema-url");
+    });
+
+    it("should keep effectiveContextWindow at or above the minimum", () => {
+      const config = PochiConfig.parse({
+        effectiveContextWindow: 200_000,
+      });
+      expect(config.effectiveContextWindow).toBe(200_000);
+    });
+
+    it("should clamp a too-small effectiveContextWindow up to the minimum", () => {
+      const config = PochiConfig.parse({
+        effectiveContextWindow: 1000,
+      });
+      expect(config.effectiveContextWindow).toBe(MinEffectiveContextWindow);
+    });
+
+    it("should not clamp effectiveContextWindow in strict mode (schema only documents the minimum)", () => {
+      const schema = makePochiConfig(true);
+      const config = schema.parse({ effectiveContextWindow: 1000 });
+      expect(config.effectiveContextWindow).toBe(1000);
     });
   });
 });

--- a/packages/common/src/configuration/types.ts
+++ b/packages/common/src/configuration/types.ts
@@ -1,4 +1,8 @@
 import z from "zod";
+import {
+  DefaultEffectiveContextWindow,
+  MinEffectiveContextWindow,
+} from "../base/constants";
 import { BrowserAgentSettingsConfig } from "../vscode-webui-bridge/types/browser-agent-settings";
 import { McpServerConfig } from "./mcp";
 import { CustomModelSetting } from "./model";
@@ -42,11 +46,15 @@ export function makePochiConfig(strict = false) {
     providers: looseRecord(CustomModelSetting, strict).optional(),
     mcp: looseRecord(McpServerConfig, strict).optional(),
     browserAgentSettings: BrowserAgentSettingsConfig.optional(),
-    effectiveContextWindow: z
-      .number()
+    effectiveContextWindow: (strict
+      ? z.number()
+      : z
+          .number()
+          .transform((value) => Math.max(value, MinEffectiveContextWindow))
+    )
       .optional()
       .describe(
-        "Token count at which auto-compaction triggers, even when the model declares a larger context window (models tend to degrade earlier on agentic tasks). Models whose real context window is smaller trigger earlier to leave room for the summary. Defaults to 160000.",
+        `Token count at which auto-compaction triggers, even when the model declares a larger context window (models tend to degrade earlier on agentic tasks). Models whose real context window is smaller trigger earlier to leave room for the summary. Minimum ${MinEffectiveContextWindow}, defaults to ${DefaultEffectiveContextWindow}.`,
       ),
   });
 }

--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -432,8 +432,11 @@ const VSCodeHostStub = {
       setAutoMemoryEnabled: (_enabled: boolean) => Promise.resolve(),
     };
   },
-  readEffectiveContextWindow: async (): Promise<number | undefined> =>
-    undefined,
+  readEffectiveContextWindow: async (): Promise<
+    ThreadSignalSerialization<number | undefined>
+  > => {
+    return {} as ThreadSignalSerialization<number | undefined>;
+  },
   readAutoMemoryState: async (
     _taskId: string,
   ): Promise<{

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -466,8 +466,12 @@ export interface VSCodeHostApi {
    * Read the global effective context window (in tokens) used to cap
    * auto-compaction. Returns undefined when not configured, in which case the
    * built-in default is used.
+   *
+   * Returns a signal so the UI can react to configuration changes in real time.
    */
-  readEffectiveContextWindow(): Promise<number | undefined>;
+  readEffectiveContextWindow(): Promise<
+    ThreadSignalSerialization<number | undefined>
+  >;
 
   readAutoMemoryState(taskId: string): Promise<{
     value: ThreadSignalSerialization<AutoMemoryTaskState | undefined>;

--- a/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
+++ b/packages/livekit/src/chat/__tests__/auto-compact-policy.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import type { Message, RequestData, Task } from "../../types";
 import {
   AutoCompactBufferTokens,
-  DefaultEffectiveContextWindow,
   MaxSummaryOutputTokens,
   findAutoCompactAttachIndex,
   getAutoCompactThreshold,
@@ -65,7 +64,7 @@ const openaiLlm = (contextWindow: number): RequestData["llm"] =>
 describe("getAutoCompactThreshold", () => {
   it("triggers at DefaultEffectiveContextWindow for large declared windows", () => {
     expect(getAutoCompactThreshold(1_000_000)).toBe(
-      DefaultEffectiveContextWindow,
+      constants.DefaultEffectiveContextWindow,
     );
   });
 
@@ -212,18 +211,16 @@ describe("shouldAutoCompact", () => {
     ).toBe(true);
   });
 
-  it("respects an explicit effectiveContextWindow on the llm", () => {
+  it("respects an explicit effectiveContextWindow param", () => {
     const messages = [assistantMessage(), userMessage()];
-    const llm = {
-      ...openaiLlm(1_000_000),
-      effectiveContextWindow: 100_000,
-    } as RequestData["llm"];
+    const llm = openaiLlm(1_000_000);
 
     expect(
       shouldAutoCompact({
         messages,
         llm,
         task: task(getAutoCompactThreshold(1_000_000, 100_000)),
+        effectiveContextWindow: 100_000,
       }),
     ).toBe(true);
 
@@ -232,16 +229,14 @@ describe("shouldAutoCompact", () => {
         messages,
         llm,
         task: task(getAutoCompactThreshold(1_000_000, 100_000) - 1),
+        effectiveContextWindow: 100_000,
       }),
     ).toBe(false);
   });
 
   it("does not trigger when totalTokens is below the effective threshold", () => {
     const messages = [assistantMessage(), userMessage()];
-    const llm = {
-      ...openaiLlm(1_000_000),
-      effectiveContextWindow: 100_000,
-    } as RequestData["llm"];
+    const llm = openaiLlm(1_000_000);
     const threshold = getAutoCompactThreshold(1_000_000, 100_000);
 
     expect(
@@ -249,6 +244,7 @@ describe("shouldAutoCompact", () => {
         messages,
         llm,
         task: task(threshold - 1),
+        effectiveContextWindow: 100_000,
       }),
     ).toBe(false);
   });

--- a/packages/livekit/src/chat/auto-compact-policy.ts
+++ b/packages/livekit/src/chat/auto-compact-policy.ts
@@ -6,11 +6,6 @@ export const MaxSummaryOutputTokens = 20_000;
 
 export const AutoCompactBufferTokens = 13_000;
 
-// Most models degrade on agentic tasks well before very large declared
-// windows are exhausted. When no effectiveContextWindow is configured,
-// auto-compaction triggers at this token count.
-export const DefaultEffectiveContextWindow = 160_000;
-
 export const MaxConsecutiveAutoCompactFailures = 3;
 
 export function getAutoCompactThreshold(
@@ -20,26 +15,17 @@ export function getAutoCompactThreshold(
   // The effective window is the point where auto-compaction triggers. When the
   // model's real context window is too small to hold that point plus the
   // summary output, back off so the compaction request itself doesn't overflow.
-  const triggerPoint = effectiveContextWindow ?? DefaultEffectiveContextWindow;
+  const triggerPoint =
+    effectiveContextWindow ?? constants.DefaultEffectiveContextWindow;
   const bufferLimit =
     contextWindow - MaxSummaryOutputTokens - AutoCompactBufferTokens;
   return Math.max(Math.min(triggerPoint, bufferLimit), 0);
 }
 
-function resolveContextWindow(llm: RequestData["llm"] | undefined): {
-  contextWindow: number;
-  effectiveContextWindow?: number;
-} {
+function resolveContextWindow(llm: RequestData["llm"] | undefined): number {
   const declared =
     llm && "contextWindow" in llm ? llm.contextWindow : undefined;
-  const effective =
-    llm && "effectiveContextWindow" in llm
-      ? llm.effectiveContextWindow
-      : undefined;
-  return {
-    contextWindow: declared || constants.DefaultContextWindow,
-    effectiveContextWindow: effective,
-  };
+  return declared || constants.DefaultContextWindow;
 }
 
 export function shouldAutoCompact({
@@ -47,11 +33,13 @@ export function shouldAutoCompact({
   llm,
   task,
   estimatedTotalTokens,
+  effectiveContextWindow,
 }: {
   messages: Message[];
   llm: RequestData["llm"] | undefined;
   task: Task | null | undefined;
   estimatedTotalTokens?: number;
+  effectiveContextWindow?: number;
 }): boolean {
   const attachIndex = findAutoCompactAttachIndex(messages);
   if (attachIndex === undefined) return false;
@@ -73,7 +61,7 @@ export function shouldAutoCompact({
   );
   if (totalTokens < constants.CompactTaskMinTokens) return false;
 
-  const { contextWindow, effectiveContextWindow } = resolveContextWindow(llm);
+  const contextWindow = resolveContextWindow(llm);
   if (
     totalTokens < getAutoCompactThreshold(contextWindow, effectiveContextWindow)
   ) {

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -92,6 +92,7 @@ function createAbortAwareUIStreamTransform(
 
 export type PrepareRequestGetters = {
   getLLM: () => RequestData["llm"];
+  getEffectiveContextWindow?: () => number | undefined;
   getEnvironment?: () => Promise<Environment>;
   getAutoMemory?: () => Promise<AutoMemoryContext | undefined>;
   isTodoModeActive?: () => boolean;

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -577,6 +577,7 @@ export class LiveChatKit<
           llm: getters.getLLM(),
           task: this.task,
           estimatedTotalTokens: estimateTotalTokens(formatters.llm(messages)),
+          effectiveContextWindow: getters.getEffectiveContextWindow?.(),
         });
 
       if (isManualCompact || isAutoCompact) {

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -47,12 +47,7 @@ const RequestData = z.object({
       baseURL: z.string().optional(),
       apiKey: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
-      effectiveContextWindow: z
-        .number()
-        .optional()
-        .describe(
-          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
-        ),
+
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -70,12 +65,7 @@ const RequestData = z.object({
       baseURL: z.string().optional(),
       apiKey: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
-      effectiveContextWindow: z
-        .number()
-        .optional()
-        .describe(
-          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
-        ),
+
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -93,12 +83,7 @@ const RequestData = z.object({
       baseURL: z.string().optional(),
       apiKey: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
-      effectiveContextWindow: z
-        .number()
-        .optional()
-        .describe(
-          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
-        ),
+
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -115,12 +100,7 @@ const RequestData = z.object({
       modelId: z.string(),
       vertex: GoogleVertexModel,
       contextWindow: z.number().describe("Context window of the model."),
-      effectiveContextWindow: z
-        .number()
-        .optional()
-        .describe(
-          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
-        ),
+
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -137,12 +117,7 @@ const RequestData = z.object({
       modelId: z.string(),
       apiKey: z.string().optional(),
       contextWindow: z.number().describe("Context window of the model."),
-      effectiveContextWindow: z
-        .number()
-        .optional()
-        .describe(
-          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
-        ),
+
       maxOutputTokens: z.number().describe("Max output tokens of the model."),
       useToolCallMiddleware: z
         .boolean()
@@ -177,12 +152,7 @@ const RequestData = z.object({
         .number()
         .optional()
         .describe("Context window of the model."),
-      effectiveContextWindow: z
-        .number()
-        .optional()
-        .describe(
-          "Effective context window used to cap auto-compaction; sourced from the global Pochi setting.",
-        ),
+
       useToolCallMiddleware: z
         .boolean()
         .optional()

--- a/packages/vscode-webui/src/features/chat/lib/display-model-to-llm.ts
+++ b/packages/vscode-webui/src/features/chat/lib/display-model-to-llm.ts
@@ -11,16 +11,12 @@ import { createModel } from "@getpochi/common/vendor/edge";
 import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
 import type { LLMRequestData } from "@getpochi/livekit";
 
-export function displayModelToLLM(
-  model: DisplayModel,
-  effectiveContextWindow?: number,
-): LLMRequestData {
+export function displayModelToLLM(model: DisplayModel): LLMRequestData {
   if (model.type === "vendor") {
     return {
       id: model.id,
       type: "vendor",
       contextWindow: model.options.contextWindow,
-      effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       getModel: () =>
         createModel(model.vendorId, {
@@ -42,7 +38,6 @@ export function displayModelToLLM(
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };
@@ -58,7 +53,6 @@ export function displayModelToLLM(
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };
@@ -81,7 +75,6 @@ export function displayModelToLLM(
         model.options.maxTokens ?? constants.DefaultMaxOutputTokens,
       contextWindow:
         model.options.contextWindow ?? constants.DefaultContextWindow,
-      effectiveContextWindow,
       useToolCallMiddleware: model.options.useToolCallMiddleware,
       contentType: model.contentType,
     };

--- a/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
+++ b/packages/vscode-webui/src/features/chat/lib/use-live-chat-kit-getters.ts
@@ -44,6 +44,9 @@ export function useLiveChatKitGetters({
   });
   const llm = useLLM({ isSubTask, modelOverride });
 
+  const effectiveContextWindow = useEffectiveContextWindow();
+  const effectiveContextWindowRef = useLatest(effectiveContextWindow);
+
   const { customAgents } = useCustomAgents(true);
   const customAgentsRef = useLatest(customAgents);
 
@@ -102,6 +105,12 @@ export function useLiveChatKitGetters({
     // biome-ignore lint/correctness/useExhaustiveDependencies(llm.current): llm is ref.
     getLLM: useCallback(() => llm.current, []),
 
+    // biome-ignore lint/correctness/useExhaustiveDependencies(effectiveContextWindowRef.current): ref is stable.
+    getEffectiveContextWindow: useCallback(
+      () => effectiveContextWindowRef.current,
+      [],
+    ),
+
     getEnvironment,
 
     getAutoMemory,
@@ -140,12 +149,11 @@ function useLLM({
   modelOverride?: DisplayModel;
 }): React.RefObject<LLMRequestData> {
   const { selectedModel } = useSelectedModels({ isSubTask });
-  const effectiveContextWindow = useEffectiveContextWindow();
 
   const model = modelOverride || selectedModel;
   const llmFromSelectedModel = ((): LLMRequestData => {
     if (!model) return undefined as never;
-    return displayModelToLLM(model, effectiveContextWindow);
+    return displayModelToLLM(model);
   })();
 
   return useLatest(llmFromSelectedModel);

--- a/packages/vscode-webui/src/lib/hooks/use-effective-context-window.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-effective-context-window.ts
@@ -1,17 +1,30 @@
 import { vscodeHost } from "@/lib/vscode";
+import { threadSignal } from "@quilted/threads/signals";
 import { useQuery } from "@tanstack/react-query";
 
 /**
  * Reads the global effective context window (in tokens) used to cap
  * auto-compaction. Returns undefined when not configured, in which case the
  * built-in default is used.
+ *
+ * The value is backed by a signal, so the hook re-renders whenever the
+ * configuration changes.
+ *
+ * @useSignals this comment is needed to enable signals in this hook
  */
 export const useEffectiveContextWindow = (): number | undefined => {
   const { data } = useQuery({
     queryKey: ["effectiveContextWindow"],
-    queryFn: () => vscodeHost.readEffectiveContextWindow(),
+    queryFn: () => fetchEffectiveContextWindow(),
     staleTime: Number.POSITIVE_INFINITY,
   });
 
-  return data ?? undefined;
+  return data?.value.value ?? undefined;
 };
+
+async function fetchEffectiveContextWindow() {
+  const result = await vscodeHost.readEffectiveContextWindow();
+  return {
+    value: threadSignal(result),
+  };
+}

--- a/packages/vscode-webui/src/lib/vscode-running-task-adaptor.ts
+++ b/packages/vscode-webui/src/lib/vscode-running-task-adaptor.ts
@@ -64,6 +64,7 @@ export class VscodeRunningTaskAdaptor implements RunningTaskAdaptor {
         }
         return llm;
       },
+      getEffectiveContextWindow: () => this.effectiveContextWindow,
       getEnvironment: () =>
         vscodeHost.readEnvironment({
           webviewKind: globalThis.POCHI_WEBVIEW_KIND,
@@ -121,7 +122,13 @@ export class VscodeRunningTaskAdaptor implements RunningTaskAdaptor {
   }
 
   private async initEffectiveContextWindow() {
-    this.effectiveContextWindow = await vscodeHost.readEffectiveContextWindow();
+    const signal = threadSignal(await vscodeHost.readEffectiveContextWindow());
+    this.effectiveContextWindow = signal.value;
+    this.addUnsubscriber(
+      signal.subscribe((effectiveContextWindow) => {
+        this.effectiveContextWindow = effectiveContextWindow;
+      }),
+    );
   }
 
   private async initModelList() {
@@ -189,9 +196,7 @@ export class VscodeRunningTaskAdaptor implements RunningTaskAdaptor {
       resolveModelFromId(selectedModelId, this.modelList) ??
       this.modelList.at(0);
 
-    return selectedModel
-      ? displayModelToLLM(selectedModel, this.effectiveContextWindow)
-      : undefined;
+    return selectedModel ? displayModelToLLM(selectedModel) : undefined;
   }
 
   private getAutoMemory() {

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1410,8 +1410,12 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     };
   };
 
-  readEffectiveContextWindow = async (): Promise<number | undefined> => {
-    return pochiConfig.value.effectiveContextWindow;
+  readEffectiveContextWindow = async (): Promise<
+    ThreadSignalSerialization<number | undefined>
+  > => {
+    return ThreadSignal.serialize(
+      computed(() => pochiConfig.value.effectiveContextWindow),
+    );
   };
 
   readAutoMemoryState = async (


### PR DESCRIPTION
## Summary
- `readEffectiveContextWindow` now returns a reactive `ThreadSignal` so the UI updates live when the setting changes.
- Enforce a 64K minimum for `effectiveContextWindow` at runtime (clamp below-min values up); the JSON schema only *documents* the minimum (no `minimum` constraint, so config parse never throws).
- Centralize `MinEffectiveContextWindow` (64_000) and `DefaultEffectiveContextWindow` (160_000) as shared constants in `packages/common/src/base/constants.ts` and use them in the config field description.
- Decouple `effectiveContextWindow` from per-LLM `LLMRequestData`: it is a globally consistent config, now threaded as one top-level value via a `getEffectiveContextWindow` getter (host bridge in the webui, `pochiConfig` in the cli) and passed into `shouldAutoCompact`.

## Test plan
- [x] `bun run test` for livekit `auto-compact-policy` (23) and common `configuration/types` (10)
- [x] `bun tsc` across all 12 packages
- [x] `bun fix` / `bun check` clean
- [x] Regenerated `assets/config.schema.json`

🤖 Generated with [Pochi](https://getpochi.com)