### PR TITLE
chore(vscode): bump version to 0.61.0-dev

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -282,7 +282,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.59.0-dev",
+      "version": "0.61.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.59.0-dev",
+  "version": "0.61.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump the `pochi` vscode extension version from `0.59.0-dev` to `0.61.0-dev`
- Update the corresponding entry in `bun.lock`

## Test plan
- [ ] CI passes

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7bc2f2fe38604610afd47fb21465f245)