### PR TITLE
refactor(livekit): replace generic message update events

### DIFF
--- a/packages/livekit/src/chat/__tests__/compact-task.test.ts
+++ b/packages/livekit/src/chat/__tests__/compact-task.test.ts
@@ -164,11 +164,16 @@ describe("compactTask", () => {
       assistantMsg("a1"),
       userMsg("u2"),
     ];
-    const commits: Array<{ name: string; args: { messages?: Message[] } }> =
-      [];
+    const commits: Array<{
+      name: string;
+      args: { id?: string; text?: string };
+    }> = [];
     const store = {
       query: () => ({ content: "memory summary" }),
-      commit: (event: { name: string; args: { messages?: Message[] } }) => {
+      commit: (event: {
+        name: string;
+        args: { id?: string; text?: string };
+      }) => {
         commits.push(event);
       },
     };
@@ -190,8 +195,11 @@ describe("compactTask", () => {
     });
     expect(commits).toHaveLength(1);
     expect(commits[0]).toMatchObject({
-      name: "v1.UpdateMessages",
-      args: { messages: [messages[2]] },
+      name: "v1.InlineCompactAttached",
+      args: {
+        id: messages[2].id,
+        text: expect.stringContaining("<compact>"),
+      },
     });
   });
 });

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -3,6 +3,7 @@ import type {
   BackgroundTaskState,
   TaskMemoryState,
 } from "@getpochi/common";
+import { Duration } from "@livestore/utils/effect";
 import type { ChatInit, ChatOnErrorCallback, ChatOnFinishCallback } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -85,6 +86,69 @@ describe("LiveChatKit memory lifecycle", () => {
       input: { path: "README.md" },
       errorText: "User aborted the tool call",
     });
+  });
+
+  it("preserves in-memory tool results when recording execution duration", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(1_000));
+      const store = new FakeStore([
+        makeTask({
+          id: "parent",
+          status: "pending-tool",
+          background: false,
+        }),
+      ]);
+      store.setTaskMessages("parent", [
+        userMessage(),
+        assistantReadFileMessage("input-available"),
+      ]);
+      const chatKit = new LiveChatKit<FakeChat>({
+        taskId: "parent",
+        store: store as unknown as LiveKitStore,
+        blobStore: {} as BlobStore,
+        chatClass: FakeChat,
+        getters: {
+          getLLM: () => ({ id: "test-model" }) as never,
+        },
+      });
+
+      chatKit.markStartToolsExecution();
+      vi.setSystemTime(new Date(1_250));
+      chatKit.chat.messages = [
+        userMessage(),
+        {
+          ...assistantReadFileMessage("input-available"),
+          parts: [
+            {
+              type: "tool-readFile",
+              toolCallId: "call-read-file",
+              state: "output-available",
+              input: { path: "README.md" },
+              output: { content: "README contents" },
+            },
+          ],
+        } as unknown as Message,
+      ];
+
+      chatKit.markEndToolsExecution();
+
+      expect(chatKit.chat.messages.at(-1)?.parts[0]).toMatchObject({
+        state: "output-available",
+        output: { content: "README contents" },
+      });
+      expect(chatKit.chat.messages.at(-1)?.metadata).toMatchObject({
+        totalToolsExecutionDuration: 250,
+      });
+      expect(store.taskMessages("parent").at(-1)?.parts[0]).toMatchObject({
+        state: "input-available",
+      });
+      expect(store.taskMessages("parent").at(-1)?.metadata).toMatchObject({
+        totalToolsExecutionDuration: 250,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("strips OpenAI item references from the failed step before saving", () => {
@@ -589,6 +653,10 @@ class FakeStore {
       this.commitUpdateTotalTokens(event.args);
       return;
     }
+    if (event.name === "v1.ToolsExecutionDurationRecorded") {
+      this.commitToolsExecutionDurationRecorded(event.args);
+      return;
+    }
     throw new Error(`Unsupported event ${event.name}`);
   }
 
@@ -604,6 +672,10 @@ class FakeStore {
 
   taskMessages(taskId: string) {
     return this.messages.get(taskId) ?? [];
+  }
+
+  setTaskMessages(taskId: string, messages: Message[]) {
+    this.messages.set(taskId, messages);
   }
 
   private commitTaskInited(args: Record<string, unknown>) {
@@ -674,6 +746,32 @@ class FakeStore {
       totalTokens: args.totalTokens as number,
       updatedAt: args.updatedAt as Date,
     });
+  }
+
+  private commitToolsExecutionDurationRecorded(args: Record<string, unknown>) {
+    const id = args.id as string;
+    const duration = Duration.toMillis(args.duration as Duration.Duration);
+    for (const [taskId, messages] of this.messages) {
+      if (!messages.some((message) => message.id === id)) continue;
+      this.messages.set(
+        taskId,
+        messages.map((message) =>
+          message.id === id
+            ? ({
+                ...message,
+                metadata: {
+                  ...message.metadata,
+                  totalToolsExecutionDuration:
+                    (message.metadata?.kind === "assistant"
+                      ? (message.metadata.totalToolsExecutionDuration ?? 0)
+                      : 0) + duration,
+                },
+              } as Message)
+            : message,
+        ),
+      );
+      return;
+    }
   }
 
   private extractTaskId(query: { hash?: string }) {

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -88,7 +88,7 @@ describe("LiveChatKit memory lifecycle", () => {
     });
   });
 
-  it("preserves in-memory tool results when recording execution duration", () => {
+  it("persists tool results when recording execution duration", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(new Date(1_000));
@@ -141,7 +141,8 @@ describe("LiveChatKit memory lifecycle", () => {
         totalToolsExecutionDuration: 250,
       });
       expect(store.taskMessages("parent").at(-1)?.parts[0]).toMatchObject({
-        state: "input-available",
+        state: "output-available",
+        output: { content: "README contents" },
       });
       expect(store.taskMessages("parent").at(-1)?.metadata).toMatchObject({
         totalToolsExecutionDuration: 250,
@@ -653,8 +654,8 @@ class FakeStore {
       this.commitUpdateTotalTokens(event.args);
       return;
     }
-    if (event.name === "v1.ToolsExecutionDurationRecorded") {
-      this.commitToolsExecutionDurationRecorded(event.args);
+    if (event.name === "v1.ToolsExecutionFinished") {
+      this.commitToolsExecutionFinished(event.args);
       return;
     }
     throw new Error(`Unsupported event ${event.name}`);
@@ -748,8 +749,9 @@ class FakeStore {
     });
   }
 
-  private commitToolsExecutionDurationRecorded(args: Record<string, unknown>) {
+  private commitToolsExecutionFinished(args: Record<string, unknown>) {
     const id = args.id as string;
+    const parts = args.parts as Message["parts"];
     const duration = Duration.toMillis(args.duration as Duration.Duration);
     for (const [taskId, messages] of this.messages) {
       if (!messages.some((message) => message.id === id)) continue;
@@ -759,6 +761,7 @@ class FakeStore {
           message.id === id
             ? ({
                 ...message,
+                parts,
                 metadata: {
                   ...message.metadata,
                   totalToolsExecutionDuration:

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -816,27 +816,13 @@ export class LiveChatKit<
     if (toolsExecution) {
       const duration = Date.now() - toolsExecution.startedAt.getTime();
       const messages = this.chat.messages;
-      const messageToUpdate = messages.find(
-        (m) => m.id === toolsExecution.messageId,
-      );
-      if (messageToUpdate) {
-        const updatedMessages = messages.map((m) => {
-          if (m.id === toolsExecution.messageId) {
-            return {
-              ...m,
-              metadata: {
-                ...m.metadata,
-                totalToolsExecutionDuration:
-                  m.metadata?.kind === "assistant" &&
-                  m.metadata.totalToolsExecutionDuration !== undefined
-                    ? m.metadata.totalToolsExecutionDuration + duration
-                    : duration,
-              },
-            };
-          }
-          return m;
-        });
-        this.store.commit(events.updateMessages({ messages: updatedMessages }));
+      if (messages.some((m) => m.id === toolsExecution.messageId)) {
+        this.store.commit(
+          events.toolsExecutionDurationRecorded({
+            id: toolsExecution.messageId,
+            duration: Duration.millis(duration),
+          }),
+        );
         const updatedMessagesFromStore = this.messages;
         this.chat.messages = updatedMessagesFromStore;
       }

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -836,8 +836,9 @@ export class LiveChatKit<
             : message,
         );
         this.store.commit(
-          events.toolsExecutionDurationRecorded({
+          events.toolsExecutionFinished({
             id: toolsExecution.messageId,
+            parts: messageToUpdate.parts,
             duration: Duration.millis(duration),
           }),
         );

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -816,15 +816,32 @@ export class LiveChatKit<
     if (toolsExecution) {
       const duration = Date.now() - toolsExecution.startedAt.getTime();
       const messages = this.chat.messages;
-      if (messages.some((m) => m.id === toolsExecution.messageId)) {
+      const messageToUpdate = messages.find(
+        (message) => message.id === toolsExecution.messageId,
+      );
+      if (messageToUpdate) {
+        const updatedMessages = messages.map((message) =>
+          message.id === toolsExecution.messageId
+            ? ({
+                ...message,
+                metadata: {
+                  ...message.metadata,
+                  totalToolsExecutionDuration:
+                    message.metadata?.kind === "assistant" &&
+                    message.metadata.totalToolsExecutionDuration !== undefined
+                      ? message.metadata.totalToolsExecutionDuration + duration
+                      : duration,
+                },
+              } as Message)
+            : message,
+        );
         this.store.commit(
           events.toolsExecutionDurationRecorded({
             id: toolsExecution.messageId,
             duration: Duration.millis(duration),
           }),
         );
-        const updatedMessagesFromStore = this.messages;
-        this.chat.messages = updatedMessagesFromStore;
+        this.chat.messages = updatedMessages;
       }
     }
   };

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -106,7 +106,7 @@ export async function compactTask({
           { verbatimTail: true },
         );
         memoryAttachMessage.parts.unshift({ type: "text", text });
-        persistInlineCompactMessage(store, memoryAttachMessage);
+        persistInlineCompactMessage(store, memoryAttachMessage.id, text);
         logger.debug(
           `Inline compact attached at index ${memoryAttachIndex}; preserving ${
             messages.length - memoryAttachIndex
@@ -126,7 +126,7 @@ export async function compactTask({
         attachIndex < messages.length - 1 ? { verbatimTail: true } : undefined,
       );
       attachMessage.parts.unshift({ type: "text", text });
-      persistInlineCompactMessage(store, attachMessage);
+      persistInlineCompactMessage(store, attachMessage.id, text);
       return;
     }
 
@@ -144,10 +144,11 @@ export async function compactTask({
 
 function persistInlineCompactMessage(
   store: LiveKitStore | undefined,
-  message: Message,
+  id: string,
+  text: string,
 ) {
   if (!store) return;
-  store.commit(events.updateMessages({ messages: [message] }));
+  store.commit(events.inlineCompactAttached({ id, text }));
 }
 
 export function findInlineCompactAttachIndex(

--- a/packages/livekit/src/chat/llm/repair-mermaid.ts
+++ b/packages/livekit/src/chat/llm/repair-mermaid.ts
@@ -145,7 +145,11 @@ export async function repairMermaid({
 
     // Commit all updated messages to the database in a single transaction
     if (updatedMessages.length > 0) {
-      store.commit(events.updateMessages({ messages: updatedMessages }));
+      store.commit(
+        events.mermaidRepaired({
+          repairs: updatedMessages.map(({ id, parts }) => ({ id, parts })),
+        }),
+      );
       logger.debug(
         `Committed ${updatedMessages.length} updated message(s) to database`,
       );

--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -5,6 +5,7 @@ import {
   deprecated,
   makeSchema,
 } from "@livestore/livestore";
+import { Duration } from "@livestore/utils/effect";
 import {
   DBMessage,
   DBUIPart,
@@ -270,10 +271,38 @@ export const events = {
       content: Schema.String,
     }),
   }),
-  updateMessages: Events.synced({
+  // @deprecated kept for backward compatibility with existing event logs
+  _updateMessages: Events.synced({
     name: "v1.UpdateMessages",
     schema: Schema.Struct({
       messages: Schema.Array(DBMessage),
+    }),
+    deprecated:
+      "Use inlineCompactAttached, mermaidRepaired, or toolsExecutionDurationRecorded instead",
+  }),
+  inlineCompactAttached: Events.synced({
+    name: "v1.InlineCompactAttached",
+    schema: Schema.Struct({
+      id: Schema.String,
+      text: Schema.String,
+    }),
+  }),
+  mermaidRepaired: Events.synced({
+    name: "v1.MermaidRepaired",
+    schema: Schema.Struct({
+      repairs: Schema.Array(
+        Schema.Struct({
+          id: Schema.String,
+          parts: Schema.Array(DBUIPart),
+        }),
+      ),
+    }),
+  }),
+  toolsExecutionDurationRecorded: Events.synced({
+    name: "v1.ToolsExecutionDurationRecorded",
+    schema: Schema.Struct({
+      id: Schema.String,
+      duration: Schema.DurationFromMillis,
     }),
   }),
   forkTaskInited: Events.synced({
@@ -514,6 +543,7 @@ const materializers = State.SQLite.materializers(events, {
         updatedAt,
       })
       .where({ id }),
+  // @deprecated materializer kept for backward compatibility
   "v1.UpdateMessages": ({ messages }) =>
     messages.map((message) =>
       tables.messages
@@ -522,6 +552,52 @@ const materializers = State.SQLite.materializers(events, {
         })
         .where({ id: message.id }),
     ),
+  "v1.InlineCompactAttached": ({ id, text }, ctx) => {
+    const row = ctx.query(
+      tables.messages.where("id", "=", id).first({ behaviour: "undefined" }),
+    );
+    if (!row) return [];
+    return tables.messages
+      .update({
+        data: {
+          ...row.data,
+          parts: [{ type: "text", text }, ...row.data.parts],
+        },
+      })
+      .where({ id });
+  },
+  "v1.MermaidRepaired": ({ repairs }, ctx) =>
+    repairs.flatMap(({ id, parts }) => {
+      const row = ctx.query(
+        tables.messages.where("id", "=", id).first({ behaviour: "undefined" }),
+      );
+      if (!row) return [];
+      return tables.messages
+        .update({ data: { ...row.data, parts: [...parts] } })
+        .where({ id });
+    }),
+  "v1.ToolsExecutionDurationRecorded": ({ id, duration }, ctx) => {
+    const row = ctx.query(
+      tables.messages.where("id", "=", id).first({ behaviour: "undefined" }),
+    );
+    if (!row) return [];
+    const previousDuration =
+      row.data.metadata?.kind === "assistant"
+        ? row.data.metadata.totalToolsExecutionDuration
+        : undefined;
+    return tables.messages
+      .update({
+        data: {
+          ...row.data,
+          metadata: {
+            ...row.data.metadata,
+            totalToolsExecutionDuration:
+              (previousDuration ?? 0) + Duration.toMillis(duration),
+          },
+        },
+      })
+      .where({ id });
+  },
   "v1.ForkTaskInited": ({ tasks, messages, files }) => [
     ...tasks.map((task) =>
       tables.tasks.insert({

--- a/packages/livekit/src/livestore/default-schema.ts
+++ b/packages/livekit/src/livestore/default-schema.ts
@@ -278,7 +278,7 @@ export const events = {
       messages: Schema.Array(DBMessage),
     }),
     deprecated:
-      "Use inlineCompactAttached, mermaidRepaired, or toolsExecutionDurationRecorded instead",
+      "Use inlineCompactAttached, mermaidRepaired, or toolsExecutionFinished instead",
   }),
   inlineCompactAttached: Events.synced({
     name: "v1.InlineCompactAttached",
@@ -298,10 +298,11 @@ export const events = {
       ),
     }),
   }),
-  toolsExecutionDurationRecorded: Events.synced({
-    name: "v1.ToolsExecutionDurationRecorded",
+  toolsExecutionFinished: Events.synced({
+    name: "v1.ToolsExecutionFinished",
     schema: Schema.Struct({
       id: Schema.String,
+      parts: Schema.Array(DBUIPart),
       duration: Schema.DurationFromMillis,
     }),
   }),
@@ -576,7 +577,7 @@ const materializers = State.SQLite.materializers(events, {
         .update({ data: { ...row.data, parts: [...parts] } })
         .where({ id });
     }),
-  "v1.ToolsExecutionDurationRecorded": ({ id, duration }, ctx) => {
+  "v1.ToolsExecutionFinished": ({ id, parts, duration }, ctx) => {
     const row = ctx.query(
       tables.messages.where("id", "=", id).first({ behaviour: "undefined" }),
     );
@@ -589,6 +590,7 @@ const materializers = State.SQLite.materializers(events, {
       .update({
         data: {
           ...row.data,
+          parts: [...parts],
           metadata: {
             ...row.data.metadata,
             totalToolsExecutionDuration:


### PR DESCRIPTION
## Summary
- deprecate the generic `UpdateMessages` event while retaining its materializer for existing event-log replay
- add precise events for inline compact attachment, Mermaid repairs, and tool execution duration
- merge targeted changes against current message state in materializers to avoid stale whole-message overwrites

## Test plan
- [x] Run `bun run test` in `packages/livekit` (102 tests)
- [x] Run `bun tsc`
- [x] Run `bun check`
- [x] Run `git diff --check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f2403a8dc6344c96b015207a1dee267f)