### PR TITLE
fix(webui): improve chat scroll stick-to-bottom behavior

### DIFF
--- a/packages/vscode-webui/src/features/approval/components/approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/approval-button.tsx
@@ -15,6 +15,7 @@ interface ApprovalButtonProps {
   isSubTask: boolean;
   task?: Task;
   subtask?: SubtaskInfo;
+  onToolCallApprovalVisible?: () => void;
   onToolsExecutionStarted?: () => void;
   onToolsExecutionEnded?: () => void;
 }
@@ -26,6 +27,7 @@ export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
   retry,
   isSubTask,
   subtask,
+  onToolCallApprovalVisible,
   onToolsExecutionStarted,
   onToolsExecutionEnded,
 }) => {
@@ -55,6 +57,7 @@ export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
           isSubTask={isSubTask}
           parentUid={task?.parentId ?? undefined}
           subtask={subtask}
+          onVisible={onToolCallApprovalVisible}
           onToolsExecutionStarted={onToolsExecutionStarted}
           onToolsExecutionEnded={onToolsExecutionEnded}
         />

--- a/packages/vscode-webui/src/features/approval/components/tool-call-approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/tool-call-approval-button.tsx
@@ -31,6 +31,7 @@ interface ToolCallApprovalButtonProps {
   taskId?: string;
   parentUid?: string;
   subtask?: SubtaskInfo;
+  onVisible?: () => void;
   onToolsExecutionStarted?: () => void;
   onToolsExecutionEnded?: () => void;
 }
@@ -42,6 +43,7 @@ export const ToolCallApprovalButton: React.FC<ToolCallApprovalButtonProps> = ({
   isSubTask,
   parentUid,
   subtask,
+  onVisible,
   onToolsExecutionStarted,
   onToolsExecutionEnded,
 }) => {
@@ -246,6 +248,11 @@ export const ToolCallApprovalButton: React.FC<ToolCallApprovalButtonProps> = ({
   }, [batchExecuteManager, taskId]);
 
   const showAccept = !isAutoApproved && isReady;
+  useEffect(() => {
+    if (showAccept) {
+      onVisible?.();
+    }
+  }, [showAccept, onVisible]);
 
   if (showAccept) {
     return (

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -84,6 +84,7 @@ interface ChatToolbarProps {
   isRepairingMermaid?: boolean;
   mcpConfigOverride?: McpConfigOverride;
   getSystemPrompt?: () => string | undefined;
+  onToolCallApprovalVisible?: () => void;
   onToolsExecutionStarted?: () => void;
   onToolsExecutionEnded?: () => void;
 }
@@ -108,6 +109,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   isRepairingMermaid = false,
   mcpConfigOverride,
   getSystemPrompt,
+  onToolCallApprovalVisible,
   onToolsExecutionStarted,
   onToolsExecutionEnded,
 }) => {
@@ -345,6 +347,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             isSubTask={isSubTask}
             task={task}
             subtask={subtask}
+            onToolCallApprovalVisible={onToolCallApprovalVisible}
             onToolsExecutionStarted={onToolsExecutionStarted}
             onToolsExecutionEnded={onToolsExecutionEnded}
           />

--- a/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.test.tsx
@@ -102,7 +102,7 @@ describe("useScrollToBottom", () => {
 
     expect(context.scrollTo).toHaveBeenCalledWith({
       top: 1000,
-      behavior: "smooth",
+      behavior: "auto",
     });
   });
 
@@ -115,6 +115,21 @@ describe("useScrollToBottom", () => {
     expect(context.scrollTo).toHaveBeenCalledWith({
       top: 1000,
       behavior: "auto",
+    });
+  });
+
+  it("scrolls when tool call approval buttons become visible", () => {
+    const context = setup();
+
+    context.scrollTo.mockClear();
+
+    act(() => {
+      context.onToolCallApprovalVisible();
+    });
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1000,
+      behavior: "smooth",
     });
   });
 });
@@ -138,7 +153,7 @@ function setup(
   const hook = renderHook(
     ({ lastUserMessageId }: HookProps) => {
       const ref = useRef<HTMLDivElement | null>(container);
-      useScrollToBottom({
+      return useScrollToBottom({
         messagesContainerRef: ref,
         lastUserMessageId,
       });
@@ -152,12 +167,18 @@ function setup(
 
   return {
     container,
+    onToolCallApprovalVisible:
+      hook.result.current?.onToolCallApprovalVisible ?? missingApprovalCallback,
     rerender: hook.rerender,
     resizeObserver: ResizeObserverMock.instances[0],
     scrollTo,
     setScrollTop,
     userScrollTo,
   };
+}
+
+function missingApprovalCallback() {
+  throw new Error("onToolCallApprovalVisible is not available");
 }
 
 function createScrollContainer() {

--- a/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useScrollToBottom } from "./use-scroll-to-bottom";
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = [];
+
+  private readonly callback: ResizeObserverCallback;
+
+  observe = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ResizeObserverMock.instances.push(this);
+  }
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+describe("useScrollToBottom", () => {
+  beforeEach(() => {
+    ResizeObserverMock.instances = [];
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not follow streaming resizes after the user scrolls away from the bottom", () => {
+    const context = setup();
+
+    context.scrollTo.mockClear();
+
+    act(() => {
+      context.userScrollTo(300);
+      context.resizeObserver.trigger();
+    });
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("continues following streaming resizes while near the bottom", () => {
+    const context = setup();
+
+    context.scrollTo.mockClear();
+    context.setScrollTop(360);
+
+    act(() => {
+      context.resizeObserver.trigger();
+    });
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1000,
+      behavior: "smooth",
+    });
+  });
+
+  it("does not scroll on rerender after the user scrolls away from the bottom", () => {
+    const context = setup();
+
+    context.scrollTo.mockClear();
+
+    act(() => {
+      context.userScrollTo(300);
+    });
+
+    context.rerender({});
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll on rerender while near the bottom", () => {
+    const context = setup();
+
+    context.scrollTo.mockClear();
+    context.setScrollTop(360);
+
+    context.rerender({});
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("scrolls when the last message changes to a user message", () => {
+    const context = setup();
+
+    context.scrollTo.mockClear();
+
+    context.rerender({
+      lastUserMessageId: "user-message-1",
+    });
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1000,
+      behavior: "smooth",
+    });
+  });
+
+  it("does not scroll for the initially observed user message id", () => {
+    const context = setup({
+      lastUserMessageId: "existing-user-message",
+    });
+
+    expect(context.scrollTo).toHaveBeenCalledOnce();
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1000,
+      behavior: "auto",
+    });
+  });
+});
+
+function setup(
+  options: {
+    lastUserMessageId?: string;
+  } = {},
+) {
+  const { container, scrollTo, setScrollTop, userScrollTo } =
+    createScrollContainer();
+
+  type HookProps = {
+    lastUserMessageId?: string;
+  };
+
+  const initialProps: HookProps = {
+    lastUserMessageId: options.lastUserMessageId,
+  };
+
+  const hook = renderHook(
+    ({ lastUserMessageId }: HookProps) => {
+      const ref = useRef<HTMLDivElement | null>(container);
+      useScrollToBottom({
+        messagesContainerRef: ref,
+        lastUserMessageId,
+      });
+    },
+    {
+      initialProps,
+    },
+  );
+
+  expect(ResizeObserverMock.instances).toHaveLength(1);
+
+  return {
+    container,
+    rerender: hook.rerender,
+    resizeObserver: ResizeObserverMock.instances[0],
+    scrollTo,
+    setScrollTop,
+    userScrollTo,
+  };
+}
+
+function createScrollContainer() {
+  let scrollTop = 500;
+  const scrollHeight = 1000;
+  const container = document.createElement("div");
+  container.appendChild(document.createElement("div"));
+
+  Object.defineProperties(container, {
+    scrollHeight: {
+      configurable: true,
+      get: () => scrollHeight,
+    },
+    clientHeight: {
+      configurable: true,
+      get: () => 500,
+    },
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    },
+  });
+
+  const scrollTo = vi.fn((scrollOptions: ScrollToOptions) => {
+    if (typeof scrollOptions.top === "number") {
+      scrollTop = Math.min(
+        scrollOptions.top,
+        scrollHeight - container.clientHeight,
+      );
+    }
+  });
+  Object.defineProperty(container, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+  });
+
+  return {
+    container,
+    scrollTo,
+    setScrollTop: (value: number) => {
+      scrollTop = value;
+    },
+    userScrollTo: (value: number) => {
+      scrollTop = value;
+      container.dispatchEvent(new Event("scroll"));
+    },
+  };
+}

--- a/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.ts
@@ -1,6 +1,6 @@
 import { useIsAtBottom } from "@/lib/hooks/use-is-at-bottom";
 import type React from "react";
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 interface UseScrollToBottomProps {
   messagesContainerRef: React.RefObject<HTMLDivElement | null>;
@@ -43,7 +43,7 @@ export function useScrollToBottom({
     }
 
     lastObservedUserMessageIdRef.current = lastUserMessageId;
-    scrollToBottom();
+    scrollToBottom(false);
   }, [lastUserMessageId, scrollToBottom]);
 
   // Initial scroll to bottom once when component mounts (without smooth behavior)
@@ -52,4 +52,12 @@ export function useScrollToBottom({
       scrollToBottom(false); // false = not smooth
     }
   }, [scrollToBottom, messagesContainerRef]);
+
+  const onToolCallApprovalVisible = useCallback(() => {
+    scrollToBottom();
+  }, [scrollToBottom]);
+
+  return {
+    onToolCallApprovalVisible,
+  };
 }

--- a/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.ts
@@ -4,21 +4,15 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 
 interface UseScrollToBottomProps {
   messagesContainerRef: React.RefObject<HTMLDivElement | null>;
-  isLoading: boolean;
-  pendingApprovalName?: string;
+  lastUserMessageId?: string;
 }
 
 export function useScrollToBottom({
   messagesContainerRef,
-  isLoading,
-  pendingApprovalName,
+  lastUserMessageId,
 }: UseScrollToBottomProps) {
-  const { isAtBottom, scrollToBottom } = useIsAtBottom(messagesContainerRef);
-  const isAtBottomRef = useRef(isAtBottom);
-
-  useEffect(() => {
-    isAtBottomRef.current = isAtBottom;
-  }, [isAtBottom]);
+  const { getIsAtBottom, scrollToBottom } = useIsAtBottom(messagesContainerRef);
+  const lastObservedUserMessageIdRef = useRef(lastUserMessageId);
 
   // Scroll to bottom when the message list height changes
   useEffect(() => {
@@ -27,7 +21,7 @@ export function useScrollToBottom({
       return;
     }
     const resizeObserver = new ResizeObserver(() => {
-      if (isAtBottomRef.current) {
+      if (getIsAtBottom()) {
         requestAnimationFrame(() => scrollToBottom());
       }
     });
@@ -36,14 +30,21 @@ export function useScrollToBottom({
     return () => {
       resizeObserver.disconnect();
     }; // clean up
-  }, [scrollToBottom, messagesContainerRef]);
+  }, [getIsAtBottom, scrollToBottom, messagesContainerRef]);
 
-  // scroll to bottom immediately when a user message is sent
+  // Scroll to bottom immediately when a user message is sent.
   useLayoutEffect(() => {
-    if (isLoading) {
-      scrollToBottom();
+    if (!lastUserMessageId) {
+      return;
     }
-  }, [isLoading, scrollToBottom]);
+
+    if (lastObservedUserMessageIdRef.current === lastUserMessageId) {
+      return;
+    }
+
+    lastObservedUserMessageIdRef.current = lastUserMessageId;
+    scrollToBottom();
+  }, [lastUserMessageId, scrollToBottom]);
 
   // Initial scroll to bottom once when component mounts (without smooth behavior)
   useLayoutEffect(() => {
@@ -51,12 +52,4 @@ export function useScrollToBottom({
       scrollToBottom(false); // false = not smooth
     }
   }, [scrollToBottom, messagesContainerRef]);
-
-  // Ensure users can always see the executing approval or the pause approval that require their input
-  // IMPORTANT: we use pendingApprovalName to ensure that we scroll to the bottom when the approval name changes
-  useLayoutEffect(() => {
-    if (!isLoading && !!pendingApprovalName) {
-      scrollToBottom(false);
-    }
-  }, [pendingApprovalName, isLoading, scrollToBottom]);
 }

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -398,7 +398,7 @@ function Chat({ user, uid, info }: ChatProps) {
   const lastUserMessageId =
     lastMessage?.role === "user" ? lastMessage.id : undefined;
 
-  useScrollToBottom({
+  const { onToolCallApprovalVisible } = useScrollToBottom({
     messagesContainerRef,
     lastUserMessageId,
   });
@@ -486,6 +486,7 @@ function Chat({ user, uid, info }: ChatProps) {
           isRepairingMermaid={!!repairingChart}
           mcpConfigOverride={mcpConfigOverride}
           getSystemPrompt={() => chatKit.latestSystemPrompt}
+          onToolCallApprovalVisible={onToolCallApprovalVisible}
           onToolsExecutionStarted={chatKit.markStartToolsExecution}
           onToolsExecutionEnded={chatKit.markEndToolsExecution}
         />

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -394,10 +394,13 @@ function Chat({ user, uid, info }: ChatProps) {
     messages,
   });
 
+  const lastMessage = messages.at(-1);
+  const lastUserMessageId =
+    lastMessage?.role === "user" ? lastMessage.id : undefined;
+
   useScrollToBottom({
     messagesContainerRef,
-    isLoading,
-    pendingApprovalName: pendingApproval?.name,
+    lastUserMessageId,
   });
   const showRenderWidgetFixButton =
     !isLoading && !pendingApproval && !!renderWidgetErrorKind;

--- a/packages/vscode-webui/src/lib/hooks/use-is-at-bottom.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-is-at-bottom.ts
@@ -1,4 +1,10 @@
-import { type RefObject, useCallback, useEffect, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 interface UseIsAtBottomOptions {
   /**
@@ -29,6 +35,7 @@ export function useIsAtBottom(
 ) {
   const { threshold = 150, defaultIsAtBottom = true } = options;
   const [isAtBottom, setIsAtBottom] = useState(defaultIsAtBottom);
+  const isAtBottomRef = useRef(defaultIsAtBottom);
 
   // Check if the scroll position is near the bottom
   const checkIfAtBottom = useCallback(() => {
@@ -38,6 +45,7 @@ export function useIsAtBottom(
     const nearBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight <=
       threshold;
+    isAtBottomRef.current = nearBottom;
     setIsAtBottom(nearBottom);
     return nearBottom;
   }, [containerRef, threshold]);
@@ -47,6 +55,8 @@ export function useIsAtBottom(
       const container = containerRef.current;
       if (!container) return;
 
+      isAtBottomRef.current = true;
+      setIsAtBottom(true);
       container.scrollTo({
         top: container.scrollHeight,
         behavior: smooth ? "smooth" : "auto",
@@ -54,6 +64,8 @@ export function useIsAtBottom(
     },
     [containerRef],
   );
+
+  const getIsAtBottom = useCallback(() => isAtBottomRef.current, []);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -81,6 +93,7 @@ export function useIsAtBottom(
 
   return {
     isAtBottom,
+    getIsAtBottom,
     scrollToBottom,
   };
 }


### PR DESCRIPTION
## Summary
- Refactored `useScrollToBottom` to use `lastUserMessageId` instead of `isLoading`/`pendingApprovalName` to scroll to bottom only when a new user message is sent.
- Updated `useIsAtBottom` to synchronously track scroll position using a mutable ref, preventing race conditions during streaming updates.
- Added comprehensive unit tests in `use-scroll-to-bottom.test.tsx` to verify scrolling behavior on resize, scroll-away, and message updates.

## Test plan
- Run unit tests: `cd packages/vscode-webui && npx vitest run src/features/chat/hooks/use-scroll-to-bottom.test.tsx` and verify they pass.
- Manually verify chat scroll stick-to-bottom and scroll-away behavior in the VS Code extension webview.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-017ca0b48d5b4983bd5742616cbc0bc6)