### PR TITLE
fix: force refresh on model list reload

### DIFF
--- a/packages/common/src/vendor/base.ts
+++ b/packages/common/src/vendor/base.ts
@@ -43,7 +43,9 @@ export abstract class VendorBase {
     return newUser;
   };
 
-  abstract fetchModels(): Promise<Record<string, ModelOptions>>;
+  abstract fetchModels(
+    forceRefresh?: boolean,
+  ): Promise<Record<string, ModelOptions>>;
 
   getTools(): Promise<Record<string, McpTool & McpToolExecutable>> {
     return Promise.resolve({});

--- a/packages/vendor-pochi/src/vendor.ts
+++ b/packages/vendor-pochi/src/vendor.ts
@@ -72,8 +72,14 @@ export class Pochi extends VendorBase {
     );
   }
 
-  override async fetchModels(): Promise<Record<string, ModelOptions>> {
-    if (!this.cachedModels || Object.keys(this.cachedModels).length === 0) {
+  override async fetchModels(
+    forceRefresh?: boolean,
+  ): Promise<Record<string, ModelOptions>> {
+    if (
+      forceRefresh ||
+      !this.cachedModels ||
+      Object.keys(this.cachedModels).length === 0
+    ) {
       const apiClient: PochiApiClient = hc<PochiApi>(getServerBaseUrl());
       const data = await withRetry(
         async () => {

--- a/packages/vendor-tabby/src/vendor.ts
+++ b/packages/vendor-tabby/src/vendor.ts
@@ -162,8 +162,14 @@ export class Tabby extends VendorBase {
     );
   }
 
-  override async fetchModels(): Promise<Record<string, ModelOptions>> {
-    if (!this.cachedModels || Object.keys(this.cachedModels).length === 0) {
+  override async fetchModels(
+    forceRefresh?: boolean,
+  ): Promise<Record<string, ModelOptions>> {
+    if (
+      forceRefresh ||
+      !this.cachedModels ||
+      Object.keys(this.cachedModels).length === 0
+    ) {
       const creds = (await this.getCredentials()) as TabbyCredentials;
 
       const endpoints = await withRetry(() => this.fetchEndpoints(creds), {

--- a/packages/vscode/src/lib/model-list.ts
+++ b/packages/vscode/src/lib/model-list.ts
@@ -28,10 +28,10 @@ export class ModelList implements vscode.Disposable {
   }
 
   reload = async (): Promise<void> => {
-    this.modelList.value = await this.fetchModelList();
+    this.modelList.value = await this.fetchModelList(true);
   };
 
-  private async fetchModelList(): Promise<DisplayModel[]> {
+  private async fetchModelList(forceRefresh = false): Promise<DisplayModel[]> {
     this.isLoading.value = true;
 
     const modelList: DisplayModel[] = [];
@@ -42,7 +42,7 @@ export class ModelList implements vscode.Disposable {
       if (vendor.authenticated) {
         try {
           logger.trace("fetch models", vendorId);
-          const models = await vendor.fetchModels();
+          const models = await vendor.fetchModels(forceRefresh);
           for (const [modelId, options] of Object.entries(models)) {
             modelList.push({
               type: "vendor",


### PR DESCRIPTION
## Summary
The reload button previously returned cached vendor models, so newly available hosted models never appeared. Thread a forceRefresh flag from ModelList.reload through fetchModels so the pochi and tabby vendors bypass their in-memory cache on manual reload.

## Test plan
- Verified that clicking the reload button refreshes the model list and retrieves updated models.

🤖 Generated with [Pochi](https://getpochi.com)