### PR TITLE
fix(vscode-webui): ensure diff viewer row highlights span full width

### DIFF
--- a/packages/vscode-webui/src/components/message/diff-viewer.tsx
+++ b/packages/vscode-webui/src/components/message/diff-viewer.tsx
@@ -35,7 +35,7 @@ const patchDiffUnsafeCSS = `
   [data-overflow="scroll"] {
     min-width: 100%;
     width: max-content;
-    --diffs-code-grid: var(--diffs-grid-number-column-width) max-content;
+    --diffs-code-grid: var(--diffs-grid-number-column-width) minmax(max-content, 1fr);
   }
   [data-diff-type="split"][data-overflow="scroll"] {
     grid-template-columns: max-content max-content;


### PR DESCRIPTION
## Summary
- Fixes the DiffViewer grid track to use `minmax(max-content, 1fr)` instead of `max-content` for the code grid.
- Ensures that row highlights stretch to the full width of the container even when scrolling.

## Screenshot
<img width="1186" height="376" alt="image" src="https://github.com/user-attachments/assets/046a7428-2ad9-4e3c-a6ab-3fe57a31f07f" />


## Test plan
- [x] Verify DiffViewer layout and styling in the UI.
- [x] Ensure line highlights span the full width of the scroll area.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-27e50fc6fddc483eac5eb04be0e5daf4)