### PR TITLE
feat(agents): add safe worktree isolation for reviews

### DIFF
--- a/packages/cli/scripts/build-cli.sh
+++ b/packages/cli/scripts/build-cli.sh
@@ -129,6 +129,8 @@ build_exe() {
                 --banner='import * as undici from "undici";' \
                 --asset-naming="[dir]/[name].[ext]" \
                 --loader .md:file \
+                --loader .ps1:file \
+                --loader .sh:file \
                 --external lightningcss \
                 --compile \
                 --outfile ./dist/pochi \

--- a/packages/cli/src/lib/__tests__/builtin-bundle.test.ts
+++ b/packages/cli/src/lib/__tests__/builtin-bundle.test.ts
@@ -1,0 +1,60 @@
+import { readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const materializedRoots: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  await Promise.all(
+    materializedRoots.splice(0).map((root) =>
+      rm(root, { recursive: true, force: true }),
+    ),
+  );
+});
+
+function createEmbeddedBlob(name: string, content: string): Blob & {
+  name: string;
+} {
+  return Object.assign(new Blob([content]), { name });
+}
+
+describe("built-in bundle", () => {
+  it("materializes scripts bundled with skills", async () => {
+    const originalBun = (
+      globalThis as { Bun?: Record<string, unknown> }
+    ).Bun;
+    vi.stubGlobal("Bun", {
+      ...originalBun,
+      embeddedFiles: [
+        createEmbeddedBlob(
+          "/app/assets/skills/worktree-isolation/SKILL.md",
+          "skill instructions",
+        ),
+        createEmbeddedBlob(
+          "/app/assets/skills/worktree-isolation/scripts/create-worktree.sh",
+          "#!/bin/sh\n",
+        ),
+      ],
+    });
+
+    const { ensureBuiltInBundle } = await import("../builtin-bundle");
+    const bundle = await ensureBuiltInBundle();
+
+    expect(bundle).not.toBeNull();
+    if (!bundle) {
+      return;
+    }
+    materializedRoots.push(path.dirname(bundle.skillsDir));
+    await expect(
+      readFile(
+        path.join(
+          bundle.skillsDir,
+          "worktree-isolation/scripts/create-worktree.sh",
+        ),
+        "utf8",
+      ),
+    ).resolves.toBe("#!/bin/sh\n");
+  });
+});

--- a/packages/cli/src/lib/builtin-bundle.ts
+++ b/packages/cli/src/lib/builtin-bundle.ts
@@ -31,8 +31,6 @@ function getEmbeddedBlobs(): readonly EmbeddedBlob[] {
 
 function classifyBlob(blob: EmbeddedBlob): ClassifiedBlob | undefined {
   const name = blob.name ?? "";
-  if (!name.toLowerCase().endsWith(".md")) return undefined;
-
   const skillIdx = name.lastIndexOf(SkillsMarker);
   const agentIdx = name.lastIndexOf(AgentsMarker);
 
@@ -43,6 +41,9 @@ function classifyBlob(blob: EmbeddedBlob): ClassifiedBlob | undefined {
       kind: "skill",
     };
   }
+
+  if (!name.toLowerCase().endsWith(".md")) return undefined;
+
   if (agentIdx !== -1) {
     return {
       blob,

--- a/packages/common/src/__tests__/worktree-isolation-script.test.ts
+++ b/packages/common/src/__tests__/worktree-isolation-script.test.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const createWorktreeScript = fileURLToPath(
+  new URL(
+    "../base/skills/worktree-isolation/scripts/create-worktree.sh",
+    import.meta.url,
+  ),
+);
+
+const temporaryDirectories: string[] = [];
+
+function runGit(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+describe.skipIf(process.platform === "win32")(
+  "worktree isolation creation script",
+  () => {
+    it("creates and initializes a durable worktree", async () => {
+      const temporaryDirectory = await mkdtemp(
+        path.join(tmpdir(), "pochi-worktree-skill-"),
+      );
+      temporaryDirectories.push(temporaryDirectory);
+      const repository = path.join(temporaryDirectory, "repository");
+
+      await mkdir(path.join(repository, ".pochi"), { recursive: true });
+      await writeFile(path.join(repository, "README.md"), "fixture\n");
+      await writeFile(path.join(repository, ".gitignore"), ".env.local\n");
+      await writeFile(path.join(repository, ".worktreeinclude"), ".env.local\n");
+      await writeFile(path.join(repository, ".env.local"), "TOKEN=test\n");
+      await writeFile(
+        path.join(repository, ".pochi/init.sh"),
+        "printf initialized > .initialized-by-skill\n",
+      );
+
+      runGit(repository, ["init"]);
+      runGit(repository, ["add", "README.md", ".gitignore", ".worktreeinclude", ".pochi/init.sh"]);
+      runGit(repository, [
+        "-c",
+        "user.name=Pochi Test",
+        "-c",
+        "user.email=pochi@example.com",
+        "commit",
+        "-m",
+        "initial commit",
+      ]);
+
+      const output = execFileSync(
+        "sh",
+        [createWorktreeScript, "--topic", "Review Auth", "--base", "HEAD"],
+        { cwd: repository, encoding: "utf8" },
+      );
+      const result = JSON.parse(output.trim().split("\n").at(-1) ?? "");
+
+      expect(result).toMatchObject({
+        ok: true,
+        branch: "worktree/review-auth",
+        base: "HEAD",
+        initialized: true,
+        error: "",
+      });
+      const canonicalRepository = await realpath(repository);
+      expect(result.root).toBe(
+        path.join(`${canonicalRepository}.worktree`, "worktree-review-auth"),
+      );
+      await expect(
+        readFile(path.join(result.root, ".env.local"), "utf8"),
+      ).resolves.toBe("TOKEN=test\n");
+      await expect(
+        readFile(path.join(result.root, ".initialized-by-skill"), "utf8"),
+      ).resolves.toBe("initialized");
+      expect(runGit(repository, ["worktree", "list", "--porcelain"])).toContain(
+        `worktree ${result.root}`,
+      );
+    });
+  },
+);

--- a/packages/common/src/__tests__/worktree-isolation-script.test.ts
+++ b/packages/common/src/__tests__/worktree-isolation-script.test.ts
@@ -25,6 +25,44 @@ function runGit(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }
 
+async function createFixtureRepository(): Promise<string> {
+  const temporaryDirectory = await mkdtemp(
+    path.join(tmpdir(), "pochi-worktree-skill-"),
+  );
+  temporaryDirectories.push(temporaryDirectory);
+  const repository = path.join(temporaryDirectory, "repository");
+
+  await mkdir(path.join(repository, ".pochi"), { recursive: true });
+  await writeFile(path.join(repository, "README.md"), "fixture\n");
+  await writeFile(path.join(repository, ".gitignore"), ".env.local\n");
+  await writeFile(path.join(repository, ".worktreeinclude"), ".env.local\n");
+  await writeFile(path.join(repository, ".env.local"), "TOKEN=test\n");
+  await writeFile(
+    path.join(repository, ".pochi/init.sh"),
+    "printf initialized > .initialized-by-skill\n",
+  );
+
+  runGit(repository, ["init"]);
+  runGit(repository, [
+    "add",
+    "README.md",
+    ".gitignore",
+    ".worktreeinclude",
+    ".pochi/init.sh",
+  ]);
+  runGit(repository, [
+    "-c",
+    "user.name=Pochi Test",
+    "-c",
+    "user.email=pochi@example.com",
+    "commit",
+    "-m",
+    "initial commit",
+  ]);
+
+  return repository;
+}
+
 afterEach(async () => {
   await Promise.all(
     temporaryDirectories.splice(0).map((directory) =>
@@ -39,52 +77,63 @@ afterEach(async () => {
 describe.skipIf(process.platform === "win32")(
   "worktree isolation creation script",
   () => {
-    it("creates and initializes a durable worktree", async () => {
-      const temporaryDirectory = await mkdtemp(
-        path.join(tmpdir(), "pochi-worktree-skill-"),
-      );
-      temporaryDirectories.push(temporaryDirectory);
-      const repository = path.join(temporaryDirectory, "repository");
-
-      await mkdir(path.join(repository, ".pochi"), { recursive: true });
-      await writeFile(path.join(repository, "README.md"), "fixture\n");
-      await writeFile(path.join(repository, ".gitignore"), ".env.local\n");
-      await writeFile(path.join(repository, ".worktreeinclude"), ".env.local\n");
-      await writeFile(path.join(repository, ".env.local"), "TOKEN=test\n");
-      await writeFile(
-        path.join(repository, ".pochi/init.sh"),
-        "printf initialized > .initialized-by-skill\n",
-      );
-
-      runGit(repository, ["init"]);
-      runGit(repository, ["add", "README.md", ".gitignore", ".worktreeinclude", ".pochi/init.sh"]);
-      runGit(repository, [
-        "-c",
-        "user.name=Pochi Test",
-        "-c",
-        "user.email=pochi@example.com",
-        "commit",
-        "-m",
-        "initial commit",
-      ]);
-
+    it("creates a durable worktree without initializing by default", async () => {
+      const repository = await createFixtureRepository();
       const output = execFileSync(
         "sh",
-        [createWorktreeScript, "--topic", "Review Auth", "--base", "HEAD"],
+        [createWorktreeScript, "--topic", "Review Default", "--base", "HEAD"],
         { cwd: repository, encoding: "utf8" },
       );
       const result = JSON.parse(output.trim().split("\n").at(-1) ?? "");
 
       expect(result).toMatchObject({
         ok: true,
-        branch: "worktree/review-auth",
+        branch: "worktree/review-default",
+        base: "HEAD",
+        initialized: false,
+        error: "",
+      });
+      const canonicalRepository = await realpath(repository);
+      expect(result.root).toBe(
+        path.join(`${canonicalRepository}.worktree`, "worktree-review-default"),
+      );
+      await expect(
+        readFile(path.join(result.root, ".env.local"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(
+        readFile(path.join(result.root, ".initialized-by-skill"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      expect(runGit(repository, ["worktree", "list", "--porcelain"])).toContain(
+        `worktree ${result.root}`,
+      );
+    });
+
+    it("copies included files and runs initialization when requested", async () => {
+      const repository = await createFixtureRepository();
+      const output = execFileSync(
+        "sh",
+        [
+          createWorktreeScript,
+          "--topic",
+          "Review Init",
+          "--base",
+          "HEAD",
+          "--init",
+        ],
+        { cwd: repository, encoding: "utf8" },
+      );
+      const result = JSON.parse(output.trim().split("\n").at(-1) ?? "");
+
+      expect(result).toMatchObject({
+        ok: true,
+        branch: "worktree/review-init",
         base: "HEAD",
         initialized: true,
         error: "",
       });
       const canonicalRepository = await realpath(repository);
       expect(result.root).toBe(
-        path.join(`${canonicalRepository}.worktree`, "worktree-review-auth"),
+        path.join(`${canonicalRepository}.worktree`, "worktree-review-init"),
       );
       await expect(
         readFile(path.join(result.root, ".env.local"), "utf8"),

--- a/packages/common/src/base/agents/reviewer.md
+++ b/packages/common/src/base/agents/reviewer.md
@@ -14,87 +14,64 @@ tools:
   - listFiles
   - searchFiles
   - createReview
+  - executeCommand(git status)
+  - executeCommand(git status *)
+  - executeCommand(git diff)
+  - executeCommand(git diff *)
+  - executeCommand(git log)
+  - executeCommand(git log *)
+  - executeCommand(git show *)
+  - executeCommand(git merge-base *)
+  - executeCommand(git rev-parse *)
+  - executeCommand(git branch --show-current)
+  - executeCommand(gh pr view *)
+  - executeCommand(gh pr diff *)
+  - executeCommand(gh api repos/*/pulls/*/comments*)
+  - executeCommand(sh */worktree-isolation/scripts/create-worktree.sh *)
+  - executeCommand(powershell -ExecutionPolicy Bypass -File *worktree-isolation*scripts*create-worktree-windows.ps1 *)
 ---
 
-You are a Code Reviewer focused on finding actionable defects and leaving high-signal inline review comments.
+You are a code reviewer. Your job is to find concrete, actionable defects and leave high-signal inline comments — not to rewrite the code or deliver a broad architecture review.
 
-Your job is not to rewrite the code or provide a broad architecture review. Your job is to identify concrete issues the author would likely fix if they knew about them.
+The bar for a finding: the original author would likely fix it once aware. That usually means it materially affects correctness, reliability, security, performance, or maintainability in a concrete way — not a style preference. When in doubt, prefer no comment over a speculative one.
 
-## Review Objective
+## Gathering evidence
 
-Flag issues that materially impact one or more of:
-- correctness
-- reliability
-- security
-- performance
-- maintainability (when the risk is concrete, not stylistic preference)
+Scope the review from the user's request; if the scope is unclear but discoverable, infer it from the repo before asking.
 
-Prefer no comments over weak/speculative comments.
+Then use the least disruptive source that gives you enough evidence:
 
-## Workflow (Follow in Order)
+- **The current workspace**, when it already contains the code under review.
+- **`gh pr diff`**, when a pull request's patch plus some surrounding file reads answer the question — no extra checkout needed.
+- **The `worktree-isolation` skill**, when you genuinely need a full checkout of another committed revision — deep navigation across the tree, or validating behavior at that revision. Follow that skill's rules; once it returns a root, operate from that root for everything that follows.
 
-1. **Scope the request**
-   - Determine which files/areas the user asked to review.
-   - If the scope is unclear but discoverable from context, infer it from the repo/files first.
+In any checkout, read-only git commands (`git diff`, `git log`, `git show`, `git merge-base`, `git status`) are the cheapest way to establish what changed and against which base — prefer diffing against the merge base with the target branch so unrelated commits on the base don't pollute the review.
 
-2. **Read before judging**
-   - Use `readFile`, `searchFiles`, `listFiles`, and `globFiles` to understand the relevant code paths.
-   - Read enough surrounding code to avoid false positives.
+When reviewing a pull request, check its existing review comments first (`gh pr view --comments`, or `gh api repos/<owner>/<repo>/pulls/<number>/comments`) so you don't duplicate feedback the author already received.
 
-3. **Evaluate findings**
-   - Look for discrete, actionable issues.
-   - Prioritize bugs and regressions over style nits.
-   - Verify the issue is real and explainable from code evidence.
+Whatever the source: never modify or discard the user's workspace state to make a review possible, and do not commit unless explicitly asked. Your command access is read-only by design — do not look for ways around it.
 
-4. **Leave inline comments**
-   - Use `createReview` once per distinct issue.
-   - Keep the selected line range as short as possible (pinpoint the root cause).
+Read enough surrounding code to know a finding is real before judging. Most false positives come from reading the diff without its context.
 
-5. **Finish**
-   - Use `attemptCompletion` to summarize what you reviewed and the main findings (or explicitly say no actionable issues found).
+## What to flag
 
-## What Counts as a Good Finding
+A finding should satisfy all of:
 
-A finding should usually satisfy ALL of these:
-- It is a real issue, not a guess.
-- It is specific and actionable.
-- It would likely be worth fixing for the original author.
-- It does not depend on hidden assumptions about intent.
-- It is not just a trivial style preference.
+- It is a real issue you can explain from code evidence, not a guess about intent.
+- It is discrete and actionable — one issue, one fixable thing.
+- It would be worth fixing to the original author.
+- It does not rest on hidden assumptions about the codebase or the author's plans.
 
-Do not leave comments for:
-- purely stylistic nits (unless they hide a bug or meaning)
-- vague "might be a problem" speculation without code evidence
-- broad refactor suggestions unrelated to a concrete defect
-- praise-only comments
+Do not comment on: pure style nits (unless they hide a bug or obscure meaning), "might be a problem" speculation without evidence, broad refactor ideas unattached to a defect, or praise.
 
-## Comment Quality Rules (for `createReview.comment`)
+When ordering your attention: correctness and regressions first, then security / data loss / crash risk, then performance with clear impact, then maintainability with immediate bug risk. Style only when it materially affects behavior or clarity.
 
-Each comment should:
-- state **why** this is a problem
-- mention the concrete scenario/input/path where it breaks (when relevant)
-- be concise (one short paragraph is preferred)
-- be constructive and matter-of-fact
-- suggest a fix direction when obvious
+## Writing comments
 
-Keep comments easy to scan. Avoid repeating file/line info already implied by the inline location.
+Each comment should state **why** it is a problem and the concrete scenario, input, or path where it breaks. Keep it to one short paragraph, matter-of-fact and constructive; suggest a fix direction when it is obvious. Don't restate file/line information the inline location already carries, and don't overstate severity — a `[P1]`/`[P2]`/`[P3]` prefix is a good way to calibrate it.
 
-## Prioritization
+## Reporting
 
-Focus order:
-1. Correctness / regressions
-2. Security / data loss / crash risks
-3. Performance issues with clear impact
-4. Maintainability issues with immediate bug risk
-5. Style only if it materially affects clarity or behavior
+Call `createReview` once per distinct issue, with `path` and the shortest 1-indexed `startLine`/`endLine` range that pinpoints the root cause.
 
-If helpful, prefix the comment with a priority tag like `[P1]`, `[P2]`, or `[P3]`.
-
-## Using createReview
-
-For each qualifying issue, call `createReview` with:
-- `path`: file path
-- `startLine` / `endLine`: minimal line range (1-indexed)
-- `comment`: the review feedback
-
-When no actionable issues are found, do not force comments. Report a clean review via `attemptCompletion`.
+Finish with `attemptCompletion`: what you reviewed and the main findings, or an explicit statement that the review is clean — never force comments to have something to show. If you created a worktree, include its path and branch and note that it was kept for the user to clean up.

--- a/packages/common/src/base/agents/reviewer.md
+++ b/packages/common/src/base/agents/reviewer.md
@@ -43,7 +43,7 @@ Then use the least disruptive source that gives you enough evidence:
 
 - **The current workspace**, when it already contains the code under review.
 - **`gh pr diff`**, when a pull request's patch plus some surrounding file reads answer the question — no extra checkout needed.
-- **The `worktree-isolation` skill**, when you genuinely need a full checkout of another committed revision — deep navigation across the tree, or validating behavior at that revision. Follow that skill's rules; once it returns a root, operate from that root for everything that follows.
+- **The `worktree-isolation` skill**, when you genuinely need a full checkout of another committed revision — deep navigation across the tree, or validating behavior at that revision. Follow that skill's rules; once it returns a root, operate from that root for everything that follows. Its default setup only creates the worktree. Request initialization only when the review cannot proceed without it, and only after checking that the main worktree's `.worktreeinclude` files and the target revision's `.pochi/init.*` script are necessary and safe.
 
 In any checkout, read-only git commands (`git diff`, `git log`, `git show`, `git merge-base`, `git status`) are the cheapest way to establish what changed and against which base — prefer diffing against the merge base with the target branch so unrelated commits on the base don't pollute the review.
 

--- a/packages/common/src/base/skills/worktree-isolation/SKILL.md
+++ b/packages/common/src/base/skills/worktree-isolation/SKILL.md
@@ -23,10 +23,11 @@ Whether the task is read-only does not decide this; what decides it is where the
 
 These hold no matter how you reached this skill:
 
-1. Worktrees are created **only** by the trusted script below. Never run `git worktree add`, create the branch, or prepare the destination yourself — the script owns setup, ignored-file propagation (`.worktreeinclude`), and project initialization.
+1. Worktrees are created **only** by the trusted script below. Never run `git worktree add`, create the branch, or prepare the destination yourself — the script owns setup and the optional initialization phase.
 2. Preparing or using a worktree must never modify, discard, or migrate any existing tracked or untracked changes in the user's workspace.
 3. Do not commit in the worktree unless the user explicitly asks for a commit.
 4. Leave the worktree and its branch in place when you finish — even after a failure, do not remove a partially created worktree. Cleanup is the user's decision.
+5. Initialization is opt-in. By default the script must not copy `.worktreeinclude` files or run project scripts.
 
 ## Creating it
 
@@ -36,6 +37,13 @@ Resolve the script relative to this `SKILL.md` and run exactly one command with 
 - Windows: `powershell -ExecutionPolicy Bypass -File <skill-directory>/scripts/create-worktree-windows.ps1 -Topic <short-topic> -Base <committed-base>`
 
 Pass the exact committed base the task requires; use `HEAD` only when the current commit really is the intended base. Do not pass shell fragments.
+
+Without an initialization flag, these commands only create the worktree and return `initialized: false`. If the task cannot proceed without project initialization, inspect the main worktree's `.worktreeinclude` and the target revision's `.pochi/init.sh` or `.pochi/init.ps1` before creating the worktree. Only after deciding that both the copied files and executed commands are necessary and safe, add the platform-specific initialization flag to the creation command:
+
+- POSIX: add `--init`
+- Windows: add `-Initialize`
+
+Initialization first copies the `.worktreeinclude` files, then runs the platform's initialization script when present. If either step fails, the script returns `ok: false` and leaves the worktree in place.
 
 The script prints a JSON result: `{ok, root, branch, base, initialized, error}`. If `ok` is false, stop and report the error.
 

--- a/packages/common/src/base/skills/worktree-isolation/SKILL.md
+++ b/packages/common/src/base/skills/worktree-isolation/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: worktree-isolation
+description: |
+  Create a durable isolated Git worktree when a task needs another committed source state or should not share the current checkout. Use it to protect the existing workspace while working from the exact branch, commit, or pull-request revision the task requires.
+compatibility: Requires Git and either POSIX sh or Windows PowerShell.
+allowed-tools: executeCommand
+---
+
+# Worktree Isolation
+
+A worktree gives you a clean checkout of an exact committed revision without touching anything in the user's current workspace.
+
+## When to use one
+
+Decide with one question: **does the current workspace already contain the source state the task needs?**
+
+- It does → stay where you are. Separation for its own sake adds no value, and a commit-based worktree can never contain the user's uncommitted changes — if the task targets those, a worktree is the wrong tool by definition.
+- It doesn't — the task targets another branch, commit, or pull-request revision, or your work could disturb the current checkout → create a worktree from that exact committed base.
+
+Whether the task is read-only does not decide this; what decides it is where the required source state lives and whether the current checkout needs protecting. If the revision you need is not available locally, obtain it through an authorized workflow or report the limitation — never quietly substitute `HEAD`.
+
+## Hard rules
+
+These hold no matter how you reached this skill:
+
+1. Worktrees are created **only** by the trusted script below. Never run `git worktree add`, create the branch, or prepare the destination yourself — the script owns setup, ignored-file propagation (`.worktreeinclude`), and project initialization.
+2. Preparing or using a worktree must never modify, discard, or migrate any existing tracked or untracked changes in the user's workspace.
+3. Do not commit in the worktree unless the user explicitly asks for a commit.
+4. Leave the worktree and its branch in place when you finish — even after a failure, do not remove a partially created worktree. Cleanup is the user's decision.
+
+## Creating it
+
+Resolve the script relative to this `SKILL.md` and run exactly one command with the current repository as `cwd`:
+
+- POSIX: `sh <skill-directory>/scripts/create-worktree.sh --topic <short-topic> --base <committed-base>`
+- Windows: `powershell -ExecutionPolicy Bypass -File <skill-directory>/scripts/create-worktree-windows.ps1 -Topic <short-topic> -Base <committed-base>`
+
+Pass the exact committed base the task requires; use `HEAD` only when the current commit really is the intended base. Do not pass shell fragments.
+
+The script prints a JSON result: `{ok, root, branch, base, initialized, error}`. If `ok` is false, stop and report the error.
+
+## Working in it
+
+From the returned `root` on, that path **is** your workspace: run every file read, search, edit, review, and command there, and never mix original-workspace paths into worktree operations (or vice versa).
+
+In your final result, report the worktree path and branch, and state that they were retained for the user to clean up explicitly.

--- a/packages/common/src/base/skills/worktree-isolation/scripts/create-worktree-windows.ps1
+++ b/packages/common/src/base/skills/worktree-isolation/scripts/create-worktree-windows.ps1
@@ -1,0 +1,142 @@
+param(
+  [string]$Topic = "",
+  [string]$Base = "HEAD"
+)
+
+$ErrorActionPreference = "Stop"
+$worktreePath = ""
+$branch = ""
+$initialized = $false
+
+function Invoke-Git {
+  param([string[]]$GitArgs)
+
+  $output = & git @GitArgs
+  if ($LASTEXITCODE -ne 0) {
+    throw "git $($GitArgs -join ' ') failed."
+  }
+  return $output
+}
+
+function Write-Result {
+  param(
+    [bool]$Ok,
+    [string]$Root,
+    [string]$Branch,
+    [string]$Revision,
+    [bool]$Initialized,
+    [string]$Message
+  )
+
+  [ordered]@{
+    ok = $Ok
+    root = $Root
+    branch = $Branch
+    base = $Revision
+    initialized = $Initialized
+    error = $Message
+  } | ConvertTo-Json -Compress
+}
+
+try {
+  $repoRoot = (Invoke-Git -GitArgs @("rev-parse", "--show-toplevel") | Select-Object -First 1).Trim()
+  if (-not $repoRoot) {
+    throw "The current directory is not inside a Git worktree."
+  }
+  Set-Location -LiteralPath $repoRoot
+
+  Invoke-Git -GitArgs @("rev-parse", "--verify", "$Base^{commit}") | Out-Null
+
+  $worktreeList = @(Invoke-Git -GitArgs @("-c", "core.quotePath=false", "worktree", "list", "--porcelain"))
+  $worktreePaths = @(
+    $worktreeList |
+      Where-Object { $_ -like "worktree *" } |
+      ForEach-Object { $_.Substring(9) }
+  )
+
+  if ($worktreePaths.Count -eq 0) {
+    throw "Git did not report a main worktree."
+  }
+
+  $mainWorktree = $worktreePaths[0]
+  $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  $slug = ($Topic.ToLowerInvariant() -replace "[^a-z0-9._-]+", "-").Trim([char[]]@("-", "."))
+  $branch = if ($slug) { "worktree/$slug" } else { "worktree/$timestamp" }
+
+  & git check-ref-format --branch $branch *> $null
+  if ($LASTEXITCODE -ne 0) {
+    $branch = "worktree/$timestamp"
+  }
+
+  & git show-ref --verify --quiet "refs/heads/$branch"
+  if ($LASTEXITCODE -eq 0) {
+    $branch = "$branch-$timestamp"
+  }
+
+  $worktreeName = $branch.Replace("/", "-")
+  $worktreeParent = if ($worktreePaths.Count -gt 1) {
+    Split-Path -Parent $worktreePaths[1]
+  } else {
+    $trimmedMainWorktree = $mainWorktree.TrimEnd([char[]]@("/", "\"))
+    "${trimmedMainWorktree}.worktree"
+  }
+  $worktreePath = Join-Path $worktreeParent $worktreeName
+
+  New-Item -ItemType Directory -Path $worktreeParent -Force | Out-Null
+  Invoke-Git -GitArgs @("worktree", "add", "-b", $branch, $worktreePath, $Base) | Out-Host
+
+  $includeFile = Join-Path $mainWorktree ".worktreeinclude"
+  if (Test-Path -LiteralPath $includeFile -PathType Leaf) {
+    try {
+      $includedFiles = @(Invoke-Git -GitArgs @(
+        "-C",
+        $mainWorktree,
+        "ls-files",
+        "--others",
+        "--ignored",
+        "--exclude-from=$includeFile"
+      ))
+
+      foreach ($relativePath in $includedFiles) {
+        if (-not $relativePath) {
+          continue
+        }
+        $segments = $relativePath -split "[\\/]"
+        if ([IO.Path]::IsPathRooted($relativePath) -or $segments -contains "..") {
+          Write-Warning "Skipping unsafe .worktreeinclude path: $relativePath"
+          continue
+        }
+
+        $sourcePath = Join-Path $mainWorktree $relativePath
+        $destinationPath = Join-Path $worktreePath $relativePath
+        try {
+          New-Item -ItemType Directory -Path (Split-Path -Parent $destinationPath) -Force | Out-Null
+          Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
+        } catch {
+          Write-Warning "Failed to copy .worktreeinclude file $relativePath`: $($_.Exception.Message)"
+        }
+      }
+    } catch {
+      Write-Warning "Failed to list .worktreeinclude files; continuing without them."
+    }
+  }
+
+  $initScript = Join-Path $worktreePath ".pochi/init.ps1"
+  if (Test-Path -LiteralPath $initScript -PathType Leaf) {
+    Push-Location -LiteralPath $worktreePath
+    try {
+      & powershell -ExecutionPolicy Bypass -File ./.pochi/init.ps1
+      if ($LASTEXITCODE -ne 0) {
+        throw "The worktree init script failed."
+      }
+    } finally {
+      Pop-Location
+    }
+    $initialized = $true
+  }
+
+  Write-Result -Ok $true -Root $worktreePath -Branch $branch -Revision $Base -Initialized $initialized -Message ""
+} catch {
+  Write-Result -Ok $false -Root $worktreePath -Branch $branch -Revision $Base -Initialized $initialized -Message $_.Exception.Message
+  exit 1
+}

--- a/packages/common/src/base/skills/worktree-isolation/scripts/create-worktree-windows.ps1
+++ b/packages/common/src/base/skills/worktree-isolation/scripts/create-worktree-windows.ps1
@@ -1,6 +1,7 @@
 param(
   [string]$Topic = "",
-  [string]$Base = "HEAD"
+  [string]$Base = "HEAD",
+  [switch]$Initialize
 )
 
 $ErrorActionPreference = "Stop"
@@ -85,10 +86,12 @@ try {
   New-Item -ItemType Directory -Path $worktreeParent -Force | Out-Null
   Invoke-Git -GitArgs @("worktree", "add", "-b", $branch, $worktreePath, $Base) | Out-Host
 
-  $includeFile = Join-Path $mainWorktree ".worktreeinclude"
-  if (Test-Path -LiteralPath $includeFile -PathType Leaf) {
-    try {
+  if ($Initialize) {
+    $includeFile = Join-Path $mainWorktree ".worktreeinclude"
+    if (Test-Path -LiteralPath $includeFile -PathType Leaf) {
       $includedFiles = @(Invoke-Git -GitArgs @(
+        "-c",
+        "core.quotePath=false",
         "-C",
         $mainWorktree,
         "ls-files",
@@ -103,35 +106,29 @@ try {
         }
         $segments = $relativePath -split "[\\/]"
         if ([IO.Path]::IsPathRooted($relativePath) -or $segments -contains "..") {
-          Write-Warning "Skipping unsafe .worktreeinclude path: $relativePath"
-          continue
+          throw "Unsafe .worktreeinclude path: $relativePath"
         }
 
         $sourcePath = Join-Path $mainWorktree $relativePath
         $destinationPath = Join-Path $worktreePath $relativePath
-        try {
-          New-Item -ItemType Directory -Path (Split-Path -Parent $destinationPath) -Force | Out-Null
-          Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
-        } catch {
-          Write-Warning "Failed to copy .worktreeinclude file $relativePath`: $($_.Exception.Message)"
-        }
+        New-Item -ItemType Directory -Path (Split-Path -Parent $destinationPath) -Force | Out-Null
+        Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
       }
-    } catch {
-      Write-Warning "Failed to list .worktreeinclude files; continuing without them."
     }
-  }
 
-  $initScript = Join-Path $worktreePath ".pochi/init.ps1"
-  if (Test-Path -LiteralPath $initScript -PathType Leaf) {
-    Push-Location -LiteralPath $worktreePath
-    try {
-      & powershell -ExecutionPolicy Bypass -File ./.pochi/init.ps1
-      if ($LASTEXITCODE -ne 0) {
-        throw "The worktree init script failed."
+    $initScript = Join-Path $worktreePath ".pochi/init.ps1"
+    if (Test-Path -LiteralPath $initScript -PathType Leaf) {
+      Push-Location -LiteralPath $worktreePath
+      try {
+        & powershell -ExecutionPolicy Bypass -File ./.pochi/init.ps1
+        if ($LASTEXITCODE -ne 0) {
+          throw "The worktree init script failed."
+        }
+      } finally {
+        Pop-Location
       }
-    } finally {
-      Pop-Location
     }
+
     $initialized = $true
   }
 

--- a/packages/common/src/base/skills/worktree-isolation/scripts/create-worktree.sh
+++ b/packages/common/src/base/skills/worktree-isolation/scripts/create-worktree.sh
@@ -4,6 +4,7 @@ set -eu
 
 topic=""
 base="HEAD"
+initialize=false
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -16,6 +17,10 @@ while [ "$#" -gt 0 ]; do
       [ "$#" -ge 2 ] || { echo "Missing value for --base" >&2; exit 2; }
       base=$2
       shift 2
+      ;;
+    --init)
+      initialize=true
+      shift
       ;;
     *)
       echo "Unknown argument: $1" >&2
@@ -104,21 +109,27 @@ if ! git worktree add -b "$branch" "$worktree_path" "$base"; then
   exit 1
 fi
 
-include_file="$main_worktree/.worktreeinclude"
-if [ -f "$include_file" ]; then
-  if included_files=$(git -C "$main_worktree" ls-files --others --ignored --exclude-from="$include_file"); then
-    printf '%s\n' "$included_files" | while IFS= read -r relative_path; do
+initialized=false
+if [ "$initialize" = true ]; then
+  include_file="$main_worktree/.worktreeinclude"
+  if [ -f "$include_file" ]; then
+    if ! included_files=$(git -c core.quotePath=false -C "$main_worktree" ls-files --others --ignored --exclude-from="$include_file"); then
+      emit_result false "$worktree_path" "$branch" "$base" false "Failed to list .worktreeinclude files."
+      exit 1
+    fi
+
+    if ! printf '%s\n' "$included_files" | while IFS= read -r relative_path; do
       [ -n "$relative_path" ] || continue
       case "$relative_path" in
         /*|../*|..)
-          echo "Skipping unsafe .worktreeinclude path: $relative_path" >&2
-          continue
+          echo "Unsafe .worktreeinclude path: $relative_path" >&2
+          exit 1
           ;;
       esac
       case "/$relative_path/" in
         */../*)
-          echo "Skipping unsafe .worktreeinclude path: $relative_path" >&2
-          continue
+          echo "Unsafe .worktreeinclude path: $relative_path" >&2
+          exit 1
           ;;
       esac
 
@@ -126,19 +137,21 @@ if [ -f "$include_file" ]; then
       destination_path="$worktree_path/$relative_path"
       if ! mkdir -p "$(dirname "$destination_path")" || ! cp "$source_path" "$destination_path"; then
         echo "Failed to copy .worktreeinclude file: $relative_path" >&2
+        exit 1
       fi
-    done
-  else
-    echo "Failed to list .worktreeinclude files; continuing without them." >&2
+    done; then
+      emit_result false "$worktree_path" "$branch" "$base" false "Failed to copy .worktreeinclude files."
+      exit 1
+    fi
   fi
-fi
 
-initialized=false
-if [ -f "$worktree_path/.pochi/init.sh" ]; then
-  if ! (cd "$worktree_path" && sh ./.pochi/init.sh); then
-    emit_result false "$worktree_path" "$branch" "$base" false "The worktree init script failed."
-    exit 1
+  if [ -f "$worktree_path/.pochi/init.sh" ]; then
+    if ! (cd "$worktree_path" && sh ./.pochi/init.sh); then
+      emit_result false "$worktree_path" "$branch" "$base" false "The worktree init script failed."
+      exit 1
+    fi
   fi
+
   initialized=true
 fi
 

--- a/packages/common/src/base/skills/worktree-isolation/scripts/create-worktree.sh
+++ b/packages/common/src/base/skills/worktree-isolation/scripts/create-worktree.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+
+set -eu
+
+topic=""
+base="HEAD"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --topic)
+      [ "$#" -ge 2 ] || { echo "Missing value for --topic" >&2; exit 2; }
+      topic=$2
+      shift 2
+      ;;
+    --base)
+      [ "$#" -ge 2 ] || { echo "Missing value for --base" >&2; exit 2; }
+      base=$2
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+emit_result() {
+  result_ok=$1
+  result_root=$2
+  result_branch=$3
+  result_base=$4
+  result_initialized=$5
+  result_error=$6
+
+  printf '{"ok":%s,"root":"%s","branch":"%s","base":"%s","initialized":%s,"error":"%s"}\n' \
+    "$result_ok" \
+    "$(json_escape "$result_root")" \
+    "$(json_escape "$result_branch")" \
+    "$(json_escape "$result_base")" \
+    "$result_initialized" \
+    "$(json_escape "$result_error")"
+}
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  emit_result false "" "" "$base" false "The current directory is not inside a Git worktree."
+  exit 1
+}
+cd "$repo_root"
+
+if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+  emit_result false "" "" "$base" false "The requested base is not a committed Git revision."
+  exit 1
+fi
+
+worktree_list=$(git -c core.quotePath=false worktree list --porcelain) || {
+  emit_result false "" "" "$base" false "Failed to list existing Git worktrees."
+  exit 1
+}
+
+main_worktree=$(printf '%s\n' "$worktree_list" | awk '/^worktree / { print substr($0, 10); exit }')
+second_worktree=$(printf '%s\n' "$worktree_list" | awk '/^worktree / { count++; if (count == 2) { print substr($0, 10); exit } }')
+
+if [ -z "$main_worktree" ]; then
+  emit_result false "" "" "$base" false "Git did not report a main worktree."
+  exit 1
+fi
+
+slug=$(printf '%s' "$topic" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-][^a-z0-9._-]*/-/g; s/^-*//; s/-*$//; s/^\.*//')
+timestamp=$(date '+%Y%m%d-%H%M%S')
+
+if [ -n "$slug" ]; then
+  branch="worktree/$slug"
+else
+  branch="worktree/$timestamp"
+fi
+
+if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+  branch="worktree/$timestamp"
+fi
+
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  branch="$branch-$timestamp"
+fi
+
+worktree_name=$(printf '%s' "$branch" | tr '/' '-')
+if [ -n "$second_worktree" ]; then
+  worktree_parent=$(dirname "$second_worktree")
+else
+  worktree_parent="${main_worktree%/}.worktree"
+fi
+worktree_path="${worktree_parent%/}/$worktree_name"
+
+if ! mkdir -p "$worktree_parent"; then
+  emit_result false "$worktree_path" "$branch" "$base" false "Failed to create the worktree parent directory."
+  exit 1
+fi
+
+if ! git worktree add -b "$branch" "$worktree_path" "$base"; then
+  emit_result false "$worktree_path" "$branch" "$base" false "git worktree add failed."
+  exit 1
+fi
+
+include_file="$main_worktree/.worktreeinclude"
+if [ -f "$include_file" ]; then
+  if included_files=$(git -C "$main_worktree" ls-files --others --ignored --exclude-from="$include_file"); then
+    printf '%s\n' "$included_files" | while IFS= read -r relative_path; do
+      [ -n "$relative_path" ] || continue
+      case "$relative_path" in
+        /*|../*|..)
+          echo "Skipping unsafe .worktreeinclude path: $relative_path" >&2
+          continue
+          ;;
+      esac
+      case "/$relative_path/" in
+        */../*)
+          echo "Skipping unsafe .worktreeinclude path: $relative_path" >&2
+          continue
+          ;;
+      esac
+
+      source_path="$main_worktree/$relative_path"
+      destination_path="$worktree_path/$relative_path"
+      if ! mkdir -p "$(dirname "$destination_path")" || ! cp "$source_path" "$destination_path"; then
+        echo "Failed to copy .worktreeinclude file: $relative_path" >&2
+      fi
+    done
+  else
+    echo "Failed to list .worktreeinclude files; continuing without them." >&2
+  fi
+fi
+
+initialized=false
+if [ -f "$worktree_path/.pochi/init.sh" ]; then
+  if ! (cd "$worktree_path" && sh ./.pochi/init.sh); then
+    emit_result false "$worktree_path" "$branch" "$base" false "The worktree init script failed."
+    exit 1
+  fi
+  initialized=true
+fi
+
+emit_result true "$worktree_path" "$branch" "$base" "$initialized" ""

--- a/packages/tools/src/__test__/select-agent-tools.test.ts
+++ b/packages/tools/src/__test__/select-agent-tools.test.ts
@@ -193,11 +193,16 @@ describe("selectAgentTools", () => {
     );
   });
 
-  it("exposes createReview only for reviewer agents that declare it", () => {
+  it("exposes declared review source tools to reviewer agents", () => {
     const reviewerTools = selectAgentTools({
       agent: createAgent({
         name: "reviewer",
-        tools: ["createReview", "readFile"],
+        tools: [
+          "createReview",
+          "executeCommand(gh pr diff *)",
+          "executeCommand(sh */worktree-isolation/scripts/create-worktree.sh *)",
+          "readFile",
+        ],
       }),
       isSubTask: false,
     });
@@ -217,7 +222,12 @@ describe("selectAgentTools", () => {
     });
 
     expect(toolNames(reviewerTools)).toEqual(
-      [...RequiredAgentToolNames, "createReview", "readFile"].sort(),
+      [
+        ...RequiredAgentToolNames,
+        "createReview",
+        "executeCommand",
+        "readFile",
+      ].sort(),
     );
     expect(toolNames(reviewerWithoutCreateReview)).toEqual(
       [...RequiredAgentToolNames, "readFile"].sort(),

--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -48,6 +48,36 @@ def fibonacci(n):
       );
     }).toThrow();
   });
+
+  it("should restrict reviewer commands to read-only PR diffs and bundled scripts", () => {
+    const rules = [
+      "gh pr diff *",
+      "sh */worktree-isolation/scripts/create-worktree.sh *",
+      "powershell -ExecutionPolicy Bypass -File *worktree-isolation*scripts*create-worktree-windows.ps1 *",
+    ];
+
+    const allowedCommands = [
+      "gh pr diff 123",
+      "gh pr diff feature-branch --patch",
+      'sh "/opt/pochi/skills/worktree-isolation/scripts/create-worktree.sh" --topic "review auth" --base HEAD',
+      'powershell -ExecutionPolicy Bypass -File "C:\\pochi\\skills\\worktree-isolation\\scripts\\create-worktree-windows.ps1" -Topic "review auth" -Base HEAD',
+    ];
+
+    for (const command of allowedCommands) {
+      expect(() => validateExecuteCommandRules(command, rules)).not.toThrow();
+    }
+
+    for (const command of [
+      "gh pr checkout 123",
+      "gh pr merge 123",
+      "git worktree add -b review/auth /tmp/review HEAD",
+      "git worktree remove /tmp/review",
+      "sh /tmp/create-worktree.sh --base HEAD",
+      "rm -rf /tmp/review",
+    ]) {
+      expect(() => validateExecuteCommandRules(command, rules)).toThrow();
+    }
+  });
 });
 
 describe("startBackgroundJob command policies", () => {

--- a/packages/tools/src/__test__/utils.test.ts
+++ b/packages/tools/src/__test__/utils.test.ts
@@ -60,7 +60,9 @@ def fibonacci(n):
       "gh pr diff 123",
       "gh pr diff feature-branch --patch",
       'sh "/opt/pochi/skills/worktree-isolation/scripts/create-worktree.sh" --topic "review auth" --base HEAD',
+      'sh "/opt/pochi/skills/worktree-isolation/scripts/create-worktree.sh" --topic "review auth" --base HEAD --init',
       'powershell -ExecutionPolicy Bypass -File "C:\\pochi\\skills\\worktree-isolation\\scripts\\create-worktree-windows.ps1" -Topic "review auth" -Base HEAD',
+      'powershell -ExecutionPolicy Bypass -File "C:\\pochi\\skills\\worktree-isolation\\scripts\\create-worktree-windows.ps1" -Topic "review auth" -Base HEAD -Initialize',
     ];
 
     for (const command of allowedCommands) {


### PR DESCRIPTION
## Summary
- add a reusable worktree-isolation skill with trusted POSIX and PowerShell setup scripts that preserve the user's existing workspace
- let reviewers choose between the current checkout, read-only GitHub PR diffs, and a full isolated checkout based on the evidence needed
- package and materialize skill script resources in the compiled CLI, with integration and command-policy coverage

## Test plan
- [x] Run `bun check`
- [x] Run `bun tsc`
- [x] Run `bun run test`
- [x] Build the compiled CLI with `bun run build` in `packages/cli`
- [x] Run focused common, tools, and CLI tests
- [x] Run `git diff --check`
- [ ] Exercise the PowerShell script on Windows (PowerShell was unavailable in the development environment)

🤖 Generated with [Pochi](https://getpochi.com)