### PR TITLE
feat(vscode): track full command history for user-opened terminals

### DIFF
--- a/packages/common/src/base/environment.ts
+++ b/packages/common/src/base/environment.ts
@@ -59,7 +59,7 @@ export const Environment = z.object({
               .string()
               .optional()
               .describe(
-                'A stable id for the terminal. Pass it to `readBackgroundJobOutput` to read the terminal\'s most recent command output. Ids prefixed with "bgjob-" are Pochi-started background jobs and can also be killed with `killBackgroundJob`; ids prefixed with "term-" are user-opened terminals and are read-only.',
+                'A stable id for the terminal. Pass it to `readBackgroundJobOutput` to read the terminal\'s content. Ids prefixed with "bgjob-" are Pochi-started background jobs and can also be killed with `killBackgroundJob`; ids prefixed with "term-" are user-opened terminals and are read-only.',
               ),
           }),
         )

--- a/packages/common/src/base/prompts/__tests__/__snapshots__/prompt.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/prompt.test.ts.snap
@@ -20,7 +20,7 @@ tsconfig.json
 package.json
 
 # Opened Terminals in Editor
-You can read a terminal's most recent command output by calling \`readBackgroundJobOutput\` with its id.
+You can read a terminal's output by calling \`readBackgroundJobOutput\` with its id.
 - Ids prefixed with "bgjob-" are Pochi-started background jobs (can be read and killed with \`killBackgroundJob\`).
 - Ids prefixed with "term-" are user-opened terminals (read-only; cannot be killed).
 * Terminal 1 (selected)

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -156,7 +156,7 @@ function getVisibleTerminals(workspace: Environment["workspace"]) {
     return "";
   }
   const header =
-    '# Opened Terminals in Editor\nYou can read a terminal\'s most recent command output by calling `readBackgroundJobOutput` with its id.\n- Ids prefixed with "bgjob-" are Pochi-started background jobs (can be read and killed with `killBackgroundJob`).\n- Ids prefixed with "term-" are user-opened terminals (read-only; cannot be killed).';
+    '# Opened Terminals in Editor\nYou can read a terminal\'s output by calling `readBackgroundJobOutput` with its id.\n- Ids prefixed with "bgjob-" are Pochi-started background jobs (can be read and killed with `killBackgroundJob`).\n- Ids prefixed with "term-" are user-opened terminals (read-only; cannot be killed).';
   return `${header}\n${terminals
     .map(
       (t) =>

--- a/packages/common/src/tool-utils/index.ts
+++ b/packages/common/src/tool-utils/index.ts
@@ -22,7 +22,7 @@ export {
   GlobalRules,
   collectAllRuleFiles,
 } from "./custom-rules";
-export { MaxTerminalOutputSize } from "./limits";
+export { MaxTerminalOutputSize, MaxTerminalHistoryLines } from "./limits";
 export {
   getShellPath,
   fixExecuteCommandOutput,

--- a/packages/common/src/tool-utils/limits.ts
+++ b/packages/common/src/tool-utils/limits.ts
@@ -5,5 +5,11 @@ export const MaxListFileCharLength = 30_000;
 export const MaxGlobFileItems = 500;
 export const MaxReadFileSize = 30_000;
 export const MaxTerminalOutputSize = 500_000;
+/**
+ * Max number of lines kept in a user-opened terminal's reconstructed history
+ * (cwd/command headers + output across multiple commands). Oldest lines are
+ * evicted first once this cap is exceeded.
+ */
+export const MaxTerminalHistoryLines = 500;
 export const MaxPersistedToolResultSize = 50_000;
 export const PersistedToolResultPreviewSize = 2_000;

--- a/packages/tools/src/read-background-job-output.ts
+++ b/packages/tools/src/read-background-job-output.ts
@@ -2,16 +2,17 @@ import z from "zod";
 import { defineClientTool } from "./types";
 
 const toolDef = {
-  description: `- Retrieves output from a running or completed background job
-- Takes a backgroundJobId parameter identifying the job
-- For terminal jobs, returns only new output since the last check
-- Returns stdout and stderr output along with job status
+  description:
+    `- Retrieves output from a running or completed background job, or from a user-opened terminal
+- Takes a backgroundJobId parameter identifying the job or terminal
+- Always returns only new content since the last check for that id
+- Returns output along with job status
 - Supports optional regex filtering to show only lines matching a pattern
-- Use this tool when you need to monitor or check the output of a long-running background job`.trim(),
+- Use this tool when you need to monitor a long-running background job, or catch up on what happened in a user-opened terminal`.trim(),
   inputSchema: z.object({
     backgroundJobId: z
       .string()
-      .describe("The ID of the background job to get output from"),
+      .describe("The ID of the background job or terminal to get output from"),
     regex: z
       .string()
       .optional()
@@ -23,7 +24,7 @@ const toolDef = {
     output: z
       .string()
       .describe(
-        "The output of the background job since last check (including stdout and stderr).",
+        "New content since the last check: stdout/stderr for background jobs (bgjob-), or a terminal transcript for user-opened terminals (term-).",
       ),
     status: z
       .enum(["idle", "running", "completed"])

--- a/packages/vscode/src/integrations/terminal/__test__/terminal-history.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/terminal-history.test.ts
@@ -1,0 +1,114 @@
+import * as assert from "assert";
+import { describe, it } from "mocha";
+import { TerminalHistoryManager } from "../terminal-history";
+
+describe("TerminalHistoryManager", () => {
+  it("accumulates cwd + command + output across multiple commands", () => {
+    const id = "term-history-test";
+    const history = TerminalHistoryManager.getOrCreate(id);
+
+    history.beginCommand("ls", "/workspace");
+    history.addChunk("file-a\nfile-b\n");
+    history.finalize();
+
+    history.beginCommand("pwd", "/workspace");
+    history.addChunk("/workspace\n");
+    history.finalize();
+
+    const result = history.readOutput();
+    assert.strictEqual(
+      result.output,
+      "/workspace$ ls\nfile-a\nfile-b\n/workspace$ pwd\n/workspace\n",
+    );
+    assert.strictEqual(result.status, "completed");
+
+    TerminalHistoryManager.delete(id);
+  });
+
+  it("omits the cwd line when cwd is unavailable", () => {
+    const id = "term-history-no-cwd";
+    const history = TerminalHistoryManager.getOrCreate(id);
+
+    history.beginCommand("echo hi");
+    history.addChunk("hi\n");
+    history.finalize();
+
+    const result = history.readOutput();
+    assert.strictEqual(result.output, "$ echo hi\nhi\n");
+
+    TerminalHistoryManager.delete(id);
+  });
+
+  it("returns only new content since the last read (incremental)", () => {
+    const id = "term-history-incremental";
+    const history = TerminalHistoryManager.getOrCreate(id);
+
+    history.beginCommand("echo one", "/workspace");
+    history.addChunk("one\n");
+    history.finalize();
+
+    const first = history.readOutput();
+    assert.strictEqual(first.output, "/workspace$ echo one\none\n");
+
+    (history as unknown as { lastReadAt: number }).lastReadAt =
+      Date.now() - 1000;
+
+    history.beginCommand("echo two", "/workspace");
+    history.addChunk("two\n");
+    history.finalize();
+
+    (history as unknown as { lastReadAt: number }).lastReadAt =
+      Date.now() - 1000;
+    const second = history.readOutput();
+    assert.strictEqual(second.output, "/workspace$ echo two\ntwo\n");
+    assert.ok(
+      !second.output.includes("echo one"),
+      "already-read history should not be returned again",
+    );
+
+    TerminalHistoryManager.delete(id);
+  });
+
+  it("getOrCreate returns the same instance for the same id", () => {
+    const id = "term-history-same-instance";
+    const a = TerminalHistoryManager.getOrCreate(id);
+    const b = TerminalHistoryManager.getOrCreate(id);
+    assert.strictEqual(a, b);
+    TerminalHistoryManager.delete(id);
+  });
+
+  it("is unresolvable once deleted (e.g. terminal closed)", () => {
+    const id = "term-history-closed";
+    TerminalHistoryManager.getOrCreate(id);
+    assert.ok(TerminalHistoryManager.get(id));
+
+    TerminalHistoryManager.delete(id);
+    assert.strictEqual(TerminalHistoryManager.get(id), undefined);
+  });
+
+  it("evicts the oldest lines once MaxTerminalHistoryLines is exceeded", () => {
+    const id = "term-history-maxlines";
+    const history = TerminalHistoryManager.getOrCreate(id);
+
+    // MaxTerminalHistoryLines is 500, and each command contributes 2 lines
+    // (header + output), so produce well over 250 commands to trigger
+    // eviction without needing huge buffers.
+    for (let i = 0; i < 260; i++) {
+      history.beginCommand(`echo ${i}`, "/workspace");
+      history.addChunk(`${i}\n`);
+      history.finalize();
+    }
+
+    const result = history.readOutput();
+    assert.ok(result.isTruncated, "expected history to be truncated");
+    // The oldest command should have been evicted.
+    assert.ok(
+      !result.output.includes("echo 0\n"),
+      "expected the oldest command to be evicted",
+    );
+    // The most recent command should still be present.
+    assert.ok(result.output.includes("echo 259"));
+
+    TerminalHistoryManager.delete(id);
+  });
+});

--- a/packages/vscode/src/integrations/terminal/output-utils.ts
+++ b/packages/vscode/src/integrations/terminal/output-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Truncates a single text chunk to fit within the specified byte limit
+ * Uses binary search to find the maximum length that fits within the limit
+ */
+export function truncateTextByLimit(chunk: string, limit: number): string {
+  let left = 0;
+  let right = chunk.length;
+
+  while (left < right) {
+    const mid = Math.floor((left + right + 1) / 2);
+    const candidate = chunk.substring(chunk.length - mid);
+
+    if (Buffer.byteLength(candidate, "utf8") <= limit) {
+      left = mid;
+    } else {
+      right = mid - 1;
+    }
+  }
+
+  return chunk.substring(chunk.length - left);
+}
+
+/**
+ * Calculates the total byte size of content
+ */
+export function calculateContentBytes(chunks: string[]): number {
+  if (chunks.length === 0) return 0;
+
+  let totalBytes = 0;
+  for (let i = 0; i < chunks.length; i++) {
+    totalBytes += Buffer.byteLength(chunks[i], "utf8");
+  }
+  return totalBytes;
+}
+
+/**
+ * Joins an array of text chunks into a single string
+ * As \r and \n has special meaning in terminal, we just join them directly
+ * @param chunks The text chunks to join
+ * @returns The joined string
+ */
+export function joinContent(chunks: string[]): string {
+  return chunks.join("");
+}

--- a/packages/vscode/src/integrations/terminal/output.ts
+++ b/packages/vscode/src/integrations/terminal/output.ts
@@ -3,6 +3,11 @@ import { assertBackgroundJobReadInterval } from "@getpochi/common";
 import { MaxTerminalOutputSize } from "@getpochi/common/tool-utils";
 import type { ExecuteCommandResult } from "@getpochi/common/vscode-webui-bridge";
 import { signal } from "@preact/signals-core";
+import {
+  calculateContentBytes,
+  joinContent,
+  truncateTextByLimit,
+} from "./output-utils";
 import type { ExecutionError } from "./utils";
 
 const logger = getLogger("TerminalOutput");
@@ -77,41 +82,6 @@ interface OutputManagerOptions {
    * for UI display
    */
   command: string;
-}
-
-/**
- * Truncates a single text chunk to fit within the specified byte limit
- * Uses binary search to find the maximum length that fits within the limit
- */
-function truncateTextByLimit(chunk: string, limit: number): string {
-  let left = 0;
-  let right = chunk.length;
-
-  while (left < right) {
-    const mid = Math.floor((left + right + 1) / 2);
-    const candidate = chunk.substring(chunk.length - mid);
-
-    if (Buffer.byteLength(candidate, "utf8") <= limit) {
-      left = mid;
-    } else {
-      right = mid - 1;
-    }
-  }
-
-  return chunk.substring(chunk.length - left);
-}
-
-/**
- * Calculates the total byte size of content
- */
-function calculateContentBytes(chunks: string[]): number {
-  if (chunks.length === 0) return 0;
-
-  let totalBytes = 0;
-  for (let i = 0; i < chunks.length; i++) {
-    totalBytes += Buffer.byteLength(chunks[i], "utf8");
-  }
-  return totalBytes;
 }
 
 export class OutputManager {
@@ -294,14 +264,4 @@ export class OutputManager {
       isTruncated,
     };
   }
-}
-
-/**
- * Joins an array of text chunks into a single string
- * As \r and \n has special meaning in terminal, we just join them directly
- * @param chunks The text chunks to join
- * @returns The joined string
- */
-function joinContent(chunks: string[]): string {
-  return chunks.join("");
 }

--- a/packages/vscode/src/integrations/terminal/terminal-history.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-history.ts
@@ -1,0 +1,278 @@
+import { getLogger } from "@/lib/logger";
+import { assertBackgroundJobReadInterval } from "@getpochi/common";
+import {
+  MaxTerminalHistoryLines,
+  MaxTerminalOutputSize,
+} from "@getpochi/common/tool-utils";
+import type { ExecuteCommandResult } from "@getpochi/common/vscode-webui-bridge";
+import { signal } from "@preact/signals-core";
+import {
+  calculateContentBytes,
+  joinContent,
+  truncateTextByLimit,
+} from "./output-utils";
+import type { ExecutionError } from "./utils";
+
+const logger = getLogger("TerminalHistory");
+
+/**
+ * Reconstructs the scrollback "history" of a user-opened terminal: cwd +
+ * command + output for every command run in it, since VS Code's stable
+ * extension API has no way to read a terminal's actual rendered screen
+ * buffer (that requires the proposed, non-shippable `onDidWriteTerminalData`
+ * API).
+ *
+ * This is intentionally a separate manager from `OutputManager`:
+ * `OutputManager` captures a single command execution (used for Pochi-started
+ * background jobs, where each job only ever cares about its own
+ * stdout/stderr). A `TerminalHistoryManager` instance instead lives for the
+ * lifetime of a terminal and accumulates every command run in it — bounded
+ * by `MaxTerminalHistoryLines` (oldest lines evicted first) in addition to
+ * the usual `MaxTerminalOutputSize` byte cap.
+ *
+ * Reads are incremental (only new content since the last read), the same
+ * "only what's new" contract as `OutputManager.readOutput`.
+ */
+export class TerminalHistoryManager {
+  private static readonly managers = new Map<string, TerminalHistoryManager>();
+
+  private readonly output = signal<ExecuteCommandResult>({
+    content: "",
+    status: "idle",
+    isTruncated: false,
+  });
+
+  /**
+   * History chunks: command headers (cwd + command line) and output,
+   * interleaved in the order they occurred.
+   */
+  private chunks: string[] = [];
+  private isTruncated = false;
+  private lastReadLength = 0; // tracks byte length, not character length
+  private lastReadAt = 0;
+
+  private constructor(public readonly id: string) {}
+
+  static getOrCreate(id: string): TerminalHistoryManager {
+    let manager = TerminalHistoryManager.managers.get(id);
+    if (!manager) {
+      manager = new TerminalHistoryManager(id);
+      TerminalHistoryManager.managers.set(id, manager);
+    }
+    return manager;
+  }
+
+  static get(id: string): TerminalHistoryManager | undefined {
+    return TerminalHistoryManager.managers.get(id);
+  }
+
+  static delete(id: string): void {
+    TerminalHistoryManager.managers.delete(id);
+  }
+
+  /**
+   * Records the start of a new command by appending a reconstructed prompt
+   * line (cwd + command) to the history, ahead of the command's own output
+   * (added separately via {@link addChunk}).
+   */
+  beginCommand(command: string, cwd?: string): void {
+    const header = cwd ? `${cwd}$ ${command}\n` : `$ ${command}\n`;
+    this.addChunk(header);
+  }
+
+  /**
+   * Appends a chunk of output (or a command header) to the history.
+   */
+  addChunk(chunk: string): void {
+    this.chunks.push(chunk);
+    this.updateOutput("running");
+  }
+
+  /**
+   * Marks the current command as finished. Unlike `OutputManager.finalize`,
+   * the manager stays alive and ready to accumulate the next command run in
+   * this terminal.
+   */
+  finalize(error?: ExecutionError): void {
+    this.updateOutput("completed", error);
+  }
+
+  /**
+   * Reads new history content since the last read.
+   * @param regex - An optional regex to filter the output lines.
+   */
+  readOutput(regex?: RegExp): {
+    output: string;
+    isTruncated: boolean;
+    status: ExecuteCommandResult["status"];
+    error?: string;
+  } {
+    const currentOutput = this.output.value.content;
+    const currentOutputBytes = Buffer.byteLength(currentOutput, "utf8");
+    const now = Date.now();
+    const previousReadAt = this.lastReadAt === 0 ? undefined : this.lastReadAt;
+    assertBackgroundJobReadInterval({
+      now,
+      previousReadAt,
+      status: this.output.value.status,
+    });
+
+    // Get the substring based on byte position
+    let newOutput = "";
+    let noMoreOutput = false;
+    if (this.lastReadLength < currentOutputBytes) {
+      // Find the character position that corresponds to lastReadLength bytes
+      const buffer = Buffer.from(currentOutput, "utf8");
+      const slicedBuffer = buffer.subarray(this.lastReadLength);
+      newOutput = slicedBuffer.toString("utf8");
+    } else if (this.output.value.status === "completed") {
+      noMoreOutput = true;
+    }
+
+    this.lastReadLength = currentOutputBytes;
+    this.lastReadAt = now;
+
+    if (regex) {
+      const lines = newOutput.split(/(\r\n|\n)/);
+      const filteredParts: string[] = [];
+
+      for (let i = 0; i < lines.length; i += 2) {
+        const lineContent = lines[i] || "";
+        const lineSeparator = lines[i + 1] || "";
+
+        if (regex.test(lineContent)) {
+          filteredParts.push(lineContent + lineSeparator);
+        }
+      }
+
+      newOutput = filteredParts.join("");
+    }
+
+    return {
+      output: newOutput,
+      isTruncated: this.output.value.isTruncated ?? false,
+      status: this.output.value.status,
+      error: noMoreOutput
+        ? `No more Output to read.${this.output.value.error ?? ""}`
+        : this.output.value.error,
+    };
+  }
+
+  /**
+   * Updates the output signal, capping history at `MaxTerminalOutputSize`
+   * bytes and `MaxTerminalHistoryLines` lines (oldest content evicted
+   * first), and keeps `lastReadLength` consistent with whatever got evicted.
+   */
+  private updateOutput(
+    status: ExecuteCommandResult["status"],
+    error?: ExecutionError,
+  ): void {
+    const { chunks: truncatedChunks, truncatedBytes } = this.truncate(
+      this.chunks,
+    );
+    this.chunks = truncatedChunks;
+
+    const newContent = joinContent(this.chunks);
+    const newContentBytes = Buffer.byteLength(newContent, "utf8");
+
+    if (truncatedBytes > 0) {
+      this.lastReadLength = Math.max(0, this.lastReadLength - truncatedBytes);
+      this.lastReadLength = Math.min(this.lastReadLength, newContentBytes);
+    }
+
+    this.output.value = {
+      content: newContent,
+      status,
+      isTruncated: this.isTruncated,
+      error: error?.message,
+    };
+  }
+
+  private truncate(chunks: string[]): {
+    chunks: string[];
+    truncatedBytes: number;
+  } {
+    let currentChunks = [...chunks];
+    const initialContentBytes = calculateContentBytes(currentChunks);
+    let contentBytes = initialContentBytes;
+    let didTruncate = false;
+
+    if (contentBytes > MaxTerminalOutputSize) {
+      didTruncate = true;
+      while (contentBytes > MaxTerminalOutputSize && currentChunks.length > 1) {
+        const removedChunk = currentChunks.shift();
+        if (!removedChunk) break;
+        contentBytes -= Buffer.byteLength(removedChunk, "utf8");
+      }
+      if (contentBytes > MaxTerminalOutputSize && currentChunks.length === 1) {
+        currentChunks[0] = truncateTextByLimit(
+          currentChunks[0],
+          MaxTerminalOutputSize,
+        );
+        contentBytes = calculateContentBytes(currentChunks);
+      }
+    }
+
+    const { chunks: lineLimitedChunks, removedBytes } = truncateToMaxLines(
+      currentChunks,
+      MaxTerminalHistoryLines,
+    );
+    if (removedBytes > 0) {
+      didTruncate = true;
+      currentChunks = lineLimitedChunks;
+      contentBytes -= removedBytes;
+    }
+
+    if (didTruncate && !this.isTruncated) {
+      this.isTruncated = true;
+      logger.warn(
+        `Terminal history truncated at ${MaxTerminalOutputSize} bytes / ${MaxTerminalHistoryLines} lines`,
+      );
+    }
+
+    return {
+      chunks: currentChunks,
+      truncatedBytes: initialContentBytes - contentBytes,
+    };
+  }
+}
+
+/**
+ * Splits text into an array of lines, each retaining its trailing line
+ * separator (\r\n or \n) if present, so re-joining the result reproduces the
+ * original text exactly.
+ */
+function splitIntoLines(text: string): string[] {
+  if (text === "") return [];
+
+  const parts = text.split(/(\r\n|\n)/);
+  const lines: string[] = [];
+  for (let i = 0; i < parts.length; i += 2) {
+    const content = parts[i] ?? "";
+    const separator = parts[i + 1] ?? "";
+    if (content === "" && separator === "") continue;
+    lines.push(content + separator);
+  }
+  return lines;
+}
+
+/**
+ * Keeps at most `maxLines` of the most recent lines across `chunks`,
+ * collapsing them into a single chunk. Returns the number of bytes removed
+ * so callers can keep read-position bookkeeping consistent.
+ */
+function truncateToMaxLines(
+  chunks: string[],
+  maxLines: number,
+): { chunks: string[]; removedBytes: number } {
+  const joined = joinContent(chunks);
+  const lines = splitIntoLines(joined);
+  if (lines.length <= maxLines) {
+    return { chunks, removedBytes: 0 };
+  }
+
+  const kept = lines.slice(lines.length - maxLines).join("");
+  const removedBytes =
+    Buffer.byteLength(joined, "utf8") - Buffer.byteLength(kept, "utf8");
+  return { chunks: [kept], removedBytes };
+}

--- a/packages/vscode/src/integrations/terminal/terminal-state.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-state.ts
@@ -3,7 +3,7 @@ import { getLogger } from "@/lib/logger";
 import { signal } from "@preact/signals-core";
 import { injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
-import { OutputManager } from "./output";
+import { TerminalHistoryManager } from "./terminal-history";
 import { TerminalJob } from "./terminal-job";
 import { ExecutionError } from "./utils";
 
@@ -35,12 +35,12 @@ export class TerminalState implements vscode.Disposable {
   private readonly terminalIds = new WeakMap<vscode.Terminal, string>();
 
   /**
-   * Maps an in-flight shell execution to the OutputManager collecting its
-   * output, so it can be finalized when the execution ends.
+   * Maps an in-flight shell execution to the TerminalHistoryManager
+   * collecting its output, so it can be finalized when the execution ends.
    */
   private readonly runningExecutions = new Map<
     vscode.TerminalShellExecution,
-    OutputManager
+    TerminalHistoryManager
   >();
 
   // Signal containing the current active terminals
@@ -97,7 +97,7 @@ export class TerminalState implements vscode.Disposable {
   private onTerminalClosed = (terminal: vscode.Terminal) => {
     const id = this.terminalIds.get(terminal);
     if (id) {
-      OutputManager.delete(id);
+      TerminalHistoryManager.delete(id);
     }
     this.onTerminalChanged();
   };
@@ -111,14 +111,17 @@ export class TerminalState implements vscode.Disposable {
     }
 
     const id = this.getTerminalId(event.terminal);
-    // Start a fresh capture for this execution so a read returns the output of
-    // the most recent command run in the terminal.
-    const outputManager = OutputManager.create({
-      id,
-      command: event.execution.commandLine.value,
-    });
-    this.runningExecutions.set(event.execution, outputManager);
-    this.captureExecutionOutput(event.execution, outputManager);
+    const command = event.execution.commandLine.value;
+    // Reuse the same manager across commands so a regular terminal's history
+    // (cwd + command + output for each command run in it) accumulates over
+    // time, the same way it would look in the terminal itself, instead of
+    // being wiped out by the next command.
+    const history = TerminalHistoryManager.getOrCreate(id);
+    const cwd = event.terminal.shellIntegration?.cwd?.fsPath;
+    history.beginCommand(command, cwd);
+
+    this.runningExecutions.set(event.execution, history);
+    this.captureExecutionOutput(event.execution, history);
     // Reflect the newly readable terminal in the environment.
     this.onTerminalChanged();
   };
@@ -126,24 +129,24 @@ export class TerminalState implements vscode.Disposable {
   private onShellExecutionEnd = (
     event: vscode.TerminalShellExecutionEndEvent,
   ) => {
-    const outputManager = this.runningExecutions.get(event.execution);
-    if (!outputManager) return;
+    const history = this.runningExecutions.get(event.execution);
+    if (!history) return;
     this.runningExecutions.delete(event.execution);
 
     const error =
       event.exitCode === undefined || event.exitCode === 0
         ? undefined
         : ExecutionError.create(`Command exited with code ${event.exitCode}.`);
-    outputManager.finalize(error);
+    history.finalize(error);
   };
 
   private async captureExecutionOutput(
     execution: vscode.TerminalShellExecution,
-    outputManager: OutputManager,
+    history: TerminalHistoryManager,
   ): Promise<void> {
     try {
       for await (const chunk of execution.read()) {
-        outputManager.addChunk(chunk);
+        history.addChunk(chunk);
       }
     } catch (error) {
       logger.debug(`Failed to read terminal shell execution output: ${error}`);

--- a/packages/vscode/src/tools/__test__/read-background-job-output.test.ts
+++ b/packages/vscode/src/tools/__test__/read-background-job-output.test.ts
@@ -3,12 +3,13 @@ import { afterEach, describe, it } from "mocha";
 import { OutputManager } from "../../integrations/terminal/output";
 
 /**
- * `readBackgroundJobOutput` resolves output through the shared `OutputManager`
- * registry keyed by a terminal id. Background jobs and (newly) user-opened
- * terminals both register their output here, which is what allows the model to
- * read any terminal by id. These tests cover that registry contract directly
- * (importing the tool itself pulls in the webview/layout module chain, which is
- * not available in the unit test host).
+ * `readBackgroundJobOutput` resolves `bgjob-` ids through the shared
+ * `OutputManager` registry keyed by job id (Pochi-started background jobs
+ * capture only their own stdout/stderr). `term-` ids (user-opened terminals)
+ * are instead backed by `TerminalHistoryManager`, tested separately in
+ * `terminal-history.test.ts`. These tests cover the `OutputManager` registry
+ * contract directly (importing the tool itself pulls in the webview/layout
+ * module chain, which is not available in the unit test host).
  */
 describe("OutputManager registry (readBackgroundJobOutput backing store)", () => {
   const createdIds: string[] = [];
@@ -40,16 +41,6 @@ describe("OutputManager registry (readBackgroundJobOutput backing store)", () =>
       `expected captured output, got: ${JSON.stringify(result)}`,
     );
     assert.strictEqual(result.status, "completed");
-  });
-
-  it("captures and returns output for a user-opened terminal id (term- prefix)", () => {
-    const id = track("term-read-test");
-    const manager = OutputManager.create({ id, command: "ls" });
-    manager.addChunk("file-a file-b\n");
-    manager.finalize();
-
-    const result = OutputManager.get(id)?.readOutput();
-    assert.ok(result?.output.includes("file-a"), "expected captured output");
   });
 
   it("returns only new output since the last read", () => {

--- a/packages/vscode/src/tools/read-background-job-output.ts
+++ b/packages/vscode/src/tools/read-background-job-output.ts
@@ -1,4 +1,5 @@
 import { OutputManager } from "@/integrations/terminal/output";
+import { TerminalHistoryManager } from "@/integrations/terminal/terminal-history";
 import { PochiWebviewPanel } from "@/integrations/webview/webview-panel";
 import type { ExecuteCommandResult } from "@getpochi/common/vscode-webui-bridge";
 import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
@@ -6,8 +7,33 @@ import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 export const readBackgroundJobOutput: ToolFunctionType<
   ClientTools["readBackgroundJobOutput"]
 > = async ({ backgroundJobId, regex }) => {
-  const outputManager = OutputManager.get(backgroundJobId);
-  if (outputManager) {
+  // "term-" ids are user-opened terminals: reads surface a running history transcript
+  if (backgroundJobId.startsWith("term-")) {
+    const history = TerminalHistoryManager.get(backgroundJobId);
+    if (!history) {
+      throw new Error(
+        `No output available for terminal "${backgroundJobId}". It may have been closed, no command has run in it yet, or shell integration is not active for it.`,
+      );
+    }
+
+    const output = history.readOutput(regex ? new RegExp(regex) : undefined);
+
+    return {
+      output: output.output,
+      isTruncated: output.isTruncated,
+      status: output.status,
+      error: output.error,
+    };
+  }
+
+  // "bgjob-" ids are Pochi-started background jobs: reads surface only that
+  // job's own stdout/stderr.
+  if (backgroundJobId.startsWith("bgjob-")) {
+    const outputManager = OutputManager.get(backgroundJobId);
+    if (!outputManager) {
+      throw new Error(`Background job with ID "${backgroundJobId}" not found.`);
+    }
+
     const output = outputManager.readOutput(
       regex ? new RegExp(regex) : undefined,
     );
@@ -18,15 +44,6 @@ export const readBackgroundJobOutput: ToolFunctionType<
       status: output.status,
       error: output.error,
     };
-  }
-
-  if (
-    backgroundJobId.startsWith("bgjob-") ||
-    backgroundJobId.startsWith("term-")
-  ) {
-    throw new Error(
-      `No output available for terminal/background job "${backgroundJobId}". It may have been closed, no command has run in it yet, or shell integration is not active for it.`,
-    );
   }
 
   const taskOutput = await readTaskOutput(backgroundJobId);


### PR DESCRIPTION
## Summary
- Add `TerminalHistoryManager`, which reconstructs a user-opened terminal's history (cwd + command + output across every command run in it), since VS Code's stable extension API has no way to read a terminal's actual rendered scrollback buffer.
- `readBackgroundJobOutput` now surfaces this accumulated transcript for `term-` ids, instead of only the most recently run command's output. `bgjob-` ids (Pochi-started background jobs) keep the existing single-command `OutputManager` behavior.
- Extract shared truncation helpers (`truncateTextByLimit`, `calculateContentBytes`, `joinContent`) into `output-utils.ts`, reused by both `OutputManager` and `TerminalHistoryManager`.
- Add a `MaxTerminalHistoryLines` cap (in addition to the existing `MaxTerminalOutputSize` byte cap) so a terminal's history doesn't grow unbounded; oldest lines are evicted first.
- Update tool/prompt descriptions to reflect that terminal reads return history, not just "most recent command output".

## Test plan
- [x] `packages/vscode`: `bun run test` — 188 passing (including new `TerminalHistoryManager` suite)
- [x] Root: `bun run test` — all tasks passing
- [x] Root: `bun check` — no lint/format issues
- [x] Root `bun tsc` and `packages/vscode` `bun tsc` — no type errors

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5692bc4f37d749e09e6fac5b40105a8f)