### PR TITLE
fix(vscode): suppress toast when copying empty terminal selection

### DIFF
--- a/packages/vscode/src/integrations/terminal/__test__/read-terminal-selection.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/read-terminal-selection.test.ts
@@ -74,11 +74,64 @@ describe("readTerminalSelection", () => {
       backgroundJobId: "term-123",
       content: "echo hello\nhello",
     });
+    // The copy command is wrapped in a Do Not Disturb toggle-on/toggle-off
+    // pair so VS Code's "no selection" notification (when it fires) doesn't
+    // pop up as a toast; see `withDoNotDisturb` in the source module.
     assert.deepStrictEqual(executeCommandCalls, [
+      "notifications.toggleDoNotDisturbMode",
       "workbench.action.terminal.copySelection",
+      "notifications.toggleDoNotDisturbMode",
     ]);
     // The clipboard must be restored to its original value afterwards.
     assert.strictEqual(getClipboardContent(), "original clipboard content");
+  });
+
+  it("still copies the selection when toggling Do Not Disturb mode fails", async () => {
+    let clipboardContent = "original clipboard content";
+    const executeCommandCalls: string[] = [];
+    const vscode = {
+      env: {
+        clipboard: {
+          readText: async () => clipboardContent,
+          writeText: async (value: string) => {
+            clipboardContent = value;
+          },
+        },
+      },
+      commands: {
+        executeCommand: async (command: string) => {
+          executeCommandCalls.push(command);
+          if (command === "notifications.toggleDoNotDisturbMode") {
+            throw new Error("command not found");
+          }
+          if (command === "workbench.action.terminal.copySelection") {
+            clipboardContent = "echo hello\nhello";
+          }
+        },
+      },
+    };
+    const { readTerminalSelection } = proxyquire
+      .noCallThru()
+      .noPreserveCache()
+      .load("../read-terminal-selection", {
+        vscode,
+        "@/lib/logger": {
+          getLogger: () => ({ debug: () => {} }),
+        },
+      }) as typeof import("../read-terminal-selection");
+
+    const result = await readTerminalSelection(fakeTerminal, "term-123");
+
+    assert.deepStrictEqual(result, {
+      terminalName: "bash",
+      backgroundJobId: "term-123",
+      content: "echo hello\nhello",
+    });
+    assert.deepStrictEqual(executeCommandCalls, [
+      "notifications.toggleDoNotDisturbMode",
+      "workbench.action.terminal.copySelection",
+      "notifications.toggleDoNotDisturbMode",
+    ]);
   });
 
   it("returns undefined when there is no selection", async () => {

--- a/packages/vscode/src/integrations/terminal/read-terminal-selection.ts
+++ b/packages/vscode/src/integrations/terminal/read-terminal-selection.ts
@@ -6,6 +6,64 @@ import * as vscode from "vscode";
 const logger = getLogger("ReadTerminalSelection");
 
 /**
+ * Serializes overlapping `withDoNotDisturb` calls so their toggle-on/toggle-off
+ * pairs can't interleave (which would otherwise leave the notification filter
+ * stuck in the wrong state). Resolves regardless of whether the previous run
+ * succeeded or failed.
+ */
+let pendingDoNotDisturb: Promise<void> = Promise.resolve();
+
+/**
+ * Best-effort toggle of VS Code's "Do Not Disturb" notification filter.
+ * `notifications.toggleDoNotDisturbMode` is a plain flip between "off" and
+ * "errors only" (see VS Code's `notificationsCommands.ts`), so calling it is
+ * safe even if we don't know the current state. Failures (e.g. the command
+ * doesn't exist on older VS Code versions or a fork) are swallowed so callers
+ * degrade to the pre-existing behavior instead of throwing.
+ */
+async function toggleDoNotDisturb(): Promise<void> {
+  try {
+    await vscode.commands.executeCommand(
+      "notifications.toggleDoNotDisturbMode",
+    );
+  } catch (error) {
+    logger.debug(`Failed to toggle Do Not Disturb mode: ${error}`);
+  }
+}
+
+/**
+ * Runs `fn` with VS Code's notification filter temporarily set to
+ * "errors only", so any non-error notification `fn` triggers (e.g. the
+ * "The terminal has no selection to copy" warning from
+ * `workbench.action.terminal.copySelection`) is silently added to the
+ * Notification Center instead of popping up as a toast.
+ *
+ * Toggling on then off again nets out to the original filter state
+ * regardless of what it was, since the command is a pure flip. Calls are
+ * serialized via `pendingDoNotDisturb` so concurrent invocations don't
+ * interleave their toggles.
+ *
+ * Caveat: if the process crashes (or `fn` never settles) between the two
+ * toggles, the user's notification filter could be left on "errors only"
+ * until they toggle it back manually via the bell icon.
+ */
+async function withDoNotDisturb<T>(fn: () => Thenable<T>): Promise<T> {
+  const run = pendingDoNotDisturb.then(async () => {
+    await toggleDoNotDisturb();
+    try {
+      return await fn();
+    } finally {
+      await toggleDoNotDisturb();
+    }
+  });
+  pendingDoNotDisturb = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
  * Reads the text currently selected in the given terminal, if any.
  *
  * VS Code has no stable API to read or observe a terminal's selection
@@ -17,7 +75,11 @@ const logger = getLogger("ReadTerminalSelection");
  * A random sentinel value is written to the clipboard before invoking the
  * copy command so we can reliably detect the "no selection" case (the copy
  * command is a no-op when nothing is selected, leaving the sentinel in
- * place).
+ * place). VS Code also shows a "The terminal has no selection to copy"
+ * notification in that case, with no supported API to check for a
+ * selection beforehand or to suppress that specific notification
+ * (microsoft/vscode#10471 rejected exposing a general context-key read
+ * API), so the copy command is run under `withDoNotDisturb` to silence it.
  */
 export async function readTerminalSelection(
   terminal: vscode.Terminal,
@@ -27,8 +89,8 @@ export async function readTerminalSelection(
   const sentinel = `__pochi_empty_selection_${randomUUID()}__`;
   try {
     await vscode.env.clipboard.writeText(sentinel);
-    await vscode.commands.executeCommand(
-      "workbench.action.terminal.copySelection",
+    await withDoNotDisturb(() =>
+      vscode.commands.executeCommand("workbench.action.terminal.copySelection"),
     );
     const result = await vscode.env.clipboard.readText();
     if (result === sentinel) {


### PR DESCRIPTION
## Summary
- `workbench.action.terminal.copySelection` (used by `readTerminalSelection` on every chat submit/new task creation) shows a "The terminal has no selection to copy" toast whenever nothing is selected in the active terminal, and VS Code has no API to check for a selection beforehand (microsoft/vscode#188173, #10471).
- Wrap the copy call in VS Code's Do Not Disturb notification filter (`notifications.toggleDoNotDisturbMode`, a pure on/off flip) so the toast is silenced while the copy runs, then restore the previous filter state immediately after.
- Each toggle call is independently guarded so a missing command (older VS Code, or a fork without it) degrades gracefully instead of breaking terminal-selection reading. Concurrent calls are serialized via a module-level promise chain so overlapping toggle pairs can't interleave.

## Test plan
- [x] `xvfb-maybe npx vscode-test --grep "readTerminalSelection"` — 5/5 passing, including a new test covering graceful degradation when the toggle command is unavailable
- [x] `tsc --noEmit` — clean

🤖 Generated with [Pochi](https://getpochi.com)