### PR TITLE
refactor(vscode-webui): move queued messages back inside chat input box

### DIFF
--- a/packages/vscode-webui/src/features/approval/components/approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/approval-button.tsx
@@ -18,6 +18,14 @@ interface ApprovalButtonProps {
   onToolCallApprovalVisible?: () => void;
   onToolsExecutionStarted?: () => void;
   onToolsExecutionEnded?: () => void;
+  /**
+   * Whether there is at least one message waiting in the queue. When true,
+   * the "Continue" button (shown after e.g. a manual stop) sends the next
+   * queued message instead of retrying / regenerating the previous turn.
+   */
+  hasQueuedMessages?: boolean;
+  /** Dequeues and sends the first queued message. */
+  onContinueWithQueuedMessage?: () => void;
 }
 
 export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
@@ -30,6 +38,8 @@ export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
   onToolCallApprovalVisible,
   onToolsExecutionStarted,
   onToolsExecutionEnded,
+  hasQueuedMessages,
+  onContinueWithQueuedMessage,
 }) => {
   const shouldShowApprovalButton = pendingApproval && allowAddToolResult;
 
@@ -49,7 +59,12 @@ export const ApprovalButton: React.FC<ApprovalButtonProps> = ({
   return (
     <div className="flex select-none gap-3 [&>button]:flex-1 [&>button]:rounded-sm">
       {pendingApproval.name === "retry" ? (
-        <RetryApprovalButton pendingApproval={pendingApproval} retry={retry} />
+        <RetryApprovalButton
+          pendingApproval={pendingApproval}
+          retry={retry}
+          hasQueuedMessages={hasQueuedMessages}
+          onContinueWithQueuedMessage={onContinueWithQueuedMessage}
+        />
       ) : (
         <ToolCallApprovalButton
           taskId={task?.id}

--- a/packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx
@@ -11,31 +11,50 @@ import type { PendingRetryApproval } from "../hooks/use-pending-retry-approval";
 interface RetryApprovalButtonProps {
   pendingApproval: PendingRetryApproval;
   retry: (error: Error) => void;
+  /**
+   * Whether there is at least one message waiting in the queue. When true,
+   * continuing should send the next queued message instead of retrying /
+   * regenerating the last assistant message.
+   */
+  hasQueuedMessages?: boolean;
+  /**
+   * Dequeues and sends the first queued message. Required when
+   * `hasQueuedMessages` is true.
+   */
+  onContinueWithQueuedMessage?: () => void;
 }
 
 export const RetryApprovalButton: React.FC<RetryApprovalButtonProps> = ({
   pendingApproval,
   retry,
+  hasQueuedMessages = false,
+  onContinueWithQueuedMessage,
 }) => {
   const { t } = useTranslation();
   const reviews = useReviews();
 
+  const handleContinue = useCallback(() => {
+    pendingApproval.stopCountdown();
+    if (hasQueuedMessages && onContinueWithQueuedMessage) {
+      // A message is already queued, so continue the chat by sending it
+      // instead of retrying / regenerating the previous turn.
+      onContinueWithQueuedMessage();
+      return;
+    }
+    retry(pendingApproval.error);
+  }, [retry, pendingApproval, hasQueuedMessages, onContinueWithQueuedMessage]);
+
   useEffect(() => {
     if (pendingApproval.countdown === 0) {
-      doRetry();
+      handleContinue();
     }
-  }, [pendingApproval]);
-
-  const doRetry = useCallback(() => {
-    pendingApproval.stopCountdown();
-    retry(pendingApproval.error);
-  }, [retry, pendingApproval]);
+  }, [pendingApproval, handleContinue]);
 
   const autoApproveGuard = useAutoApproveGuard();
   const onAccept = useCallback(() => {
     autoApproveGuard.current = "auto";
-    doRetry();
-  }, [autoApproveGuard, doRetry]);
+    handleContinue();
+  }, [autoApproveGuard, handleContinue]);
 
   useHandleChatEvents({
     sendRetry: onAccept,

--- a/packages/vscode-webui/src/features/chat/components/__stories__/queued-messages.stories.tsx
+++ b/packages/vscode-webui/src/features/chat/components/__stories__/queued-messages.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 
-import type { QueuedMessage } from "../../hooks/use-chat-submit";
+import type {
+  ActiveSelection,
+  TerminalTextSelection,
+} from "@getpochi/common/vscode-webui-bridge";
+import type { DraftMessage } from "../../hooks/use-chat-submit";
 import { QueuedMessages } from "../queued-messages";
 
 const meta = {
@@ -15,33 +19,105 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const sampleActiveSelection: ActiveSelection = {
+  filepath:
+    "packages/vscode-webui/src/features/chat/components/queued-messages.tsx",
+  range: {
+    start: { line: 10, character: 0 },
+    end: { line: 20, character: 0 },
+  },
+  content: `export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
+  messages,
+  onRemove,
+  onSteer,
+}) => {`,
+};
+
+const sampleTerminalTextSelection: TerminalTextSelection = {
+  terminalName: "bash",
+  content: "$ bun run test\n✓ all tests passed",
+};
+
 export const Default: Story = {
   args: {
     messages: [
-      queuedMessage("Hello, this is a test message."),
-      queuedMessage(
-        "This is another test message that is very long and should be truncated, This is another test message that is very long and should be truncated.",
-      ),
-      queuedMessage(
-        "Prompt with mention, <file>packages/vscode-webui/src/features/chat/components/queued-messages</file>",
-      ),
-      queuedMessage(`This is a prompt with multi line.
-      This is another line`),
-      queuedMessage("This is a todo mode prompt", true),
-      queuedMessage("This is a prompt"),
-      queuedMessage("This is a prompt"),
-      queuedMessage("This is a prompt"),
-      queuedMessage("This is a prompt"),
+      queuedMessage({ text: "Hello, this is a test message." }),
+      queuedMessage({
+        text: "This is another test message that is very long and should be truncated, This is another test message that is very long and should be truncated.",
+      }),
+      queuedMessage({
+        text: "Prompt with mention, <file>packages/vscode-webui/src/features/chat/components/queued-messages</file>",
+      }),
+      queuedMessage({
+        text: `This is a prompt with multi line.
+      This is another line`,
+      }),
+      queuedMessage({ text: "This is a todo mode prompt", isTodoMode: true }),
+      queuedMessage({
+        text: "This is a prompt with an active editor selection",
+        activeSelection: sampleActiveSelection,
+      }),
+      queuedMessage({
+        text: "This is a prompt with an active terminal selection",
+        activeTerminalTextSelection: sampleTerminalTextSelection,
+      }),
+      queuedMessage({
+        text: "This is a prompt with both selections",
+        activeSelection: sampleActiveSelection,
+        activeTerminalTextSelection: sampleTerminalTextSelection,
+      }),
+      queuedMessage({
+        text: "This is a prompt with attached files",
+        filesCount: 2,
+      }),
+      queuedMessage({
+        text: "This is a prompt with pending reviews",
+        reviewsCount: 3,
+      }),
+      queuedMessage({
+        text: "This is a prompt with files and reviews",
+        filesCount: 1,
+        reviewsCount: 2,
+      }),
+      queuedMessage({
+        text: "This is a prompt with files, reviews and selections",
+        filesCount: 2,
+        reviewsCount: 1,
+        activeSelection: sampleActiveSelection,
+        activeTerminalTextSelection: sampleTerminalTextSelection,
+      }),
+      queuedMessage({ text: "This is a prompt" }),
     ],
   },
 };
 
-function queuedMessage(text: string, isTodoMode = false): QueuedMessage {
+function queuedMessage({
+  text,
+  isTodoMode = false,
+  filesCount = 0,
+  reviewsCount = 0,
+  userEditsCount = 0,
+  activeSelection,
+  activeTerminalTextSelection,
+}: {
+  text: string;
+  isTodoMode?: boolean;
+  filesCount?: number;
+  reviewsCount?: number;
+  userEditsCount?: number;
+  activeSelection?: ActiveSelection;
+  activeTerminalTextSelection?: TerminalTextSelection;
+}): DraftMessage {
   return {
-    text,
-    files: [],
-    reviews: [],
-    userEdits: [],
-    isTodoMode,
+    parts: [],
+    raw: {
+      text,
+      filesCount,
+      reviewsCount,
+      userEditsCount,
+      isTodoMode,
+      activeSelection,
+      activeTerminalTextSelection,
+    },
   };
 }

--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -15,6 +15,8 @@ import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import type { Review } from "@getpochi/common/vscode-webui-bridge";
 import type { ReactNode } from "@tanstack/react-router";
 import type { ChatInput } from "../hooks/use-chat-input-state";
+import type { DraftMessage } from "../hooks/use-chat-submit";
+import { QueuedMessages } from "./queued-messages";
 
 interface ChatInputFormProps {
   input: ChatInput;
@@ -43,6 +45,9 @@ interface ChatInputFormProps {
   onAttachFile?: () => void;
   contextMenuSide?: "top" | "bottom";
   className?: string;
+  queuedMessages?: DraftMessage[];
+  onRemoveQueuedMessage?: (index: number) => void;
+  onSteerQueuedMessage?: (index: number) => void;
 }
 
 export interface ChatInputFormHandle {
@@ -79,6 +84,9 @@ export const ChatInputForm = forwardRef<
     onAttachFile,
     contextMenuSide = "top",
     className,
+    queuedMessages = [],
+    onRemoveQueuedMessage,
+    onSteerQueuedMessage,
   },
   ref,
 ) {
@@ -147,6 +155,17 @@ export const ChatInputForm = forwardRef<
         <ReviewBadges reviews={reviews} />
       </div>
       <DevRetryCountdown pendingApproval={pendingApproval} status={status} />
+      {queuedMessages.length > 0 && (
+        <QueuedMessages
+          messages={queuedMessages}
+          onRemove={(index) => onRemoveQueuedMessage?.(index)}
+          onSteer={
+            onSteerQueuedMessage
+              ? (index) => onSteerQueuedMessage(index)
+              : undefined
+          }
+        />
+      )}
       {children}
     </FormEditor>
   );

--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -48,6 +48,7 @@ interface ChatInputFormProps {
   queuedMessages?: DraftMessage[];
   onRemoveQueuedMessage?: (index: number) => void;
   onSteerQueuedMessage?: (index: number) => void;
+  allowSteer?: boolean;
 }
 
 export interface ChatInputFormHandle {
@@ -87,6 +88,7 @@ export const ChatInputForm = forwardRef<
     queuedMessages = [],
     onRemoveQueuedMessage,
     onSteerQueuedMessage,
+    allowSteer,
   },
   ref,
 ) {
@@ -164,6 +166,7 @@ export const ChatInputForm = forwardRef<
               ? (index) => onSteerQueuedMessage(index)
               : undefined
           }
+          allowSteer={allowSteer}
         />
       )}
       {children}

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -62,10 +62,6 @@ vi.mock("@/features/approval", () => ({
   FixWidgetButton: () => null,
   isRetryApprovalCountingDown: () => false,
 }));
-vi.mock("@/features/chat", () => ({
-  useAutoApproveGuard: () => ({ current: "stop" }),
-  useToolCallLifeCycle: () => ({ completeToolCalls: [] }),
-}));
 vi.mock("@/features/settings", () => ({
   AutoApproveMenu: () => null,
   useAutoApprove: () => ({ autoApproveActive: false }),
@@ -125,10 +121,12 @@ vi.mock("../hooks/use-chat-input-state", () => ({
 }));
 vi.mock("../hooks/use-chat-status", () => ({
   useChatStatus: () => ({
-    isExecuting: false,
-    isBusyCore: false,
-    isSubmitDisabled: false,
-    showStopButton: false,
+    isAboutToExecuteWithAutoApprove: false,
+    isRunning: false,
+    isSubmitEnabled: true,
+    isStopEnabled: false,
+    allowSendMessage: true,
+    allowSteer: true,
   }),
 }));
 vi.mock("../hooks/use-chat-submit", () => ({

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -9,7 +9,9 @@ const chatSubmitMocks = vi.hoisted(() => ({
   useChatSubmit: vi.fn(() => ({
     handleSubmit: vi.fn(),
     handleSteerSubmit: vi.fn(),
+    handleSteerQueuedMessage: vi.fn(),
     handleStop: vi.fn(),
+    pauseQueueRef: { current: false },
   })),
 }));
 

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -13,7 +13,6 @@ import {
   isRetryApprovalCountingDown,
   type useApprovalAndRetry,
 } from "@/features/approval";
-import { useToolCallLifeCycle } from "@/features/chat";
 import {
   AutoApproveMenu,
   useAutoApprove,
@@ -118,7 +117,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   const { messages, sendMessage, addToolOutput, status } = chat;
   const isLoading = status === "streaming" || status === "submitted";
   const totalTokens = task?.totalTokens || 0;
-  const { completeToolCalls } = useToolCallLifeCycle();
 
   const { input, setInput, clearInput } = useChatInputState();
 
@@ -226,22 +224,25 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
 
   const blockingState = useBlockingOperations(blockingOperations);
 
-  const { isExecuting, isBusyCore, isSubmitDisabled, showStopButton } =
-    useChatStatus({
-      isModelsLoading,
-      isModelValid: !!selectedModel,
-      isLoading,
-      isInputEmpty: !input.text.trim() && queuedMessages.length === 0,
-      isFilesEmpty: files.length === 0,
-      isReviewsEmpty: reviews.length === 0,
-      isUploadingAttachments,
-      blockingState,
-    });
+  const {
+    isRunning,
+    isSubmitEnabled,
+    isStopEnabled,
+    allowSendMessage,
+    allowSteer,
+  } = useChatStatus({
+    isModelValid: !!selectedModel,
+    isLoading,
+    isInputEmpty: !input.text.trim() && queuedMessages.length === 0,
+    isFilesEmpty: files.length === 0,
+    isReviewsEmpty: reviews.length === 0,
+    isUploadingAttachments,
+    blockingState,
+    taskStatus: task?.status,
+  });
 
   const compactEnabled = !(
-    isLoading ||
-    isExecuting ||
-    totalTokens < constants.CompactTaskMinTokens
+    isRunning || totalTokens < constants.CompactTaskMinTokens
   );
   const AutoApproveIcon = autoApproveActive ? ShieldCheck : ShieldOff;
 
@@ -255,14 +256,17 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     input,
     clearInput,
     attachmentUpload,
-    isSubmitDisabled,
     isLoading,
+    isRunning,
+    isSubmitEnabled,
+    isStopEnabled,
+    allowSendMessage,
+    allowSteer,
     pendingApproval,
-    blockingState,
     queuedMessages,
     setQueuedMessages,
     reviews,
-    taskId: taskId,
+    taskId,
     includeUserEdits,
     isTodoMode: todoModeSelected,
     canCreateTodo: !todoModeDisabled,
@@ -271,27 +275,24 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   });
 
   // Auto dequeue when ready
+  const taskStatus = task?.status;
   useEffect(() => {
-    const isReady =
+    const shouldAutoDequeue =
       status === "ready" &&
-      !isExecuting &&
-      !isBusyCore &&
-      completeToolCalls.length === 0 &&
-      !!selectedModel &&
-      (!pendingApproval || pendingApproval.name === "retry") &&
-      (task?.status === "pending-input" || task?.status === "completed");
+      allowSendMessage &&
+      !pendingApproval &&
+      (taskStatus === undefined ||
+        taskStatus === "pending-input" ||
+        taskStatus === "completed");
 
-    if (isReady && queuedMessages.length > 0) {
+    if (shouldAutoDequeue && queuedMessages.length > 0) {
       handleSteerQueuedMessage(0);
     }
   }, [
     status,
-    isExecuting,
-    isBusyCore,
-    completeToolCalls.length,
-    selectedModel,
+    allowSendMessage,
     pendingApproval,
-    task?.status,
+    taskStatus,
     queuedMessages,
     handleSteerQueuedMessage,
   ]);
@@ -330,7 +331,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   const useTaskChangedFilesHelpers = useTaskChangedFiles(
     task?.id as string,
     messages,
-    isExecuting,
   );
 
   const showRenderWidgetFixButton =
@@ -339,7 +339,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     !pendingApproval;
 
   const showSubmitReviewButton =
-    !isSubmitDisabled &&
+    isSubmitEnabled &&
     !!reviews.length &&
     !!messages.length &&
     !isLoading &&
@@ -418,7 +418,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           setInput={setInput}
           onSubmit={handleSubmit}
           onCtrlSubmit={handleSteerSubmit}
-          isLoading={isLoading || isExecuting}
+          isLoading={isRunning}
           onPaste={handlePasteAttachment}
           pendingApproval={pendingApproval}
           status={status}
@@ -435,6 +435,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           queuedMessages={queuedMessages}
           onRemoveQueuedMessage={handleRemoveQueuedMessage}
           onSteerQueuedMessage={handleSteerQueuedMessage}
+          allowSteer={allowSteer}
           onAttachFile={() => fileInputRef.current?.click()}
           onSelectTodoMode={
             showTodoMode ? () => setTodoModeSelected(true) : undefined
@@ -531,8 +532,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             />
           )}
           <SubmitStopButton
-            isSubmitDisabled={isSubmitDisabled}
-            showStopButton={showStopButton}
+            isButtonEnabled={isSubmitEnabled || isStopEnabled}
+            showStopButton={isRunning}
             onSubmit={handleSubmit}
             onStop={handleStop}
           />
@@ -543,14 +544,14 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
 };
 
 interface SubmitStopButtonProps {
-  isSubmitDisabled: boolean;
+  isButtonEnabled: boolean;
   showStopButton: boolean;
   onSubmit: () => void;
   onStop: () => void;
 }
 
 const SubmitStopButton: React.FC<SubmitStopButtonProps> = ({
-  isSubmitDisabled,
+  isButtonEnabled,
   showStopButton,
   onSubmit,
   onStop,
@@ -560,7 +561,7 @@ const SubmitStopButton: React.FC<SubmitStopButtonProps> = ({
       type="button"
       variant="ghost"
       size="icon"
-      disabled={isSubmitDisabled}
+      disabled={!isButtonEnabled}
       className="button-focus h-6 w-6 p-0"
       onClick={() => {
         if (showStopButton) {

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -257,6 +257,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     attachmentUpload,
     isSubmitDisabled,
     isLoading,
+    isPendingToolCall: task?.status === "pending-tool",
     pendingApproval,
     blockingState,
     queuedMessages,

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -376,6 +376,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             onToolCallApprovalVisible={onToolCallApprovalVisible}
             onToolsExecutionStarted={onToolsExecutionStarted}
             onToolsExecutionEnded={onToolsExecutionEnded}
+            hasQueuedMessages={queuedMessages.length > 0}
+            onContinueWithQueuedMessage={() => handleSteerQueuedMessage(0)}
           />
           {showRenderWidgetFixButton ? (
             <div className="flex select-none gap-3 [&>button]:flex-1 [&>button]:rounded-sm">

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -257,7 +257,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     attachmentUpload,
     isSubmitDisabled,
     isLoading,
-    isPendingToolCall: task?.status === "pending-tool",
     pendingApproval,
     blockingState,
     queuedMessages,

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -13,7 +13,7 @@ import {
   isRetryApprovalCountingDown,
   type useApprovalAndRetry,
 } from "@/features/approval";
-import { useAutoApproveGuard, useToolCallLifeCycle } from "@/features/chat";
+import { useToolCallLifeCycle } from "@/features/chat";
 import {
   AutoApproveMenu,
   useAutoApprove,
@@ -48,14 +48,13 @@ import {
 } from "../hooks/use-blocking-operations";
 import { useChatInputState } from "../hooks/use-chat-input-state";
 import { useChatStatus } from "../hooks/use-chat-status";
-import { type QueuedMessage, useChatSubmit } from "../hooks/use-chat-submit";
+import { type DraftMessage, useChatSubmit } from "../hooks/use-chat-submit";
 import { useInlineCompactTask } from "../hooks/use-inline-compact-task";
 import { useNewCompactTask } from "../hooks/use-new-compact-task";
 import { useShowCompleteSubtaskButton } from "../hooks/use-subtask-completed";
 import type { SubtaskInfo } from "../hooks/use-subtask-info";
 import { ChatInputForm } from "./chat-input-form";
 import { ErrorMessageView } from "./error-message-view";
-import { QueuedMessages } from "./queued-messages";
 import { SubmitReviewsButton } from "./submit-review-button";
 import { CompleteSubtaskButton } from "./subtask";
 
@@ -123,7 +122,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
 
   const { input, setInput, clearInput } = useChatInputState();
 
-  const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
+  const [queuedMessages, setQueuedMessages] = useState<DraftMessage[]>([]);
   const [excludedUserEditsContext, setExcludedUserEditsContext] =
     useState<string>();
   const lastCheckpointHash = task?.lastCheckpointHash ?? undefined;
@@ -246,7 +245,12 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   );
   const AutoApproveIcon = autoApproveActive ? ShieldCheck : ShieldOff;
 
-  const { handleSubmit, handleSteerSubmit, handleStop } = useChatSubmit({
+  const {
+    handleSubmit,
+    handleSteerSubmit,
+    handleSteerQueuedMessage,
+    handleStop,
+  } = useChatSubmit({
     chat,
     input,
     clearInput,
@@ -266,20 +270,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     onBeforeSendText: createTodoBeforeSend,
   });
 
-  const autoApproveGuard = useAutoApproveGuard();
-  const handleSteerQueuedMessage = useCallback(
-    (index: number) => {
-      setQueuedMessages((prev) => {
-        const message = prev[index];
-        if (!message) return prev;
-        return [message, ...prev.filter((_, i) => i !== index)];
-      });
-      autoApproveGuard.current = "stop";
-      handleStop();
-    },
-    [autoApproveGuard, handleStop],
-  );
-
+  // Auto dequeue when ready
   useEffect(() => {
     const isReady =
       status === "ready" &&
@@ -287,10 +278,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
       !isBusyCore &&
       completeToolCalls.length === 0 &&
       !!selectedModel &&
-      (!pendingApproval || pendingApproval.name === "retry");
+      (!pendingApproval || pendingApproval.name === "retry") &&
+      (task?.status === "pending-input" || task?.status === "completed");
 
     if (isReady && queuedMessages.length > 0) {
-      handleSubmit(undefined, { flushQueuedMessages: true });
+      handleSteerQueuedMessage(0);
     }
   }, [
     status,
@@ -298,10 +290,19 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     isBusyCore,
     completeToolCalls.length,
     selectedModel,
-    queuedMessages.length,
     pendingApproval,
-    handleSubmit,
+    task?.status,
+    queuedMessages,
+    handleSteerQueuedMessage,
   ]);
+
+  // Remove a message from queue
+  const handleRemoveQueuedMessage = useCallback(
+    (index: number) => {
+      setQueuedMessages(queuedMessages.filter((_, i) => i !== index));
+    },
+    [queuedMessages],
+  );
 
   const allowAddToolResult = !blockingState.isBusy;
   useAddCompleteToolCalls({
@@ -355,7 +356,6 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   const hasVisibleChangedFiles =
     useTaskChangedFilesHelpers.visibleChangedFiles.length > 0;
   const hasVisibleContextPanel = hasVisibleTodos || hasVisibleChangedFiles;
-  const hasQueuedMessages = queuedMessages.length > 0;
 
   return (
     <>
@@ -388,24 +388,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           />
         </div>
       </div>
-      {hasQueuedMessages && (
-        <QueuedMessages
-          messages={queuedMessages}
-          onRemove={(index) =>
-            setQueuedMessages((prev) => prev.filter((_, i) => i !== index))
-          }
-          onSteer={handleSteerQueuedMessage}
-        />
-      )}
       {hasVisibleContextPanel && (
-        <div
-          className={cn(
-            "mt-1.5 rounded-sm rounded-b-none border border-border border-b-0",
-            {
-              "mt-0": hasQueuedMessages,
-            },
-          )}
-        >
+        <div className="mt-1.5 rounded-sm rounded-b-none border border-border border-b-0">
           {hasVisibleTodos && (
             <TodoList
               todos={visibleTodos}
@@ -446,6 +430,9 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           onRemoveUserEdits={() =>
             setExcludedUserEditsContext(userEditsContext)
           }
+          queuedMessages={queuedMessages}
+          onRemoveQueuedMessage={handleRemoveQueuedMessage}
+          onSteerQueuedMessage={handleSteerQueuedMessage}
           onAttachFile={() => fileInputRef.current?.click()}
           onSelectTodoMode={
             showTodoMode ? () => setTodoModeSelected(true) : undefined
@@ -453,7 +440,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           todoModeDisabled={todoModeDisabled}
           contextMenuSide="top"
           className={cn({
-            "rounded-t-none": hasVisibleContextPanel || hasQueuedMessages,
+            "rounded-t-none": hasVisibleContextPanel,
           })}
         >
           {files.length > 0 && (
@@ -566,8 +553,6 @@ const SubmitStopButton: React.FC<SubmitStopButtonProps> = ({
   onSubmit,
   onStop,
 }) => {
-  const autoApproveGuard = useAutoApproveGuard();
-
   return (
     <Button
       type="button"
@@ -577,7 +562,6 @@ const SubmitStopButton: React.FC<SubmitStopButtonProps> = ({
       className="button-focus h-6 w-6 p-0"
       onClick={() => {
         if (showStopButton) {
-          autoApproveGuard.current = "stop";
           onStop();
         } else {
           onSubmit();

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
@@ -120,6 +120,36 @@ describe("QueuedMessages", () => {
     expect(getByLabelText("activeSelectionBadge.terminal: bash")).toBeTruthy();
     expect(container.textContent).not.toContain("bash");
   });
+
+  it("disables the steer button when allowSteer is false", () => {
+    const { getByLabelText } = render(
+      <QueuedMessages
+        messages={[queuedMessage({ text: "check this" })]}
+        onRemove={vi.fn()}
+        onSteer={vi.fn()}
+        allowSteer={false}
+      />,
+    );
+
+    expect((getByLabelText("chat.steer") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("enables the steer button when allowSteer is true and onSteer is provided", () => {
+    const { getByLabelText } = render(
+      <QueuedMessages
+        messages={[queuedMessage({ text: "check this" })]}
+        onRemove={vi.fn()}
+        onSteer={vi.fn()}
+        allowSteer={true}
+      />,
+    );
+
+    expect((getByLabelText("chat.steer") as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
 });
 
 function queuedMessage({

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
+import type {
+  ActiveSelection,
+  TerminalTextSelection,
+} from "@getpochi/common/vscode-webui-bridge";
 import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { QueuedMessage } from "../hooks/use-chat-submit";
+import type { DraftMessage } from "../hooks/use-chat-submit";
 import { QueuedMessages } from "./queued-messages";
 
 vi.mock("react-i18next", () => ({
@@ -9,6 +13,17 @@ vi.mock("react-i18next", () => ({
     t: (key: string, values?: { count?: number }) =>
       values?.count === undefined ? key : `${key}:${values.count}`,
   }),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  isVSCodeEnvironment: () => false,
+  vscodeHost: {
+    openFile: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/hooks/use-visible-terminals", () => ({
+  useVisibleTerminals: () => ({ openBackgroundJobTerminal: vi.fn() }),
 }));
 
 describe("QueuedMessages", () => {
@@ -26,20 +41,94 @@ describe("QueuedMessages", () => {
     expect(container.querySelectorAll(".lucide-list-end")).toHaveLength(1);
     expect(container.querySelectorAll(".lucide-target")).toHaveLength(1);
   });
+
+  it("shows a fallback title and file/review counts when text is empty", () => {
+    const { getByText } = render(
+      <QueuedMessages
+        messages={[
+          queuedMessage({ text: "  ", filesCount: 2, reviewsCount: 1 }),
+        ]}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(getByText("chat.noMessage")).toBeTruthy();
+    expect(getByText("chat.fileCount:2 · chat.reviewCount:1")).toBeTruthy();
+  });
+
+  it("renders a minimal icon-only preview for the active editor selection captured at queue time", () => {
+    const activeSelection: ActiveSelection = {
+      filepath: "/workspace/foo.ts",
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 2, character: 0 },
+      },
+      content: "const foo = 1;",
+    };
+
+    const { container, getByLabelText } = render(
+      <QueuedMessages
+        messages={[queuedMessage({ text: "check this", activeSelection })]}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    // Icon-only trigger, keyed to the filepath, without a visible filename label.
+    expect(getByLabelText("/workspace/foo.ts")).toBeTruthy();
+    expect(container.textContent).not.toContain("foo.ts");
+  });
+
+  it("renders a minimal icon-only preview for the active terminal selection captured at queue time", () => {
+    const activeTerminalTextSelection: TerminalTextSelection = {
+      terminalName: "bash",
+      content: "echo hello",
+    };
+
+    const { container, getByLabelText } = render(
+      <QueuedMessages
+        messages={[
+          queuedMessage({
+            text: "check this",
+            activeTerminalTextSelection,
+          }),
+        ]}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    // Icon-only trigger, keyed to the terminal name, without a visible name label.
+    expect(getByLabelText("activeSelectionBadge.terminal: bash")).toBeTruthy();
+    expect(container.textContent).not.toContain("bash");
+  });
 });
 
 function queuedMessage({
   text,
   isTodoMode = false,
+  filesCount = 0,
+  reviewsCount = 0,
+  userEditsCount = 0,
+  activeSelection,
+  activeTerminalTextSelection,
 }: {
   text: string;
   isTodoMode?: boolean;
-}): QueuedMessage {
+  filesCount?: number;
+  reviewsCount?: number;
+  userEditsCount?: number;
+  activeSelection?: ActiveSelection;
+  activeTerminalTextSelection?: TerminalTextSelection;
+}): DraftMessage {
   return {
-    text,
-    files: [],
-    reviews: [],
-    userEdits: [],
-    isTodoMode,
+    parts: [],
+    raw: {
+      text,
+      filesCount,
+      reviewsCount,
+      userEditsCount,
+      isTodoMode,
+      activeSelection,
+      activeTerminalTextSelection,
+    },
   };
 }

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
@@ -56,6 +56,26 @@ describe("QueuedMessages", () => {
     expect(getByText("chat.fileCount:2 · chat.reviewCount:1")).toBeTruthy();
   });
 
+  it("shows the user edit count alongside file/review counts", () => {
+    const { getByText } = render(
+      <QueuedMessages
+        messages={[
+          queuedMessage({
+            text: "  ",
+            filesCount: 2,
+            reviewsCount: 1,
+            userEditsCount: 3,
+          }),
+        ]}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(
+      getByText("chat.fileCount:2 · chat.reviewCount:1 · chat.userEditCount:3"),
+    ).toBeTruthy();
+  });
+
   it("renders a minimal icon-only preview for the active editor selection captured at queue time", () => {
     const activeSelection: ActiveSelection = {
       filepath: "/workspace/foo.ts",

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
@@ -1,15 +1,47 @@
+import { CodeBlock } from "@/components/message";
 import { Button } from "@/components/ui/button";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { useVisibleTerminals } from "@/lib/hooks/use-visible-terminals";
 import { cn } from "@/lib/utils";
+import { getActiveSelectionLabel } from "@/lib/utils/active-selection";
+import {
+  getFileExtension,
+  languageIdFromExtension,
+} from "@/lib/utils/languages";
+import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
 import { parseTitle } from "@getpochi/common/message-utils";
-import { CornerDownRight, ListEnd, Target, Trash2 } from "lucide-react";
+import type {
+  ActiveSelection,
+  TerminalTextSelection,
+} from "@getpochi/common/vscode-webui-bridge";
+import {
+  CornerDownRight,
+  FileCode,
+  ListEnd,
+  Target,
+  TerminalIcon,
+  Trash2,
+} from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import type { QueuedMessage } from "../hooks/use-chat-submit";
+import type { DraftMessage } from "../hooks/use-chat-submit";
 
 interface QueuedMessagesProps {
-  messages: QueuedMessage[];
+  messages: DraftMessage[];
   onRemove: (index: number) => void;
   onSteer?: (index: number) => void;
+}
+
+interface RenderMessage {
+  title: string;
+  details: string;
+  isTodoMode?: boolean;
+  activeSelection?: ActiveSelection;
+  activeTerminalTextSelection?: TerminalTextSelection;
 }
 
 export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
@@ -18,26 +50,34 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
   onSteer,
 }) => {
   const { t } = useTranslation();
-  const renderMessages = useMemo(() => {
-    return messages.map(({ text, files, reviews, isTodoMode }) => {
+  const renderMessages = useMemo<RenderMessage[]>(() => {
+    return messages.map(({ raw }) => {
+      const {
+        text = "",
+        filesCount = 0,
+        reviewsCount = 0,
+        isTodoMode,
+        activeSelection,
+        activeTerminalTextSelection,
+      } = raw;
       const title = text.trim() ? parseTitle(text) : t("chat.noMessage");
       const details = [
-        files.length > 0 ? t("chat.fileCount", { count: files.length }) : "",
-        reviews.length > 0
-          ? t("chat.reviewCount", { count: reviews.length })
-          : "",
+        filesCount > 0 ? t("chat.fileCount", { count: filesCount }) : "",
+        reviewsCount > 0 ? t("chat.reviewCount", { count: reviewsCount }) : "",
       ].filter(Boolean);
 
       return {
         title,
         details: details.join(" · "),
         isTodoMode,
+        activeSelection,
+        activeTerminalTextSelection,
       };
     });
   }, [messages, t]);
 
   return (
-    <div className="mx-5 flex max-h-28 flex-col gap-0.5 overflow-y-auto rounded-t-sm border border-[var(--input-border)] border-b-0 bg-input px-3 pt-1.5 pb-1.5 shadow-lg">
+    <div className="mx-1 mt-1 mb-1.5 flex max-h-28 flex-col gap-0.5 overflow-y-auto rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
       {renderMessages.map((message, index) => (
         <div
           key={index}
@@ -65,6 +105,16 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
               </span>
             ) : null}
           </div>
+          {message.activeSelection && (
+            <ActiveSelectionPreviewIcon
+              activeSelection={message.activeSelection}
+            />
+          )}
+          {message.activeTerminalTextSelection && (
+            <TerminalSelectionPreviewIcon
+              terminalTextSelection={message.activeTerminalTextSelection}
+            />
+          )}
           <div className="flex shrink-0 items-center gap-1">
             <Button
               variant="ghost"
@@ -95,5 +145,117 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
         </div>
       ))}
     </div>
+  );
+};
+
+interface ActiveSelectionPreviewIconProps {
+  activeSelection: ActiveSelection;
+}
+
+const ActiveSelectionPreviewIcon: React.FC<ActiveSelectionPreviewIconProps> = ({
+  activeSelection,
+}) => {
+  const { t } = useTranslation();
+
+  if (!activeSelection) {
+    return null;
+  }
+
+  const { filepath, range, content, notebookCell } = activeSelection;
+
+  if (content.length === 0) {
+    return null;
+  }
+
+  const extension = getFileExtension(filepath);
+  const language = languageIdFromExtension(extension) || "typescript";
+  const label = getActiveSelectionLabel(activeSelection, t);
+
+  const onClick = () => {
+    if (!isVSCodeEnvironment()) return;
+    vscodeHost.openFile(filepath, {
+      start: range.start.line + 1,
+      end: range.end.line + 1,
+      cellId: notebookCell?.cellId,
+    });
+  };
+
+  return (
+    <HoverCard openDelay={300} closeDelay={200}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={filepath}
+          className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm hover:bg-zinc-200 active:bg-zinc-200 dark:active:bg-zinc-700 dark:hover:bg-zinc-700"
+        >
+          <FileCode className="size-3.5" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent className="w-auto max-w-[90vw] p-0" align="end">
+        <div className="flex max-w-[300px] items-center gap-1.5 truncate border-b px-2 py-1.5 font-medium text-xs">
+          <FileCode className="size-3.5 shrink-0" />
+          <span className="truncate">{label}</span>
+        </div>
+        <div className="max-h-[60vh] overflow-auto">
+          <CodeBlock
+            language={language}
+            value={content}
+            isMinimalView={true}
+            className="m-0 border-none"
+          />
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
+interface TerminalSelectionPreviewIconProps {
+  terminalTextSelection: TerminalTextSelection;
+}
+
+const TerminalSelectionPreviewIcon: React.FC<
+  TerminalSelectionPreviewIconProps
+> = ({ terminalTextSelection }) => {
+  const { t } = useTranslation();
+  const { terminalName, backgroundJobId, content } = terminalTextSelection;
+  const { openBackgroundJobTerminal } = useVisibleTerminals();
+
+  if (content.length === 0) {
+    return null;
+  }
+
+  const onClick = () => {
+    if (!isVSCodeEnvironment() || !backgroundJobId) return;
+    openBackgroundJobTerminal?.(backgroundJobId);
+  };
+
+  return (
+    <HoverCard openDelay={300} closeDelay={200}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={`${t("activeSelectionBadge.terminal")}: ${terminalName}`}
+          className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm hover:bg-zinc-200 active:bg-zinc-200 dark:active:bg-zinc-700 dark:hover:bg-zinc-700"
+        >
+          <TerminalIcon className="size-3.5" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent className="w-auto max-w-[90vw] p-0" align="end">
+        <div className="flex max-w-[300px] items-center gap-1.5 truncate border-b px-2 py-1.5 font-medium text-xs">
+          <TerminalIcon className="size-3.5 shrink-0" />
+          <span className="truncate">{terminalName}</span>
+        </div>
+        <div className="max-h-[60vh] overflow-auto">
+          <CodeBlock
+            language="shell"
+            value={content}
+            isMinimalView={true}
+            className="m-0 border-none"
+          />
+        </div>
+      </HoverCardContent>
+    </HoverCard>
   );
 };

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
@@ -34,6 +34,7 @@ interface QueuedMessagesProps {
   messages: DraftMessage[];
   onRemove: (index: number) => void;
   onSteer?: (index: number) => void;
+  allowSteer?: boolean;
 }
 
 interface RenderMessage {
@@ -48,6 +49,7 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
   messages,
   onRemove,
   onSteer,
+  allowSteer = true,
 }) => {
   const { t } = useTranslation();
   const renderMessages = useMemo<RenderMessage[]>(() => {
@@ -126,7 +128,7 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
               type="button"
               onClick={() => onSteer?.(index)}
               aria-label={t("chat.steer")}
-              disabled={!onSteer}
+              disabled={!onSteer || !allowSteer}
               className={cn(
                 "h-7 gap-1 rounded-full px-1.5 text-muted-foreground text-sm",
                 "hover:bg-transparent hover:text-foreground",

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
@@ -56,6 +56,7 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
         text = "",
         filesCount = 0,
         reviewsCount = 0,
+        userEditsCount = 0,
         isTodoMode,
         activeSelection,
         activeTerminalTextSelection,
@@ -64,6 +65,9 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
       const details = [
         filesCount > 0 ? t("chat.fileCount", { count: filesCount }) : "",
         reviewsCount > 0 ? t("chat.reviewCount", { count: reviewsCount }) : "",
+        userEditsCount > 0
+          ? t("chat.userEditCount", { count: userEditsCount })
+          : "",
       ].filter(Boolean);
 
       return {

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
@@ -1,8 +1,11 @@
-import { useToolCallLifeCycle } from "../lib/chat-state";
+import { getLogger } from "@getpochi/common";
+import type { Task } from "@getpochi/livekit";
+import { useAutoApproveGuard, useToolCallLifeCycle } from "../lib/chat-state";
 import type { BlockingState } from "./use-blocking-operations";
 
+const logger = getLogger("useChatStatus");
+
 interface UseChatStatusProps {
-  isModelsLoading: boolean;
   isModelValid: boolean;
   isLoading: boolean;
   isInputEmpty: boolean;
@@ -10,10 +13,10 @@ interface UseChatStatusProps {
   isReviewsEmpty: boolean;
   isUploadingAttachments: boolean;
   blockingState: BlockingState;
+  taskStatus: Task["status"] | undefined;
 }
 
 export function useChatStatus({
-  isModelsLoading,
   isModelValid,
   isLoading,
   isInputEmpty,
@@ -21,30 +24,54 @@ export function useChatStatus({
   isReviewsEmpty,
   isUploadingAttachments,
   blockingState,
+  taskStatus,
 }: UseChatStatusProps) {
-  const { isExecuting } = useToolCallLifeCycle();
+  const { isExecuting, completeToolCalls } = useToolCallLifeCycle();
+  const autoApproveGuard = useAutoApproveGuard();
+  const isAboutToExecuteWithAutoApprove =
+    !isLoading &&
+    !isExecuting &&
+    taskStatus === "pending-tool" &&
+    autoApproveGuard.current === "auto" &&
+    completeToolCalls.length === 0;
 
-  const isBusyCore = isModelsLoading || blockingState.isBusy;
+  const isRunning =
+    blockingState.isBusy ||
+    isLoading ||
+    isAboutToExecuteWithAutoApprove ||
+    isExecuting;
 
-  const showEditTodos = !isBusyCore;
+  // `submit`: send or queue message
+  const isSubmitEnabled =
+    !isUploadingAttachments &&
+    (!isInputEmpty || !isFilesEmpty || !isReviewsEmpty);
 
-  const isSubmitDisabled =
-    isBusyCore ||
-    !isModelValid ||
-    isUploadingAttachments ||
-    (!isLoading &&
-      isInputEmpty &&
-      isFilesEmpty &&
-      isReviewsEmpty &&
-      !isExecuting);
+  // `stop`: stop chat streaming or tool execution
+  const isStopEnabled =
+    !blockingState.isBusy &&
+    (isLoading || isAboutToExecuteWithAutoApprove || isExecuting);
 
-  const showStopButton = isExecuting || isLoading || isUploadingAttachments;
+  // `sendMessage`: start chat streaming
+  const allowSendMessage =
+    !blockingState.isBusy &&
+    isModelValid &&
+    !isLoading &&
+    !isAboutToExecuteWithAutoApprove &&
+    !isExecuting;
 
-  return {
-    isExecuting,
-    isBusyCore,
-    showEditTodos,
-    isSubmitDisabled,
-    showStopButton,
+  // `steer`: (if running, stop), then send a new message
+  const allowSteer = !blockingState.isBusy && isModelValid;
+
+  const allStatus = {
+    isAboutToExecuteWithAutoApprove,
+    isRunning,
+    isSubmitEnabled,
+    isStopEnabled,
+    allowSendMessage,
+    allowSteer,
   };
+
+  logger.trace("allStatus", allStatus);
+
+  return allStatus;
 }

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -622,6 +622,7 @@ function setup({
         } as never,
         isSubmitDisabled: false,
         isLoading: props.isLoading,
+        isPendingToolCall: false,
         includeUserEdits: props.includeUserEdits,
         blockingState: {
           isBusy: false,

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -606,6 +606,20 @@ function setup({
         setQueuedMessages(props.queuedMessages);
       }, [props.queuedMessages]);
 
+      // Mirrors the derivation performed by `useChatStatus` for a
+      // model-valid, non-blocking scenario, so these tests can focus on
+      // `useChatSubmit`'s own behavior without re-deriving all of the
+      // underlying blocking/model-loading state.
+      const isExecuting = chatStateMocks.isExecuting;
+      const isRunning = props.isLoading || isExecuting;
+      const isInputEmpty = !initialInputText.trim();
+      const isFilesEmpty = files.length === 0;
+      const isReviewsEmpty = reviews.length === 0;
+      const isSubmitEnabled = !isInputEmpty || !isFilesEmpty || !isReviewsEmpty;
+      const isStopEnabled = isRunning;
+      const allowSendMessage = !isRunning;
+      const allowSteer = true;
+
       const result = useChatSubmit({
         chat: {
           sendMessage,
@@ -620,14 +634,13 @@ function setup({
           clearFiles,
           clearError: vi.fn(),
         } as never,
-        isSubmitDisabled: false,
         isLoading: props.isLoading,
+        isRunning,
+        isSubmitEnabled,
+        isStopEnabled,
+        allowSendMessage,
+        allowSteer,
         includeUserEdits: props.includeUserEdits,
-        blockingState: {
-          isBusy: false,
-          busyLabel: undefined,
-          activeOperation: undefined,
-        },
         pendingApproval: undefined,
         queuedMessages,
         setQueuedMessages,

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -622,7 +622,6 @@ function setup({
         } as never,
         isSubmitDisabled: false,
         isLoading: props.isLoading,
-        isPendingToolCall: false,
         includeUserEdits: props.includeUserEdits,
         blockingState: {
           isBusy: false,

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -1,9 +1,13 @@
-import type { Review } from "@getpochi/common/vscode-webui-bridge";
+import type {
+  ActiveSelection,
+  Review,
+  TerminalTextSelection,
+} from "@getpochi/common/vscode-webui-bridge";
 // @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
-import type React from "react";
+import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { type QueuedMessage, useChatSubmit } from "./use-chat-submit";
+import { type DraftMessage, useChatSubmit } from "./use-chat-submit";
 
 const chatStateMocks = vi.hoisted(() => ({
   autoApproveGuard: { current: "auto" },
@@ -15,7 +19,11 @@ const messageUtilsMocks = vi.hoisted(() => ({
 }));
 const vscodeMocks = vi.hoisted(() => ({
   deleteReviews: vi.fn(),
-  readTerminalSelection: vi.fn(async () => undefined),
+  readTerminalSelection: vi.fn(async () => undefined as unknown),
+  isVSCodeEnvironment: { value: false },
+}));
+const activeSelectionMock = vi.hoisted(() => ({
+  value: undefined as ActiveSelection | undefined,
 }));
 const userEditsMocks = vi.hoisted(() => ({
   userEdits: [] as Array<{
@@ -31,7 +39,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/lib/hooks/use-active-selection", () => ({
-  useActiveSelection: () => undefined,
+  useActiveSelection: () => activeSelectionMock.value,
 }));
 
 vi.mock("@/lib/hooks/use-user-edits", () => ({
@@ -43,7 +51,7 @@ vi.mock("@/lib/message-utils", () => ({
 }));
 
 vi.mock("@/lib/vscode", () => ({
-  isVSCodeEnvironment: () => false,
+  isVSCodeEnvironment: () => vscodeMocks.isVSCodeEnvironment.value,
   vscodeHost: {
     deleteReviews: vscodeMocks.deleteReviews,
     readTerminalSelection: vscodeMocks.readTerminalSelection,
@@ -66,304 +74,390 @@ describe("useChatSubmit", () => {
     vscodeMocks.readTerminalSelection.mockReset();
     vscodeMocks.readTerminalSelection.mockResolvedValue(undefined);
     userEditsMocks.userEdits = [];
+    vscodeMocks.isVSCodeEnvironment.value = false;
+    activeSelectionMock.value = undefined;
   });
 
-  it("queues Enter submissions while the chat is busy without stopping", async () => {
-    const context = setup({ isLoading: true });
+  describe("handleSubmit", () => {
+    it("queues Enter submissions while the chat is busy without stopping", async () => {
+      const context = setup({ isLoading: true });
 
-    await act(async () => {
-      await context.hook.result.current.handleSubmit();
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
+
+      expect(context.queuedMessages).toEqual([
+        draftMessage({ text: "follow up" }),
+      ]);
+      expect(context.clearInput).toHaveBeenCalledOnce();
+      expect(context.stopChat).not.toHaveBeenCalled();
+      expect(context.sendMessage).not.toHaveBeenCalled();
+      expect(chatStateMocks.autoApproveGuard.current).toBe("auto");
     });
 
-    expect(context.queuedMessages).toEqual([
-      queuedMessage({ text: "follow up" }),
-    ]);
-    expect(context.clearInput).toHaveBeenCalledOnce();
-    expect(context.stopChat).not.toHaveBeenCalled();
-    expect(chatStateMocks.batchAbort).not.toHaveBeenCalled();
-    expect(context.sendMessage).not.toHaveBeenCalled();
-    expect(chatStateMocks.autoApproveGuard.current).toBe("auto");
-  });
+    it("also queues while tool calls are executing", async () => {
+      chatStateMocks.isExecuting = true;
+      const context = setup({ isLoading: false });
 
-  it("queues Command+Enter submissions and stops the current stream", async () => {
-    const context = setup({ isLoading: true });
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
 
-    await act(async () => {
-      await context.hook.result.current.handleSteerSubmit();
+      expect(context.queuedMessages).toEqual([
+        draftMessage({ text: "follow up" }),
+      ]);
+      expect(context.sendMessage).not.toHaveBeenCalled();
     });
 
-    expect(context.queuedMessages).toEqual([
-      queuedMessage({ text: "follow up" }),
-    ]);
-    expect(context.clearInput).toHaveBeenCalledOnce();
-    expect(context.stopChat).toHaveBeenCalledOnce();
-    expect(context.sendMessage).not.toHaveBeenCalled();
-    expect(chatStateMocks.autoApproveGuard.current).toBe("stop");
-  });
+    it("does nothing for an empty submission", async () => {
+      const context = setup({ isLoading: false, inputText: "" });
 
-  it("does not interrupt Command+Enter when there is no current or queued message", async () => {
-    const context = setup({ isLoading: true, inputText: "" });
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
 
-    await act(async () => {
-      await context.hook.result.current.handleSteerSubmit();
+      expect(context.queuedMessages).toEqual([]);
+      expect(context.clearInput).not.toHaveBeenCalled();
+      expect(context.sendMessage).not.toHaveBeenCalled();
     });
 
-    expect(context.queuedMessages).toEqual([]);
-    expect(context.clearInput).not.toHaveBeenCalled();
-    expect(context.stopChat).not.toHaveBeenCalled();
-    expect(context.sendMessage).not.toHaveBeenCalled();
-    expect(chatStateMocks.autoApproveGuard.current).toBe("auto");
-  });
+    it("sends immediately when the chat is idle", async () => {
+      const context = setup({ isLoading: false });
 
-  it("keeps the visible queue stable when Command+Enter interrupts with queued messages", async () => {
-    const firstQueuedMessage = queuedMessage({ text: "first queued message" });
-    const context = setup({
-      isLoading: true,
-      queuedMessages: [firstQueuedMessage],
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
+
+      expect(context.clearInput).toHaveBeenCalledOnce();
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:follow up"],
+      });
+      expect(chatStateMocks.autoApproveGuard.current).toBe("auto");
     });
 
-    await act(async () => {
-      await context.hook.result.current.handleSteerSubmit();
+    it("sends immediately when idle even if messages are already queued", async () => {
+      const existing = draftMessage({ text: "already queued" });
+      const context = setup({
+        isLoading: false,
+        queuedMessages: [existing],
+      });
+
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
+
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:follow up"],
+      });
+      // The pre-existing queue is left untouched by an immediate send.
+      expect(context.queuedMessages).toEqual([existing]);
     });
 
-    expect(context.queuedMessages).toEqual([firstQueuedMessage]);
-    expect(context.clearInput).toHaveBeenCalledOnce();
-    expect(context.stopChat).toHaveBeenCalledOnce();
-    expect(context.sendMessage).not.toHaveBeenCalled();
-    expect(chatStateMocks.autoApproveGuard.current).toBe("stop");
+    it("queues files and reviews while the chat is busy", async () => {
+      const file = new File(["image"], "queued.png", { type: "image/png" });
+      const review = createReview("review-1");
+      const context = setup({
+        isLoading: true,
+        files: [file],
+        reviews: [review],
+      });
 
-    context.setIsLoading(false);
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
+
+      expect(context.queuedMessages).toEqual([
+        draftMessage({ text: "follow up", filesCount: 1, reviewsCount: 1 }),
+      ]);
+      expect(context.upload).toHaveBeenCalledOnce();
+      expect(context.clearInput).toHaveBeenCalledOnce();
+      expect(context.clearFiles).toHaveBeenCalledOnce();
+      expect(vscodeMocks.deleteReviews).toHaveBeenCalledWith(["review-1"]);
+      expect(context.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("captures todo mode on queued submissions and resets it", async () => {
+      const onTodoModeQueued = vi.fn();
+      const context = setup({
+        isLoading: true,
+        isTodoMode: true,
+        onTodoModeQueued,
+      });
+
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
+
+      expect(context.queuedMessages).toEqual([
+        draftMessage({ text: "follow up", isTodoMode: true }),
+      ]);
+      expect(onTodoModeQueued).toHaveBeenCalledOnce();
+    });
+
+    it("triggers onBeforeSendText when sending an immediate todo-mode message", async () => {
+      const onBeforeSendText = vi.fn();
+      const context = setup({
+        isLoading: false,
+        isTodoMode: true,
+        onBeforeSendText,
+      });
+
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
+
+      expect(onBeforeSendText).toHaveBeenCalledWith("follow up");
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:follow up"],
       });
     });
 
-    expect(context.queuedMessages).toEqual([firstQueuedMessage]);
-    expect(context.sendMessage).toHaveBeenNthCalledWith(1, {
-      parts: ["text:follow up"],
+    it("does not trigger onBeforeSendText when todo creation is disabled", async () => {
+      const onBeforeSendText = vi.fn();
+      const context = setup({
+        isLoading: false,
+        isTodoMode: true,
+        canCreateTodo: false,
+        onBeforeSendText,
+      });
+
+      await act(async () => {
+        await context.result.current.handleSubmit();
+      });
+
+      expect(onBeforeSendText).not.toHaveBeenCalled();
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:follow up"],
+      });
+    });
+  });
+
+  describe("handleSteerSubmit", () => {
+    it("stops the current stream and sends the message immediately", async () => {
+      const context = setup({ isLoading: true });
+
+      let promise: Promise<void>;
+      await act(async () => {
+        promise = context.result.current.handleSteerSubmit();
+      });
+
+      await act(async () => {
+        context.rerender({ isLoading: false });
+      });
+
+      await act(async () => {
+        await promise;
+      });
+
+      expect(context.clearInput).toHaveBeenCalledOnce();
+      expect(context.stopChat).toHaveBeenCalledOnce();
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:follow up"],
+      });
+      expect(context.queuedMessages).toEqual([]);
+      expect(chatStateMocks.autoApproveGuard.current).toBe("auto");
     });
 
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
+    it("aborts executing tool calls before sending", async () => {
+      chatStateMocks.isExecuting = true;
+      const context = setup({ isLoading: false });
+
+      let promise: Promise<void>;
+      await act(async () => {
+        promise = context.result.current.handleSteerSubmit();
+      });
+
+      await act(async () => {
+        chatStateMocks.isExecuting = false;
+        context.rerender({ isLoading: false });
+      });
+
+      await act(async () => {
+        await promise;
+      });
+
+      expect(chatStateMocks.batchAbort).toHaveBeenCalledOnce();
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:follow up"],
       });
     });
 
-    expect(context.queuedMessages).toEqual([]);
-    expect(context.sendMessage).toHaveBeenNthCalledWith(2, {
-      parts: ["text:first queued message"],
-    });
-  });
+    it("sends immediately without stopping when the chat is already idle", async () => {
+      const context = setup({ isLoading: false });
 
-  it("stores Command+Enter submissions as hidden pending messages while idle with queued messages", async () => {
-    const firstQueuedMessage = queuedMessage({ text: "first queued message" });
-    const context = setup({
-      isLoading: false,
-      queuedMessages: [firstQueuedMessage],
-    });
+      await act(async () => {
+        await context.result.current.handleSteerSubmit();
+      });
 
-    await act(async () => {
-      await context.hook.result.current.handleSteerSubmit();
-    });
-
-    expect(context.queuedMessages).toEqual([firstQueuedMessage]);
-    expect(context.clearInput).toHaveBeenCalledOnce();
-    expect(context.stopChat).not.toHaveBeenCalled();
-    expect(context.sendMessage).not.toHaveBeenCalled();
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
+      expect(context.stopChat).not.toHaveBeenCalled();
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:follow up"],
       });
     });
 
-    expect(context.queuedMessages).toEqual([firstQueuedMessage]);
-    expect(context.sendMessage).toHaveBeenCalledWith({
-      parts: ["text:follow up"],
-    });
-  });
+    it("does not interrupt or send when there is nothing to submit", async () => {
+      const context = setup({ isLoading: true, inputText: "" });
 
-  it("keeps adding Enter submissions when queued messages already exist", async () => {
-    const context = setup({
-      isLoading: false,
-      queuedMessages: [queuedMessage({ text: "first queued message" })],
-    });
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit();
-    });
-
-    expect(context.queuedMessages).toEqual([
-      queuedMessage({ text: "first queued message" }),
-      queuedMessage({ text: "follow up" }),
-    ]);
-    expect(context.clearInput).toHaveBeenCalledOnce();
-    expect(context.sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("flushes only queued messages for the ready effect", async () => {
-    const context = setup({
-      isLoading: false,
-      queuedMessages: [
-        queuedMessage({ text: "first queued message" }),
-        queuedMessage({ text: "second queued message" }),
-      ],
-    });
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
+      await act(async () => {
+        await context.result.current.handleSteerSubmit();
       });
-    });
 
-    expect(context.queuedMessages).toEqual([
-      queuedMessage({ text: "second queued message" }),
-    ]);
-    expect(context.clearInput).not.toHaveBeenCalled();
-    expect(context.sendMessage).toHaveBeenCalledWith({
-      parts: ["text:first queued message"],
+      expect(context.clearInput).not.toHaveBeenCalled();
+      expect(context.stopChat).not.toHaveBeenCalled();
+      expect(context.sendMessage).not.toHaveBeenCalled();
     });
   });
 
-  it("queues files and reviews while the chat is busy", async () => {
-    const file = new File(["image"], "queued.png", { type: "image/png" });
-    const review = createReview("review-1");
-    const context = setup({
-      isLoading: true,
-      files: [file],
-      reviews: [review],
-    });
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit();
-    });
-
-    expect(context.queuedMessages).toEqual([
-      queuedMessage({ text: "follow up", files: [file], reviews: [review] }),
-    ]);
-    expect(context.clearInput).toHaveBeenCalledOnce();
-    expect(context.clearFiles).toHaveBeenCalledOnce();
-    expect(vscodeMocks.deleteReviews).toHaveBeenCalledWith(["review-1"]);
-    expect(context.sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("captures todo mode on queued submissions", async () => {
-    const context = setup({ isLoading: true, isTodoMode: true });
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit();
-    });
-
-    expect(context.queuedMessages).toEqual([
-      queuedMessage({ text: "follow up", isTodoMode: true }),
-    ]);
-  });
-
-  it("resets todo mode after queueing a todo submission", async () => {
-    const onTodoModeQueued = vi.fn();
-    const context = setup({
-      isLoading: true,
-      isTodoMode: true,
-      onTodoModeQueued,
-    });
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit();
-    });
-
-    expect(onTodoModeQueued).toHaveBeenCalledOnce();
-  });
-
-  it("uses queued todo mode when flushing queued messages", async () => {
-    const onBeforeSendText = vi.fn();
-    const context = setup({
-      isLoading: false,
-      isTodoMode: true,
-      onBeforeSendText,
-      queuedMessages: [
-        queuedMessage({ text: "regular queued message", isTodoMode: false }),
-        queuedMessage({ text: "todo queued message", isTodoMode: true }),
-      ],
-    });
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
+  describe("handleSteerQueuedMessage", () => {
+    it("stops the current stream, sends the selected queued message, and removes it from the queue", async () => {
+      const first = draftMessage({ text: "first queued message" });
+      const second = draftMessage({ text: "second queued message" });
+      const context = setup({
+        isLoading: true,
+        queuedMessages: [first, second],
       });
-    });
-    expect(onBeforeSendText).not.toHaveBeenCalled();
 
-    context.hook.rerender();
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
+      let promise: Promise<void>;
+      await act(async () => {
+        promise = context.result.current.handleSteerQueuedMessage(0);
       });
+
+      await act(async () => {
+        context.rerender({ isLoading: false });
+      });
+
+      await act(async () => {
+        await promise;
+      });
+
+      expect(context.stopChat).toHaveBeenCalledOnce();
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:first queued message"],
+      });
+      expect(context.queuedMessages).toEqual([second]);
     });
-    expect(onBeforeSendText).toHaveBeenCalledWith("todo queued message");
+
+    it("does nothing when the index has no matching queued message", () => {
+      const context = setup({ isLoading: true, queuedMessages: [] });
+
+      act(() => {
+        context.result.current.handleSteerQueuedMessage(0);
+      });
+
+      expect(context.stopChat).not.toHaveBeenCalled();
+      expect(context.sendMessage).not.toHaveBeenCalled();
+      expect(context.queuedMessages).toEqual([]);
+    });
   });
 
-  it("does not apply queued todo mode when todo creation is disabled", async () => {
-    const onBeforeSendText = vi.fn();
-    const context = setup({
-      isLoading: false,
-      canCreateTodo: false,
-      onBeforeSendText,
-      queuedMessages: [
-        queuedMessage({ text: "todo queued message", isTodoMode: true }),
-      ],
-    });
-
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
-      });
-    });
-
-    expect(onBeforeSendText).not.toHaveBeenCalled();
-    expect(context.sendMessage).toHaveBeenCalledWith({
-      parts: ["text:todo queued message"],
-    });
-  });
-
-  it("flushes queued files and reviews from the queued item", async () => {
-    const file = new File(["image"], "queued.png", { type: "image/png" });
-    const review = createReview("review-1");
-    const uploadedFile = {
-      type: "file" as const,
-      filename: "queued.png",
-      mediaType: "image/png",
-      url: "blob:queued",
+  it("captures selection context when the message is created and reuses it when a queued message is later steered, instead of re-reading it at flush time", async () => {
+    const queueTimeActiveSelection: ActiveSelection = {
+      filepath: "/workspace/queued.ts",
+      range: {
+        start: { line: 1, character: 0 },
+        end: { line: 1, character: 5 },
+      },
+      content: "queue-time selection",
     };
-    const context = setup({
-      isLoading: false,
-      queuedMessages: [
-        queuedMessage({ text: "check this", files: [file], reviews: [review] }),
-      ],
-      uploadFiles: vi.fn(() => Promise.resolve([uploadedFile])),
+    const queueTimeTerminalSelection: TerminalTextSelection = {
+      terminalName: "queue-time terminal",
+      content: "queue-time terminal text",
+    };
+
+    vscodeMocks.isVSCodeEnvironment.value = true;
+    activeSelectionMock.value = queueTimeActiveSelection;
+    vscodeMocks.readTerminalSelection.mockResolvedValue(
+      queueTimeTerminalSelection,
+    );
+
+    const context = setup({ isLoading: true });
+
+    // Queue the message while the chat is busy: this is where selection
+    // context is captured.
+    await act(async () => {
+      await context.result.current.handleSubmit();
+    });
+
+    expect(vscodeMocks.readTerminalSelection).toHaveBeenCalledOnce();
+    expect(context.queuedMessages).toEqual([
+      draftMessage({
+        text: "follow up",
+        activeSelection: queueTimeActiveSelection,
+        activeTerminalTextSelection: queueTimeTerminalSelection,
+      }),
+    ]);
+
+    // Selection changes before the queued message is actually flushed.
+    activeSelectionMock.value = {
+      filepath: "/workspace/other.ts",
+      range: {
+        start: { line: 9, character: 0 },
+        end: { line: 9, character: 3 },
+      },
+      content: "send-time selection",
+    };
+    vscodeMocks.readTerminalSelection.mockResolvedValue({
+      terminalName: "send-time terminal",
+      content: "send-time terminal text",
+    });
+
+    let steerPromise: Promise<void>;
+    await act(async () => {
+      steerPromise = context.result.current.handleSteerQueuedMessage(0);
     });
 
     await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
-      });
+      context.rerender({ isLoading: false });
     });
 
-    expect(context.uploadFiles).toHaveBeenCalledWith([file]);
+    await act(async () => {
+      await steerPromise;
+    });
+
+    // The message was already fully prepared at queue time, so flushing it
+    // must not re-read the selection context.
+    expect(vscodeMocks.readTerminalSelection).toHaveBeenCalledOnce();
+    expect(context.sendMessage).toHaveBeenCalledWith({
+      parts: ["text:follow up"],
+    });
+  });
+
+  it("still captures selection context at send time for a fresh, non-queued submission", async () => {
+    const sendTimeActiveSelection: ActiveSelection = {
+      filepath: "/workspace/fresh.ts",
+      range: {
+        start: { line: 2, character: 0 },
+        end: { line: 2, character: 4 },
+      },
+      content: "fresh selection",
+    };
+    const sendTimeTerminalSelection: TerminalTextSelection = {
+      terminalName: "fresh terminal",
+      content: "fresh terminal text",
+    };
+
+    vscodeMocks.isVSCodeEnvironment.value = true;
+    activeSelectionMock.value = sendTimeActiveSelection;
+    vscodeMocks.readTerminalSelection.mockResolvedValue(
+      sendTimeTerminalSelection,
+    );
+
+    const context = setup({ isLoading: false });
+
+    await act(async () => {
+      await context.result.current.handleSubmit();
+    });
+
+    expect(vscodeMocks.readTerminalSelection).toHaveBeenCalledOnce();
     expect(messageUtilsMocks.prepareMessageParts).toHaveBeenCalledWith(
       expect.any(Function),
-      "check this",
-      [uploadedFile],
-      [review],
+      "follow up",
       [],
-      undefined,
-      undefined,
+      [],
+      [],
+      sendTimeActiveSelection,
+      sendTimeTerminalSelection,
     );
-    expect(context.clearFiles).not.toHaveBeenCalled();
-    expect(context.sendMessage).toHaveBeenCalledWith({
-      parts: ["text:check this"],
-    });
   });
 
   it("excludes user edits after they are removed from the input", async () => {
@@ -381,7 +475,7 @@ describe("useChatSubmit", () => {
     });
 
     await act(async () => {
-      await context.hook.result.current.handleSubmit();
+      await context.result.current.handleSubmit();
     });
 
     expect(messageUtilsMocks.prepareMessageParts).toHaveBeenCalledWith(
@@ -395,7 +489,7 @@ describe("useChatSubmit", () => {
     );
   });
 
-  it("preserves excluded user edits when flushing a queued message", async () => {
+  it("preserves excluded user edits when creating a queued message", async () => {
     userEditsMocks.userEdits = [
       {
         filepath: "src/example.ts",
@@ -410,19 +504,7 @@ describe("useChatSubmit", () => {
     });
 
     await act(async () => {
-      await context.hook.result.current.handleSubmit();
-    });
-
-    expect(context.queuedMessages).toEqual([
-      queuedMessage({ text: "follow up", userEdits: [] }),
-    ]);
-
-    context.setIsLoading(false);
-    context.setIncludeUserEdits(true);
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
-      });
+      await context.result.current.handleSubmit();
     });
 
     expect(messageUtilsMocks.prepareMessageParts).toHaveBeenCalledWith(
@@ -434,9 +516,13 @@ describe("useChatSubmit", () => {
       undefined,
       undefined,
     );
+
+    expect(context.queuedMessages).toEqual([
+      draftMessage({ text: "follow up", userEditsCount: 0 }),
+    ]);
   });
 
-  it("preserves included user edits when flushing a queued message", async () => {
+  it("preserves included user edits when creating a queued message", async () => {
     const queuedUserEdits = [
       {
         filepath: "src/example.ts",
@@ -452,28 +538,15 @@ describe("useChatSubmit", () => {
     });
 
     await act(async () => {
-      await context.hook.result.current.handleSubmit();
+      await context.result.current.handleSubmit();
     });
 
     expect(context.queuedMessages).toEqual([
-      queuedMessage({ text: "follow up", userEdits: queuedUserEdits }),
+      draftMessage({
+        text: "follow up",
+        userEditsCount: queuedUserEdits.length,
+      }),
     ]);
-
-    userEditsMocks.userEdits = [
-      {
-        filepath: "src/other.ts",
-        diff: "+const value = 2;",
-        added: 1,
-        removed: 0,
-      },
-    ];
-    context.setIsLoading(false);
-    context.setIncludeUserEdits(false);
-    await act(async () => {
-      await context.hook.result.current.handleSubmit(undefined, {
-        flushQueuedMessages: true,
-      });
-    });
 
     expect(messageUtilsMocks.prepareMessageParts).toHaveBeenCalledWith(
       expect.any(Function),
@@ -493,16 +566,15 @@ function setup({
   queuedMessages: initialQueuedMessages = [],
   files = [],
   reviews = [],
-  includeUserEdits = true,
+  includeUserEdits: initialIncludeUserEdits = true,
   isTodoMode = false,
   canCreateTodo = true,
   onTodoModeQueued,
   onBeforeSendText,
-  uploadFiles = vi.fn(() => Promise.resolve([])),
 }: {
   isLoading: boolean;
   inputText?: string;
-  queuedMessages?: QueuedMessage[];
+  queuedMessages?: DraftMessage[];
   files?: File[];
   reviews?: Review[];
   includeUserEdits?: boolean;
@@ -510,17 +582,7 @@ function setup({
   canCreateTodo?: boolean;
   onTodoModeQueued?: () => void;
   onBeforeSendText?: (text: string) => void;
-  uploadFiles?: ReturnType<typeof vi.fn>;
 }) {
-  let queuedMessages = initialQueuedMessages;
-  let isLoading = initialIsLoading;
-  let shouldIncludeUserEdits = includeUserEdits;
-  const setQueuedMessages = vi.fn(
-    (value: React.SetStateAction<QueuedMessage[]>) => {
-      queuedMessages =
-        typeof value === "function" ? value(queuedMessages) : value;
-    },
-  ) as React.Dispatch<React.SetStateAction<QueuedMessage[]>>;
   const sendMessage = vi.fn(() => Promise.resolve());
   const stopChat = vi.fn();
   const clearInput = vi.fn();
@@ -528,82 +590,119 @@ function setup({
 
   const upload = vi.fn(() => Promise.resolve([]));
 
-  const hook = renderHook(() =>
-    useChatSubmit({
-      chat: {
-        sendMessage,
-        stop: stopChat,
+  const hook = renderHook(
+    (props: {
+      isLoading: boolean;
+      includeUserEdits: boolean;
+      queuedMessages: DraftMessage[];
+    }) => {
+      const [queuedMessages, setQueuedMessages] = React.useState(
+        props.queuedMessages,
+      );
+
+      // Keep the state in sync with props for manual rerenders if needed,
+      // but also allow internal state updates to trigger rerenders.
+      React.useEffect(() => {
+        setQueuedMessages(props.queuedMessages);
+      }, [props.queuedMessages]);
+
+      const result = useChatSubmit({
+        chat: {
+          sendMessage,
+          stop: stopChat,
+        },
+        input: { json: null, text: initialInputText },
+        clearInput,
+        attachmentUpload: {
+          files,
+          isUploading: false,
+          upload,
+          clearFiles,
+          clearError: vi.fn(),
+        } as never,
+        isSubmitDisabled: false,
+        isLoading: props.isLoading,
+        includeUserEdits: props.includeUserEdits,
+        blockingState: {
+          isBusy: false,
+          busyLabel: undefined,
+          activeOperation: undefined,
+        },
+        pendingApproval: undefined,
+        queuedMessages,
+        setQueuedMessages,
+        reviews,
+        taskId: "task-1",
+        isTodoMode,
+        canCreateTodo,
+        onTodoModeQueued,
+        onBeforeSendText,
+      });
+
+      return { ...result, queuedMessages };
+    },
+    {
+      initialProps: {
+        isLoading: initialIsLoading,
+        includeUserEdits: initialIncludeUserEdits,
+        queuedMessages: initialQueuedMessages,
       },
-      input: { json: null, text: initialInputText },
-      clearInput,
-      attachmentUpload: {
-        files,
-        isUploading: false,
-        upload,
-        uploadFiles,
-        clearFiles,
-        clearError: vi.fn(),
-      } as never,
-      isSubmitDisabled: false,
-      isLoading,
-      blockingState: {
-        isBusy: false,
-        busyLabel: undefined,
-        activeOperation: undefined,
-      },
-      pendingApproval: undefined,
-      queuedMessages,
-      setQueuedMessages,
-      reviews,
-      taskId: "task-1",
-      includeUserEdits: shouldIncludeUserEdits,
-      isTodoMode,
-      canCreateTodo,
-      onTodoModeQueued,
-      onBeforeSendText,
-    }),
+    },
   );
 
   return {
-    hook,
+    result: hook.result,
+    rerender: (
+      props: Partial<{
+        isLoading: boolean;
+        includeUserEdits: boolean;
+        queuedMessages: DraftMessage[];
+      }>,
+    ) =>
+      hook.rerender({
+        isLoading: props.isLoading ?? initialIsLoading,
+        includeUserEdits: props.includeUserEdits ?? initialIncludeUserEdits,
+        queuedMessages: props.queuedMessages ?? initialQueuedMessages,
+      }),
     get queuedMessages() {
-      return queuedMessages;
+      return hook.result.current.queuedMessages;
     },
     clearInput,
     clearFiles,
-    uploadFiles,
+    upload,
     sendMessage,
     stopChat,
-    setIsLoading(value: boolean) {
-      isLoading = value;
-      hook.rerender();
-    },
-    setIncludeUserEdits(value: boolean) {
-      shouldIncludeUserEdits = value;
-      hook.rerender();
-    },
   };
 }
 
-function queuedMessage({
+function draftMessage({
   text,
-  files = [],
-  reviews = [],
-  userEdits = [],
+  filesCount = 0,
+  reviewsCount = 0,
+  userEditsCount = 0,
   isTodoMode = false,
+  activeSelection,
+  activeTerminalTextSelection,
 }: {
   text: string;
-  files?: File[];
-  reviews?: Review[];
-  userEdits?: QueuedMessage["userEdits"];
+  filesCount?: number;
+  reviewsCount?: number;
+  userEditsCount?: number;
   isTodoMode?: boolean;
-}): QueuedMessage {
+  activeSelection?: ActiveSelection;
+  activeTerminalTextSelection?: TerminalTextSelection;
+}): DraftMessage {
   return {
-    text,
-    files,
-    reviews,
-    userEdits,
-    isTodoMode,
+    parts: [`text:${text}`] as unknown as DraftMessage["parts"],
+    raw: {
+      text,
+      filesCount,
+      reviewsCount,
+      userEditsCount,
+      isTodoMode,
+      activeSelection,
+      activeTerminalTextSelection,
+    },
   };
 }
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -8,9 +8,14 @@ import type { Message } from "@getpochi/livekit";
 
 import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import { useUserEdits } from "@/lib/hooks/use-user-edits";
-import type { FileDiff, Review } from "@getpochi/common/vscode-webui-bridge";
+import type {
+  ActiveSelection,
+  Review,
+  TerminalTextSelection,
+} from "@getpochi/common/vscode-webui-bridge";
+import type { FileUIPart } from "ai";
 import type React from "react";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useAutoApproveGuard,
@@ -23,19 +28,19 @@ import type { ChatInput } from "./use-chat-input-state";
 const logger = getLogger("UseChatSubmit");
 
 type UseChatReturn = Pick<UseChatHelpers<Message>, "sendMessage" | "stop">;
-
 type UseAttachmentUploadReturn = ReturnType<typeof useAttachmentUpload>;
 
-export interface QueuedMessage {
-  text: string;
-  files: File[];
-  reviews: Review[];
-  userEdits: FileDiff[];
-  isTodoMode: boolean;
-}
-
-interface SubmitOptions {
-  flushQueuedMessages?: boolean;
+export interface DraftMessage {
+  parts: Message["parts"];
+  raw: {
+    text?: string;
+    filesCount?: number;
+    reviewsCount?: number;
+    userEditsCount?: number;
+    isTodoMode?: boolean;
+    activeSelection?: ActiveSelection;
+    activeTerminalTextSelection?: TerminalTextSelection;
+  };
 }
 
 interface UseChatSubmitProps {
@@ -47,8 +52,8 @@ interface UseChatSubmitProps {
   isLoading: boolean;
   blockingState: BlockingState;
   pendingApproval: PendingApproval | undefined;
-  queuedMessages: QueuedMessage[];
-  setQueuedMessages: React.Dispatch<React.SetStateAction<QueuedMessage[]>>;
+  queuedMessages: DraftMessage[];
+  setQueuedMessages: React.Dispatch<React.SetStateAction<DraftMessage[]>>;
   reviews: Review[];
   taskId: string;
   includeUserEdits?: boolean;
@@ -85,7 +90,6 @@ export function useChatSubmit({
   const { isExecuting } = useToolCallLifeCycle();
   const batchExecuteManager = useBatchExecuteManager();
   const { t } = useTranslation();
-  const pendingSteerMessageRef = useRef<QueuedMessage | undefined>(undefined);
 
   const abortExecutingToolCalls = useCallback(() => {
     batchExecuteManager.abort(taskId, "user-abort");
@@ -99,28 +103,51 @@ export function useChatSubmit({
     files,
     isUploading,
     upload,
-    uploadFiles,
     clearFiles,
     clearError: clearUploadError,
   } = attachmentUpload;
 
-  const handleStop = useCallback(() => {
+  const readyResolvers = useRef<(() => void)[]>([]);
+
+  useEffect(() => {
+    if (!isLoading && !isExecuting && readyResolvers.current.length > 0) {
+      const resolvers = readyResolvers.current;
+      readyResolvers.current = [];
+      for (const resolve of resolvers) {
+        resolve();
+      }
+    }
+  }, [isLoading, isExecuting]);
+
+  const waitForReady = useCallback(() => {
+    if (!isLoading && !isExecuting) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      readyResolvers.current.push(resolve);
+    });
+  }, [isLoading, isExecuting]);
+
+  const handleStop = useCallback(async () => {
+    autoApproveGuard.current = "stop";
+
     // Compacting is not allowed to be stopped.
-    if (blockingState.isBusy) return;
+    if (blockingState.isBusy) {
+      return false;
+    }
 
     if (isExecuting) {
       abortExecutingToolCalls();
-      return true;
-    }
-
-    if (isLoading) {
+    } else if (isLoading) {
       stopChat();
-      return true;
     }
 
     if (pendingApproval?.name === "retry") {
       pendingApproval.stopCountdown();
     }
+
+    await waitForReady();
+    return true;
   }, [
     blockingState.isBusy,
     isExecuting,
@@ -128,81 +155,125 @@ export function useChatSubmit({
     pendingApproval,
     abortExecutingToolCalls,
     stopChat,
+    autoApproveGuard,
+    waitForReady,
   ]);
 
-  const createCurrentMessage = useCallback(() => {
-    const currentMessage: QueuedMessage = {
-      text: input.text.trim(),
-      files: [...files],
-      reviews: [...reviews],
-      userEdits: includeUserEdits ? [...userEdits] : [],
-      isTodoMode,
-    };
+  const createMessage = useCallback(async (): Promise<
+    DraftMessage | undefined
+  > => {
+    const text = input.text.trim();
+    const currentFiles = [...files];
+    const currentReviews = [...reviews];
 
     if (
-      currentMessage.text.length === 0 &&
-      currentMessage.files.length === 0 &&
-      currentMessage.reviews.length === 0
+      text.length === 0 &&
+      currentFiles.length === 0 &&
+      currentReviews.length === 0
     ) {
       return undefined;
     }
 
-    return currentMessage;
-  }, [files, includeUserEdits, input.text, isTodoMode, reviews, userEdits]);
+    // Capture the user's selection context (editor + terminal) right now.
+    const currentUserEdits = includeUserEdits ? [...userEdits] : [];
+    const currentSelection = activeSelection;
 
-  const clearCurrentMessage = useCallback(
-    (currentMessage: QueuedMessage) => {
-      clearInput();
-      if (currentMessage.files.length > 0) {
+    // Terminal selection can only be read on demand (there's no reactive
+    // VS Code API for it), so this is the only chance to snapshot it.
+    const currentTerminalTextSelection = isVSCodeEnvironment()
+      ? await vscodeHost.readTerminalSelection()
+      : undefined;
+
+    let uploadedAttachments: FileUIPart[] = [];
+    if (currentFiles.length > 0) {
+      try {
+        logger.debug("Uploading files...");
+        uploadedAttachments = await upload();
+        logger.debug("Files uploaded.");
         clearFiles();
+      } catch (error) {
+        // Error is already handled by the hook
+        return undefined;
       }
-      if (currentMessage.reviews.length > 0) {
-        vscodeHost.deleteReviews(
-          currentMessage.reviews.map((review) => review.id),
-        );
-      }
-    },
-    [clearFiles, clearInput],
-  );
-
-  const queueCurrentInput = useCallback(() => {
-    const queuedMessage = createCurrentMessage();
-    if (!queuedMessage) return false;
-
-    setQueuedMessages((prev) => [...prev, queuedMessage]);
-    clearCurrentMessage(queuedMessage);
-    if (queuedMessage.isTodoMode) {
-      onTodoModeQueued?.();
     }
-    return true;
+
+    clearUploadError();
+    clearInput();
+    if (currentReviews.length > 0) {
+      vscodeHost.deleteReviews(currentReviews.map((review) => review.id));
+    }
+
+    const raw = {
+      text,
+      filesCount: currentFiles.length,
+      reviewsCount: currentReviews.length,
+      userEditsCount: currentUserEdits.length,
+      isTodoMode,
+      activeSelection: currentSelection,
+      activeTerminalTextSelection: currentTerminalTextSelection,
+    };
+    const parts = prepareMessageParts(
+      t,
+      text,
+      uploadedAttachments,
+      currentReviews,
+      currentUserEdits,
+      currentSelection,
+      currentTerminalTextSelection,
+    );
+
+    return { parts, raw };
   }, [
-    clearCurrentMessage,
-    createCurrentMessage,
-    onTodoModeQueued,
-    setQueuedMessages,
+    t,
+    input.text,
+    files,
+    reviews,
+    userEdits,
+    includeUserEdits,
+    activeSelection,
+    upload,
+    clearFiles,
+    clearUploadError,
+    clearInput,
+    isTodoMode,
   ]);
 
-  const queuePendingSteerInput = useCallback(() => {
-    const queuedMessage = createCurrentMessage();
-    if (!queuedMessage) return false;
+  const sendChatMessage = useCallback(
+    async (message: DraftMessage) => {
+      if (isSubmitDisabled) {
+        return;
+      }
 
-    pendingSteerMessageRef.current = queuedMessage;
-    clearCurrentMessage(queuedMessage);
-    if (queuedMessage.isTodoMode) {
-      onTodoModeQueued?.();
-    }
-    return true;
-  }, [clearCurrentMessage, createCurrentMessage, onTodoModeQueued]);
+      const shouldCreateTodo = message.raw.isTodoMode && canCreateTodo;
+      if (message.raw.text && shouldCreateTodo) {
+        onBeforeSendText?.(message.raw.text);
+      }
+
+      if (pendingApproval?.name === "retry") {
+        pendingApproval.stopCountdown();
+      }
+
+      autoApproveGuard.current = "auto";
+      await sendMessage({
+        parts: message.parts,
+      });
+    },
+    [
+      isSubmitDisabled,
+      canCreateTodo,
+      onBeforeSendText,
+      pendingApproval,
+      autoApproveGuard,
+      sendMessage,
+    ],
+  );
 
   /**
-   * Handles form submission, sending both the current input and any queued messages.
-   * This function supports text and file attachments.
+   * Handles form submission, send the current input to chat if not running, otherwise send it to the message queue.
+   * Including text input, file attachments, reviews and active selections.
    */
   const handleSubmit = useCallback(
-    async (
-      e?: React.FormEvent<HTMLFormElement>,
-      options: SubmitOptions = {},
-    ) => {
+    async (e?: React.FormEvent<HTMLFormElement>) => {
       e?.preventDefault();
 
       logger.debug("handleSubmit");
@@ -210,155 +281,30 @@ export function useChatSubmit({
       // Uploading / Compacting is not allowed to be stopped.
       if (blockingState.isBusy || isUploading) return;
 
+      const message = await createMessage();
+      if (!message) {
+        return;
+      }
+
       if (isLoading || isExecuting) {
-        queueCurrentInput();
-        return;
-      }
-
-      const content = input.text.trim();
-      const hasQueueableCurrentMessage =
-        content.length > 0 || files.length > 0 || reviews.length > 0;
-      const shouldQueueCurrentInput =
-        !options.flushQueuedMessages &&
-        queuedMessages.length > 0 &&
-        hasQueueableCurrentMessage;
-      if (shouldQueueCurrentInput) {
-        // When a queue already exists, an explicit user submission keeps
-        // building the queue. The ready effect is responsible for flushing it.
-        queueCurrentInput();
-        return;
-      }
-
-      const hasQueuedMessages = queuedMessages.length > 0;
-      const pendingSteerMessage = options.flushQueuedMessages
-        ? pendingSteerMessageRef.current
-        : undefined;
-      const shouldUseQueuedMessage =
-        options.flushQueuedMessages ||
-        (hasQueuedMessages && !hasQueueableCurrentMessage);
-      const queuedMessage =
-        pendingSteerMessage ??
-        (shouldUseQueuedMessage ? queuedMessages[0] : undefined);
-      const hasPendingSteerMessage = !!pendingSteerMessage;
-      const text = queuedMessage?.text ?? content;
-      const messageFiles = queuedMessage?.files ?? files;
-      const messageReviews = queuedMessage?.reviews ?? reviews;
-      const messageUserEdits =
-        queuedMessage?.userEdits ?? (includeUserEdits ? userEdits : []);
-      const shouldCreateTodo =
-        (queuedMessage?.isTodoMode ?? isTodoMode) && canCreateTodo;
-
-      // Disallow empty submissions
-      if (
-        text.length === 0 &&
-        messageFiles.length === 0 &&
-        messageReviews.length === 0
-      ) {
-        return;
-      }
-
-      if (isSubmitDisabled) {
-        return;
-      }
-
-      if (pendingApproval?.name === "retry") {
-        pendingApproval.stopCountdown();
-      }
-
-      // Send queued messages one at a time. The ready effect will flush the
-      // next queued message after the current one finishes.
-      if (hasPendingSteerMessage) {
-        pendingSteerMessageRef.current = undefined;
-      } else {
-        setQueuedMessages(hasQueuedMessages ? queuedMessages.slice(1) : []);
-      }
-      if (!options.flushQueuedMessages && content) {
-        clearInput();
-      }
-
-      if (text.length > 0 && shouldCreateTodo) {
-        onBeforeSendText?.(text);
-      }
-
-      // Terminal selection can only be read on demand (there's no reactive
-      // VS Code API for it), so capture it once at send time.
-      const activeTerminalTextSelection = isVSCodeEnvironment()
-        ? await vscodeHost.readTerminalSelection()
-        : undefined;
-
-      if (messageFiles.length > 0) {
-        try {
-          logger.debug("Uploading files...");
-          const uploadedAttachments = queuedMessage
-            ? await uploadFiles(messageFiles)
-            : await upload();
-          const parts = prepareMessageParts(
-            t,
-            text,
-            uploadedAttachments,
-            messageReviews,
-            messageUserEdits,
-            activeSelection,
-            activeTerminalTextSelection,
-          );
-          logger.debug("Sending message with files");
-
-          if (!queuedMessage) {
-            clearFiles();
-          }
-          autoApproveGuard.current = "auto";
-          await sendMessage({
-            parts,
-          });
-        } catch (error) {
-          // Error is already handled by the hook
-          return;
+        setQueuedMessages((prev) => [...prev, message]);
+        if (message.raw.isTodoMode) {
+          onTodoModeQueued?.();
         }
-      } else if (text.length > 0 || messageReviews.length > 0) {
-        clearUploadError();
-        const parts = prepareMessageParts(
-          t,
-          text,
-          [],
-          messageReviews,
-          messageUserEdits,
-          activeSelection,
-          activeTerminalTextSelection,
-        );
-
-        autoApproveGuard.current = "auto";
-        await sendMessage({
-          parts,
-        });
+        return;
       }
+
+      sendChatMessage(message);
     },
     [
-      isSubmitDisabled,
-      files,
-      input,
-      autoApproveGuard,
-      upload,
-      uploadFiles,
-      sendMessage,
-      clearInput,
-      clearUploadError,
       blockingState.isBusy,
-      queuedMessages,
-      setQueuedMessages,
       isUploading,
-      t,
-      clearFiles,
-      reviews,
-      userEdits,
-      includeUserEdits,
-      activeSelection,
       isLoading,
       isExecuting,
-      queueCurrentInput,
-      pendingApproval,
-      onBeforeSendText,
-      isTodoMode,
-      canCreateTodo,
+      sendChatMessage,
+      setQueuedMessages,
+      createMessage,
+      onTodoModeQueued,
     ],
   );
 
@@ -370,45 +316,70 @@ export function useChatSubmit({
 
       if (blockingState.isBusy || isUploading) return;
 
-      const hasVisibleQueue = queuedMessages.length > 0;
-      const isRunActive = isLoading || isExecuting;
-
-      if (!hasVisibleQueue && !isRunActive) {
-        await handleSubmit(e);
+      const message = await createMessage();
+      if (!message) {
         return;
       }
 
-      const didCaptureMessage = hasVisibleQueue
-        ? queuePendingSteerInput()
-        : queueCurrentInput();
-      const shouldInterrupt =
-        isRunActive && (hasVisibleQueue || didCaptureMessage);
-      const shouldPauseAutoApprove = didCaptureMessage || shouldInterrupt;
-      if (!shouldPauseAutoApprove) return;
+      let ready = !isLoading && !isExecuting;
+      if (!ready) {
+        ready = await handleStop();
+      }
 
-      autoApproveGuard.current = "stop";
-      if (shouldInterrupt) {
-        handleStop();
-        return;
+      if (ready) {
+        sendChatMessage(message);
+      } else {
+        setQueuedMessages((messages) => [...messages, message]);
       }
     },
     [
-      autoApproveGuard,
       blockingState.isBusy,
-      handleStop,
-      handleSubmit,
-      isExecuting,
-      isLoading,
       isUploading,
-      queueCurrentInput,
-      queuePendingSteerInput,
-      queuedMessages.length,
+      isLoading,
+      isExecuting,
+      sendChatMessage,
+      createMessage,
+      handleStop,
+      setQueuedMessages,
+    ],
+  );
+
+  const handleSteerQueuedMessage = useCallback(
+    async (index: number) => {
+      if (blockingState.isBusy) return;
+
+      const messages = [...queuedMessages];
+      const message = messages[index];
+      if (message) {
+        const updatedMessages = messages.filter((_, i) => i !== index);
+        setQueuedMessages(updatedMessages);
+
+        let ready = !isLoading && !isExecuting;
+        if (!ready) {
+          ready = await handleStop();
+        }
+        if (ready) {
+          sendChatMessage(message);
+        } else {
+          setQueuedMessages(messages);
+        }
+      }
+    },
+    [
+      blockingState.isBusy,
+      isLoading,
+      isExecuting,
+      handleStop,
+      queuedMessages,
+      setQueuedMessages,
+      sendChatMessage,
     ],
   );
 
   return {
     handleSubmit,
     handleSteerSubmit,
+    handleSteerQueuedMessage,
     handleStop,
   };
 }

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -22,7 +22,6 @@ import {
   useBatchExecuteManager,
   useToolCallLifeCycle,
 } from "../lib/chat-state";
-import type { BlockingState } from "./use-blocking-operations";
 import type { ChatInput } from "./use-chat-input-state";
 
 const logger = getLogger("UseChatSubmit");
@@ -48,9 +47,12 @@ interface UseChatSubmitProps {
   input: ChatInput;
   clearInput: () => void;
   attachmentUpload: UseAttachmentUploadReturn;
-  isSubmitDisabled: boolean;
   isLoading: boolean;
-  blockingState: BlockingState;
+  isRunning: boolean;
+  isSubmitEnabled: boolean;
+  isStopEnabled: boolean;
+  allowSendMessage: boolean;
+  allowSteer: boolean;
   pendingApproval: PendingApproval | undefined;
   queuedMessages: DraftMessage[];
   setQueuedMessages: React.Dispatch<React.SetStateAction<DraftMessage[]>>;
@@ -72,9 +74,12 @@ export function useChatSubmit({
   input,
   clearInput,
   attachmentUpload,
-  isSubmitDisabled,
   isLoading,
-  blockingState,
+  isRunning,
+  isSubmitEnabled,
+  isStopEnabled,
+  allowSendMessage,
+  allowSteer,
   pendingApproval,
   queuedMessages,
   setQueuedMessages,
@@ -101,62 +106,59 @@ export function useChatSubmit({
   const { sendMessage, stop: stopChat } = chat;
   const {
     files,
-    isUploading,
     upload,
     clearFiles,
     clearError: clearUploadError,
   } = attachmentUpload;
 
-  const readyResolvers = useRef<(() => void)[]>([]);
+  const readyResolvers = useRef<((r: true) => void)[]>([]);
 
   useEffect(() => {
-    if (!isLoading && !isExecuting && readyResolvers.current.length > 0) {
+    if (allowSendMessage && readyResolvers.current.length > 0) {
       const resolvers = readyResolvers.current;
       readyResolvers.current = [];
       for (const resolve of resolvers) {
-        resolve();
+        resolve(true);
       }
     }
-  }, [isLoading, isExecuting]);
+  }, [allowSendMessage]);
 
   const waitForReady = useCallback(() => {
-    if (!isLoading && !isExecuting) {
-      return Promise.resolve();
+    if (allowSendMessage) {
+      return Promise.resolve(true);
     }
-    return new Promise<void>((resolve) => {
+    return new Promise<true>((resolve) => {
       readyResolvers.current.push(resolve);
     });
-  }, [isLoading, isExecuting]);
+  }, [allowSendMessage]);
 
   const handleStop = useCallback(async () => {
-    autoApproveGuard.current = "stop";
-
-    // Compacting is not allowed to be stopped.
-    if (blockingState.isBusy) {
+    if (!isStopEnabled) {
       return false;
     }
 
+    autoApproveGuard.current = "stop";
+
     if (isExecuting) {
       abortExecutingToolCalls();
-    } else if (isLoading) {
+    }
+
+    if (isLoading) {
       stopChat();
     }
 
     if (pendingApproval?.name === "retry") {
       pendingApproval.stopCountdown();
     }
-
-    await waitForReady();
     return true;
   }, [
-    blockingState.isBusy,
+    isStopEnabled,
     isExecuting,
     isLoading,
     pendingApproval,
     abortExecutingToolCalls,
     stopChat,
     autoApproveGuard,
-    waitForReady,
   ]);
 
   const createMessage = useCallback(async (): Promise<
@@ -240,10 +242,6 @@ export function useChatSubmit({
 
   const sendChatMessage = useCallback(
     async (message: DraftMessage) => {
-      if (isSubmitDisabled) {
-        return;
-      }
-
       const shouldCreateTodo = message.raw.isTodoMode && canCreateTodo;
       if (message.raw.text && shouldCreateTodo) {
         onBeforeSendText?.(message.raw.text);
@@ -259,7 +257,6 @@ export function useChatSubmit({
       });
     },
     [
-      isSubmitDisabled,
       canCreateTodo,
       onBeforeSendText,
       pendingApproval,
@@ -278,32 +275,30 @@ export function useChatSubmit({
 
       logger.debug("handleSubmit");
 
-      // Uploading / Compacting is not allowed to be stopped.
-      if (blockingState.isBusy || isUploading) return;
+      if (!isSubmitEnabled) {
+        return;
+      }
 
       const message = await createMessage();
       if (!message) {
         return;
       }
 
-      if (isLoading || isExecuting) {
+      if (allowSendMessage) {
+        sendChatMessage(message);
+      } else {
         setQueuedMessages((prev) => [...prev, message]);
         if (message.raw.isTodoMode) {
           onTodoModeQueued?.();
         }
-        return;
       }
-
-      sendChatMessage(message);
     },
     [
-      blockingState.isBusy,
-      isUploading,
-      isLoading,
-      isExecuting,
+      isSubmitEnabled,
+      allowSendMessage,
       sendChatMessage,
-      setQueuedMessages,
       createMessage,
+      setQueuedMessages,
       onTodoModeQueued,
     ],
   );
@@ -314,39 +309,49 @@ export function useChatSubmit({
 
       logger.debug("handleSteerSubmit");
 
-      if (blockingState.isBusy || isUploading) return;
+      if (!isSubmitEnabled) {
+        return;
+      }
 
       const message = await createMessage();
       if (!message) {
         return;
       }
 
-      let ready = !isLoading && !isExecuting;
-      if (!ready) {
-        ready = await handleStop();
+      let readyToSend = allowSendMessage;
+      if (isRunning) {
+        readyToSend = (await handleStop()) && (await waitForReady());
       }
 
-      if (ready) {
+      if (readyToSend) {
         sendChatMessage(message);
       } else {
         setQueuedMessages((messages) => [...messages, message]);
+        if (message.raw.isTodoMode) {
+          onTodoModeQueued?.();
+        }
       }
     },
     [
-      blockingState.isBusy,
-      isUploading,
-      isLoading,
-      isExecuting,
+      isSubmitEnabled,
+      isRunning,
+      allowSendMessage,
       sendChatMessage,
       createMessage,
       handleStop,
+      waitForReady,
       setQueuedMessages,
+      onTodoModeQueued,
     ],
   );
 
   const handleSteerQueuedMessage = useCallback(
     async (index: number) => {
-      if (blockingState.isBusy) return;
+      logger.debug("handleSteerQueuedMessage");
+
+      if (!allowSteer) {
+        return;
+      }
 
       const messages = [...queuedMessages];
       const message = messages[index];
@@ -354,22 +359,22 @@ export function useChatSubmit({
         const updatedMessages = messages.filter((_, i) => i !== index);
         setQueuedMessages(updatedMessages);
 
-        let ready = !isLoading && !isExecuting;
-        if (!ready) {
-          ready = await handleStop();
+        let readyToSend = allowSendMessage;
+        if (isRunning) {
+          readyToSend = (await handleStop()) && (await waitForReady());
         }
-        if (ready) {
+
+        if (readyToSend) {
           sendChatMessage(message);
-        } else {
-          setQueuedMessages(messages);
         }
       }
     },
     [
-      blockingState.isBusy,
-      isLoading,
-      isExecuting,
+      allowSteer,
+      allowSendMessage,
+      isRunning,
       handleStop,
+      waitForReady,
       queuedMessages,
       setQueuedMessages,
       sendChatMessage,

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -50,6 +50,7 @@ interface UseChatSubmitProps {
   attachmentUpload: UseAttachmentUploadReturn;
   isSubmitDisabled: boolean;
   isLoading: boolean;
+  isPendingToolCall: boolean;
   blockingState: BlockingState;
   pendingApproval: PendingApproval | undefined;
   queuedMessages: DraftMessage[];
@@ -74,6 +75,7 @@ export function useChatSubmit({
   attachmentUpload,
   isSubmitDisabled,
   isLoading,
+  isPendingToolCall,
   blockingState,
   pendingApproval,
   queuedMessages,
@@ -138,7 +140,9 @@ export function useChatSubmit({
 
     if (isExecuting) {
       abortExecutingToolCalls();
-    } else if (isLoading) {
+    }
+
+    if (isLoading) {
       stopChat();
     }
 
@@ -286,7 +290,7 @@ export function useChatSubmit({
         return;
       }
 
-      if (isLoading || isExecuting) {
+      if (isLoading || isExecuting || isPendingToolCall) {
         setQueuedMessages((prev) => [...prev, message]);
         if (message.raw.isTodoMode) {
           onTodoModeQueued?.();
@@ -301,6 +305,7 @@ export function useChatSubmit({
       isUploading,
       isLoading,
       isExecuting,
+      isPendingToolCall,
       sendChatMessage,
       setQueuedMessages,
       createMessage,
@@ -321,7 +326,7 @@ export function useChatSubmit({
         return;
       }
 
-      let ready = !isLoading && !isExecuting;
+      let ready = !isLoading && !isExecuting && !isPendingToolCall;
       if (!ready) {
         ready = await handleStop();
       }
@@ -337,6 +342,7 @@ export function useChatSubmit({
       isUploading,
       isLoading,
       isExecuting,
+      isPendingToolCall,
       sendChatMessage,
       createMessage,
       handleStop,
@@ -354,7 +360,7 @@ export function useChatSubmit({
         const updatedMessages = messages.filter((_, i) => i !== index);
         setQueuedMessages(updatedMessages);
 
-        let ready = !isLoading && !isExecuting;
+        let ready = !isLoading && !isExecuting && !isPendingToolCall;
         if (!ready) {
           ready = await handleStop();
         }
@@ -369,6 +375,7 @@ export function useChatSubmit({
       blockingState.isBusy,
       isLoading,
       isExecuting,
+      isPendingToolCall,
       handleStop,
       queuedMessages,
       setQueuedMessages,

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -50,7 +50,6 @@ interface UseChatSubmitProps {
   attachmentUpload: UseAttachmentUploadReturn;
   isSubmitDisabled: boolean;
   isLoading: boolean;
-  isPendingToolCall: boolean;
   blockingState: BlockingState;
   pendingApproval: PendingApproval | undefined;
   queuedMessages: DraftMessage[];
@@ -75,7 +74,6 @@ export function useChatSubmit({
   attachmentUpload,
   isSubmitDisabled,
   isLoading,
-  isPendingToolCall,
   blockingState,
   pendingApproval,
   queuedMessages,
@@ -140,9 +138,7 @@ export function useChatSubmit({
 
     if (isExecuting) {
       abortExecutingToolCalls();
-    }
-
-    if (isLoading) {
+    } else if (isLoading) {
       stopChat();
     }
 
@@ -290,7 +286,7 @@ export function useChatSubmit({
         return;
       }
 
-      if (isLoading || isExecuting || isPendingToolCall) {
+      if (isLoading || isExecuting) {
         setQueuedMessages((prev) => [...prev, message]);
         if (message.raw.isTodoMode) {
           onTodoModeQueued?.();
@@ -305,7 +301,6 @@ export function useChatSubmit({
       isUploading,
       isLoading,
       isExecuting,
-      isPendingToolCall,
       sendChatMessage,
       setQueuedMessages,
       createMessage,
@@ -326,7 +321,7 @@ export function useChatSubmit({
         return;
       }
 
-      let ready = !isLoading && !isExecuting && !isPendingToolCall;
+      let ready = !isLoading && !isExecuting;
       if (!ready) {
         ready = await handleStop();
       }
@@ -342,7 +337,6 @@ export function useChatSubmit({
       isUploading,
       isLoading,
       isExecuting,
-      isPendingToolCall,
       sendChatMessage,
       createMessage,
       handleStop,
@@ -360,7 +354,7 @@ export function useChatSubmit({
         const updatedMessages = messages.filter((_, i) => i !== index);
         setQueuedMessages(updatedMessages);
 
-        let ready = !isLoading && !isExecuting && !isPendingToolCall;
+        let ready = !isLoading && !isExecuting;
         if (!ready) {
           ready = await handleStop();
         }
@@ -375,7 +369,6 @@ export function useChatSubmit({
       blockingState.isBusy,
       isLoading,
       isExecuting,
-      isPendingToolCall,
       handleStop,
       queuedMessages,
       setQueuedMessages,

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -43,6 +43,7 @@
     "noMessage": "No message",
     "fileCount": "{{count}} files",
     "reviewCount": "{{count}} reviews",
+    "userEditCount": "{{count}} edits",
     "steer": "Steer",
     "copyImage": "Copy Image",
     "openImage": "Open Image",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -42,6 +42,7 @@
     "noMessage": "メッセージなし",
     "fileCount": "{{count}} 件のファイル",
     "reviewCount": "{{count}} 件のレビュー",
+    "userEditCount": "{{count}} 件の編集",
     "steer": "介入",
     "copyImage": "画像をコピー",
     "openImage": "画像を開く",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -41,6 +41,7 @@
     "noMessage": "메시지 없음",
     "fileCount": "파일 {{count}}개",
     "reviewCount": "리뷰 {{count}}개",
+    "userEditCount": "편집 {{count}}개",
     "steer": "개입",
     "copyImage": "이미지 복사",
     "openImage": "이미지 열기",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -41,6 +41,7 @@
     "noMessage": "无消息",
     "fileCount": "{{count}} 个文件",
     "reviewCount": "{{count}} 条评审",
+    "userEditCount": "{{count}} 处编辑",
     "steer": "介入",
     "copyImage": "复制图片",
     "openImage": "打开图片",

--- a/packages/vscode-webui/src/lib/hooks/use-attachment-upload.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-attachment-upload.ts
@@ -126,8 +126,8 @@ export function useAttachmentUpload(options?: UseAttachmentUploadOptions) {
     return validateAndAddFiles(files);
   };
 
-  const uploadFiles = async (filesToUpload: File[]): Promise<FileUIPart[]> => {
-    if (!filesToUpload.length) {
+  const upload = async (): Promise<FileUIPart[]> => {
+    if (!files.length) {
       return [];
     }
 
@@ -138,7 +138,7 @@ export function useAttachmentUpload(options?: UseAttachmentUploadOptions) {
     abortController.current = new AbortController();
 
     try {
-      const uploadPromises = filesToUpload.map(async (file) => {
+      const uploadPromises = files.map(async (file) => {
         return {
           type: "file",
           filename: file.name || "unnamed-file",
@@ -167,10 +167,6 @@ export function useAttachmentUpload(options?: UseAttachmentUploadOptions) {
     }
   };
 
-  const upload = async (): Promise<FileUIPart[]> => {
-    return uploadFiles(files);
-  };
-
   const cancelUpload = () => {
     if (abortController.current) {
       abortController.current.abort();
@@ -191,7 +187,6 @@ export function useAttachmentUpload(options?: UseAttachmentUploadOptions) {
     clearFiles,
     clearError,
     upload,
-    uploadFiles,
     cancelUpload,
 
     // Event handlers

--- a/packages/vscode-webui/src/lib/hooks/use-task-changed-files.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-task-changed-files.ts
@@ -15,11 +15,7 @@ async function fetchTaskChangedFiles(taskId: string) {
 }
 
 /** @useSignals this comment is needed to enable signals in this hook */
-export const useTaskChangedFiles = (
-  taskId: string,
-  messages: Message[],
-  _isExecuting?: boolean,
-) => {
+export const useTaskChangedFiles = (taskId: string, messages: Message[]) => {
   // Use query to fetch and subscribe to signals
   const { data } = useQuery({
     queryKey: ["taskChangedFiles", taskId],


### PR DESCRIPTION
## Summary
- Render queued messages inside `ChatInputForm` again instead of as a sibling above it, while keeping the steer button, default-Enter-queues behavior, and rich `QueuedMessage` payload from #1759/#1765.
- Capture editor/terminal selection context at queue time (via `DraftMessage`) so a queued message reuses the selection that was active when it was queued, rather than whatever is active when it's later flushed/steered.
- Unify the chat submit/queue flow with a single `DraftMessage` (pre-built message parts + raw metadata) used for both immediate sends and queued messages, and add per-message active editor/terminal selection previews in the queued messages list.

## Test plan
- [ ] `bun run test` in `packages/vscode-webui` (unit tests for `chat-toolbar`, `queued-messages`, `use-chat-submit`)
- [ ] Manually verify queuing a message with an active editor/terminal selection preserves that selection preview and content on send/steer
- [ ] Manually verify queued messages render inside the chat input box with working remove/steer actions

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ca7b000ab8524dffa2283537801f3cc6)