### PR TITLE
feat(chat): estimate tokens with CJK-aware ratios and calibrate against real usage

### DIFF
--- a/packages/common/src/base/message.ts
+++ b/packages/common/src/base/message.ts
@@ -5,6 +5,11 @@ export const MessageMetadata = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("assistant"),
     totalTokens: z.number(),
+    // True when `totalTokens` falls back to our heuristic estimate because
+    // the provider did not report usage; false/undefined means it's the real
+    // token count reported by the provider. Used to gate token-estimate
+    // calibration to only trust actual provider usage.
+    totalTokensIsEstimated: z.boolean().optional(),
     finishReason: z.custom<FinishReason>(),
     startedAt: z.coerce.date().optional(),
     finishedAt: z.coerce.date().optional(),

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -14,11 +14,14 @@ import {
   type Task,
 } from "../..";
 import { LiveChatKit } from "../live-chat-kit";
-import { getTokenCalibrationFactor, resetTokenCalibration } from "../token-utils";
+import { resetTokenCalibration } from "../token-utils";
 
 describe("LiveChatKit memory lifecycle", () => {
-  // onFinish exercises token-estimate calibration (a process-wide, in-memory
-  // singleton), so reset it between tests to keep them order-independent.
+  // Per-model calibration state lives in a module-level map keyed by
+  // `llm.id`; reset it between tests to keep them order-independent. Note
+  // that calibration is now driven from `flexible-chat-transport.ts` (using
+  // the provider's real `inputTokens` during streaming), not from
+  // `LiveChatKit.onFinish`, so it is no longer exercised directly here.
   beforeEach(() => {
     resetTokenCalibration();
   });
@@ -316,67 +319,6 @@ describe("LiveChatKit memory lifecycle", () => {
     expect(chatKit.chat.messages.map((message) => message.id)).toContain(
       "user-1",
     );
-  });
-
-  it("calibrates the token estimator against real provider usage on finish", () => {
-    const store = new FakeStore([
-      makeTask({
-        id: "parent",
-        status: "pending-model",
-        background: false,
-      }),
-    ]);
-    const chatKit = new LiveChatKit<FakeChat>({
-      taskId: "parent",
-      store: store as unknown as LiveKitStore,
-      blobStore: {} as BlobStore,
-      chatClass: FakeChat,
-      getters: {
-        getLLM: () => ({ id: "test-model" }) as never,
-      },
-    });
-
-    // Keep the non-message contribution to the estimate at zero so the total
-    // estimate stays small relative to the (deliberately huge) reported
-    // totalTokens below, giving a clear signal that calibration ran.
-    setLatestRequestSnapshot(chatKit, 0, 0);
-    chatKit.chat.messages = [userMessage(), assistantMessage()];
-    chatKit.chat.finish(assistantMessage());
-
-    expect(getTokenCalibrationFactor()).toBeGreaterThan(1);
-  });
-
-  it("does not calibrate against our own fallback estimate", () => {
-    const store = new FakeStore([
-      makeTask({
-        id: "parent",
-        status: "pending-model",
-        background: false,
-      }),
-    ]);
-    const chatKit = new LiveChatKit<FakeChat>({
-      taskId: "parent",
-      store: store as unknown as LiveKitStore,
-      blobStore: {} as BlobStore,
-      chatClass: FakeChat,
-      getters: {
-        getLLM: () => ({ id: "test-model" }) as never,
-      },
-    });
-
-    setLatestRequestSnapshot(chatKit, 0, 0);
-    chatKit.chat.messages = [userMessage(), assistantMessage()];
-    chatKit.chat.finish({
-      ...assistantMessage(),
-      metadata: {
-        kind: "assistant",
-        finishReason: "stop",
-        totalTokens: 20_000,
-        totalTokensIsEstimated: true,
-      },
-    } as unknown as Message);
-
-    expect(getTokenCalibrationFactor()).toBe(1);
   });
 
   it("updates task total tokens from the formatted compact estimate", () => {

--- a/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
+++ b/packages/livekit/src/chat/__tests__/live-chat-kit-memory.test.ts
@@ -5,7 +5,7 @@ import type {
 } from "@getpochi/common";
 import { Duration } from "@livestore/utils/effect";
 import type { ChatInit, ChatOnErrorCallback, ChatOnFinishCallback } from "ai";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type BlobStore,
   type LiveKitStore,
@@ -14,8 +14,15 @@ import {
   type Task,
 } from "../..";
 import { LiveChatKit } from "../live-chat-kit";
+import { getTokenCalibrationFactor, resetTokenCalibration } from "../token-utils";
 
 describe("LiveChatKit memory lifecycle", () => {
+  // onFinish exercises token-estimate calibration (a process-wide, in-memory
+  // singleton), so reset it between tests to keep them order-independent.
+  beforeEach(() => {
+    resetTokenCalibration();
+  });
+
   it("starts background task scheduling after the first stream finishes", async () => {
     const store = new FakeStore([
       makeTask({
@@ -309,6 +316,67 @@ describe("LiveChatKit memory lifecycle", () => {
     expect(chatKit.chat.messages.map((message) => message.id)).toContain(
       "user-1",
     );
+  });
+
+  it("calibrates the token estimator against real provider usage on finish", () => {
+    const store = new FakeStore([
+      makeTask({
+        id: "parent",
+        status: "pending-model",
+        background: false,
+      }),
+    ]);
+    const chatKit = new LiveChatKit<FakeChat>({
+      taskId: "parent",
+      store: store as unknown as LiveKitStore,
+      blobStore: {} as BlobStore,
+      chatClass: FakeChat,
+      getters: {
+        getLLM: () => ({ id: "test-model" }) as never,
+      },
+    });
+
+    // Keep the non-message contribution to the estimate at zero so the total
+    // estimate stays small relative to the (deliberately huge) reported
+    // totalTokens below, giving a clear signal that calibration ran.
+    setLatestRequestSnapshot(chatKit, 0, 0);
+    chatKit.chat.messages = [userMessage(), assistantMessage()];
+    chatKit.chat.finish(assistantMessage());
+
+    expect(getTokenCalibrationFactor()).toBeGreaterThan(1);
+  });
+
+  it("does not calibrate against our own fallback estimate", () => {
+    const store = new FakeStore([
+      makeTask({
+        id: "parent",
+        status: "pending-model",
+        background: false,
+      }),
+    ]);
+    const chatKit = new LiveChatKit<FakeChat>({
+      taskId: "parent",
+      store: store as unknown as LiveKitStore,
+      blobStore: {} as BlobStore,
+      chatClass: FakeChat,
+      getters: {
+        getLLM: () => ({ id: "test-model" }) as never,
+      },
+    });
+
+    setLatestRequestSnapshot(chatKit, 0, 0);
+    chatKit.chat.messages = [userMessage(), assistantMessage()];
+    chatKit.chat.finish({
+      ...assistantMessage(),
+      metadata: {
+        kind: "assistant",
+        finishReason: "stop",
+        totalTokens: 20_000,
+        totalTokensIsEstimated: true,
+      },
+    } as unknown as Message);
+
+    expect(getTokenCalibrationFactor()).toBe(1);
   });
 
   it("updates task total tokens from the formatted compact estimate", () => {

--- a/packages/livekit/src/chat/__tests__/token-utils.test.ts
+++ b/packages/livekit/src/chat/__tests__/token-utils.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DefaultCjkCharsPerToken,
+  DefaultOtherCharsPerToken,
+  estimateTokens,
+  getTokenCalibrationFactor,
+  resetTokenCalibration,
+  updateTokenCalibration,
+} from "../token-utils";
+
+describe("estimateTokens", () => {
+  beforeEach(() => {
+    resetTokenCalibration();
+  });
+
+  it("estimates non-CJK text using the default chars-per-token ratio", () => {
+    const text = "a".repeat(40);
+    expect(estimateTokens(text)).toBe(
+      Math.ceil(40 / DefaultOtherCharsPerToken),
+    );
+  });
+
+  it("estimates CJK text using a smaller, denser chars-per-token ratio", () => {
+    const text = "你".repeat(40);
+    expect(estimateTokens(text)).toBe(Math.ceil(40 / DefaultCjkCharsPerToken));
+  });
+
+  it("buckets mixed CJK and non-CJK text separately", () => {
+    const other = "a".repeat(40);
+    const cjk = "你".repeat(40);
+    // Each bucket's chars are divided by its own ratio and summed before
+    // rounding, so the combined estimate should match that computation.
+    const combined = Math.ceil(
+      40 / DefaultOtherCharsPerToken + 40 / DefaultCjkCharsPerToken,
+    );
+    expect(estimateTokens(other + cjk)).toBe(combined);
+  });
+
+  it("estimates CJK text as more tokens per character than plain ASCII of the same length", () => {
+    const asciiEstimate = estimateTokens("a".repeat(100));
+    const cjkEstimate = estimateTokens("你".repeat(100));
+    expect(cjkEstimate).toBeGreaterThan(asciiEstimate);
+  });
+});
+
+describe("token calibration", () => {
+  beforeEach(() => {
+    resetTokenCalibration();
+  });
+
+  it("defaults to a calibration factor of 1", () => {
+    expect(getTokenCalibrationFactor()).toBe(1);
+  });
+
+  it("ignores non-positive inputs", () => {
+    updateTokenCalibration(0, 100);
+    updateTokenCalibration(100, 0);
+    updateTokenCalibration(-5, 100);
+    expect(getTokenCalibrationFactor()).toBe(1);
+  });
+
+  it("nudges the factor up when actual usage exceeds the estimate", () => {
+    const before = estimateTokens("a".repeat(400));
+    updateTokenCalibration(200, 100);
+    const factor = getTokenCalibrationFactor();
+    expect(factor).toBeGreaterThan(1);
+    const after = estimateTokens("a".repeat(400));
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("nudges the factor down when actual usage is below the estimate", () => {
+    updateTokenCalibration(50, 100);
+    expect(getTokenCalibrationFactor()).toBeLessThan(1);
+  });
+
+  it("converges gradually via EMA rather than jumping straight to the new ratio", () => {
+    updateTokenCalibration(200, 100); // ratio = 2
+    const factor = getTokenCalibrationFactor();
+    expect(factor).toBeGreaterThan(1);
+    expect(factor).toBeLessThan(2);
+  });
+
+  it("converges toward the true ratio (not its sqrt) across repeated samples", () => {
+    // Simulate the real call pattern: each sample's "estimated" value is
+    // produced by estimateTokens/computeContextWindowUsage using the *current*
+    // factor, and the true chars-per-token ratio of the (fixed) underlying
+    // text implies actual usage is consistently 2x the raw heuristic.
+    const rawEstimate = 100;
+    for (let i = 0; i < 200; i++) {
+      const calibratedEstimate = rawEstimate * getTokenCalibrationFactor();
+      updateTokenCalibration(rawEstimate * 2, calibratedEstimate);
+    }
+    expect(getTokenCalibrationFactor()).toBeCloseTo(2, 1);
+  });
+
+  it("clamps the factor within a bounded range to resist outliers", () => {
+    for (let i = 0; i < 50; i++) {
+      updateTokenCalibration(10_000, 1);
+    }
+    expect(getTokenCalibrationFactor()).toBeLessThanOrEqual(3);
+
+    resetTokenCalibration();
+    for (let i = 0; i < 50; i++) {
+      updateTokenCalibration(1, 10_000);
+    }
+    expect(getTokenCalibrationFactor()).toBeGreaterThanOrEqual(0.3);
+  });
+});

--- a/packages/livekit/src/chat/__tests__/token-utils.test.ts
+++ b/packages/livekit/src/chat/__tests__/token-utils.test.ts
@@ -3,16 +3,15 @@ import {
   DefaultCjkCharsPerToken,
   DefaultOtherCharsPerToken,
   estimateTokens,
-  getTokenCalibrationFactor,
+  getModelCalibrationFactor,
+  getModelCalibrationKey,
   resetTokenCalibration,
-  updateTokenCalibration,
+  updateModelCalibration,
 } from "../token-utils";
 
-describe("estimateTokens", () => {
-  beforeEach(() => {
-    resetTokenCalibration();
-  });
+const modelKey = "test-model";
 
+describe("estimateTokens", () => {
   it("estimates non-CJK text using the default chars-per-token ratio", () => {
     const text = "a".repeat(40);
     expect(estimateTokens(text)).toBe(
@@ -41,68 +40,102 @@ describe("estimateTokens", () => {
     const cjkEstimate = estimateTokens("你".repeat(100));
     expect(cjkEstimate).toBeGreaterThan(asciiEstimate);
   });
+
+  it("applies an explicit calibration factor rather than reading global state", () => {
+    const text = "a".repeat(400);
+    const raw = estimateTokens(text);
+    expect(estimateTokens(text, 2)).toBe(Math.ceil(raw * 2));
+    expect(estimateTokens(text, 0.5)).toBe(Math.ceil(raw * 0.5));
+  });
 });
 
-describe("token calibration", () => {
+describe("getModelCalibrationKey", () => {
+  it("uses the llm's id as the key", () => {
+    expect(getModelCalibrationKey({ id: "gpt-4" })).toBe("gpt-4");
+  });
+
+  it("falls back to a default key when no llm is given", () => {
+    expect(getModelCalibrationKey(undefined)).toBe("default");
+  });
+});
+
+describe("per-model token calibration", () => {
   beforeEach(() => {
     resetTokenCalibration();
   });
 
-  it("defaults to a calibration factor of 1", () => {
-    expect(getTokenCalibrationFactor()).toBe(1);
+  it("defaults to a calibration factor of 1 for any model", () => {
+    expect(getModelCalibrationFactor(modelKey)).toBe(1);
+    expect(getModelCalibrationFactor("other-model")).toBe(1);
   });
 
   it("ignores non-positive inputs", () => {
-    updateTokenCalibration(0, 100);
-    updateTokenCalibration(100, 0);
-    updateTokenCalibration(-5, 100);
-    expect(getTokenCalibrationFactor()).toBe(1);
+    updateModelCalibration(modelKey, 0, 100);
+    updateModelCalibration(modelKey, 100, 0);
+    updateModelCalibration(modelKey, -5, 100);
+    expect(getModelCalibrationFactor(modelKey)).toBe(1);
   });
 
-  it("nudges the factor up when actual usage exceeds the estimate", () => {
-    const before = estimateTokens("a".repeat(400));
-    updateTokenCalibration(200, 100);
-    const factor = getTokenCalibrationFactor();
-    expect(factor).toBeGreaterThan(1);
-    const after = estimateTokens("a".repeat(400));
-    expect(after).toBeGreaterThan(before);
+  it("nudges the factor up when actual usage exceeds the raw estimate", () => {
+    updateModelCalibration(modelKey, 200, 100);
+    expect(getModelCalibrationFactor(modelKey)).toBeGreaterThan(1);
   });
 
-  it("nudges the factor down when actual usage is below the estimate", () => {
-    updateTokenCalibration(50, 100);
-    expect(getTokenCalibrationFactor()).toBeLessThan(1);
+  it("nudges the factor down when actual usage is below the raw estimate", () => {
+    updateModelCalibration(modelKey, 50, 100);
+    expect(getModelCalibrationFactor(modelKey)).toBeLessThan(1);
   });
 
   it("converges gradually via EMA rather than jumping straight to the new ratio", () => {
-    updateTokenCalibration(200, 100); // ratio = 2
-    const factor = getTokenCalibrationFactor();
+    updateModelCalibration(modelKey, 200, 100); // ratio = 2
+    const factor = getModelCalibrationFactor(modelKey);
     expect(factor).toBeGreaterThan(1);
     expect(factor).toBeLessThan(2);
   });
 
-  it("converges toward the true ratio (not its sqrt) across repeated samples", () => {
-    // Simulate the real call pattern: each sample's "estimated" value is
-    // produced by estimateTokens/computeContextWindowUsage using the *current*
-    // factor, and the true chars-per-token ratio of the (fixed) underlying
-    // text implies actual usage is consistently 2x the raw heuristic.
+  it("converges toward the true ratio across repeated samples of a raw (uncalibrated) estimate", () => {
+    // Unlike the old design, callers are expected to always pass the raw
+    // (factor=1) estimate, so no sqrt-convergence risk here: the ratio
+    // computed each time is against a fixed baseline.
     const rawEstimate = 100;
     for (let i = 0; i < 200; i++) {
-      const calibratedEstimate = rawEstimate * getTokenCalibrationFactor();
-      updateTokenCalibration(rawEstimate * 2, calibratedEstimate);
+      updateModelCalibration(modelKey, rawEstimate * 2, rawEstimate);
     }
-    expect(getTokenCalibrationFactor()).toBeCloseTo(2, 1);
+    expect(getModelCalibrationFactor(modelKey)).toBeCloseTo(2, 1);
   });
 
   it("clamps the factor within a bounded range to resist outliers", () => {
     for (let i = 0; i < 50; i++) {
-      updateTokenCalibration(10_000, 1);
+      updateModelCalibration(modelKey, 10_000, 1);
     }
-    expect(getTokenCalibrationFactor()).toBeLessThanOrEqual(3);
+    expect(getModelCalibrationFactor(modelKey)).toBeLessThanOrEqual(3);
 
-    resetTokenCalibration();
+    resetTokenCalibration(modelKey);
     for (let i = 0; i < 50; i++) {
-      updateTokenCalibration(1, 10_000);
+      updateModelCalibration(modelKey, 1, 10_000);
     }
-    expect(getTokenCalibrationFactor()).toBeGreaterThanOrEqual(0.3);
+    expect(getModelCalibrationFactor(modelKey)).toBeGreaterThanOrEqual(0.3);
+  });
+
+  it("isolates calibration state per model", () => {
+    updateModelCalibration("model-a", 200, 100); // ratio = 2, factor > 1
+    expect(getModelCalibrationFactor("model-a")).toBeGreaterThan(1);
+    expect(getModelCalibrationFactor("model-b")).toBe(1);
+  });
+
+  it("resetTokenCalibration(modelKey) only clears that model's state", () => {
+    updateModelCalibration("model-a", 200, 100);
+    updateModelCalibration("model-b", 200, 100);
+    resetTokenCalibration("model-a");
+    expect(getModelCalibrationFactor("model-a")).toBe(1);
+    expect(getModelCalibrationFactor("model-b")).toBeGreaterThan(1);
+  });
+
+  it("resetTokenCalibration() with no key clears all models", () => {
+    updateModelCalibration("model-a", 200, 100);
+    updateModelCalibration("model-b", 200, 100);
+    resetTokenCalibration();
+    expect(getModelCalibrationFactor("model-a")).toBe(1);
+    expect(getModelCalibrationFactor("model-b")).toBe(1);
   });
 });

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -298,7 +298,10 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
                 part.totalUsage.totalTokens || estimateTotalTokens(llmMessages),
               // Lets downstream consumers (e.g. token-estimate calibration)
               // tell apart real provider usage from our heuristic fallback.
-              totalTokensIsEstimated: !part.totalUsage.totalTokens,
+              // Only set when true; keep undefined otherwise so it's omitted.
+              totalTokensIsEstimated: part.totalUsage.totalTokens
+                ? undefined
+                : true,
               finishReason: part.finishReason,
               startedAt: requestStartedAt,
               finishedAt: now,

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -41,7 +41,13 @@ import {
   createToolCallMiddleware,
 } from "./middlewares";
 import { createModel } from "./models";
-import { estimateTokens, estimateTotalTokens } from "./token-utils";
+import {
+  estimateTokens,
+  estimateTotalTokens,
+  getModelCalibrationFactor,
+  getModelCalibrationKey,
+  updateModelCalibration,
+} from "./token-utils";
 
 export type OnStartCallback = (options: {
   messages: Message[];
@@ -54,6 +60,14 @@ export type FinishedRequestSnapshot = {
   systemPrompt: string;
   systemPromptTokens: number;
   toolsTokens: number;
+  /**
+   * The per-model calibration factor snapshotted at the start of this
+   * request, used to compute `systemPromptTokens`/`toolsTokens` above. Passed
+   * through so downstream consumers (e.g. `computeContextWindowUsage`) can
+   * estimate the rest of the conversation with the same factor, rather than
+   * re-reading a possibly-since-updated value.
+   */
+  calibrationFactor: number;
 };
 
 function createAbortAwareUIStreamTransform(
@@ -167,6 +181,13 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     const todoModeEnabled =
       !this.isSubTask && hasActiveTodos(environment?.todos);
 
+    // Snapshot the per-model calibration factor once so every estimate
+    // computed for this request agrees, even if another concurrent request
+    // (for this model or another) updates calibration state while this one
+    // is in flight.
+    const modelCalibrationKey = getModelCalibrationKey(llm);
+    const calibrationFactor = getModelCalibrationFactor(modelCalibrationKey);
+
     await this.onStart?.({
       messages,
       environment,
@@ -223,8 +244,11 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
       { todoModeEnabled, todos: environment?.todos },
     );
     const systemPrompt = this.systemPromptOverride ?? generatedSystemPrompt;
-    const systemPromptTokens = estimateTokens(systemPrompt);
-    const toolsTokens = estimateTokens(JSON.stringify(tools));
+    const systemPromptTokens = estimateTokens(systemPrompt, calibrationFactor);
+    const toolsTokens = estimateTokens(
+      JSON.stringify(tools),
+      calibrationFactor,
+    );
 
     const preparedMessages = await prepareMessages(messages);
     const llmMessages = formatters.llm(preparedMessages);
@@ -290,18 +314,40 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
               lastMessage.metadata?.kind === "assistant"
                 ? lastMessage.metadata
                 : undefined;
+
+            const { inputTokens, totalTokens } = part.totalUsage;
+            if (inputTokens) {
+              // Calibrate using *input* tokens only, against the raw
+              // (uncalibrated) estimate of exactly the input content sent
+              // for this request (system prompt + tools + messages).
+              // Comparing against `totalTokens` instead would fold in
+              // output/completion usage, which can include invisible
+              // reasoning tokens we have no text to estimate from -- that
+              // gap has nothing to do with our chars-per-token ratios and
+              // would bias the factor for the wrong reason.
+              const rawInputEstimate =
+                (systemPromptTokens +
+                  toolsTokens +
+                  estimateTotalTokens(llmMessages, calibrationFactor)) /
+                calibrationFactor;
+              updateModelCalibration(
+                modelCalibrationKey,
+                inputTokens,
+                rawInputEstimate,
+              );
+            }
+
             return {
               kind: "assistant",
               // The client only consumes the aggregated total token count here.
               // Detailed usage shape differences are a server/protocol concern.
               totalTokens:
-                part.totalUsage.totalTokens || estimateTotalTokens(llmMessages),
-              // Lets downstream consumers (e.g. token-estimate calibration)
-              // tell apart real provider usage from our heuristic fallback.
-              // Only set when true; keep undefined otherwise so it's omitted.
-              totalTokensIsEstimated: part.totalUsage.totalTokens
-                ? undefined
-                : true,
+                totalTokens ||
+                estimateTotalTokens(llmMessages, calibrationFactor),
+              // Lets downstream consumers tell apart real provider usage from
+              // our heuristic fallback. Only set when true; keep undefined
+              // otherwise so it's omitted.
+              totalTokensIsEstimated: totalTokens ? undefined : true,
               finishReason: part.finishReason,
               startedAt: requestStartedAt,
               finishedAt: now,
@@ -315,6 +361,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
             systemPrompt,
             systemPromptTokens,
             toolsTokens,
+            calibrationFactor,
           });
         },
       })

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -296,6 +296,9 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
               // Detailed usage shape differences are a server/protocol concern.
               totalTokens:
                 part.totalUsage.totalTokens || estimateTotalTokens(llmMessages),
+              // Lets downstream consumers (e.g. token-estimate calibration)
+              // tell apart real provider usage from our heuristic fallback.
+              totalTokensIsEstimated: !part.totalUsage.totalTokens,
               finishReason: part.finishReason,
               startedAt: requestStartedAt,
               finishedAt: now,

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -66,7 +66,8 @@ import { replaceAttemptCompletionWithTodoSubtask } from "./todo-completion-utils
 import {
   computeContextWindowUsage,
   estimateTotalTokens,
-  updateTokenCalibration,
+  getModelCalibrationFactor,
+  getModelCalibrationKey,
 } from "./token-utils";
 
 const logger = getLogger("LiveChatKit");
@@ -580,7 +581,10 @@ export class LiveChatKit<
           messages,
           llm: getters.getLLM(),
           task: this.task,
-          estimatedTotalTokens: estimateTotalTokens(formatters.llm(messages)),
+          estimatedTotalTokens: estimateTotalTokens(
+            formatters.llm(messages),
+            getModelCalibrationFactor(getModelCalibrationKey(getters.getLLM())),
+          ),
           effectiveContextWindow: getters.getEffectiveContextWindow?.(),
         });
 
@@ -984,26 +988,17 @@ export class LiveChatKit<
     const finishReason = streamFinishReason ?? message.metadata?.finishReason;
     const status = toTaskStatus(message, finishReason);
 
+    // Calibration is now handled directly in `flexible-chat-transport.ts`,
+    // where it can compare the provider's real `inputTokens` against the
+    // pre-request input-only estimate for that same model. Doing it there
+    // (rather than here against `totalTokens`) avoids contaminating the
+    // calibration with invisible reasoning tokens, which show up in
+    // output/completion usage but have no corresponding visible text for us
+    // to estimate from.
     const contextWindowUsage = computeContextWindowUsage(
       formatters.llm(this.chat.messages),
       this.latestRequestSnapshot,
     );
-
-    // Only calibrate against real provider usage, never against our own
-    // fallback estimate (that would just chase its own tail).
-    if (contextWindowUsage && !message.metadata.totalTokensIsEstimated) {
-      const estimatedTotalTokens =
-        contextWindowUsage.system +
-        contextWindowUsage.tools +
-        contextWindowUsage.messages +
-        contextWindowUsage.files +
-        contextWindowUsage.toolResults +
-        contextWindowUsage.projectMemory;
-      updateTokenCalibration(
-        message.metadata.totalTokens,
-        estimatedTotalTokens,
-      );
-    }
 
     let duration = undefined;
     if (
@@ -1106,7 +1101,12 @@ export class LiveChatKit<
     this.store.commit(
       events.updateTotalTokens({
         id: this.taskId,
-        totalTokens: estimateTotalTokens(formatters.llm(messages)),
+        totalTokens: estimateTotalTokens(
+          formatters.llm(messages),
+          getModelCalibrationFactor(
+            getModelCalibrationKey(this.getters.getLLM()),
+          ),
+        ),
         updatedAt: new Date(),
       }),
     );

--- a/packages/livekit/src/chat/live-chat-kit.ts
+++ b/packages/livekit/src/chat/live-chat-kit.ts
@@ -63,7 +63,11 @@ import { prepareForkTaskData } from "./fork-task-tools";
 import { compactTask, repairMermaid } from "./llm";
 import { createModel } from "./models";
 import { replaceAttemptCompletionWithTodoSubtask } from "./todo-completion-utils";
-import { computeContextWindowUsage, estimateTotalTokens } from "./token-utils";
+import {
+  computeContextWindowUsage,
+  estimateTotalTokens,
+  updateTokenCalibration,
+} from "./token-utils";
 
 const logger = getLogger("LiveChatKit");
 const OverrideMessagesSideEffectTimeoutMs = 12_000;
@@ -984,6 +988,22 @@ export class LiveChatKit<
       formatters.llm(this.chat.messages),
       this.latestRequestSnapshot,
     );
+
+    // Only calibrate against real provider usage, never against our own
+    // fallback estimate (that would just chase its own tail).
+    if (contextWindowUsage && !message.metadata.totalTokensIsEstimated) {
+      const estimatedTotalTokens =
+        contextWindowUsage.system +
+        contextWindowUsage.tools +
+        contextWindowUsage.messages +
+        contextWindowUsage.files +
+        contextWindowUsage.toolResults +
+        contextWindowUsage.projectMemory;
+      updateTokenCalibration(
+        message.metadata.totalTokens,
+        estimatedTotalTokens,
+      );
+    }
 
     let duration = undefined;
     if (

--- a/packages/livekit/src/chat/token-utils.ts
+++ b/packages/livekit/src/chat/token-utils.ts
@@ -13,8 +13,8 @@ export const ImageEstimatedTokens = 1000;
  * - CJK text (Chinese/Japanese/Korean) tokenizes much closer to one token per
  *   character, since BPE vocabularies rarely merge multiple CJK ideographs
  *   into a single token, so a much smaller ratio is used.
- * These are starting points only; `updateTokenCalibration` nudges the
- * effective ratio toward whatever the active model's tokenizer actually
+ * These are starting points only; `updateModelCalibration` nudges the
+ * effective ratio toward whatever each model's tokenizer actually
  * produces.
  */
 export const DefaultOtherCharsPerToken = 4;
@@ -35,80 +35,112 @@ function countCharBuckets(text: string): {
 }
 
 /**
- * Session-local calibration factor, blended equally into both char buckets.
- * Updated via an exponential moving average (see `updateTokenCalibration`)
- * whenever we learn a request's real token usage from the provider, so the
- * heuristic estimate gradually tracks the active model's actual tokenizer.
- * This is intentionally in-memory only: it resets on restart rather than
- * persisting across sessions.
+ * Per-model calibration factor, blended equally into both char buckets.
+ * Updated via an exponential moving average (see `updateModelCalibration`)
+ * whenever we learn a request's real *input* token usage from the provider,
+ * so the heuristic estimate gradually tracks that model's actual tokenizer.
+ *
+ * Keyed by model (see `getModelCalibrationKey`) rather than a single process-
+ * wide value: different models/providers have meaningfully different
+ * chars-per-token ratios, and tasks can run concurrently against different
+ * models (main task + forked sub-agents), so sharing one factor would let
+ * them contaminate each other's calibration. This is intentionally in-memory
+ * only: it resets on restart rather than persisting across sessions.
  */
 const TokenCalibrationEmaAlpha = 0.3;
 const MinTokenCalibrationFactor = 0.3;
 const MaxTokenCalibrationFactor = 3;
 
-let tokenCalibrationFactor = 1;
+const calibrationFactorByModel = new Map<string, number>();
 
-/** @internal exported for testing */
-export function getTokenCalibrationFactor(): number {
-  return tokenCalibrationFactor;
+/** Stable identifier used to key per-model calibration state. */
+export function getModelCalibrationKey(
+  llm: { id: string } | undefined,
+): string {
+  return llm?.id ?? "default";
 }
 
 /** @internal exported for testing */
-export function resetTokenCalibration(): void {
-  tokenCalibrationFactor = 1;
+export function getModelCalibrationFactor(modelKey: string): number {
+  return calibrationFactorByModel.get(modelKey) ?? 1;
+}
+
+/** @internal exported for testing */
+export function resetTokenCalibration(modelKey?: string): void {
+  if (modelKey) {
+    calibrationFactorByModel.delete(modelKey);
+  } else {
+    calibrationFactorByModel.clear();
+  }
 }
 
 /**
- * Nudges the calibration factor toward `actualTokens / estimatedTokens` using
- * an EMA, so future `estimateTokens` calls gradually track the real
- * tokenizer's behavior. Pass whatever (already-calibrated) estimate
- * `estimateTokens`/`computeContextWindowUsage` produced for the same content
- * the provider counted; this function divides the current factor back out
- * internally so the comparison is against the raw, uncalibrated heuristic
- * rather than compounding on top of the previous calibration (which would
- * otherwise make the factor converge toward the sqrt of the true ratio
- * instead of the true ratio itself). Ignored when either input is
- * non-positive.
+ * Nudges `modelKey`'s calibration factor toward
+ * `actualTokens / rawEstimatedTokens` using an EMA, so future `estimateTokens`
+ * calls for that model gradually track its real tokenizer's behavior.
+ *
+ * Both arguments must refer to the *uncalibrated* (raw, factor=1) heuristic
+ * estimate of exactly the content the provider counted for `actualTokens`.
+ * In practice this means comparing against `inputTokens` (the request's
+ * prompt token count) rather than `totalTokens`: output/completion usage can
+ * include invisible reasoning tokens for content we never see and therefore
+ * can't estimate, and attributing that gap to the chars-per-token ratio
+ * would bias the factor upward for reasons unrelated to tokenization,
+ * eventually triggering context compaction too early. Ignored when either
+ * input is non-positive.
  */
-export function updateTokenCalibration(
+export function updateModelCalibration(
+  modelKey: string,
   actualTokens: number,
-  estimatedTokens: number,
+  rawEstimatedTokens: number,
 ): void {
-  if (actualTokens <= 0 || estimatedTokens <= 0) return;
-  const rawEstimatedTokens = estimatedTokens / tokenCalibrationFactor;
+  if (actualTokens <= 0 || rawEstimatedTokens <= 0) return;
+  const current = getModelCalibrationFactor(modelKey);
   const ratio = actualTokens / rawEstimatedTokens;
   const next =
-    tokenCalibrationFactor * (1 - TokenCalibrationEmaAlpha) +
-    ratio * TokenCalibrationEmaAlpha;
-  tokenCalibrationFactor = Math.min(
-    Math.max(next, MinTokenCalibrationFactor),
-    MaxTokenCalibrationFactor,
+    current * (1 - TokenCalibrationEmaAlpha) + ratio * TokenCalibrationEmaAlpha;
+  calibrationFactorByModel.set(
+    modelKey,
+    Math.min(
+      Math.max(next, MinTokenCalibrationFactor),
+      MaxTokenCalibrationFactor,
+    ),
   );
 }
 
-export function estimateTokens(text: string): number {
+/**
+ * `calibrationFactor` should be a value snapshotted once per request (e.g.
+ * via `getModelCalibrationFactor` at the start of `sendMessages`) rather than
+ * re-read for every call, so that all estimates computed over the course of
+ * a single request stay internally consistent even if another concurrent
+ * request updates the shared per-model state in the meantime.
+ */
+export function estimateTokens(text: string, calibrationFactor = 1): number {
   const { otherChars, cjkChars } = countCharBuckets(text);
   const raw =
     otherChars / DefaultOtherCharsPerToken + cjkChars / DefaultCjkCharsPerToken;
-  return Math.ceil(raw * tokenCalibrationFactor);
+  return Math.ceil(raw * calibrationFactor);
 }
 
 /**
  * Estimates the total number of tokens across all message parts.
  * Used as a fallback when the provider does not return a usage total.
  */
-export function estimateTotalTokens(messages: Message[]): number {
+export function estimateTotalTokens(
+  messages: Message[],
+  calibrationFactor = 1,
+): number {
   let totalTokens = 0;
   for (const message of messages) {
     for (const part of message.parts) {
       if (part.type === "text") {
-        totalTokens += estimateTokens(part.text);
+        totalTokens += estimateTokens(part.text, calibrationFactor);
       } else if (part.type === "reasoning") {
-        totalTokens += estimateTokens(part.text);
+        totalTokens += estimateTokens(part.text, calibrationFactor);
       } else if (part.type === "file") {
         totalTokens += ImageEstimatedTokens;
       } else if (isStaticToolUIPart(part)) {
-        totalTokens += estimateTokens(JSON.stringify(part));
+        totalTokens += estimateTokens(JSON.stringify(part), calibrationFactor);
       }
     }
   }
@@ -127,7 +159,10 @@ export type TokenBreakdown = {
  * Buckets message tokens into non-overlapping breakdown categories used by
  * `ContextWindowUsage`.
  */
-export function estimateTokenBreakdown(messages: Message[]): TokenBreakdown {
+export function estimateTokenBreakdown(
+  messages: Message[],
+  calibrationFactor = 1,
+): TokenBreakdown {
   let messagesTokens = 0;
   let filesTokens = 0;
   let toolResultsTokens = 0;
@@ -143,7 +178,7 @@ export function estimateTokenBreakdown(messages: Message[]): TokenBreakdown {
           const reminders = contentStr.match(reminderRegex);
           if (reminders) {
             for (const reminder of reminders) {
-              const tokens = estimateTokens(reminder);
+              const tokens = estimateTokens(reminder, calibrationFactor);
               if (prompts.isAutoMemorySystemReminder(reminder)) {
                 projectMemoryTokens += tokens;
               } else {
@@ -153,11 +188,14 @@ export function estimateTokenBreakdown(messages: Message[]): TokenBreakdown {
             contentStr = contentStr.replace(reminderRegex, "");
           }
         }
-        messagesTokens += estimateTokens(contentStr);
+        messagesTokens += estimateTokens(contentStr, calibrationFactor);
       } else if (part.type === "file") {
         filesTokens += ImageEstimatedTokens;
       } else if (isStaticToolUIPart(part)) {
-        messagesTokens += estimateTokens(JSON.stringify(part.input || {}));
+        messagesTokens += estimateTokens(
+          JSON.stringify(part.input || {}),
+          calibrationFactor,
+        );
         if (part.state === "output-available" && part.output) {
           const output = (part as unknown as { output: unknown }).output;
           let outputTokens = 0;
@@ -167,7 +205,7 @@ export function estimateTokenBreakdown(messages: Message[]): TokenBreakdown {
           } else {
             const resultStr =
               typeof output === "string" ? output : JSON.stringify(output);
-            outputTokens = estimateTokens(resultStr);
+            outputTokens = estimateTokens(resultStr, calibrationFactor);
           }
 
           const toolName = part.type.replace(/^tool-/, "");
@@ -178,9 +216,12 @@ export function estimateTokenBreakdown(messages: Message[]): TokenBreakdown {
           }
         }
       } else if (part.type === "reasoning") {
-        messagesTokens += estimateTokens(part.text);
+        messagesTokens += estimateTokens(part.text, calibrationFactor);
       } else {
-        messagesTokens += estimateTokens(JSON.stringify(part));
+        messagesTokens += estimateTokens(
+          JSON.stringify(part),
+          calibrationFactor,
+        );
       }
     }
   }
@@ -199,10 +240,22 @@ export function estimateTokenBreakdown(messages: Message[]): TokenBreakdown {
  * breakdown with the system-prompt and tools token counts captured at the
  * request boundary. Returns `undefined` when the total is zero so callers can
  * skip persisting an empty usage.
+ *
+ * `request.calibrationFactor` (defaulting to 1) is applied to the messages
+ * breakdown too, so it should be the same factor snapshotted when
+ * `systemPromptTokens`/`toolsTokens` were computed -- keeping every bucket of
+ * a single snapshot internally consistent even if the model's calibration
+ * factor has since moved on (e.g. from a later, concurrent request).
  */
 export function computeContextWindowUsage(
   messages: Message[],
-  request: { systemPromptTokens?: number; toolsTokens?: number } | undefined,
+  request:
+    | {
+        systemPromptTokens?: number;
+        toolsTokens?: number;
+        calibrationFactor?: number;
+      }
+    | undefined,
 ): ContextWindowUsage | undefined {
   const {
     messagesTokens,
@@ -210,7 +263,7 @@ export function computeContextWindowUsage(
     toolResultsTokens,
     systemReminderTokens,
     projectMemoryTokens,
-  } = estimateTokenBreakdown(messages);
+  } = estimateTokenBreakdown(messages, request?.calibrationFactor ?? 1);
 
   const systemTokens =
     (request?.systemPromptTokens || 0) + systemReminderTokens;

--- a/packages/livekit/src/chat/token-utils.ts
+++ b/packages/livekit/src/chat/token-utils.ts
@@ -5,8 +5,92 @@ import type { Message } from "../types";
 
 export const ImageEstimatedTokens = 1000;
 
+/**
+ * Approximate chars-per-token ratios used for token estimation, tuned for
+ * common BPE tokenizers (e.g. cl100k/o200k):
+ * - Non-CJK text (mostly Latin-script prose/code) tokenizes at roughly 4
+ *   chars/token.
+ * - CJK text (Chinese/Japanese/Korean) tokenizes much closer to one token per
+ *   character, since BPE vocabularies rarely merge multiple CJK ideographs
+ *   into a single token, so a much smaller ratio is used.
+ * These are starting points only; `updateTokenCalibration` nudges the
+ * effective ratio toward whatever the active model's tokenizer actually
+ * produces.
+ */
+export const DefaultOtherCharsPerToken = 4;
+export const DefaultCjkCharsPerToken = 1.5;
+
+// Covers CJK Unified Ideographs (+ Extension A), Hiragana/Katakana, Hangul
+// syllables, and fullwidth forms/punctuation commonly seen in CJK text.
+const CjkCharPattern =
+  /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7a3\uff00-\uffef]/g;
+
+function countCharBuckets(text: string): {
+  otherChars: number;
+  cjkChars: number;
+} {
+  const cjkChars = text.match(CjkCharPattern)?.length ?? 0;
+  const otherChars = text.length - cjkChars;
+  return { otherChars, cjkChars };
+}
+
+/**
+ * Session-local calibration factor, blended equally into both char buckets.
+ * Updated via an exponential moving average (see `updateTokenCalibration`)
+ * whenever we learn a request's real token usage from the provider, so the
+ * heuristic estimate gradually tracks the active model's actual tokenizer.
+ * This is intentionally in-memory only: it resets on restart rather than
+ * persisting across sessions.
+ */
+const TokenCalibrationEmaAlpha = 0.3;
+const MinTokenCalibrationFactor = 0.3;
+const MaxTokenCalibrationFactor = 3;
+
+let tokenCalibrationFactor = 1;
+
+/** @internal exported for testing */
+export function getTokenCalibrationFactor(): number {
+  return tokenCalibrationFactor;
+}
+
+/** @internal exported for testing */
+export function resetTokenCalibration(): void {
+  tokenCalibrationFactor = 1;
+}
+
+/**
+ * Nudges the calibration factor toward `actualTokens / estimatedTokens` using
+ * an EMA, so future `estimateTokens` calls gradually track the real
+ * tokenizer's behavior. Pass whatever (already-calibrated) estimate
+ * `estimateTokens`/`computeContextWindowUsage` produced for the same content
+ * the provider counted; this function divides the current factor back out
+ * internally so the comparison is against the raw, uncalibrated heuristic
+ * rather than compounding on top of the previous calibration (which would
+ * otherwise make the factor converge toward the sqrt of the true ratio
+ * instead of the true ratio itself). Ignored when either input is
+ * non-positive.
+ */
+export function updateTokenCalibration(
+  actualTokens: number,
+  estimatedTokens: number,
+): void {
+  if (actualTokens <= 0 || estimatedTokens <= 0) return;
+  const rawEstimatedTokens = estimatedTokens / tokenCalibrationFactor;
+  const ratio = actualTokens / rawEstimatedTokens;
+  const next =
+    tokenCalibrationFactor * (1 - TokenCalibrationEmaAlpha) +
+    ratio * TokenCalibrationEmaAlpha;
+  tokenCalibrationFactor = Math.min(
+    Math.max(next, MinTokenCalibrationFactor),
+    MaxTokenCalibrationFactor,
+  );
+}
+
 export function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
+  const { otherChars, cjkChars } = countCharBuckets(text);
+  const raw =
+    otherChars / DefaultOtherCharsPerToken + cjkChars / DefaultCjkCharsPerToken;
+  return Math.ceil(raw * tokenCalibrationFactor);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Estimate token counts using separate chars-per-token ratios for CJK vs. non-CJK text, since CJK text tokenizes much closer to 1 token/char under common BPE tokenizers (cl100k/o200k) than the previous flat 4 chars/token heuristic.
- Add a session-local calibration factor (`updateTokenCalibration`) that nudges the heuristic estimate toward the model's actual reported token usage via an EMA, so estimates gradually track the real tokenizer.
- Wire calibration updates into `live-chat-kit.ts`/`flexible-chat-transport.ts` so real usage feeds back into the estimator.

## Test plan
- [x] `bun run test` (unit tests for `token-utils.ts` and `live-chat-kit-memory.test.ts`)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b02c407c59aa4e91b5a5d55cc213d783)