### PR TITLE
fix(webui): make background task debug scrolling reliable

### DIFF
--- a/packages/vscode-webui/src/components/task-thread.test.tsx
+++ b/packages/vscode-webui/src/components/task-thread.test.tsx
@@ -1,0 +1,95 @@
+import type { Message } from "@getpochi/livekit";
+// @vitest-environment jsdom
+import { act, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TaskThread, type TaskThreadSource } from "./task-thread";
+
+const mocks = vi.hoisted(() => ({
+  scrollToBottom: vi.fn(),
+  resizeCallback: undefined as ResizeObserverCallback | undefined,
+}));
+
+vi.mock("@/components/message/message-list", () => ({
+  MessageList: ({
+    containerRef,
+  }: {
+    containerRef: React.RefObject<HTMLDivElement | null>;
+  }) => (
+    <div ref={containerRef}>
+      <div />
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/hooks/use-is-at-bottom", () => ({
+  useIsAtBottom: () => ({
+    isAtBottom: true,
+    scrollToBottom: mocks.scrollToBottom,
+  }),
+}));
+
+vi.mock("@getpochi/common", () => ({
+  formatters: { ui: (messages: Message[]) => messages },
+}));
+
+const message = {
+  id: "message-1",
+  role: "assistant",
+  parts: [{ type: "text", text: "Finished" }],
+} as Message;
+
+function makeSource(messages: Message[]): TaskThreadSource {
+  return { messages, todos: [] };
+}
+
+describe("TaskThread scrolling", () => {
+  beforeEach(() => {
+    mocks.scrollToBottom.mockReset();
+    mocks.resizeCallback = undefined;
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          mocks.resizeCallback = callback;
+        }
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+  });
+
+  it("scrolls after the first messages are rendered in instant mode", async () => {
+    const { rerender } = render(
+      <TaskThread source={makeSource([])} instantAutoScroll />,
+    );
+    mocks.scrollToBottom.mockClear();
+
+    rerender(<TaskThread source={makeSource([message])} instantAutoScroll />);
+
+    await waitFor(() => {
+      expect(mocks.scrollToBottom).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("keeps resize-driven scrolling pinned to the bottom in instant mode", () => {
+    render(<TaskThread source={makeSource([message])} instantAutoScroll />);
+    mocks.scrollToBottom.mockClear();
+
+    act(() => mocks.resizeCallback?.([], {} as ResizeObserver));
+
+    expect(mocks.scrollToBottom).toHaveBeenCalledWith(false);
+  });
+
+  it("preserves smooth resize-driven scrolling by default", () => {
+    render(<TaskThread source={makeSource([message])} />);
+    mocks.scrollToBottom.mockClear();
+
+    act(() => mocks.resizeCallback?.([], {} as ResizeObserver));
+
+    expect(mocks.scrollToBottom).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/vscode-webui/src/components/task-thread.tsx
+++ b/packages/vscode-webui/src/components/task-thread.tsx
@@ -23,13 +23,19 @@ export const TaskThread: React.FC<{
     image?: string | null;
   };
   showMessageList?: boolean;
+  className?: string;
+  messageListClassName?: string;
   scrollAreaClassName?: string;
+  instantAutoScroll?: boolean;
 }> = ({
   source,
   user,
   assistant,
   showMessageList = true,
+  className,
+  messageListClassName,
   scrollAreaClassName,
+  instantAutoScroll = false,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
@@ -47,6 +53,7 @@ export const TaskThread: React.FC<{
   const newTaskContainer = useRef<HTMLDivElement>(null);
   const { isAtBottom, scrollToBottom } = useIsAtBottom(newTaskContainer);
   const isAtBottomRef = useRef(isAtBottom);
+  const hasInitiallyScrolledRef = useRef(false);
 
   useEffect(() => {
     isAtBottomRef.current = isAtBottom;
@@ -63,7 +70,7 @@ export const TaskThread: React.FC<{
     }
     const resizeObserver = new ResizeObserver(() => {
       if (isAtBottomRef.current) {
-        requestAnimationFrame(() => scrollToBottom());
+        requestAnimationFrame(() => scrollToBottom(!instantAutoScroll));
       }
     });
     resizeObserver.observe(container);
@@ -71,22 +78,43 @@ export const TaskThread: React.FC<{
     return () => {
       resizeObserver.disconnect();
     }; // clean up
-  }, [scrollToBottom, showMessageList]);
+  }, [instantAutoScroll, scrollToBottom, showMessageList]);
 
-  // Initial scroll to bottom once when component mounts (without smooth behavior)
   useLayoutEffect(() => {
-    if (newTaskContainer.current) {
-      scrollToBottom(false); // false = not smooth
+    if (!instantAutoScroll && newTaskContainer.current) {
+      scrollToBottom(false);
     }
-  }, [scrollToBottom]);
+  }, [instantAutoScroll, scrollToBottom]);
+
+  useLayoutEffect(() => {
+    if (
+      instantAutoScroll &&
+      showMessageList &&
+      renderMessages.length > 0 &&
+      !hasInitiallyScrolledRef.current &&
+      newTaskContainer.current
+    ) {
+      hasInitiallyScrolledRef.current = true;
+      scrollToBottom(false);
+    }
+  }, [
+    instantAutoScroll,
+    renderMessages.length,
+    scrollToBottom,
+    showMessageList,
+  ]);
 
   return (
-    <div className="flex flex-col">
+    <div className={cn("flex flex-col", className)}>
       {showMessageList && (
         <MessageList
-          className={cn("px-1 py-0.5", {
-            "mt-2": !renderMessages.length,
-          })}
+          className={cn(
+            "px-1 py-0.5",
+            {
+              "mt-2": !renderMessages.length,
+            },
+            messageListClassName,
+          )}
           viewportClassname={cn(
             "max-h-[300px] my-1 rounded-sm border",
             scrollAreaClassName,

--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { BackgroundTaskDebugPanel } from "./background-task-debug-panel";
+
+const task = {
+  id: "task-1",
+  title: "Background task",
+  status: "failed",
+  updatedAt: new Date(),
+  todos: [],
+  error: { message: "A detailed failure message" },
+};
+
+vi.mock("@/components/task-thread", () => ({
+  TaskThread: ({
+    className,
+    messageListClassName,
+    scrollAreaClassName,
+    instantAutoScroll,
+  }: {
+    className?: string;
+    messageListClassName?: string;
+    scrollAreaClassName?: string;
+    instantAutoScroll?: boolean;
+  }) => (
+    <div
+      data-testid="task-thread"
+      className={className}
+      data-message-list-class-name={messageListClassName}
+      data-scroll-area-class-name={scrollAreaClassName}
+      data-instant-auto-scroll={instantAutoScroll}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/features/settings", () => ({
+  useIsDevMode: () => [true],
+}));
+
+vi.mock("@/lib/hooks/use-background-task-state", () => ({
+  useBackgroundTaskState: () => ({
+    backgroundTaskState: {
+      useCase: "explore",
+      parentTaskId: "parent-task-id",
+      tools: ["readFile"],
+    },
+  }),
+}));
+
+vi.mock("@getpochi/livekit", () => ({
+  catalog: {
+    queries: {
+      backgroundTasks$: "backgroundTasks",
+      makeTaskQuery: () => "task",
+      makeMessagesQuery: () => "messages",
+    },
+  },
+}));
+
+vi.mock("@/lib/use-default-store", () => ({
+  useDefaultStore: () => ({
+    useQuery: (query: string) => {
+      if (query === "backgroundTasks") return [task];
+      if (query === "task") return task;
+      return [];
+    },
+  }),
+}));
+
+describe("BackgroundTaskDebugPanel", () => {
+  it("uses a single borderless scroll area that fills the remaining height", () => {
+    render(<BackgroundTaskDebugPanel />);
+
+    fireEvent.click(screen.getByText("Background task"));
+
+    const taskThread = screen.getByTestId("task-thread");
+    expect(taskThread.classList.contains("min-h-0")).toBe(true);
+    expect(taskThread.classList.contains("flex-1")).toBe(true);
+    expect(taskThread.dataset.messageListClassName).toBe(
+      "mb-0 min-h-0 overflow-hidden px-0 py-0",
+    );
+    expect(taskThread.dataset.scrollAreaClassName).toBe(
+      "m-0 h-full max-h-none rounded-none border-0",
+    );
+    expect(taskThread.dataset.instantAutoScroll).toBe("true");
+
+    const detailBodyClasses = taskThread.parentElement?.classList;
+    expect(detailBodyClasses?.contains("flex")).toBe(true);
+    expect(detailBodyClasses?.contains("min-h-0")).toBe(true);
+    expect(detailBodyClasses?.contains("flex-1")).toBe(true);
+    expect(detailBodyClasses?.contains("flex-col")).toBe(true);
+    expect(detailBodyClasses?.contains("overflow-hidden")).toBe(true);
+    expect(taskThread.dataset.scrollAreaClassName).not.toContain("100vh");
+  });
+});

--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
@@ -286,10 +286,13 @@ function BackgroundTaskDetail({
           <DetailRow label="Error" value={task.error.message} fullWidth />
         )}
       </div>
-      <div className="min-h-0 flex-1 overflow-hidden p-2">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-2">
         <TaskThread
           source={source}
-          scrollAreaClassName="max-h-none h-[calc(100vh-180px)]"
+          className="min-h-0 flex-1"
+          messageListClassName="mb-0 min-h-0 overflow-hidden px-0 py-0"
+          scrollAreaClassName="m-0 h-full max-h-none rounded-none border-0"
+          instantAutoScroll
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- size the background task detail thread from the panel's actual remaining height instead of a viewport estimate
- remove the duplicate border and outer scroll container from the debug panel
- reliably pin the debug thread to the bottom while preserving normal task thread scrolling behavior
- add regression coverage for panel layout and both instant/default auto-scroll modes

## Test plan
- [x] Run focused Vitest tests for `TaskThread` and `BackgroundTaskDebugPanel`
- [x] Run `bun tsc`
- [x] Run `bun check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e30ff4b06bf9412684772e4238d6ff23)