### PR TITLE
feat(agents): bind custom agent models to subtasks

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -30,7 +30,10 @@ import { cn, tw } from "@/lib/utils";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { constants } from "@getpochi/common";
 import { hasActiveTodos } from "@getpochi/common/message-utils";
-import type { McpConfigOverride } from "@getpochi/common/vscode-webui-bridge";
+import type {
+  DisplayModel,
+  McpConfigOverride,
+} from "@getpochi/common/vscode-webui-bridge";
 import type { Message, Task } from "@getpochi/livekit";
 import { type Todo, initTodoModeTodos } from "@getpochi/tools";
 import {
@@ -73,6 +76,8 @@ interface ChatToolbarProps {
   attachmentUpload: ReturnType<typeof useAttachmentUpload>;
   isSubTask: boolean;
   subtask?: SubtaskInfo;
+  /** Makes an unlisted model available as the current selection. */
+  modelOverride?: DisplayModel;
   displayError: Error | undefined;
   showRenderWidgetFixButton?: boolean;
   todos: Todo[];
@@ -97,6 +102,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   attachmentUpload,
   isSubTask,
   subtask,
+  modelOverride,
   task,
   displayError,
   showRenderWidgetFixButton: shouldShowRenderWidgetFixButton,
@@ -186,7 +192,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     isFetching: isFetchingModels,
     reload: reloadModels,
     updateSelectedModelId,
-  } = useSelectedModels({ isSubTask });
+  } = useSelectedModels({ isSubTask, modelOverride });
 
   const { autoApproveActive } = useAutoApprove({ isSubTask });
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-set-subtask-model.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-set-subtask-model.ts
@@ -8,7 +8,10 @@ export const useSetSubtaskModel = ({
   customAgent,
 }: { isSubTask: boolean; customAgent?: ValidCustomAgentFile }) => {
   const { customAgentModel } = useCustomAgent(customAgent?.name);
-  const { updateSelectedModelId } = useSelectedModels({ isSubTask });
+  const { updateSelectedModelId } = useSelectedModels({
+    isSubTask,
+    modelOverride: customAgentModel,
+  });
 
   useEffect(() => {
     if (!isSubTask) return;

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -114,15 +114,20 @@ function Chat({ user, uid, info }: ChatProps) {
   }, [isSubTask, initSubtaskAutoApproveSettings]);
 
   const {
+    customAgent,
+    customAgentModel,
+    isLoading: isCustomAgentLoading,
+  } = useCustomAgent(subtask?.agent);
+  const modelOverride =
+    isSubTask && customAgent?.model ? customAgentModel : undefined;
+  const {
     isLoading: isModelsLoading,
     selectedModel,
     updateSelectedModelId,
   } = useSelectedModels({
     isSubTask,
+    modelOverride,
   });
-  const { customAgent, isLoading: isCustomAgentLoading } = useCustomAgent(
-    subtask?.agent,
-  );
   const attemptCompletionSchema = useMemo(() => {
     const resultSchema = customAgent?.isBuiltIn
       ? customAgent._internal?.resultSchema
@@ -156,6 +161,8 @@ function Chat({ user, uid, info }: ChatProps) {
     todoModeActive: todoModeActiveRef,
     isSubTask,
     omitCustomRules: isSubTask && customAgent?.omitAgentsMd === true,
+    // Navigation follows the mutable selection, so toolbar changes take effect.
+    modelOverride: isSubTask ? selectedModel : undefined,
     mcpConfigOverride,
     taskId: uid,
   });
@@ -479,6 +486,7 @@ function Chat({ user, uid, info }: ChatProps) {
           attachmentUpload={attachmentUpload}
           isSubTask={isSubTask}
           subtask={subtask}
+          modelOverride={modelOverride}
           displayError={displayError}
           showRenderWidgetFixButton={showRenderWidgetFixButton}
           onUpdateIsPublicShared={chatKit.updateIsPublicShared}

--- a/packages/vscode-webui/src/features/settings/hooks/use-selected-models.test.tsx
+++ b/packages/vscode-webui/src/features/settings/hooks/use-selected-models.test.tsx
@@ -1,0 +1,77 @@
+import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useSelectedModels } from "./use-selected-models";
+
+const mocks = vi.hoisted(() => ({
+  updateSubtaskSelectedModel: vi.fn(),
+  publicModel: {
+    id: "public-model",
+    name: "Public model",
+    type: "vendor",
+    vendorId: "pochi",
+    modelId: "public-model",
+    options: {},
+  } as DisplayModel,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@/lib/hooks/use-model-list", () => ({
+  useModelList: () => ({
+    modelList: [mocks.publicModel],
+    isLoading: false,
+    isFetching: false,
+  }),
+}));
+vi.mock("@/lib/hooks/use-paying-plan", () => ({
+  usePayingPlan: () => ({
+    plan: "pro",
+    isFreebieWhitelistedForSuperModel: true,
+  }),
+}));
+vi.mock("../store", () => ({
+  useSettingsStore: () => ({
+    selectedModel: { id: mocks.publicModel.id, name: mocks.publicModel.name },
+    subtaskSelectedModel: {
+      id: "internal-explore",
+      name: "internal-explore",
+    },
+    updateSelectedModel: vi.fn(),
+    updateSubtaskSelectedModel: mocks.updateSubtaskSelectedModel,
+  }),
+}));
+
+describe("useSelectedModels", () => {
+  it("resolves modelOverride without adding it to the selectable list", () => {
+    const modelOverride = {
+      id: "internal-explore",
+      name: "internal-explore",
+    } as DisplayModel;
+    const { result } = renderHook(() =>
+      useSelectedModels({ isSubTask: true, modelOverride }),
+    );
+
+    expect(result.current.selectedModel).toBe(modelOverride);
+    expect(
+      result.current.groupedModels
+        ?.flatMap((group) => group.models)
+        .some((model) => model.id === modelOverride.id),
+    ).toBe(false);
+
+    act(() => result.current.updateSelectedModelId(modelOverride.id));
+    expect(mocks.updateSubtaskSelectedModel).toHaveBeenCalledWith({
+      id: modelOverride.id,
+      name: modelOverride.name,
+    });
+
+    mocks.updateSubtaskSelectedModel.mockClear();
+    act(() => result.current.updateSelectedModelId(mocks.publicModel.id));
+    expect(mocks.updateSubtaskSelectedModel).toHaveBeenCalledWith({
+      id: mocks.publicModel.id,
+      name: mocks.publicModel.name,
+    });
+  });
+});

--- a/packages/vscode-webui/src/features/settings/hooks/use-selected-models.ts
+++ b/packages/vscode-webui/src/features/settings/hooks/use-selected-models.ts
@@ -16,6 +16,8 @@ export type ModelGroups = ModelGroup[];
 
 type UseSelectedModelsOptions = {
   isSubTask: boolean;
+  /** Resolves a current model without adding it to the selectable list. */
+  modelOverride?: DisplayModel;
 };
 
 const useModelSelectionState = (isSubtask: boolean) => {
@@ -36,6 +38,7 @@ const useModelSelectionState = (isSubtask: boolean) => {
 export function useSelectedModels(options?: UseSelectedModelsOptions) {
   const { t } = useTranslation();
   const isSubTask = options?.isSubTask ?? false;
+  const modelOverride = options?.modelOverride;
 
   const {
     modelList: models,
@@ -81,17 +84,21 @@ export function useSelectedModels(options?: UseSelectedModelsOptions) {
   const selectedModel = useMemo<DisplayModel | undefined>(() => {
     const targetModelId = storedSelectedModel?.id;
     if (!targetModelId) return undefined;
+    if (modelOverride?.id === targetModelId) return modelOverride;
     return models?.find((m) => m.id === targetModelId);
-  }, [storedSelectedModel, models]);
+  }, [storedSelectedModel, models, modelOverride]);
 
   const updateSelectedModelId = useCallback(
     (modelId: string | undefined) => {
       if (!modelId) return;
-      const model = models?.find((m) => m.id === modelId);
+      const model =
+        modelOverride?.id === modelId
+          ? modelOverride
+          : models?.find((m) => m.id === modelId);
       if (!model) return;
       updateSelectedModel(pick(model, ["id", "name"]));
     },
-    [models, updateSelectedModel],
+    [models, modelOverride, updateSelectedModel],
   );
 
   const payingInfo = usePayingPlan();

--- a/packages/vscode-webui/src/lib/hooks/use-custom-agents.test.tsx
+++ b/packages/vscode-webui/src/lib/hooks/use-custom-agents.test.tsx
@@ -1,0 +1,63 @@
+import type {
+  DisplayModel,
+  ValidCustomAgentFile,
+} from "@getpochi/common/vscode-webui-bridge";
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useCustomAgent } from "./use-custom-agents";
+
+const fixtures = vi.hoisted(() => {
+  const credentialModel = {
+    id: "public-model",
+    name: "Public model",
+    type: "vendor",
+    vendorId: "pochi",
+    modelId: "public-model",
+    options: {},
+    getCredentials: vi.fn(),
+  } as DisplayModel;
+  const agent = {
+    name: "explore",
+    description: "Explore",
+    systemPrompt: "Explore",
+    filePath: "explore.md",
+    isBuiltIn: true,
+    model: "internal-explore",
+  } satisfies ValidCustomAgentFile;
+
+  return {
+    agent,
+    credentialModel,
+    modelList: [credentialModel],
+    parentModel: credentialModel,
+  };
+});
+
+vi.mock("@/features/settings", () => ({
+  useSelectedModels: () => ({ selectedModel: fixtures.parentModel }),
+}));
+vi.mock("./use-model-list", () => ({
+  useModelList: () => ({
+    modelList: fixtures.modelList,
+    isLoading: false,
+    isFetching: false,
+  }),
+}));
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: { value: [fixtures.agent] } }),
+}));
+vi.mock("../vscode", () => ({
+  vscodeHost: {},
+}));
+
+describe("useCustomAgent", () => {
+  it("keeps a synthesized built-in model referentially stable", () => {
+    const { result, rerender } = renderHook(() => useCustomAgent("explore"));
+    const firstModel = result.current.customAgentModel;
+
+    rerender();
+
+    expect(result.current.customAgentModel).toBe(firstModel);
+  });
+});

--- a/packages/vscode-webui/src/lib/hooks/use-custom-agents.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-custom-agents.ts
@@ -1,11 +1,13 @@
 import { useSelectedModels } from "@/features/settings";
 import {
   type CustomAgentFile,
+  type DisplayModel,
   type ValidCustomAgentFile,
   isValidCustomAgentFile,
 } from "@getpochi/common/vscode-webui-bridge";
 import { threadSignal } from "@quilted/threads/signals";
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { resolveModelFromId } from "../utils/resolve-model-from-id";
 import { vscodeHost } from "../vscode";
 import { useModelList } from "./use-model-list";
@@ -49,30 +51,50 @@ export function useCustomAgents(filterValidFiles = false) {
 }
 
 export const useCustomAgent = (name?: string) => {
-  const { customAgents, isLoading } = useCustomAgents(true);
-  const { modelList } = useModelList(true);
+  const { customAgents, isLoading: customAgentsLoading } =
+    useCustomAgents(true);
+  const {
+    modelList,
+    isLoading: modelListLoading,
+    isFetching: modelListFetching,
+  } = useModelList(false);
   const { selectedModel: parentTaskModel } = useSelectedModels({
     isSubTask: false,
   });
-  // Use the parent task's model as the initial fallback model for the subtask.
-  let customAgentModel = parentTaskModel;
+  const customAgent = name
+    ? customAgents.find((agent) => agent.name === name)
+    : undefined;
+  const customAgentModel = useMemo<DisplayModel | undefined>(() => {
+    if (!customAgent?.model) return parentTaskModel;
 
-  if (!name) {
-    return {
-      customAgent: undefined,
-      customAgentModel: parentTaskModel,
-      isLoading,
-    };
-  }
-
-  const customAgent = customAgents?.find((agent) => agent.name === name);
-  if (customAgent?.model) {
     const resolvedModel = resolveModelFromId(customAgent.model, modelList);
-    // if customAgent has configured model, use it
-    if (resolvedModel) {
-      customAgentModel = resolvedModel;
+    if (resolvedModel) return resolvedModel;
+
+    if (customAgent.isBuiltIn) {
+      // Built-in special models are currently served by the Pochi vendor.
+      const credentialSource = modelList?.find(
+        (model) => model.type === "vendor" && model.vendorId === "pochi",
+      );
+      if (credentialSource?.type === "vendor") {
+        return {
+          type: "vendor",
+          id: customAgent.model,
+          name: customAgent.model,
+          vendorId: "pochi",
+          modelId: customAgent.model,
+          options: {},
+          getCredentials: credentialSource.getCredentials,
+        };
+      }
     }
-  }
+
+    return parentTaskModel;
+  }, [customAgent?.model, customAgent?.isBuiltIn, modelList, parentTaskModel]);
+  const isCustomAgentModelLoading =
+    !!customAgent?.model && (modelListLoading || modelListFetching);
+  const isLoading =
+    !!name && (customAgentsLoading || isCustomAgentModelLoading);
+
   return {
     customAgent,
     customAgentModel,


### PR DESCRIPTION
## Summary
- **Support modelOverride in useSelectedModels**: Allows unlisted or synthesized models (such as built-in special models) to be selected and resolved correctly without being added to the selectable list.
- **Memoize customAgentModel in useCustomAgent**: Resolves a known unmemoized-object re-render-loop risk in synthesized fallback models by memoizing the resolved model.
- **Thread modelOverride**: Propagates the custom agent model down through the Chat page, toolbar, and subtask set-model hooks.

## Test plan
- [x] Run unit tests for `useSelectedModels` verifying that `modelOverride` is resolved correctly and update callback propagates changes.
- [x] Run unit tests for `useCustomAgent` verifying that the synthesized built-in model is referentially stable across re-renders.
- [x] Run typescript type check (`bun tsc`) to ensure types are correct across all packages.
- [x] Run formatting/linting check (`bun check`) to ensure no issues exist.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-199fa1cdee564d6c86c097dfc8832e50)