### PR TITLE
feat(vscode-webui): show line count in terminal selection preview

### DIFF
--- a/packages/vscode-webui/src/components/message/__tests__/active-selection.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/active-selection.test.tsx
@@ -7,7 +7,10 @@ import {
 } from "../active-selection";
 
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) =>
+      options?.count !== undefined ? `${key}:${options.count}` : key,
+  }),
 }));
 
 vi.mock("@/components/ui/hover-card", () => ({
@@ -128,6 +131,39 @@ describe("TerminalSelectionPart", () => {
     const codeBlock = screen.getByTestId("code-block");
     expect(codeBlock.getAttribute("data-language")).toBe("shell");
     expect(codeBlock.textContent).toBe("echo hello");
+  });
+
+  it("shows the number of lines in the selected content", () => {
+    const { container } = render(
+      <TerminalSelectionPart
+        terminalTextSelection={{
+          terminalName: "zsh",
+          backgroundJobId: "term-1",
+          content: "line1\nline2\nline3",
+        }}
+      />,
+    );
+
+    expect(visibleText(container)).toContain("activeSelectionBadge.lines:3");
+
+    const badge = container.querySelector("span.cursor-pointer");
+    expect(badge?.getAttribute("aria-label")).toContain(
+      "activeSelectionBadge.lines:3",
+    );
+  });
+
+  it("does not count a trailing newline as an extra line", () => {
+    const { container } = render(
+      <TerminalSelectionPart
+        terminalTextSelection={{
+          terminalName: "zsh",
+          backgroundJobId: "term-1",
+          content: "line1\nline2\n",
+        }}
+      />,
+    );
+
+    expect(visibleText(container)).toContain("activeSelectionBadge.lines:2");
   });
 
   it("opens the terminal via openBackgroundJobTerminal when clicked", () => {

--- a/packages/vscode-webui/src/components/message/active-selection.tsx
+++ b/packages/vscode-webui/src/components/message/active-selection.tsx
@@ -89,6 +89,8 @@ export const TerminalSelectionPart: React.FC<TerminalSelectionProps> = ({
     return null;
   }
 
+  const lineCount = getLineCount(content);
+
   const onClick = () => {
     if (!isVSCodeEnvironment() || !backgroundJobId) return;
     openBackgroundJobTerminal?.(backgroundJobId);
@@ -103,11 +105,17 @@ export const TerminalSelectionPart: React.FC<TerminalSelectionProps> = ({
               e.stopPropagation();
               onClick();
             }}
-            aria-label={`${t("activeSelectionBadge.terminal")}: ${terminalName}`}
+            aria-label={`${t("activeSelectionBadge.terminal")}: ${terminalName} (${t("activeSelectionBadge.lines", { count: lineCount })})`}
             className="mx-px cursor-pointer rounded-sm border border-border box-decoration-clone p-0.5 text-sm/6 hover:bg-zinc-200 active:bg-zinc-200 dark:active:bg-zinc-700 dark:hover:bg-zinc-700"
           >
             <TerminalIcon className="inline-block size-3.5 align-text-bottom" />
-            <span className="ml-0.5 break-words">{terminalName}</span>
+            <span className="ml-0.5 break-words">
+              {terminalName}
+              <span className="text-zinc-500 dark:text-zinc-400">
+                {" "}
+                ({t("activeSelectionBadge.lines", { count: lineCount })})
+              </span>
+            </span>
           </span>
         </div>
       </HoverCardTrigger>
@@ -124,3 +132,12 @@ export const TerminalSelectionPart: React.FC<TerminalSelectionProps> = ({
     </HoverCard>
   );
 };
+
+/**
+ * Counts the number of lines in the given text, ignoring a single trailing
+ * newline (so `"a\nb\n"` is treated as 2 lines, not 3).
+ */
+function getLineCount(content: string): number {
+  const trimmed = content.endsWith("\n") ? content.slice(0, -1) : content;
+  return trimmed.length === 0 ? 0 : trimmed.split("\n").length;
+}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -445,7 +445,9 @@
   "activeSelectionBadge": {
     "cell": "Cell",
     "addContext": "Add Context",
-    "terminal": "Terminal"
+    "terminal": "Terminal",
+    "lines_one": "{{count}} line",
+    "lines_other": "{{count}} lines"
   },
   "todoModeBadge": {
     "remove": "Remove todo mode"

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -439,7 +439,9 @@
   "activeSelectionBadge": {
     "cell": "セル",
     "addContext": "コンテキストを追加",
-    "terminal": "ターミナル"
+    "terminal": "ターミナル",
+    "lines_one": "{{count}}行",
+    "lines_other": "{{count}}行"
   },
   "todoModeBadge": {
     "remove": "Todoモードを削除"

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -437,7 +437,9 @@
   "activeSelectionBadge": {
     "cell": "셀",
     "addContext": "컨텍스트 추가",
-    "terminal": "터미널"
+    "terminal": "터미널",
+    "lines_one": "{{count}}줄",
+    "lines_other": "{{count}}줄"
   },
   "todoModeBadge": {
     "remove": "Todo 모드 제거"

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -437,7 +437,9 @@
   "activeSelectionBadge": {
     "cell": "单元格",
     "addContext": "添加上下文",
-    "terminal": "终端"
+    "terminal": "终端",
+    "lines_one": "{{count}} 行",
+    "lines_other": "{{count}} 行"
   },
   "todoModeBadge": {
     "remove": "移除 Todo 模式"


### PR DESCRIPTION
## Summary
- Terminal selections don't have accessible line numbers (VS Code has no listen API for terminal buffers), so this surfaces the number of selected lines instead, e.g. `zsh (10 lines)`, as a good alternative discussed in Slack.
- Adds a `getLineCount` helper that ignores a single trailing newline so `"a\nb\n"` counts as 2 lines, not 3.
- Adds pluralized i18n key `activeSelectionBadge.lines` across en/zh/ko/jp locales.
- Includes the line count in the badge's `aria-label` for accessibility.

## Test plan
- [x] `bun run test` (packages/vscode-webui) — added/updated unit tests in `active-selection.test.tsx` covering line-count rendering and trailing-newline handling
- [x] `bun check` — biome, ast-grep, and i18n consistency checks pass
- [x] `bun tsc` — type checks pass across all packages

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-06f054b66453409bafa2004a199be8fa)