### PR TITLE
feat(cli): support binding custom agent models to subtasks

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -57,7 +57,6 @@ import { loadAgents } from "./lib/load-agents";
 import { loadSkills } from "./lib/load-skills";
 import {
   containsSlashCommandReference,
-  getModelFromSlashCommand,
   replaceSlashCommandReferences,
 } from "./lib/match-slash-command";
 import {
@@ -353,9 +352,7 @@ const program = new Command()
     // Create AbortController for task cancellation with graceful shutdown
     const abortController = createAbortControllerWithGracefulShutdown(program);
 
-    const llm = await createLLMConfig(program, options, {
-      customAgents,
-    });
+    const llm = await createLLMConfig(program, options);
 
     const localFs = new LocalFileSystem(process.cwd());
     const taskFs = new TaskFileSystem(store);
@@ -419,6 +416,7 @@ const program = new Command()
         }
       },
       customAgents,
+      resolveSubTaskLLM,
       skills,
       mcpHub,
       abortSignal: abortController.signal,
@@ -612,29 +610,62 @@ async function parseTaskInput(
 async function createLLMConfig(
   program: Program,
   options: ProgramOpts,
-  slashCommandContext: {
-    customAgents: ValidCustomAgentFile[];
-  },
 ): Promise<LLMRequestData> {
-  const model =
-    (await getModelFromSlashCommand(options.prompt, slashCommandContext)) ||
-    options.model;
+  const model = options.model;
+  const llm = await resolveListedLLMConfig(model);
+  if (llm) return llm;
 
-  const llm =
-    (await createLLMConfigWithVendors(program, model)) ||
-    (await createLLMConfigWithPochi(model)) ||
-    (await createLLMConfigWithProviders(program, model));
-  if (!llm) {
+  const separatorIndex = model.indexOf("/");
+  const vendorId = model.slice(0, separatorIndex);
+  if (vendorId in getVendors()) {
     return program.error(
-      `Model '${model}' not found. Please check your configuration or run 'pochi model list' to see available models.`,
+      `Model '${model.slice(separatorIndex + 1)}' not found. Please run 'pochi model list' to see available models.`,
     );
   }
 
-  return llm;
+  return program.error(
+    `Model '${model}' not found. Please check your configuration or run 'pochi model list' to see available models.`,
+  );
+}
+
+async function resolveListedLLMConfig(
+  model: string,
+): Promise<LLMRequestData | undefined> {
+  const separatorIndex = model.indexOf("/");
+  const vendorId = model.slice(0, separatorIndex);
+  if (vendorId in getVendors()) {
+    return createLLMConfigWithVendors(model);
+  }
+
+  return (
+    (await createLLMConfigWithPochi(model)) ||
+    (await createLLMConfigWithProviders(model))
+  );
+}
+
+async function resolveSubTaskLLM(
+  customAgent: ValidCustomAgentFile,
+): Promise<LLMRequestData | undefined> {
+  if (!customAgent.model) return;
+
+  const modelId = customAgent.model;
+  const resolvedModel = await resolveListedLLMConfig(modelId);
+  if (resolvedModel) return resolvedModel;
+  if (!customAgent.isBuiltIn) return;
+
+  const vendor = getVendor("pochi");
+  return {
+    id: modelId,
+    type: "vendor",
+    getModel: () =>
+      createModel("pochi", {
+        modelId,
+        getCredentials: vendor.getCredentials,
+      }),
+  };
 }
 
 async function createLLMConfigWithVendors(
-  program: Program,
   model: string,
 ): Promise<LLMRequestData | undefined> {
   const sep = model.indexOf("/");
@@ -647,11 +678,7 @@ async function createLLMConfigWithVendors(
     const models =
       await vendors[vendorId as keyof typeof vendors].fetchModels();
     const options = models[modelId];
-    if (!options) {
-      return program.error(
-        `Model '${modelId}' not found. Please run 'pochi model' to see available models.`,
-      );
-    }
+    if (!options) return;
     return {
       id: `${vendorId}/${modelId}`,
       type: "vendor",
@@ -693,7 +720,6 @@ async function createLLMConfigWithPochi(
 }
 
 async function createLLMConfigWithProviders(
-  program: Program,
   model: string,
 ): Promise<LLMRequestData | undefined> {
   const sep = model.indexOf("/");
@@ -704,11 +730,7 @@ async function createLLMConfigWithProviders(
   const modelSetting = modelProvider?.models?.[modelId];
   if (!modelProvider) return;
 
-  if (!modelSetting) {
-    return program.error(
-      `Model '${model}' not found. Please check your configuration or run 'pochi model' to see available models.`,
-    );
-  }
+  if (!modelSetting) return;
 
   if (modelProvider.kind === "ai-gateway") {
     return {

--- a/packages/cli/src/lib/__tests__/match-slash-command.test.ts
+++ b/packages/cli/src/lib/__tests__/match-slash-command.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   containsSlashCommandReference,
   extractSlashCommandNames,
-  getModelFromSlashCommand,
   replaceSlashCommandReferences,
 } from "../match-slash-command";
-import type { CustomAgent } from "@getpochi/tools";
 import type {
   ValidCustomAgentFile,
   ValidSkillFile,
@@ -74,36 +72,6 @@ describe("match-slash-command", () => {
       expect(extractSlashCommandNames("[link](https://example.com/path)")).toEqual([]);
       expect(extractSlashCommandNames("![image](https://example.com/image.png)")).toEqual([]);
     });  });
-
-  describe("getModelFromSlashCommand", () => {
-    const customAgents: CustomAgent[] = [
-      {
-        name: "agent-with-model",
-        description: "",
-        systemPrompt: "",
-        model: "agent-model",
-      },
-      {
-        name: "agent-without-model",
-        description: "",
-        systemPrompt: "",
-      },
-    ];
-
-    it("should return model from agent if available", async () => {
-      const model = await getModelFromSlashCommand("/agent-with-model", {
-        customAgents,
-      });
-      expect(model).toBe("agent-model");
-    });
-
-    it("should return undefined if no model is found", async () => {
-      const model = await getModelFromSlashCommand("/agent-without-model", {
-        customAgents,
-      });
-      expect(model).toBeUndefined();
-    });
-  });
 
   describe("replaceSlashCommandReferences", () => {
     const customAgents: ValidCustomAgentFile[] = [

--- a/packages/cli/src/lib/load-agents.ts
+++ b/packages/cli/src/lib/load-agents.ts
@@ -8,7 +8,6 @@ import type {
   ValidCustomAgentFile,
 } from "@getpochi/common/vscode-webui-bridge";
 import { isValidCustomAgentFile } from "@getpochi/common/vscode-webui-bridge";
-import type { CustomAgent } from "@getpochi/tools";
 import { uniqueBy } from "remeda";
 import { getBuiltInAgentsDir } from "./builtin-agents-dir";
 
@@ -107,8 +106,4 @@ export async function loadAgents(
     logger.error("Failed to load custom agents", error);
     return [];
   }
-}
-
-export function getModelFromCustomAgent(agent: CustomAgent | undefined) {
-  return agent?.model;
 }

--- a/packages/cli/src/lib/match-slash-command.ts
+++ b/packages/cli/src/lib/match-slash-command.ts
@@ -3,14 +3,12 @@ import type {
   CustomAgentFile,
   SkillFile,
 } from "@getpochi/common/vscode-webui-bridge";
-import type { CustomAgent } from "@getpochi/tools";
 import type { Parent, Text } from "mdast";
 import { gfmToMarkdown } from "mdast-util-gfm";
 import { toMarkdown } from "mdast-util-to-markdown";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import { SKIP, visit } from "unist-util-visit";
-import { getModelFromCustomAgent } from "./load-agents";
 
 const IGNORED_NODE_TYPES = [
   "code",
@@ -66,33 +64,6 @@ export function extractSlashCommandNames(prompt: string): string[] {
   }
 
   return [...new Set(allCommands)];
-}
-
-export async function getModelFromSlashCommand(
-  prompt: string | undefined,
-  options: {
-    customAgents: CustomAgent[];
-  },
-): Promise<string | undefined> {
-  if (prompt && containsSlashCommandReference(prompt)) {
-    const commandNames = extractSlashCommandNames(prompt);
-
-    if (!commandNames.length) {
-      return undefined;
-    }
-
-    for (const commandName of commandNames) {
-      // 1. try to get model from agent
-      const targetAgent = options.customAgents.find(
-        (x) => x.name === commandName,
-      );
-      const agentModel = getModelFromCustomAgent(targetAgent);
-      if (agentModel) {
-        return agentModel;
-      }
-    }
-  }
-  return undefined;
 }
 
 export async function replaceSlashCommandReferences(

--- a/packages/cli/src/running-task-adaptor.ts
+++ b/packages/cli/src/running-task-adaptor.ts
@@ -6,7 +6,10 @@ import {
   FileStateCache,
   maybePersistToolResult,
 } from "@getpochi/common/tool-utils";
-import { resolveToolCallArgs } from "@getpochi/common/vscode-webui-bridge";
+import {
+  type ValidCustomAgentFile,
+  resolveToolCallArgs,
+} from "@getpochi/common/vscode-webui-bridge";
 import {
   type BlobStore,
   type LLMRequestData,
@@ -14,7 +17,7 @@ import {
   type UITools,
   processContentOutput,
 } from "@getpochi/livekit";
-import type { CustomAgent, Skill } from "@getpochi/tools";
+import type { Skill } from "@getpochi/tools";
 import type { ToolUIPart } from "ai";
 import { BackgroundJobManager } from "./lib/background-job-manager";
 import type { FileSystem } from "./lib/file-system";
@@ -30,7 +33,7 @@ interface CliRunningTaskAdaptorOptions {
   cwd: string;
   rg: string;
   filesystem: FileSystem;
-  customAgents?: CustomAgent[];
+  customAgents?: ValidCustomAgentFile[];
   skills?: Skill[];
   mcpHub?: McpHub;
   parentTaskId?: string;
@@ -45,7 +48,7 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
   private readonly cwd: string;
   private readonly rg: string;
   private readonly filesystem: FileSystem;
-  private readonly customAgents: CustomAgent[] | undefined;
+  private readonly customAgents: ValidCustomAgentFile[] | undefined;
   private readonly skills: Skill[] | undefined;
   private readonly mcpHub: McpHub | undefined;
   private readonly parentTaskId: string | undefined;

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -20,7 +20,10 @@ import {
   FileStateCache,
   maybePersistToolResult,
 } from "@getpochi/common/tool-utils";
-import { resolveToolCallArgs } from "@getpochi/common/vscode-webui-bridge";
+import {
+  type ValidCustomAgentFile,
+  resolveToolCallArgs,
+} from "@getpochi/common/vscode-webui-bridge";
 import type { UITools } from "@getpochi/livekit";
 import {
   type BlobStore,
@@ -123,7 +126,12 @@ export interface RunnerOptions {
   /**
    * Available custom agents for the new task tool
    */
-  customAgents?: CustomAgent[];
+  customAgents?: ValidCustomAgentFile[];
+
+  /**
+   * Resolves a model configured by a subagent.
+   */
+  resolveSubTaskLLM?: ToolCallOptions["resolveSubTaskLLM"];
 
   /**
    * Available skills for skill tool
@@ -244,6 +252,7 @@ export class TaskRunner {
       blobStore: this.blobStore,
 
       customAgents: options.customAgents,
+      resolveSubTaskLLM: options.resolveSubTaskLLM,
       skills: options.skills,
       mcpHub: options.mcpHub,
       backgroundJobManager: this.backgroundJobManager,

--- a/packages/cli/src/tools/new-task.ts
+++ b/packages/cli/src/tools/new-task.ts
@@ -2,19 +2,19 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { getLogger } from "@getpochi/common";
+import type { ValidCustomAgentFile } from "@getpochi/common/vscode-webui-bridge";
 import { formatFollowupQuestions } from "@getpochi/livekit";
-import type {
-  ClientTools,
-  CustomAgent,
-  ToolFunctionType,
-} from "@getpochi/tools";
+import type { ClientTools, ToolFunctionType } from "@getpochi/tools";
 import ReconnectingWebSocket from "reconnecting-websocket";
 import { WebSocket } from "ws";
 import {
   isMjpegToMp4ConverterAvailable,
   startMjpegToMp4Converter,
 } from "../lib/ffmpeg-mjpeg-to-mp4";
-import type { ToolCallOptions } from "../types";
+import type {
+  CreateSubTaskRunnerOverrideOptions,
+  ToolCallOptions,
+} from "../types";
 
 const logger = getLogger("newTask");
 
@@ -37,7 +37,7 @@ export const newTask =
     }
 
     // Find the custom agent if agentType is specified
-    let customAgent: CustomAgent | undefined;
+    let customAgent: ValidCustomAgentFile | undefined;
     if (agentType && options.customAgents) {
       customAgent = options.customAgents.find(
         (agent) => agent.name === agentType,
@@ -48,6 +48,10 @@ export const newTask =
         );
       }
     }
+
+    const subTaskLLM = customAgent?.model
+      ? await options.resolveSubTaskLLM?.(customAgent)
+      : undefined;
 
     // for browser agent
     let finalize: (() => Promise<void>) | undefined = undefined;
@@ -117,9 +121,12 @@ export const newTask =
       }
     }
 
-    const overrideOptions: { customAgent?: CustomAgent; maxSteps?: number } = {
+    const overrideOptions: CreateSubTaskRunnerOverrideOptions = {
       customAgent,
     };
+    if (subTaskLLM) {
+      overrideOptions.llm = subTaskLLM;
+    }
     if (customAgent?.name === "browser") {
       overrideOptions.maxSteps = SubTaskBrowserAgentMaxSteps;
     }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,7 +1,8 @@
 import type { BrowserSessionStore } from "@getpochi/common/browser";
 import type { McpHub } from "@getpochi/common/mcp-utils";
 import type { FileStateCache } from "@getpochi/common/tool-utils";
-import type { BlobStore } from "@getpochi/livekit";
+import type { ValidCustomAgentFile } from "@getpochi/common/vscode-webui-bridge";
+import type { BlobStore, LLMRequestData } from "@getpochi/livekit";
 import type { CustomAgent, Skill } from "@getpochi/tools";
 import type { BackgroundJobManager } from "./lib/background-job-manager";
 import type { FileSystem } from "./lib/file-system";
@@ -33,7 +34,14 @@ export interface ToolCallOptions {
   /**
    * Available custom agents for tools that support them (e.g., newTask)
    */
-  customAgents?: CustomAgent[];
+  customAgents?: ValidCustomAgentFile[];
+
+  /**
+   * Resolves a model configured by a subagent.
+   */
+  resolveSubTaskLLM?: (
+    customAgent: ValidCustomAgentFile,
+  ) => Promise<LLMRequestData | undefined>;
 
   /**
    * Available skills for tools that support them (e.g., skill)
@@ -66,6 +74,7 @@ export interface ToolCallOptions {
 
 export interface CreateSubTaskRunnerOverrideOptions {
   customAgent?: CustomAgent;
+  llm?: LLMRequestData;
   maxSteps?: number;
   maxRetries?: number;
 }


### PR DESCRIPTION
## Summary
- Supports resolving and binding custom agent models to subtasks in the `newTask` tool.
- Threads `resolveSubTaskLLM` down to `TaskRunner` and `CliRunningTaskAdaptor`.
- Simplifies model configuration parsing to allow proper provider fallbacks.

## Test plan
- Verified that all unit tests pass with `bun run test`.
- Verified type safety with `bun tsc`.
- Verified formatting/linting with `bun check`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-91ff61ea4c864f2e8359027d2186dd94)