### PR TITLE
fix(vscode-webui): hide sub-agent placeholder while awaiting approval or after cancellation

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/__tests__/browser-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/browser-view.test.tsx
@@ -125,6 +125,51 @@ describe("BrowserView", () => {
     });
   });
 
+  it("does not render a placeholder while awaiting approval", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <BrowserView
+        uid="browser-uid"
+        tool={browserTool}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("browserView.paused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
+  it("does not render a placeholder after cancellation", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <BrowserView
+        uid="browser-uid"
+        tool={
+          {
+            type: "tool-newTask",
+            toolCallId: "browser-call",
+            state: "output-error",
+            input: {
+              agentType: "browser",
+              description: "Use the browser",
+            },
+            errorText: "User aborted the tool call",
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("browserView.paused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
   it("shows the trajectory in the footer when a live frame is in the card body", async () => {
     useStoreFileMock.mockReturnValue(undefined);
     subscribeFrameMock.mockImplementation((_uid, setFrame) => {

--- a/packages/vscode-webui/src/features/tools/components/__tests__/planner-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/planner-view.test.tsx
@@ -130,6 +130,51 @@ describe("PlannerView", () => {
     });
   });
 
+  it("does not render a placeholder while awaiting approval", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <PlannerView
+        uid="planner-uid"
+        tool={plannerTool}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("plannerView.planCreationPaused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
+  it("does not render a placeholder after cancellation", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <PlannerView
+        uid="planner-uid"
+        tool={
+          {
+            type: "tool-newTask",
+            toolCallId: "planner-call",
+            state: "output-error",
+            input: {
+              agentType: "planner",
+              description: "Create a plan",
+            },
+            errorText: "User aborted the tool call",
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("plannerView.planCreationPaused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
   it("shows the trajectory in the footer when a plan is in the card body", () => {
     useStoreFileMock.mockReturnValue({ content: "# Plan" });
 

--- a/packages/vscode-webui/src/features/tools/components/__tests__/sub-agent-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/sub-agent-view.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SubAgentView } from "../new-task/sub-agent-view";
+
+vi.mock("@/components/task-thread", () => ({
+  TaskThread: () => <div />,
+}));
+
+vi.mock("@/features/chat", () => ({
+  FixedStateChatContextProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("../tool-call-lite", () => ({
+  ToolCallLite: () => <span />,
+}));
+
+vi.mock("@/lib/hooks/use-navigate", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/lib/use-default-store", () => ({
+  useDefaultStore: () => ({ storeId: "store-id" }),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  isVSCodeEnvironment: () => false,
+}));
+
+vi.mock("../status-icon", () => ({
+  StatusIcon: () => <span />,
+}));
+
+const browserTool = {
+  type: "tool-newTask",
+  toolCallId: "browser-call",
+  state: "input-available",
+  input: {
+    agentType: "browser",
+    description: "Use the browser",
+  },
+} as never;
+
+describe("SubAgentView", () => {
+  it("does not render a separator below a header-only card", () => {
+    const { container } = render(
+      <SubAgentView
+        uid="browser-uid"
+        tool={browserTool}
+        isExecuting={false}
+        taskSource={undefined}
+      >
+        {null}
+      </SubAgentView>,
+    );
+
+    const header = container.firstElementChild?.firstElementChild;
+    expect(header?.className).not.toContain("border-b");
+  });
+
+  it("renders a separator when the card has a body", () => {
+    const { container } = render(
+      <SubAgentView
+        uid="browser-uid"
+        tool={browserTool}
+        isExecuting={true}
+        taskSource={undefined}
+      >
+        <div>Browser content</div>
+      </SubAgentView>,
+    );
+
+    const header = container.firstElementChild?.firstElementChild;
+    expect(header?.className).toContain("border-b");
+  });
+});

--- a/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
@@ -2,6 +2,10 @@ import { useStoreFile } from "@/components/files-provider";
 import { TaskThread } from "@/components/task-thread";
 import { FixedStateChatContextProvider } from "@/features/chat";
 import { browserSessionManager } from "@/lib/browser-session-manager";
+import {
+  getToolPartError,
+  isToolCallCancellationError,
+} from "@/lib/tool-call-error";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { NewTaskToolViewProps } from ".";
@@ -29,6 +33,11 @@ export function BrowserView(props: NewTaskToolViewProps) {
   const showRecordingVideo = !!videoUrl && (!isExecuting || hasToolSettled);
   const showBrowserFrame = !!frame;
   const showBrowserArtifact = showRecordingVideo || showBrowserFrame;
+  const hasTaskThread = !!taskSource && taskSource.messages.length > 1;
+  const hidePlaceholder =
+    (!isExecuting && tool.state === "input-available") ||
+    isToolCallCancellationError(getToolPartError(tool));
+  const showBody = showBrowserArtifact || hasTaskThread || !hidePlaceholder;
 
   return (
     <SubAgentView
@@ -40,44 +49,46 @@ export function BrowserView(props: NewTaskToolViewProps) {
       showToolCall={showBrowserArtifact}
       showTaskThread={showBrowserArtifact}
     >
-      <div className="aspect-video w-full overflow-hidden">
-        {showRecordingVideo ? (
-          // biome-ignore lint/a11y/useMediaCaption: No audio track available
-          <video
-            src={`${videoUrl}#t=${BrowserRecordingVideoOffsetSeconds}`}
-            controls
-            playsInline
-            className="h-full w-full object-contain"
-          />
-        ) : showBrowserFrame ? (
-          <img
-            src={`data:image/jpeg;base64,${frame}`}
-            alt="Browser view"
-            className="h-full w-full object-contain"
-          />
-        ) : taskSource && taskSource.messages.length > 1 ? (
-          <div className="h-full w-full">
-            <FixedStateChatContextProvider
-              toolCallStatusRegistry={toolCallStatusRegistryRef?.current}
-            >
-              <TaskThread
-                source={taskSource}
-                showMessageList={true}
-                scrollAreaClassName="border-none h-full w-full my-0"
-                assistant={{ name: "Browser" }}
-              />
-            </FixedStateChatContextProvider>
-          </div>
-        ) : (
-          <div className="flex h-full w-full items-center justify-center p-3 text-muted-foreground">
-            <span className="text-base">
-              {isExecuting
-                ? t("browserView.executing")
-                : t("browserView.paused")}
-            </span>
-          </div>
-        )}
-      </div>
+      {showBody ? (
+        <div className="aspect-video w-full overflow-hidden">
+          {showRecordingVideo ? (
+            // biome-ignore lint/a11y/useMediaCaption: No audio track available
+            <video
+              src={`${videoUrl}#t=${BrowserRecordingVideoOffsetSeconds}`}
+              controls
+              playsInline
+              className="h-full w-full object-contain"
+            />
+          ) : showBrowserFrame ? (
+            <img
+              src={`data:image/jpeg;base64,${frame}`}
+              alt="Browser view"
+              className="h-full w-full object-contain"
+            />
+          ) : hasTaskThread ? (
+            <div className="h-full w-full">
+              <FixedStateChatContextProvider
+                toolCallStatusRegistry={toolCallStatusRegistryRef?.current}
+              >
+                <TaskThread
+                  source={taskSource}
+                  showMessageList={true}
+                  scrollAreaClassName="border-none h-full w-full my-0"
+                  assistant={{ name: "Browser" }}
+                />
+              </FixedStateChatContextProvider>
+            </div>
+          ) : (
+            <div className="flex h-full w-full items-center justify-center p-3 text-muted-foreground">
+              <span className="text-base">
+                {isExecuting
+                  ? t("browserView.executing")
+                  : t("browserView.paused")}
+              </span>
+            </div>
+          )}
+        </div>
+      ) : null}
     </SubAgentView>
   );
 }

--- a/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
@@ -11,6 +11,10 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { FixedStateChatContextProvider, useSendRetry } from "@/features/chat";
 import { useNavigate } from "@/lib/hooks/use-navigate";
 import { useReviewPlanTutorialCounter } from "@/lib/hooks/use-review-plan-tutorial-counter";
+import {
+  getToolPartError,
+  isToolCallCancellationError,
+} from "@/lib/tool-call-error";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
 import { FilePenLine, Play } from "lucide-react";
@@ -38,6 +42,9 @@ export function PlannerView(props: NewTaskToolViewProps) {
   const file = useStoreFile("/plan.md");
   const planContent = file?.content;
   const showPlanArtifact = !!planContent;
+  const hidePlaceholder =
+    (!isExecuting && tool.state === "input-available") ||
+    isToolCallCancellationError(getToolPartError(tool));
   const sendRetry = useSendRetry();
   const navigate = useNavigate();
   const { count, incrementCount } = useReviewPlanTutorialCounter();
@@ -165,7 +172,7 @@ export function PlannerView(props: NewTaskToolViewProps) {
             assistant={{ name: "Planner" }}
           />
         </FixedStateChatContextProvider>
-      ) : (
+      ) : hidePlaceholder ? null : (
         <div className="flex h-[300px] w-full items-center justify-center p-3 text-muted-foreground">
           <span className="text-base">
             {isExecuting

--- a/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
@@ -56,6 +56,7 @@ export function SubAgentView({
 
   const showFooter =
     showToolCallLite || footerActions || canShowFooterTaskThread;
+  const hasContent = children != null || !!showFooter;
   const navigate = useNavigate();
   const store = useDefaultStore();
   const toolTitle = tool.input?.agentType;
@@ -80,7 +81,8 @@ export function SubAgentView({
     <div className="mt-2 flex flex-col overflow-hidden rounded-md border shadow-sm">
       <div
         className={cn(
-          "flex items-start gap-2 border-b bg-muted/30 px-3 py-2 font-medium text-muted-foreground text-xs",
+          "flex items-start gap-2 bg-muted/30 px-3 py-2 font-medium text-muted-foreground text-xs",
+          hasContent && "border-b",
           uid && taskSource?.parentId && isVSCodeEnvironment()
             ? "group cursor-pointer transition-colors hover:bg-muted hover:text-foreground"
             : "",


### PR DESCRIPTION
## Summary
- Hide the paused/executing placeholder messages in `BrowserView` and `PlannerView` when the sub-agent task is awaiting user approval or has been cancelled.
- Ensure the card body correctly renders empty/null space instead of showing confusing placeholder states during these inactive periods.
- Add comprehensive vitest unit tests in `browser-view.test.tsx` and `planner-view.test.tsx` to verify correct behavior.

## Screenshot
<img width="1054" height="792" alt="image" src="https://github.com/user-attachments/assets/fb4ed7d7-43c4-4312-a6e2-edc754b52f78" />

<img width="788" height="828" alt="image" src="https://github.com/user-attachments/assets/1d970ce5-b9a9-4a13-8669-ce618f66790b" />


## Test plan
- [x] Run unit tests: `bun run test` to verify that `BrowserView` and `PlannerView` do not render placeholder text when awaiting approval or cancelled.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fc73a7c3dd02442cb5fb82ef90a19c7d)