### PR TITLE
fix(vscode-webui): simplify terminal selection badge line count format

### DIFF
--- a/packages/vscode-webui/src/components/message/__tests__/active-selection.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/active-selection.test.tsx
@@ -144,12 +144,10 @@ describe("TerminalSelectionPart", () => {
       />,
     );
 
-    expect(visibleText(container)).toContain("activeSelectionBadge.lines:3");
+    expect(visibleText(container)).toContain("zsh:3");
 
     const badge = container.querySelector("span.cursor-pointer");
-    expect(badge?.getAttribute("aria-label")).toContain(
-      "activeSelectionBadge.lines:3",
-    );
+    expect(badge?.getAttribute("aria-label")).toContain("zsh:3");
   });
 
   it("does not count a trailing newline as an extra line", () => {
@@ -163,7 +161,7 @@ describe("TerminalSelectionPart", () => {
       />,
     );
 
-    expect(visibleText(container)).toContain("activeSelectionBadge.lines:2");
+    expect(visibleText(container)).toContain("zsh:2");
   });
 
   it("opens the terminal via openBackgroundJobTerminal when clicked", () => {

--- a/packages/vscode-webui/src/components/message/active-selection.tsx
+++ b/packages/vscode-webui/src/components/message/active-selection.tsx
@@ -106,9 +106,9 @@ export const TerminalSelectionPart: React.FC<TerminalSelectionProps> = ({
               onClick();
             }}
             aria-label={`${t("activeSelectionBadge.terminal")}: ${terminalName}:${lineCount}`}
-            className="mx-px cursor-pointer rounded-sm border border-border box-decoration-clone p-0.5 text-sm/6 hover:bg-zinc-200 active:bg-zinc-200 dark:active:bg-zinc-700 dark:hover:bg-zinc-700"
+            className="mx-px inline-flex cursor-pointer items-center rounded-sm border border-border box-decoration-clone p-0.5 text-sm/6 hover:bg-zinc-200 active:bg-zinc-200 dark:active:bg-zinc-700 dark:hover:bg-zinc-700"
           >
-            <TerminalIcon className="inline-block size-3.5 align-text-bottom" />
+            <TerminalIcon className="block size-3.5 shrink-0" />
             <span className="ml-0.5 break-words">
               {terminalName}
               <span className="text-zinc-500 dark:text-zinc-400">

--- a/packages/vscode-webui/src/components/message/active-selection.tsx
+++ b/packages/vscode-webui/src/components/message/active-selection.tsx
@@ -105,15 +105,14 @@ export const TerminalSelectionPart: React.FC<TerminalSelectionProps> = ({
               e.stopPropagation();
               onClick();
             }}
-            aria-label={`${t("activeSelectionBadge.terminal")}: ${terminalName} (${t("activeSelectionBadge.lines", { count: lineCount })})`}
+            aria-label={`${t("activeSelectionBadge.terminal")}: ${terminalName}:${lineCount}`}
             className="mx-px cursor-pointer rounded-sm border border-border box-decoration-clone p-0.5 text-sm/6 hover:bg-zinc-200 active:bg-zinc-200 dark:active:bg-zinc-700 dark:hover:bg-zinc-700"
           >
             <TerminalIcon className="inline-block size-3.5 align-text-bottom" />
             <span className="ml-0.5 break-words">
               {terminalName}
               <span className="text-zinc-500 dark:text-zinc-400">
-                {" "}
-                ({t("activeSelectionBadge.lines", { count: lineCount })})
+                :{lineCount}
               </span>
             </span>
           </span>

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -445,9 +445,7 @@
   "activeSelectionBadge": {
     "cell": "Cell",
     "addContext": "Add Context",
-    "terminal": "Terminal",
-    "lines_one": "{{count}} line",
-    "lines_other": "{{count}} lines"
+    "terminal": "Terminal"
   },
   "todoModeBadge": {
     "remove": "Remove todo mode"

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -439,9 +439,7 @@
   "activeSelectionBadge": {
     "cell": "セル",
     "addContext": "コンテキストを追加",
-    "terminal": "ターミナル",
-    "lines_one": "{{count}}行",
-    "lines_other": "{{count}}行"
+    "terminal": "ターミナル"
   },
   "todoModeBadge": {
     "remove": "Todoモードを削除"

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -437,9 +437,7 @@
   "activeSelectionBadge": {
     "cell": "셀",
     "addContext": "컨텍스트 추가",
-    "terminal": "터미널",
-    "lines_one": "{{count}}줄",
-    "lines_other": "{{count}}줄"
+    "terminal": "터미널"
   },
   "todoModeBadge": {
     "remove": "Todo 모드 제거"

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -437,9 +437,7 @@
   "activeSelectionBadge": {
     "cell": "单元格",
     "addContext": "添加上下文",
-    "terminal": "终端",
-    "lines_one": "{{count}} 行",
-    "lines_other": "{{count}} 行"
+    "terminal": "终端"
   },
   "todoModeBadge": {
     "remove": "移除 Todo 模式"


### PR DESCRIPTION
## Summary
- Replace the pluralized "N line(s)" i18n string in the terminal selection badge with a compact "name:count" format
- Remove now-unused `activeSelectionBadge.lines_one` / `lines_other` locale keys from en/jp/ko/zh translations
- Update tests to match the new badge text/aria-label format

## Test plan
- [x] `bun run test` in `packages/vscode-webui` (321 tests passed)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-2e44160af58849aa9eb9d2fb830723da)


---

Preview:

<img width="496" height="188" alt="image" src="https://github.com/user-attachments/assets/7013b6fd-4cf3-4721-9aa0-d97f9ffda9e1" />

