### PR TITLE
fix(vscode-webui): remove trailing blank space in browser agent card

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
@@ -37,7 +37,6 @@ export function BrowserView(props: NewTaskToolViewProps) {
   const hidePlaceholder =
     (!isExecuting && tool.state === "input-available") ||
     isToolCallCancellationError(getToolPartError(tool));
-  const showBody = showBrowserArtifact || hasTaskThread || !hidePlaceholder;
 
   return (
     <SubAgentView
@@ -49,7 +48,7 @@ export function BrowserView(props: NewTaskToolViewProps) {
       showToolCall={showBrowserArtifact}
       showTaskThread={showBrowserArtifact}
     >
-      {showBody ? (
+      {showBrowserArtifact ? (
         <div className="aspect-video w-full overflow-hidden">
           {showRecordingVideo ? (
             // biome-ignore lint/a11y/useMediaCaption: No audio track available
@@ -59,34 +58,30 @@ export function BrowserView(props: NewTaskToolViewProps) {
               playsInline
               className="h-full w-full object-contain"
             />
-          ) : showBrowserFrame ? (
+          ) : (
             <img
               src={`data:image/jpeg;base64,${frame}`}
               alt="Browser view"
               className="h-full w-full object-contain"
             />
-          ) : hasTaskThread ? (
-            <div className="h-full w-full">
-              <FixedStateChatContextProvider
-                toolCallStatusRegistry={toolCallStatusRegistryRef?.current}
-              >
-                <TaskThread
-                  source={taskSource}
-                  showMessageList={true}
-                  scrollAreaClassName="border-none h-full w-full my-0"
-                  assistant={{ name: "Browser" }}
-                />
-              </FixedStateChatContextProvider>
-            </div>
-          ) : (
-            <div className="flex h-full w-full items-center justify-center p-3 text-muted-foreground">
-              <span className="text-base">
-                {isExecuting
-                  ? t("browserView.executing")
-                  : t("browserView.paused")}
-              </span>
-            </div>
           )}
+        </div>
+      ) : hasTaskThread ? (
+        <FixedStateChatContextProvider
+          toolCallStatusRegistry={toolCallStatusRegistryRef?.current}
+        >
+          <TaskThread
+            source={taskSource}
+            showMessageList={true}
+            scrollAreaClassName="border-none"
+            assistant={{ name: "Browser" }}
+          />
+        </FixedStateChatContextProvider>
+      ) : !hidePlaceholder ? (
+        <div className="flex aspect-video w-full items-center justify-center overflow-hidden p-3 text-muted-foreground">
+          <span className="text-base">
+            {isExecuting ? t("browserView.executing") : t("browserView.paused")}
+          </span>
         </div>
       ) : null}
     </SubAgentView>


### PR DESCRIPTION
## Summary
- The browser sub-agent card showed a large empty area at the bottom in some cases.
- Root cause: the text-only trajectory (`TaskThread`) fallback was wrapped in an `aspect-video` (16:9) container that forces a tall height, while the thread's own scroll viewport is capped at `max-h-[300px]`. The difference rendered as trailing blank space.
- Fix: scope `aspect-video` to the actual browser artifact (recorded video / live frame) and the executing/paused placeholder; let the trajectory thread size naturally.

## Test plan
- [x] `bun run test -- src/features/tools/components/__tests__/browser-view.test.tsx` (6 passing)
- [x] `bun tsc` clean for the file
- [x] `biome check` clean for the file
- [ ] Visually confirm no blank space under the browser agent card when showing the text trajectory, and that video/frame/placeholder still render at 16:9

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0189f8ffe9b64adda89264705be62eb6)