### PR TITLE
fix(vscode-webui): make project memory setting global

### DIFF
--- a/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.test.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
-import { renderHook, act } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { useAutoMemoryEnabled } from "./use-auto-memory-enabled";
+import { renderHook } from "@testing-library/react";
 import { useQuery } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoMemoryEnabled } from "./use-auto-memory-enabled";
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: vi.fn(),
@@ -19,21 +19,22 @@ describe("useAutoMemoryEnabled", () => {
     vi.clearAllMocks();
   });
 
-  it("should default to globalEnabled when override is undefined", () => {
+  it("returns the global setting", () => {
     vi.mocked(useQuery).mockReturnValue({
       data: {
         value: {
-          value: true,
+          value: false,
         },
+        setAutoMemoryEnabled: vi.fn(),
       },
     } as any);
 
     const { result } = renderHook(() => useAutoMemoryEnabled());
 
-    expect(result.current.autoMemoryEnabled).toBe(true);
+    expect(result.current.autoMemoryEnabled).toBe(false);
   });
 
-  it("should default to true if globalEnabled data is not yet available", () => {
+  it("defaults to true while the global setting is loading", () => {
     vi.mocked(useQuery).mockReturnValue({
       data: undefined,
     } as any);
@@ -41,54 +42,25 @@ describe("useAutoMemoryEnabled", () => {
     const { result } = renderHook(() => useAutoMemoryEnabled());
 
     expect(result.current.autoMemoryEnabled).toBe(true);
+    expect(result.current.setAutoMemoryEnabled).toBeUndefined();
   });
 
-  it("should use local override state and override global value", () => {
+  it("updates the global setting through the VS Code host", () => {
+    const setAutoMemoryEnabled = vi.fn();
     vi.mocked(useQuery).mockReturnValue({
       data: {
         value: {
-          value: false,
+          value: true,
         },
+        setAutoMemoryEnabled,
       },
     } as any);
 
     const { result } = renderHook(() => useAutoMemoryEnabled());
 
-    // Initially inherits globalEnabled (false)
-    expect(result.current.autoMemoryEnabled).toBe(false);
+    result.current.setAutoMemoryEnabled?.(false);
 
-    // Override to true
-    act(() => {
-      result.current.setAutoMemoryEnabled?.(true);
-    });
-
-    expect(result.current.autoMemoryEnabled).toBe(true);
-
-    // Override to false
-    act(() => {
-      result.current.setAutoMemoryEnabled?.(false);
-    });
-
-    expect(result.current.autoMemoryEnabled).toBe(false);
-  });
-
-  it("should have higher priority even if global is false", () => {
-    vi.mocked(useQuery).mockReturnValue({
-      data: {
-        value: {
-          value: false,
-        },
-      },
-    } as any);
-
-    const { result } = renderHook(() => useAutoMemoryEnabled());
-
-    expect(result.current.autoMemoryEnabled).toBe(false);
-
-    act(() => {
-      result.current.setAutoMemoryEnabled?.(true);
-    });
-
-    expect(result.current.autoMemoryEnabled).toBe(true);
+    expect(setAutoMemoryEnabled).toHaveBeenCalledOnce();
+    expect(setAutoMemoryEnabled).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-auto-memory-enabled.ts
@@ -1,7 +1,6 @@
 import { vscodeHost } from "@/lib/vscode";
 import { threadSignal } from "@quilted/threads/signals";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
 
 /** @useSignals this comment is needed to enable signals in this hook */
 export const useAutoMemoryEnabled = () => {
@@ -11,16 +10,9 @@ export const useAutoMemoryEnabled = () => {
     staleTime: Number.POSITIVE_INFINITY,
   });
 
-  const [overrideEnabled, setOverrideEnabled] = useState<boolean | undefined>(
-    undefined,
-  );
-
-  const globalEnabled = data?.value.value ?? true;
   return {
-    autoMemoryEnabled: overrideEnabled ?? globalEnabled,
-    setAutoMemoryEnabled: data
-      ? (enabled: boolean) => setOverrideEnabled(enabled)
-      : undefined,
+    autoMemoryEnabled: data?.value.value ?? true,
+    setAutoMemoryEnabled: data?.setAutoMemoryEnabled,
   };
 };
 


### PR DESCRIPTION
## Summary
- remove the per-task local override for the Project Memory toggle
- persist toggle changes through the VS Code host's global configuration
- update hook tests to cover global reads and writes

## Test plan
- [x] Run the focused `useAutoMemoryEnabled` unit tests
- [x] Run TypeScript checks for `packages/vscode-webui`
- [x] Run repository formatting and lint checks with `bun check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b448d678dd7b4c93b8ad343734c25c1f)