### PR TITLE
fix(vscode-webui): hide sub-agent placeholder and document CLI classes

### DIFF
--- a/packages/cli/src/attachment-utils.ts
+++ b/packages/cli/src/attachment-utils.ts
@@ -5,6 +5,17 @@ import { prompts } from "@getpochi/common";
 import { type BlobStore, fileToUri } from "@getpochi/livekit";
 import type { FileUIPart, TextUIPart } from "ai";
 
+/**
+ * Processes a list of file attachments (local or remote URLs) for a CLI task.
+ * Converts local files to data URIs stored in the BlobStore, resolves mime types
+ * for remote files (including special handling for YouTube video URLs), and generates
+ * system reminders and file parts for the AI model's prompt.
+ *
+ * @param attachments Array of file paths or remote URLs representing the attachments.
+ * @param blobStore Storage backend for uploading and managing media content.
+ * @param program Commander CLI Command instance used to report fatal attachment errors.
+ * @returns A promise resolving to an array of prompt parts (text reminders and file attachments).
+ */
 export async function processAttachments(
   attachments: string[],
   blobStore: BlobStore,
@@ -89,6 +100,13 @@ export async function processAttachments(
   return parts;
 }
 
+/**
+ * Derives the mime type of a file based on its file extension.
+ * Defaults to "application/octet-stream" if the extension is unknown.
+ *
+ * @param filePath Path or URL of the file.
+ * @returns The resolved mime type string.
+ */
 function getMimeType(filePath: string): string {
   const extension = path.extname(filePath).toLowerCase();
   switch (extension) {
@@ -116,6 +134,13 @@ function getMimeType(filePath: string): string {
   }
 }
 
+/**
+ * Checks if a given string is a valid URL and represents a remote protocol (e.g. http, https, gs).
+ * Excludes "file:" protocol URLs as they refer to local files.
+ *
+ * @param str The string path or URL to check.
+ * @returns True if the string is a remote URL, false otherwise.
+ */
 function isUrl(str: string): boolean {
   try {
     const url = new URL(str);

--- a/packages/cli/src/running-task-adaptor.ts
+++ b/packages/cli/src/running-task-adaptor.ts
@@ -24,40 +24,92 @@ import type { ToolCallOptions } from "./types";
 
 const logger = getLogger("CliRunningTaskAdaptor");
 
+/**
+ * Options required to initialize the CliRunningTaskAdaptor.
+ */
 interface CliRunningTaskAdaptorOptions {
+  /** Storage bucket for managing large files and media content */
   blobStore: BlobStore;
+  /** LLM request configuration and metadata */
   llm: LLMRequestData;
+  /** Current working directory for the task execution */
   cwd: string;
+  /** Path to the ripgrep binary used for fast file searches */
   rg: string;
+  /** File system abstraction for reading and writing files */
   filesystem: FileSystem;
+  /** List of registered custom agents available to the runner */
   customAgents?: CustomAgent[];
+  /** List of registered custom skills available to the runner */
   skills?: Skill[];
+  /** MCP (Model Context Protocol) hub for managing external tools and server integrations */
   mcpHub?: McpHub;
+  /** ID of the parent task, if this adaptor is running a sub-task */
   parentTaskId?: string;
+  /** File state cache of the parent task, used to seed the sub-task cache */
   parentFileStateCache?: FileStateCache;
+  /** Manager responsible for loading and saving long-term project/user memory */
   autoMemoryManager?: AutoMemoryManager;
+  /** Flag to determine if project-level long-term memory is enabled */
   projectMemoryEnabled?: boolean;
 }
 
+/**
+ * CliRunningTaskAdaptor implements the RunningTaskAdaptor interface from @getpochi/livekit.
+ * It coordinates task execution context, environment variables, custom agents, skills,
+ * tool invocation routing, file state caching, and active background jobs within the CLI environment.
+ */
 export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
+  /** Storage bucket for managing large files and media content */
   private readonly blobStore: BlobStore;
+
+  /** LLM request configuration and metadata */
   private readonly llm: LLMRequestData;
+
+  /** Current working directory for the task execution */
   private readonly cwd: string;
+
+  /** Path to the ripgrep binary used for fast file searches */
   private readonly rg: string;
+
+  /** File system abstraction for reading and writing files */
   private readonly filesystem: FileSystem;
+
+  /** List of registered custom agents available to the runner */
   private readonly customAgents: CustomAgent[] | undefined;
+
+  /** List of registered custom skills available to the runner */
   private readonly skills: Skill[] | undefined;
+
+  /** MCP (Model Context Protocol) hub for managing external tools and server integrations */
   private readonly mcpHub: McpHub | undefined;
+
+  /** ID of the parent task, if this adaptor is running a sub-task */
   private readonly parentTaskId: string | undefined;
+
+  /** File state cache of the parent task, used to seed the sub-task cache */
   private readonly parentFileStateCache: FileStateCache | undefined;
+
+  /** Maps task IDs to their corresponding FileStateCache to track changes per task */
   private readonly fileStateCaches = new Map<string, FileStateCache>();
+
+  /** Manager responsible for loading and saving long-term project/user memory */
   private readonly autoMemoryManager: AutoMemoryManager;
+
+  /** Flag to determine if project-level long-term memory is enabled */
   private readonly projectMemoryEnabled: boolean;
+
+  /** Maps task IDs to their corresponding BackgroundJobManager to isolate background processes */
   private readonly backgroundJobManagers = new Map<
     string,
     BackgroundJobManager
   >();
 
+  /**
+   * Constructs a new CliRunningTaskAdaptor instance.
+   *
+   * @param options Configuration options for initializing the adaptor.
+   */
   constructor(options: CliRunningTaskAdaptorOptions) {
     this.blobStore = options.blobStore;
     this.llm = options.llm;
@@ -74,6 +126,10 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
     this.projectMemoryEnabled = options.projectMemoryEnabled ?? true;
   }
 
+  /**
+   * Cleans up resources allocated by this adaptor, particularly killing all
+   * active background jobs spawned by running tasks.
+   */
   dispose() {
     for (const manager of this.backgroundJobManagers.values()) {
       manager.killAll();
@@ -81,6 +137,12 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
     this.backgroundJobManagers.clear();
   }
 
+  /**
+   * Retrieves getters for various pieces of request-scoped context such as LLM config,
+   * environment variables, long-term memory, MCP metadata, custom agents, and skills.
+   *
+   * @param context Context containing the current taskId and optional working directory override.
+   */
   getRequestGetters(context: { taskId: string; cwd: string | undefined }) {
     return {
       getLLM: () => this.llm,
@@ -110,9 +172,16 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
     };
   }
 
+  /**
+   * Executes a tool call requested by an agent. If the tool call is from a sub-task,
+   * it propagates the file state cache from the parent task.
+   *
+   * @param args Arguments specifying the tool call details (name, input, taskId, etc.).
+   */
   async executeToolCall(
     args: Parameters<RunningTaskAdaptor["executeToolCall"]>[0],
   ) {
+    // Propagate the parent's file state cache if this task is a newly spawned sub-task.
     if (args.parentTaskId) {
       this.copyFileStateCacheIfAbsent(args.parentTaskId, args.taskId);
     }
@@ -124,6 +193,7 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
       input: resolveToolCallArgs(args.input, args.storeId),
     } as ToolUIPart<UITools>;
 
+    // Execute the tool call and process any generated content (e.g. converting HTML to markdown)
     const result = await processContentOutput(
       this.blobStore,
       await executeToolCall(
@@ -135,6 +205,7 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
       ),
     );
 
+    // Persist the tool execution result for the task history
     return maybePersistToolResult(
       args.toolName,
       args.toolCallId,
@@ -143,14 +214,25 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
     );
   }
 
+  /**
+   * Handles errors encountered during task execution.
+   */
   onTaskError(taskId: string, error: Error) {
     logger.warn({ taskId, error }, "Task execution failed");
   }
 
+  /**
+   * Clears the file state cache for a specific task, marking all cached files as written.
+   */
   clearFileStateCache(taskId: string) {
     this.fileStateCaches.get(taskId)?.markAllAsWritten();
   }
 
+  /**
+   * Creates the options configuration required to run a specific tool call.
+   *
+   * @param taskId The ID of the task for which the tool is being executed.
+   */
   private createToolCallOptions(taskId: string): ToolCallOptions {
     return {
       rg: this.rg,
@@ -164,6 +246,14 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
     };
   }
 
+  /**
+   * Copies the file state cache from a source task to a target task if the target
+   * cache does not already exist or is empty. This is crucial for passing file modifications
+   * and state context down to child sub-tasks.
+   *
+   * @param sourceTaskId The ID of the parent or source task.
+   * @param targetTaskId The ID of the child or target task.
+   */
   private copyFileStateCacheIfAbsent(
     sourceTaskId: string,
     targetTaskId: string,
@@ -187,6 +277,9 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
     this.fileStateCaches.set(targetTaskId, target);
   }
 
+  /**
+   * Retrieves or lazily initializes the FileStateCache for a given task.
+   */
   private getFileStateCache(taskId: string) {
     let cache = this.fileStateCaches.get(taskId);
     if (!cache) {
@@ -196,6 +289,9 @@ export class CliRunningTaskAdaptor implements RunningTaskAdaptor {
     return cache;
   }
 
+  /**
+   * Retrieves or lazily initializes the BackgroundJobManager for a given task.
+   */
   private getBackgroundJobManager(taskId: string) {
     let manager = this.backgroundJobManagers.get(taskId);
     if (!manager) {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -69,3 +69,5 @@ export interface CreateSubTaskRunnerOverrideOptions {
   maxSteps?: number;
   maxRetries?: number;
 }
+
+export type Test2 = string;

--- a/packages/common/src/base/constants.ts
+++ b/packages/common/src/base/constants.ts
@@ -1,3 +1,7 @@
+/**
+ * Known XML-style tags that should be preserved in messages during markdown parsing/formatting
+ * or escaped/handled specially to avoid breaking HTML rendering.
+ */
 export const KnownTags = [
   "file",
   "compact",
@@ -6,21 +10,64 @@ export const KnownTags = [
   "issue",
 ] as const;
 
+/**
+ * Minimum number of total tokens in a task session required before auto-compaction (summarization)
+ * is allowed or triggered.
+ */
 export const CompactTaskMinTokens = 50_000;
 
+/**
+ * Default context window size (in tokens) used if a model does not declare its own context window.
+ */
 export const DefaultContextWindow = 100_000;
+
+/**
+ * Default maximum output tokens for LLM generation if not specified by the model's options.
+ */
 export const DefaultMaxOutputTokens = 4096;
 
+/**
+ * Default effective context window threshold (in tokens) at which auto-compaction triggers,
+ * even if the model declares a larger context window. This is because agentic tasks tend to
+ * degrade in quality when the context grows too large.
+ */
 export const DefaultEffectiveContextWindow = 160_000;
+
+/**
+ * Minimum allowable effective context window threshold (in tokens) for auto-compaction.
+ */
 export const MinEffectiveContextWindow = 64_000;
 
+/**
+ * Throttle duration (in milliseconds) for streaming UI updates from the chat or sub-tasks,
+ * used to prevent rendering lag by batching rapid updates.
+ */
 export const StreamingUpdateThrottleMs = 100;
 
+/**
+ * The reserved internal agent name used when executing the sub-task that attempts to
+ * verify and complete active todos.
+ */
 export const AttemptTodoCompletionAgentName = "attemptTodoCompletion";
 
+/**
+ * HTTP header key used to pass the current Pochi task ID to remote API requests.
+ */
 export const PochiTaskIdHeader = "x-pochi-task-id";
+
+/**
+ * HTTP header key used to pass the current Pochi store ID to remote API requests.
+ */
 export const PochiStoreIdHeader = "x-pochi-store-id";
+
+/**
+ * HTTP header key used to identify the Pochi client (e.g. VS Code, CLI) making the request.
+ */
 export const PochiClientHeader = "x-pochi-client";
+
+/**
+ * HTTP header key used to indicate the specific use case or intent of the request.
+ */
 export const PochiRequestUseCaseHeader = "x-pochi-request-use-case";
 
 /**

--- a/packages/vscode-webui/src/features/tools/components/__tests__/browser-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/browser-view.test.tsx
@@ -125,6 +125,51 @@ describe("BrowserView", () => {
     });
   });
 
+  it("does not render a placeholder while awaiting approval", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <BrowserView
+        uid="browser-uid"
+        tool={browserTool}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("browserView.paused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
+  it("does not render a placeholder after cancellation", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <BrowserView
+        uid="browser-uid"
+        tool={
+          {
+            type: "tool-newTask",
+            toolCallId: "browser-call",
+            state: "output-error",
+            input: {
+              agentType: "browser",
+              description: "Use the browser",
+            },
+            errorText: "User aborted the tool call",
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("browserView.paused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
   it("shows the trajectory in the footer when a live frame is in the card body", async () => {
     useStoreFileMock.mockReturnValue(undefined);
     subscribeFrameMock.mockImplementation((_uid, setFrame) => {

--- a/packages/vscode-webui/src/features/tools/components/__tests__/planner-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/planner-view.test.tsx
@@ -130,6 +130,51 @@ describe("PlannerView", () => {
     });
   });
 
+  it("does not render a placeholder while awaiting approval", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <PlannerView
+        uid="planner-uid"
+        tool={plannerTool}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("plannerView.planCreationPaused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
+  it("does not render a placeholder after cancellation", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <PlannerView
+        uid="planner-uid"
+        tool={
+          {
+            type: "tool-newTask",
+            toolCallId: "planner-call",
+            state: "output-error",
+            input: {
+              agentType: "planner",
+              description: "Create a plan",
+            },
+            errorText: "User aborted the tool call",
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("plannerView.planCreationPaused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
   it("shows the trajectory in the footer when a plan is in the card body", () => {
     useStoreFileMock.mockReturnValue({ content: "# Plan" });
 

--- a/packages/vscode-webui/src/features/tools/components/__tests__/sub-agent-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/sub-agent-view.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SubAgentView } from "../new-task/sub-agent-view";
+
+vi.mock("@/components/task-thread", () => ({
+  TaskThread: () => <div />,
+}));
+
+vi.mock("@/features/chat", () => ({
+  FixedStateChatContextProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("../tool-call-lite", () => ({
+  ToolCallLite: () => <span />,
+}));
+
+vi.mock("@/lib/hooks/use-navigate", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/lib/use-default-store", () => ({
+  useDefaultStore: () => ({ storeId: "store-id" }),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  isVSCodeEnvironment: () => false,
+}));
+
+vi.mock("../status-icon", () => ({
+  StatusIcon: () => <span />,
+}));
+
+const browserTool = {
+  type: "tool-newTask",
+  toolCallId: "browser-call",
+  state: "input-available",
+  input: {
+    agentType: "browser",
+    description: "Use the browser",
+  },
+} as never;
+
+describe("SubAgentView", () => {
+  it("does not render a separator below a header-only card", () => {
+    const { container } = render(
+      <SubAgentView
+        uid="browser-uid"
+        tool={browserTool}
+        isExecuting={false}
+        taskSource={undefined}
+      >
+        {null}
+      </SubAgentView>,
+    );
+
+    const header = container.firstElementChild?.firstElementChild;
+    expect(header?.className).not.toContain("border-b");
+  });
+
+  it("renders a separator when the card has a body", () => {
+    const { container } = render(
+      <SubAgentView
+        uid="browser-uid"
+        tool={browserTool}
+        isExecuting={true}
+        taskSource={undefined}
+      >
+        <div>Browser content</div>
+      </SubAgentView>,
+    );
+
+    const header = container.firstElementChild?.firstElementChild;
+    expect(header?.className).toContain("border-b");
+  });
+});

--- a/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/browser-view.tsx
@@ -2,6 +2,10 @@ import { useStoreFile } from "@/components/files-provider";
 import { TaskThread } from "@/components/task-thread";
 import { FixedStateChatContextProvider } from "@/features/chat";
 import { browserSessionManager } from "@/lib/browser-session-manager";
+import {
+  getToolPartError,
+  isToolCallCancellationError,
+} from "@/lib/tool-call-error";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { NewTaskToolViewProps } from ".";
@@ -29,6 +33,11 @@ export function BrowserView(props: NewTaskToolViewProps) {
   const showRecordingVideo = !!videoUrl && (!isExecuting || hasToolSettled);
   const showBrowserFrame = !!frame;
   const showBrowserArtifact = showRecordingVideo || showBrowserFrame;
+  const hasTaskThread = !!taskSource && taskSource.messages.length > 1;
+  const hidePlaceholder =
+    (!isExecuting && tool.state === "input-available") ||
+    isToolCallCancellationError(getToolPartError(tool));
+  const showBody = showBrowserArtifact || hasTaskThread || !hidePlaceholder;
 
   return (
     <SubAgentView
@@ -40,44 +49,46 @@ export function BrowserView(props: NewTaskToolViewProps) {
       showToolCall={showBrowserArtifact}
       showTaskThread={showBrowserArtifact}
     >
-      <div className="aspect-video w-full overflow-hidden">
-        {showRecordingVideo ? (
-          // biome-ignore lint/a11y/useMediaCaption: No audio track available
-          <video
-            src={`${videoUrl}#t=${BrowserRecordingVideoOffsetSeconds}`}
-            controls
-            playsInline
-            className="h-full w-full object-contain"
-          />
-        ) : showBrowserFrame ? (
-          <img
-            src={`data:image/jpeg;base64,${frame}`}
-            alt="Browser view"
-            className="h-full w-full object-contain"
-          />
-        ) : taskSource && taskSource.messages.length > 1 ? (
-          <div className="h-full w-full">
-            <FixedStateChatContextProvider
-              toolCallStatusRegistry={toolCallStatusRegistryRef?.current}
-            >
-              <TaskThread
-                source={taskSource}
-                showMessageList={true}
-                scrollAreaClassName="border-none h-full w-full my-0"
-                assistant={{ name: "Browser" }}
-              />
-            </FixedStateChatContextProvider>
-          </div>
-        ) : (
-          <div className="flex h-full w-full items-center justify-center p-3 text-muted-foreground">
-            <span className="text-base">
-              {isExecuting
-                ? t("browserView.executing")
-                : t("browserView.paused")}
-            </span>
-          </div>
-        )}
-      </div>
+      {showBody ? (
+        <div className="aspect-video w-full overflow-hidden">
+          {showRecordingVideo ? (
+            // biome-ignore lint/a11y/useMediaCaption: No audio track available
+            <video
+              src={`${videoUrl}#t=${BrowserRecordingVideoOffsetSeconds}`}
+              controls
+              playsInline
+              className="h-full w-full object-contain"
+            />
+          ) : showBrowserFrame ? (
+            <img
+              src={`data:image/jpeg;base64,${frame}`}
+              alt="Browser view"
+              className="h-full w-full object-contain"
+            />
+          ) : hasTaskThread ? (
+            <div className="h-full w-full">
+              <FixedStateChatContextProvider
+                toolCallStatusRegistry={toolCallStatusRegistryRef?.current}
+              >
+                <TaskThread
+                  source={taskSource}
+                  showMessageList={true}
+                  scrollAreaClassName="border-none h-full w-full my-0"
+                  assistant={{ name: "Browser" }}
+                />
+              </FixedStateChatContextProvider>
+            </div>
+          ) : (
+            <div className="flex h-full w-full items-center justify-center p-3 text-muted-foreground">
+              <span className="text-base">
+                {isExecuting
+                  ? t("browserView.executing")
+                  : t("browserView.paused")}
+              </span>
+            </div>
+          )}
+        </div>
+      ) : null}
     </SubAgentView>
   );
 }

--- a/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
@@ -11,6 +11,10 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { FixedStateChatContextProvider, useSendRetry } from "@/features/chat";
 import { useNavigate } from "@/lib/hooks/use-navigate";
 import { useReviewPlanTutorialCounter } from "@/lib/hooks/use-review-plan-tutorial-counter";
+import {
+  getToolPartError,
+  isToolCallCancellationError,
+} from "@/lib/tool-call-error";
 import { useDefaultStore } from "@/lib/use-default-store";
 import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
 import { FilePenLine, Play } from "lucide-react";
@@ -38,6 +42,9 @@ export function PlannerView(props: NewTaskToolViewProps) {
   const file = useStoreFile("/plan.md");
   const planContent = file?.content;
   const showPlanArtifact = !!planContent;
+  const hidePlaceholder =
+    (!isExecuting && tool.state === "input-available") ||
+    isToolCallCancellationError(getToolPartError(tool));
   const sendRetry = useSendRetry();
   const navigate = useNavigate();
   const { count, incrementCount } = useReviewPlanTutorialCounter();
@@ -165,7 +172,7 @@ export function PlannerView(props: NewTaskToolViewProps) {
             assistant={{ name: "Planner" }}
           />
         </FixedStateChatContextProvider>
-      ) : (
+      ) : hidePlaceholder ? null : (
         <div className="flex h-[300px] w-full items-center justify-center p-3 text-muted-foreground">
           <span className="text-base">
             {isExecuting

--- a/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
@@ -56,6 +56,7 @@ export function SubAgentView({
 
   const showFooter =
     showToolCallLite || footerActions || canShowFooterTaskThread;
+  const hasContent = children != null || !!showFooter;
   const navigate = useNavigate();
   const store = useDefaultStore();
   const toolTitle = tool.input?.agentType;
@@ -80,7 +81,8 @@ export function SubAgentView({
     <div className="mt-2 flex flex-col overflow-hidden rounded-md border shadow-sm">
       <div
         className={cn(
-          "flex items-start gap-2 border-b bg-muted/30 px-3 py-2 font-medium text-muted-foreground text-xs",
+          "flex items-start gap-2 bg-muted/30 px-3 py-2 font-medium text-muted-foreground text-xs",
+          hasContent && "border-b",
           uid && taskSource?.parentId && isVSCodeEnvironment()
             ? "group cursor-pointer transition-colors hover:bg-muted hover:text-foreground"
             : "",


### PR DESCRIPTION
## Summary
- **Fix sub-agent placeholder**: Hide the sub-agent paused/executing placeholder in `BrowserView` and `PlannerView` when awaiting approval or after cancellation.
- **Document CLI classes**: Added detailed JSDoc and inline comments to `running-task-adaptor.ts` and `attachment-utils.ts` in `packages/cli` to clarify sub-task propagation and attachment handling.
- **Document constants**: Added JSDoc comments to system-wide constants in `packages/common/src/base/constants.ts`.

## Test plan
- Verified that all unit and integration tests pass cleanly via the pre-push hook.
- Run `bun check` and confirmed zero formatting/linting issues.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ca41f6fcfc304b56ad3f9688d86bc366)