### PR TITLE
fix(vscode-webui): adjust height of terminal context badge

### DIFF
--- a/packages/vscode-webui/src/components/message/active-selection.tsx
+++ b/packages/vscode-webui/src/components/message/active-selection.tsx
@@ -106,9 +106,9 @@ export const TerminalSelectionPart: React.FC<TerminalSelectionProps> = ({
               onClick();
             }}
             aria-label={`${t("activeSelectionBadge.terminal")}: ${terminalName}:${lineCount}`}
-            className="mx-px inline-flex cursor-pointer items-center rounded-sm border border-border box-decoration-clone p-0.5 text-sm/6 hover:bg-zinc-200 active:bg-zinc-200 dark:active:bg-zinc-700 dark:hover:bg-zinc-700"
+            className="mx-px cursor-pointer rounded-sm border border-border box-decoration-clone p-0.5 text-sm/6 hover:bg-zinc-200 active:bg-zinc-200 dark:active:bg-zinc-700 dark:hover:bg-zinc-700"
           >
-            <TerminalIcon className="block size-3.5 shrink-0" />
+            <TerminalIcon className="mx-0.5 inline size-3.5 align-middle" />
             <span className="ml-0.5 break-words">
               {terminalName}
               <span className="text-zinc-500 dark:text-zinc-400">


### PR DESCRIPTION
## Summary
- The terminal selection badge used `inline-flex items-center` on its wrapper and `display: block` on the `TerminalIcon`, which computed height differently from the normal inline flow used by the file/TS badges, making it render visually shorter.
- Aligned the terminal badge markup with `FileBadge` so it relies on the same `text-sm/6` line-height, and centered the icon with `align-middle`.

## Test plan
- [x] `bun run tsc` (type check passes)
- [x] `bun check` (lint/format/i18n checks pass)
- [ ] Manually verify the terminal context badge height matches file/TS badges in the chat input

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4bae0e9606ad443292507e3f537afae5)


---

Preview:

<img width="357" height="112" alt="Screenshot 2026-07-28 202749" src="https://github.com/user-attachments/assets/44722508-4cbe-45af-b66b-54343499b40c" />
