### PR TITLE
fix(vscode-webui): add more spacing between add context row and queued messages

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
@@ -83,7 +83,7 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
   }, [messages, t]);
 
   return (
-    <div className="mx-1 mt-1 mb-1.5 flex max-h-28 flex-col gap-0.5 overflow-y-auto rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
+    <div className="mx-1 mt-2 mb-1.5 flex max-h-28 flex-col gap-0.5 overflow-y-auto rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
       {renderMessages.map((message, index) => (
         <div
           key={index}


### PR DESCRIPTION
## Summary
- Increase top margin of the queued messages panel (`mt-1` → `mt-2`) so there's clearer visual separation from the "+ Add" context row above it.

## Test plan
- [ ] Visually verify spacing between "+ Add" row and queued messages panel in the chat input box.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-46d911b9c5b1460fa9f512da9540e0da)

---

Preview:

<img width="522" height="152" alt="Screenshot 2026-07-28 203220" src="https://github.com/user-attachments/assets/59d9f846-4778-4eb9-a000-efcec09146ef" />
