### PR TITLE
fix(vscode-webui): refresh repaired Mermaid on share pages

### DIFF
--- a/packages/vscode-webui/src/features/share/page.tsx
+++ b/packages/vscode-webui/src/features/share/page.tsx
@@ -4,7 +4,7 @@ import { VSCodeWebProvider } from "@/components/vscode-web-provider";
 import { ChatContextProvider } from "@/features/chat";
 import { cn } from "@/lib/utils";
 import { formatters } from "@getpochi/common";
-import { type ResizeEvent, ShareEvent } from "@getpochi/common/share-utils";
+import type { ResizeEvent } from "@getpochi/common/share-utils";
 import type { Message } from "@getpochi/livekit";
 import { toTaskStatus } from "@getpochi/livekit";
 import { createChannel } from "bidc";
@@ -12,6 +12,7 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ErrorMessageView } from "../chat/components/error-message-view";
 import { TodoList } from "../todo";
+import { useShareData } from "./use-share-data";
 
 type BIDCChannel = ReturnType<typeof createChannel>;
 
@@ -222,63 +223,8 @@ export function SharePage() {
   );
 }
 
-function useShareData({
-  isStorePathname,
-  channel,
-}: { channel?: BIDCChannel | undefined; isStorePathname: boolean }) {
-  const [data, setData] = useState<ShareEvent>();
-
-  const fetchCfShareData = useCallback(() => {
-    const api = location.pathname.replace("/html", "/json");
-    const token = getTokenFromHash();
-    fetch(
-      api,
-      token
-        ? {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        : undefined,
-    )
-      .then(async (res) => {
-        const data = await res.json();
-        const parsed = ShareEvent.parse(data);
-        setData(parsed);
-      })
-      .catch((err) => {
-        console.error("Failed to fetch share data", err);
-      });
-  }, []);
-
-  const subscribeChannelData = useCallback(() => {
-    if (!channel) return;
-    channel.receive((data) => {
-      setData(ShareEvent.parse(data));
-    });
-  }, [channel]);
-
-  useEffect(() => {
-    if (isStorePathname) {
-      fetchCfShareData();
-    } else {
-      subscribeChannelData();
-    }
-  }, [isStorePathname, fetchCfShareData, subscribeChannelData]);
-
-  return data;
-}
-
 function isStorePathname() {
   const regex = /\/stores\/([^\/]+)\/tasks\/([^\/]+)\/html/;
   const match = location.pathname.match(regex);
   return !!match;
-}
-
-function getTokenFromHash() {
-  const hash = window.location.hash.substring(1); // Remove the # character
-  if (hash) {
-    const hashParams = new URLSearchParams(hash);
-    return hashParams.get("token");
-  }
 }

--- a/packages/vscode-webui/src/features/share/use-share-data.test.tsx
+++ b/packages/vscode-webui/src/features/share/use-share-data.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useShareData } from "./use-share-data";
+
+describe("useShareData", () => {
+  beforeEach(() => {
+    window.history.replaceState(
+      {},
+      "",
+      "/stores/store-1/tasks/task-1/html#token=owner-token",
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes share data when a store event is received", async () => {
+    let eventsController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+    let jsonRequestCount = 0;
+    const encoder = new TextEncoder();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.endsWith("/json")) {
+        jsonRequestCount += 1;
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              makeShareData(
+                jsonRequestCount === 1 ? "invalid mermaid" : "fixed mermaid",
+              ),
+            ),
+        } as Response);
+      }
+      if (url.endsWith("/events")) {
+        return Promise.resolve({
+          ok: true,
+          body: new ReadableStream<Uint8Array>({
+            start(controller) {
+              eventsController = controller;
+              init?.signal?.addEventListener(
+                "abort",
+                () => controller.close(),
+                { once: true },
+              );
+            },
+          }),
+        } as Response);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(() =>
+      useShareData({ isStorePathname: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current?.messages?.[0]?.parts).toEqual([
+        { type: "text", text: "invalid mermaid" },
+      ]);
+    });
+
+    if (!eventsController) {
+      throw new Error("Share events stream was not created");
+    }
+    eventsController.enqueue(
+      encoder.encode('data: {"name":"v1.MermaidRepaired","args":{}}\n\n'),
+    );
+
+    await waitFor(() => {
+      expect(result.current?.messages?.[0]?.parts).toEqual([
+        { type: "text", text: "fixed mermaid" },
+      ]);
+    });
+
+    const eventRequest = fetchMock.mock.calls.find(([input]) =>
+      input.toString().endsWith("/events"),
+    );
+    expect(eventRequest?.[1]).toMatchObject({
+      headers: { Authorization: "Bearer owner-token" },
+    });
+
+    const signal = (eventRequest?.[1] as RequestInit).signal;
+    expect(signal?.aborted).toBe(false);
+    unmount();
+    expect(signal?.aborted).toBe(true);
+  });
+});
+
+function makeShareData(text: string) {
+  return {
+    type: "share" as const,
+    messages: [
+      {
+        id: "message-1",
+        role: "assistant",
+        parts: [{ type: "text", text }],
+      },
+    ],
+  };
+}

--- a/packages/vscode-webui/src/features/share/use-share-data.ts
+++ b/packages/vscode-webui/src/features/share/use-share-data.ts
@@ -1,0 +1,146 @@
+import { getLogger } from "@getpochi/common";
+import { ShareEvent } from "@getpochi/common/share-utils";
+import type { createChannel } from "bidc";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const logger = getLogger("useShareData");
+
+type BIDCChannel = ReturnType<typeof createChannel>;
+
+export function useShareData({
+  isStorePathname,
+  channel,
+}: { channel?: BIDCChannel; isStorePathname: boolean }) {
+  const [data, setData] = useState<ShareEvent>();
+  const shareDataRequestId = useRef(0);
+
+  const fetchCfShareData = useCallback(async (signal: AbortSignal) => {
+    const api = location.pathname.replace("/html", "/json");
+    const token = getTokenFromHash();
+    const requestId = ++shareDataRequestId.current;
+
+    try {
+      const response = await fetch(api, makeFetchOptions(token, signal));
+      if (!response.ok) {
+        throw new Error(`Share data request failed with ${response.status}`);
+      }
+      const nextData = ShareEvent.parse(await response.json());
+      if (!signal.aborted && requestId === shareDataRequestId.current) {
+        setData(nextData);
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        logger.error("Failed to fetch share data", error);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isStorePathname) return;
+
+    const abortController = new AbortController();
+    const token = getTokenFromHash();
+    const eventsApi = location.pathname.replace("/html", "/events");
+
+    void fetchCfShareData(abortController.signal);
+    void subscribeCfShareData({
+      api: eventsApi,
+      token,
+      signal: abortController.signal,
+      onEvent: () => fetchCfShareData(abortController.signal),
+    });
+
+    return () => abortController.abort();
+  }, [isStorePathname, fetchCfShareData]);
+
+  useEffect(() => {
+    if (isStorePathname || !channel) return;
+
+    channel.receive((nextData) => {
+      setData(ShareEvent.parse(nextData));
+    });
+  }, [isStorePathname, channel]);
+
+  return data;
+}
+
+async function subscribeCfShareData({
+  api,
+  token,
+  signal,
+  onEvent,
+}: {
+  api: string;
+  token: string | null;
+  signal: AbortSignal;
+  onEvent: () => Promise<void>;
+}) {
+  while (!signal.aborted) {
+    try {
+      const response = await fetch(api, makeFetchOptions(token, signal));
+      if (!response.ok) {
+        throw new Error(`Share events request failed with ${response.status}`);
+      }
+      if (!response.body) {
+        throw new Error("Share events response has no body");
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (!signal.aborted) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split(/\r?\n\r?\n/);
+        buffer = events.pop() ?? "";
+
+        for (const event of events) {
+          if (event.split(/\r?\n/).some((line) => line.startsWith("data:"))) {
+            await onEvent();
+          }
+        }
+      }
+    } catch (error) {
+      if (signal.aborted) return;
+      logger.error("Failed to subscribe to share events", error);
+      await waitForRetry(signal);
+    }
+  }
+}
+
+function makeFetchOptions(token: string | null, signal: AbortSignal) {
+  return {
+    signal,
+    headers: token
+      ? {
+          Authorization: `Bearer ${token}`,
+        }
+      : undefined,
+  };
+}
+
+function waitForRetry(signal: AbortSignal) {
+  return new Promise<void>((resolve) => {
+    const timeoutId = setTimeout(resolve, 1000);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeoutId);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+function getTokenFromHash() {
+  const hash = window.location.hash.substring(1);
+  if (hash) {
+    const hashParams = new URLSearchParams(hash);
+    return hashParams.get("token");
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- subscribe store-backed share pages to authenticated LiveStore events
- refresh share snapshots after persisted updates so repaired Mermaid content appears without reloading
- prevent stale request races and clean up event streams on unmount
- add regression coverage for refreshes, authorization forwarding, and cleanup

## Test plan
- [x] `bun run test -- src/features/share/use-share-data.test.tsx`
- [x] `bun tsc` in `packages/vscode-webui`
- [x] `bun check`
- [x] `bun run build:share` in `packages/vscode-webui`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-314c9189197045b6b0de49157b132d3a)