### PR TITLE
fix(vscode-webui): hide planner footer actions when no body content exists

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/__tests__/planner-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/planner-view.test.tsx
@@ -175,6 +175,34 @@ describe("PlannerView", () => {
     expect(lastSubAgentProps()?.children).toBeNull();
   });
 
+  it("does not render a placeholder after the tool call is rejected", () => {
+    useStoreFileMock.mockReturnValue(undefined);
+
+    render(
+      <PlannerView
+        uid="planner-uid"
+        tool={
+          {
+            type: "tool-newTask",
+            toolCallId: "planner-call",
+            state: "output-available",
+            input: {
+              agentType: "planner",
+              description: "Create a plan",
+            },
+            output: { error: "User rejected the tool call" },
+          } as never
+        }
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("plannerView.planCreationPaused")).toBeNull();
+    expect(lastSubAgentProps()?.children).toBeNull();
+  });
+
   it("shows the trajectory in the footer when a plan is in the card body", () => {
     useStoreFileMock.mockReturnValue({ content: "# Plan" });
 

--- a/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
@@ -42,11 +42,12 @@ export function PlannerView(props: NewTaskToolViewProps) {
   const file = useStoreFile("/plan.md");
   const planContent = file?.content;
   const showPlanArtifact = !!planContent;
-  const hasBodyContent =
-    showPlanArtifact || (!!taskSource && taskSource.messages.length > 1);
   const hidePlaceholder =
     (!isExecuting && tool.state === "input-available") ||
     isToolCallCancellationError(getToolPartError(tool));
+  const hasBodyContent =
+    showPlanArtifact ||
+    (!hidePlaceholder && !!taskSource && taskSource.messages.length > 1);
   const sendRetry = useSendRetry();
   const navigate = useNavigate();
   const { count, incrementCount } = useReviewPlanTutorialCounter();

--- a/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/planner-view.tsx
@@ -42,6 +42,8 @@ export function PlannerView(props: NewTaskToolViewProps) {
   const file = useStoreFile("/plan.md");
   const planContent = file?.content;
   const showPlanArtifact = !!planContent;
+  const hasBodyContent =
+    showPlanArtifact || (!!taskSource && taskSource.messages.length > 1);
   const hidePlaceholder =
     (!isExecuting && tool.state === "input-available") ||
     isToolCallCancellationError(getToolPartError(tool));
@@ -101,7 +103,8 @@ export function PlannerView(props: NewTaskToolViewProps) {
       }
       footerActions={
         isVSCodeEnvironment() &&
-        isLastPart && (
+        isLastPart &&
+        hasBodyContent && (
           <>
             <HoverCard
               openDelay={0}

--- a/packages/vscode-webui/src/lib/tool-call-error.ts
+++ b/packages/vscode-webui/src/lib/tool-call-error.ts
@@ -57,6 +57,7 @@ export function isToolCallCancellationError(
   return (
     error === getToolCallErrorMessage("user-abort") ||
     error === getToolCallErrorMessage("previous-tool-call-failed") ||
+    error === getToolCallErrorMessage("user-reject") ||
     error === "Tool call was cancelled"
   );
 }


### PR DESCRIPTION
## Summary
* Only show footer actions in the planner-view when there is actual plan content or message history available.
* Prevents rendering empty/stale action overlays before a plan has been generated or when no messages exist.

## Screenshot
<img width="814" height="684" alt="image" src="https://github.com/user-attachments/assets/803f3571-f6bc-4b71-90b3-76ef6aa56b76" />
<img width="820" height="158" alt="image" src="https://github.com/user-attachments/assets/44d3c2eb-c95c-49ce-ab6d-4670bf8beedd" />


## Test plan
- [x] Run `bun check` to ensure code formatting and linting pass.
- [ ] Verify that the footer actions are hidden when the planner is first opened and has no plan or message history.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-dbe7005195184c0dbbe0b5525762a34f)