### PR TITLE
fix(vscode-webui): expose todo mode outside dev mode

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -65,7 +65,6 @@ vi.mock("@/features/approval", () => ({
 vi.mock("@/features/settings", () => ({
   AutoApproveMenu: () => null,
   useAutoApprove: () => ({ autoApproveActive: false }),
-  useIsDevMode: () => [false, vi.fn()],
   useSelectedModels: () => ({
     groupedModels: [],
     selectedModel: { id: "model-1" },
@@ -148,8 +147,17 @@ vi.mock("../hooks/use-subtask-completed", () => ({
   useShowCompleteSubtaskButton: () => false,
 }));
 vi.mock("./chat-input-form", () => ({
-  ChatInputForm: ({ children }: { children: React.ReactNode }) => (
-    <form>{children}</form>
+  ChatInputForm: ({
+    children,
+    onSelectTodoMode,
+  }: {
+    children: React.ReactNode;
+    onSelectTodoMode?: () => void;
+  }) => (
+    <form>
+      {onSelectTodoMode && <div data-testid="todo-mode-entry" />}
+      {children}
+    </form>
   ),
 }));
 vi.mock("./error-message-view", () => ({
@@ -213,15 +221,17 @@ describe("ChatToolbar", () => {
     chatSubmitMocks.useChatSubmit.mockClear();
   });
 
-  it("renders todos in root task pages", () => {
+  it("renders todo mode and todos in root task pages", () => {
     renderToolbar(false);
 
+    expect(screen.getByTestId("todo-mode-entry")).toBeTruthy();
     expect(screen.getByTestId("todo-list")).toBeTruthy();
   });
 
-  it("does not render audit todos in subtask pages", () => {
+  it("does not render todo mode or audit todos in subtask pages", () => {
     renderToolbar(true);
 
+    expect(screen.queryByTestId("todo-mode-entry")).toBeNull();
     expect(screen.queryByTestId("todo-list")).toBeNull();
   });
 

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -16,7 +16,6 @@ import {
 import {
   AutoApproveMenu,
   useAutoApprove,
-  useIsDevMode,
   useSelectedModels,
 } from "@/features/settings";
 import { type TodoCompletionUpdate, TodoList } from "@/features/todo";
@@ -152,13 +151,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     }
   }, [excludedUserEditsContext, userEditsContext]);
 
-  const [isDevMode] = useIsDevMode();
-  const canUseTodoMode = isDevMode === true;
   const [todoModeSelected, setTodoModeSelected] = useState(false);
-  // Show the todo mode entry in dev mode, but disable it (rather than hide it)
-  // while the task already has active todos so it stays discoverable.
-  const showTodoMode = canUseTodoMode && !isSubTask;
+  const showTodoMode = !isSubTask;
   const todoModeDisabled = hasActiveTodos(todos);
+  // Disable the todo mode entry (rather than hide it) while the task already
+  // has active todos so it stays discoverable.
   const canSelectTodoMode = showTodoMode && !todoModeDisabled;
 
   useEffect(() => {

--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -6,11 +6,7 @@ import {
   type CreateWorktreeType,
   WorktreeSelect,
 } from "@/components/worktree-select";
-import {
-  useIsDevMode,
-  useSelectedModels,
-  useSettingsStore,
-} from "@/features/settings";
+import { useSelectedModels, useSettingsStore } from "@/features/settings";
 import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import type { useAttachmentUpload } from "@/lib/hooks/use-attachment-upload";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
@@ -48,9 +44,6 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
   const { draft: input, setDraft: setInput, clearDraft } = useTaskInputDraft();
   const [planMode, setPlanMode] = useState(false);
   const [todoModeSelected, setTodoModeSelected] = useState(false);
-  const [isDevMode] = useIsDevMode();
-  const canUseTodoMode = isDevMode === true;
-  const todoMode = canUseTodoMode && todoModeSelected;
   const togglePlanMode = useCallback(() => {
     setPlanMode((enabled) => {
       const nextEnabled = !enabled;
@@ -65,10 +58,9 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
     setPlanMode((enabled) => !enabled);
   }, []);
   const selectTodoMode = useCallback(() => {
-    if (!canUseTodoMode) return;
     setPlanMode(false);
     setTodoModeSelected(true);
-  }, [canUseTodoMode]);
+  }, []);
   const {
     globalMcpConfig,
     mcpConfigOverride,
@@ -241,8 +233,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
     }) => {
       const { shouldCreateWorktree } = options || {};
       const shouldCreatePlan = options?.shouldCreatePlan ?? planMode;
-      const shouldCreateTodo =
-        canUseTodoMode && (options?.shouldCreateTodo ?? todoMode);
+      const shouldCreateTodo = options?.shouldCreateTodo ?? todoModeSelected;
 
       if (isCreatingTask) return;
 
@@ -314,8 +305,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       setDebouncedIsCreatingTask,
       createWorktreeAndOpenTask,
       planMode,
-      todoMode,
-      canUseTodoMode,
+      todoModeSelected,
     ],
   );
 
@@ -364,7 +354,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
         reviews={emptyReviews}
         onSwitchSubmitMode={switchSubmitMode}
         isPlanMode={planMode}
-        onSelectTodoMode={canUseTodoMode ? selectTodoMode : undefined}
+        onSelectTodoMode={selectTodoMode}
         onAttachFile={() => fileInputRef.current?.click()}
         contextMenuSide="bottom"
       >
@@ -401,7 +391,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
             reloadModels={reloadModels}
             triggerClassName="sidebar-model-select"
           />
-          {todoMode && (
+          {todoModeSelected && (
             <TodoModeBadge onRemove={() => setTodoModeSelected(false)} />
           )}
         </div>


### PR DESCRIPTION
## Summary
- remove the Dev Mode gate from Todo mode in new and existing root tasks
- keep Todo mode hidden for subtasks and disabled when active todos already exist
- update toolbar tests to cover root-task and subtask visibility

## Test plan
- [x] `bun vitest --run src/features/chat/components/chat-toolbar.test.tsx`
- [x] `bun run tsc` in `packages/vscode-webui`
- [x] `bun check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-b5c3c9fac2b544339df861547e7031fe)