### PR TITLE
feat(vscode-webui): enable todo mode for all users

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -16,7 +16,6 @@ import {
 import {
   AutoApproveMenu,
   useAutoApprove,
-  useIsDevMode,
   useSelectedModels,
 } from "@/features/settings";
 import { type TodoCompletionUpdate, TodoList } from "@/features/todo";
@@ -152,12 +151,9 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     }
   }, [excludedUserEditsContext, userEditsContext]);
 
-  const [isDevMode] = useIsDevMode();
-  const canUseTodoMode = isDevMode === true;
   const [todoModeSelected, setTodoModeSelected] = useState(false);
-  // Show the todo mode entry in dev mode, but disable it (rather than hide it)
-  // while the task already has active todos so it stays discoverable.
-  const showTodoMode = canUseTodoMode && !isSubTask;
+  // Disable todo mode (rather than hide it) while active todos exist so it stays discoverable.
+  const showTodoMode = !isSubTask;
   const todoModeDisabled = hasActiveTodos(todos);
   const canSelectTodoMode = showTodoMode && !todoModeDisabled;
 

--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -6,11 +6,7 @@ import {
   type CreateWorktreeType,
   WorktreeSelect,
 } from "@/components/worktree-select";
-import {
-  useIsDevMode,
-  useSelectedModels,
-  useSettingsStore,
-} from "@/features/settings";
+import { useSelectedModels, useSettingsStore } from "@/features/settings";
 import { useActiveSelection } from "@/lib/hooks/use-active-selection";
 import type { useAttachmentUpload } from "@/lib/hooks/use-attachment-upload";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
@@ -48,9 +44,6 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
   const { draft: input, setDraft: setInput, clearDraft } = useTaskInputDraft();
   const [planMode, setPlanMode] = useState(false);
   const [todoModeSelected, setTodoModeSelected] = useState(false);
-  const [isDevMode] = useIsDevMode();
-  const canUseTodoMode = isDevMode === true;
-  const todoMode = canUseTodoMode && todoModeSelected;
   const togglePlanMode = useCallback(() => {
     setPlanMode((enabled) => {
       const nextEnabled = !enabled;
@@ -65,10 +58,9 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
     setPlanMode((enabled) => !enabled);
   }, []);
   const selectTodoMode = useCallback(() => {
-    if (!canUseTodoMode) return;
     setPlanMode(false);
     setTodoModeSelected(true);
-  }, [canUseTodoMode]);
+  }, []);
   const {
     globalMcpConfig,
     mcpConfigOverride,
@@ -241,8 +233,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
     }) => {
       const { shouldCreateWorktree } = options || {};
       const shouldCreatePlan = options?.shouldCreatePlan ?? planMode;
-      const shouldCreateTodo =
-        canUseTodoMode && (options?.shouldCreateTodo ?? todoMode);
+      const shouldCreateTodo = options?.shouldCreateTodo ?? todoModeSelected;
 
       if (isCreatingTask) return;
 
@@ -314,8 +305,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       setDebouncedIsCreatingTask,
       createWorktreeAndOpenTask,
       planMode,
-      todoMode,
-      canUseTodoMode,
+      todoModeSelected,
     ],
   );
 
@@ -364,7 +354,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
         reviews={emptyReviews}
         onSwitchSubmitMode={switchSubmitMode}
         isPlanMode={planMode}
-        onSelectTodoMode={canUseTodoMode ? selectTodoMode : undefined}
+        onSelectTodoMode={selectTodoMode}
         onAttachFile={() => fileInputRef.current?.click()}
         contextMenuSide="bottom"
       >
@@ -401,7 +391,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
             reloadModels={reloadModels}
             triggerClassName="sidebar-model-select"
           />
-          {todoMode && (
+          {todoModeSelected && (
             <TodoModeBadge onRemove={() => setTodoModeSelected(false)} />
           )}
         </div>


### PR DESCRIPTION
## Summary
- Remove the developer-mode restriction from Todo Mode in the VS Code webview.
- Make Todo Mode available and discoverable for all users in the chat toolbar and task input interfaces.
- Clean up unused imports and state hooks (`useIsDevMode`) that were previously required to guard Todo Mode.

## Test plan
- Run unit tests in `packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx` and verify they pass.
- Manually verify that Todo Mode is selectable and works in both chat toolbar and task input.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-edeb16d0f0ef4859b801bb0a53fee501)