### PR TITLE
fix(vscode-webui): sync submitted user edits with input

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/user-edits.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/user-edits.tsx
@@ -4,20 +4,12 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { EditSummary } from "@/features/tools";
-import { useUserEdits } from "@/lib/hooks/use-user-edits";
 import { cn } from "@/lib/utils";
 import { vscodeHost } from "@/lib/vscode";
 import type { FileDiff } from "@getpochi/common/vscode-webui-bridge";
 import { FilePenLine, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../ui/button";
-
-interface UserEditsBadgeProps {
-  className?: string;
-  taskId: string;
-  lastCheckpoint: string;
-  onRemove?: () => void;
-}
 
 interface UserEditsProps {
   userEdits: FileDiff[];
@@ -26,24 +18,6 @@ interface UserEditsProps {
   className?: string;
   onRemove?: () => void;
 }
-
-export const UserEditsBadge: React.FC<UserEditsBadgeProps> = ({
-  taskId,
-  className,
-  lastCheckpoint,
-  onRemove,
-}) => {
-  const userEdits = useUserEdits(taskId);
-
-  return (
-    <UserEdits
-      userEdits={userEdits}
-      className={className}
-      originCheckpoint={lastCheckpoint}
-      onRemove={onRemove}
-    />
-  );
-};
 
 export const UserEdits: React.FC<UserEditsProps> = ({
   userEdits,

--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -10,9 +10,9 @@ import type { UseChatHelpers } from "@ai-sdk/react";
 import type { Message } from "@getpochi/livekit";
 
 import { ReviewBadges } from "@/components/prompt-form/review-badges";
-import { UserEditsBadge } from "@/components/prompt-form/user-edits";
+import { UserEdits } from "@/components/prompt-form/user-edits";
 import { useActiveSelection } from "@/lib/hooks/use-active-selection";
-import type { Review } from "@getpochi/common/vscode-webui-bridge";
+import type { FileDiff, Review } from "@getpochi/common/vscode-webui-bridge";
 import type { ReactNode } from "@tanstack/react-router";
 import type { ChatInput } from "../hooks/use-chat-input-state";
 import type { DraftMessage } from "../hooks/use-chat-submit";
@@ -34,9 +34,8 @@ interface ChatInputFormProps {
   isSubTask: boolean;
   children?: ReactNode;
   reviews: Review[];
-  taskId?: string;
+  userEdits?: FileDiff[];
   lastCheckpointHash?: string;
-  includeUserEdits?: boolean;
   onRemoveUserEdits?: () => void;
   onSwitchSubmitMode?: () => void;
   isPlanMode?: boolean;
@@ -74,9 +73,8 @@ export const ChatInputForm = forwardRef<
     messageContent,
     isSubTask,
     reviews,
-    taskId,
+    userEdits = [],
     lastCheckpointHash,
-    includeUserEdits = true,
     onRemoveUserEdits,
     children,
     onSwitchSubmitMode,
@@ -147,10 +145,10 @@ export const ChatInputForm = forwardRef<
           todoModeDisabled={todoModeDisabled}
         />
         <ActiveSelectionBadge />
-        {includeUserEdits && taskId && lastCheckpointHash && (
-          <UserEditsBadge
-            taskId={taskId}
-            lastCheckpoint={lastCheckpointHash}
+        {userEdits.length > 0 && lastCheckpointHash && (
+          <UserEdits
+            userEdits={userEdits}
+            originCheckpoint={lastCheckpointHash}
             onRemove={onRemoveUserEdits}
           />
         )}

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -14,6 +14,14 @@ const chatSubmitMocks = vi.hoisted(() => ({
     pauseQueueRef: { current: false },
   })),
 }));
+const userEditsMocks = vi.hoisted(() => ({
+  userEdits: [] as Array<{
+    filepath: string;
+    diff: string;
+    added: number;
+    removed: number;
+  }>,
+}));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -99,7 +107,7 @@ vi.mock("@/lib/hooks/use-reviews", () => ({
   useReviews: () => [],
 }));
 vi.mock("@/lib/hooks/use-user-edits", () => ({
-  useUserEdits: () => [],
+  useUserEdits: () => userEditsMocks.userEdits,
 }));
 vi.mock("@/lib/hooks/use-task-changed-files", () => ({
   useTaskChangedFiles: () => ({
@@ -169,7 +177,7 @@ const auditTodo: Todo = {
   priority: "medium",
 };
 
-function renderToolbar(isSubTask: boolean) {
+function renderToolbar(isSubTask: boolean, lastCheckpointHash?: string) {
   render(
     <ChatToolbar
       chat={
@@ -195,7 +203,12 @@ function renderToolbar(isSubTask: boolean) {
       }
       isSubTask={isSubTask}
       task={
-        { id: "task-1", todos: undefined, totalTokens: 0 } as unknown as Task
+        {
+          id: "task-1",
+          todos: undefined,
+          totalTokens: 0,
+          lastCheckpointHash,
+        } as unknown as Task
       }
       displayError={undefined}
       todos={[auditTodo]}
@@ -211,6 +224,7 @@ function renderToolbar(isSubTask: boolean) {
 describe("ChatToolbar", () => {
   beforeEach(() => {
     chatSubmitMocks.useChatSubmit.mockClear();
+    userEditsMocks.userEdits = [];
   });
 
   it("renders todos in root task pages", () => {
@@ -231,6 +245,36 @@ describe("ChatToolbar", () => {
     expect(chatSubmitMocks.useChatSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         canCreateTodo: false,
+      }),
+    );
+  });
+
+  it("submits no user edits after they disappear from the input", () => {
+    renderToolbar(false, "checkpoint-1");
+
+    expect(chatSubmitMocks.useChatSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userEdits: [],
+      }),
+    );
+  });
+
+  it("submits the user edits shown in the input", () => {
+    const userEdits = [
+      {
+        filepath: "src/example.ts",
+        diff: "+const value = 1;",
+        added: 1,
+        removed: 0,
+      },
+    ];
+    userEditsMocks.userEdits = userEdits;
+
+    renderToolbar(false, "checkpoint-1");
+
+    expect(chatSubmitMocks.useChatSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userEdits,
       }),
     );
   });

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -140,8 +140,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
       userEdits.map(({ filepath, diff }) => [filepath, diff]),
     ]);
   }, [lastCheckpointHash, taskId, userEdits]);
-  const includeUserEdits =
-    !userEditsContext || excludedUserEditsContext !== userEditsContext;
+  const includedUserEdits =
+    userEditsContext !== undefined &&
+    excludedUserEditsContext !== userEditsContext
+      ? userEdits
+      : [];
 
   useEffect(() => {
     if (
@@ -272,8 +275,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     queuedMessages,
     setQueuedMessages,
     reviews,
+    userEdits: includedUserEdits,
     taskId,
-    includeUserEdits,
     isTodoMode: todoModeSelected,
     canCreateTodo: !todoModeDisabled,
     onTodoModeQueued: resetTodoMode,
@@ -432,9 +435,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           messageContent={messageContent}
           isSubTask={isSubTask}
           reviews={reviews}
-          taskId={taskId}
+          userEdits={includedUserEdits}
           lastCheckpointHash={lastCheckpointHash}
-          includeUserEdits={includeUserEdits}
           onRemoveUserEdits={() =>
             setExcludedUserEditsContext(userEditsContext)
           }

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -42,10 +42,6 @@ vi.mock("@/lib/hooks/use-active-selection", () => ({
   useActiveSelection: () => activeSelectionMock.value,
 }));
 
-vi.mock("@/lib/hooks/use-user-edits", () => ({
-  useUserEdits: () => userEditsMocks.userEdits,
-}));
-
 vi.mock("@/lib/message-utils", () => ({
   prepareMessageParts: messageUtilsMocks.prepareMessageParts,
 }));
@@ -640,11 +636,11 @@ function setup({
         isStopEnabled,
         allowSendMessage,
         allowSteer,
-        includeUserEdits: props.includeUserEdits,
         pendingApproval: undefined,
         queuedMessages,
         setQueuedMessages,
         reviews,
+        userEdits: props.includeUserEdits ? userEditsMocks.userEdits : [],
         taskId: "task-1",
         isTodoMode,
         canCreateTodo,

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -7,9 +7,9 @@ import { getLogger } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
 
 import { useActiveSelection } from "@/lib/hooks/use-active-selection";
-import { useUserEdits } from "@/lib/hooks/use-user-edits";
 import type {
   ActiveSelection,
+  FileDiff,
   Review,
   TerminalTextSelection,
 } from "@getpochi/common/vscode-webui-bridge";
@@ -57,8 +57,8 @@ interface UseChatSubmitProps {
   queuedMessages: DraftMessage[];
   setQueuedMessages: React.Dispatch<React.SetStateAction<DraftMessage[]>>;
   reviews: Review[];
+  userEdits: FileDiff[];
   taskId: string;
-  includeUserEdits?: boolean;
   isTodoMode?: boolean;
   canCreateTodo?: boolean;
   onTodoModeQueued?: () => void;
@@ -84,8 +84,8 @@ export function useChatSubmit({
   queuedMessages,
   setQueuedMessages,
   reviews,
+  userEdits,
   taskId,
-  includeUserEdits = true,
   isTodoMode = false,
   canCreateTodo = true,
   onTodoModeQueued,
@@ -100,7 +100,6 @@ export function useChatSubmit({
     batchExecuteManager.abort(taskId, "user-abort");
   }, [batchExecuteManager, taskId]);
 
-  const userEdits = useUserEdits(taskId);
   const activeSelection = useActiveSelection();
 
   const { sendMessage, stop: stopChat } = chat;
@@ -177,7 +176,7 @@ export function useChatSubmit({
     }
 
     // Capture the user's selection context (editor + terminal) right now.
-    const currentUserEdits = includeUserEdits ? [...userEdits] : [];
+    const currentUserEdits = [...userEdits];
     const currentSelection = activeSelection;
 
     // Terminal selection can only be read on demand (there's no reactive
@@ -231,7 +230,6 @@ export function useChatSubmit({
     files,
     reviews,
     userEdits,
-    includeUserEdits,
     activeSelection,
     upload,
     clearFiles,


### PR DESCRIPTION
## Summary
- use a single user-edit snapshot for both input rendering and message submission
- prevent branch switches from submitting stale edits after the input badge disappears
- add coverage for visible and cleared user-edit submission states

## Test plan
- [x] Run `bun run test -- src/features/chat/components/chat-toolbar.test.tsx src/features/chat/hooks/use-chat-submit.test.tsx`
- [x] Run `bun tsc` in `packages/vscode-webui`
- [x] Run `bun check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-40d36fdf840746e4b4f517576d07ba01)