### PR TITLE
docs: correct weekly update #35 Add Context menu (no Plan mode)

### DIFF
--- a/packages/docs/content/docs/developer-updates/2026-07-24-weekly-update-35.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-07-24-weekly-update-35.mdx
@@ -53,7 +53,7 @@ More below!
 
   <div class="w-1/2 md:ml-8 *:shadow-xl/30 *:rounded-lg">![Completed steps showing how long each one took](https://assets.docs.getpochi.com/docs/c9/c9226ed76f6e208fc28c010f495ed224a7a855166cd8b114250e1d90ac375970)</div>
 
-- **One menu for context and working modes:** The new **Add Context** menu lets you attach the active selection, files, or folders and switch Todo or Plan mode, all from the prompt toolbar.
+- **One menu for context and working modes:** The new **Add Context** menu lets you attach the active selection, files, or folders and switch Todo mode, all from the prompt toolbar.
 
   Clear badges show which context and mode will be used before you submit, and the Todo toggle that used to sit in the toolbar now lives inside this menu so the controls are in one place. [**#1753**](https://github.com/TabbyML/pochi/pull/1753)
 


### PR DESCRIPTION
## Summary
Weekly Update #35 describes the new **Add Context** menu (#1753) as letting you "switch Todo or **Plan mode**." The shipped menu only toggles **Todo**.

`packages/vscode-webui/src/components/prompt-form/add-context-menu.tsx` renders exactly three items — Files and folders, Attach files, Todo — with a single `onSelectTodoMode` prop. There is no Plan mode item or handler in this menu.

Plan mode is a real feature, but it lives on a separate surface (Shift+Tab / the submit-dropdown button), not the Add Context menu. The PR #1753 description mentioned Plan mode, but that scope did not ship in the menu.

## Change
Line 56: `switch Todo or Plan mode` → `switch Todo mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)