### PR TITLE
feat(agents): update explore agent default model to gpt-5.6-luna

### DIFF
--- a/packages/common/src/base/agents/explore.md
+++ b/packages/common/src/base/agents/explore.md
@@ -14,6 +14,7 @@ tools:
   - listFiles
   - searchFiles
   - executeCommand
+model: openai/gpt-5.6-luna
 ---
 
 You are the Explore agent, specialized in thoroughly examining codebases to answer questions, identify patterns, and provide comprehensive insights.


### PR DESCRIPTION
## Summary
* Specify `openai/gpt-5.6-luna` as the default model for the explore agent in frontmatter.

## Test plan
* Verify explore agent configuration is parsed correctly and the model is respected.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d42b69d0521e4f19a5491e077d32c191)