### PR TITLE
fix(vscode-webui): clarify project memory toggle behavior

### DIFF
--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -385,10 +385,17 @@ export function TokenUsage({
                             />
                           </label>
                         </TooltipTrigger>
-                        <TooltipContent>
-                          {autoMemoryEnabled
-                            ? t("tokenUsage.projectMemoryDisable")
-                            : t("tokenUsage.projectMemoryEnable")}
+                        <TooltipContent className="max-w-[260px]">
+                          <div className="flex flex-col gap-1">
+                            <div>
+                              {autoMemoryEnabled
+                                ? t("tokenUsage.projectMemoryDisable")
+                                : t("tokenUsage.projectMemoryEnable")}
+                            </div>
+                            <div className="text-muted-foreground">
+                              {t("tokenUsage.projectMemoryToggleDescription")}
+                            </div>
+                          </div>
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -85,6 +85,7 @@
     "projectMemoryEnable": "Enable Project Memory",
     "projectMemoryDisable": "Disable Project Memory",
     "projectMemoryDescription": "Pochi learns about your project as you work and saves it to MEMORY.md, so future tasks start with helpful context.",
+    "projectMemoryToggleDescription": "This only controls whether saved memory is included in task context. Pochi always continues learning and saving memory.",
     "viewProjectMemory": "View",
     "viewProjectMemoryTooltip": "Open the MEMORY.md index for this workspace.",
     "viewTaskMemoryButtonTooltip": "Open the task memory summary that compacting will reuse.",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -85,6 +85,7 @@
     "projectMemoryEnable": "プロジェクトメモリを有効化",
     "projectMemoryDisable": "プロジェクトメモリを無効化",
     "projectMemoryDescription": "Pochi が作業中にプロジェクトについて学んだ内容を MEMORY.md に保存し、今後のタスクで役立つ文脈として再利用します。",
+    "projectMemoryToggleDescription": "この設定は、保存済みメモリをタスクのコンテキストに読み込むかどうかのみを制御します。Pochi は常に学習とメモリの保存を続けます。",
     "viewProjectMemory": "表示",
     "viewProjectMemoryTooltip": "このワークスペースの MEMORY.md インデックスを開きます。",
     "viewTaskMemoryButtonTooltip": "タスク圧縮時に再利用されるタスクメモリの要約を開きます。",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -84,6 +84,7 @@
     "projectMemoryEnable": "프로젝트 메모리 활성화",
     "projectMemoryDisable": "프로젝트 메모리 비활성화",
     "projectMemoryDescription": "Pochi 가 작업 중 프로젝트에 대해 학습한 내용을 MEMORY.md 에 저장하여, 향후 작업에서 유용한 맥락으로 재사용합니다.",
+    "projectMemoryToggleDescription": "이 설정은 저장된 메모리를 작업 컨텍스트에 불러올지 여부만 제어합니다. Pochi 는 항상 계속 학습하고 메모리를 저장합니다.",
     "viewProjectMemory": "보기",
     "viewProjectMemoryTooltip": "이 워크스페이스의 MEMORY.md 인덱스를 엽니다.",
     "viewTaskMemoryButtonTooltip": "작업 압축 시 재사용되는 작업 메모리 요약을 엽니다.",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -84,6 +84,7 @@
     "projectMemoryEnable": "启用项目记忆",
     "projectMemoryDisable": "停用项目记忆",
     "projectMemoryDescription": "Pochi 会在工作过程中学习你的项目并自动保存到 MEMORY.md，后续任务将带着这些上下文启动。",
+    "projectMemoryToggleDescription": "此开关仅控制是否将已有记忆读入任务上下文。Pochi 始终会继续学习并保存记忆。",
     "viewProjectMemory": "查看",
     "viewProjectMemoryTooltip": "打开此工作区的 MEMORY.md 索引文件。",
     "viewTaskMemoryButtonTooltip": "打开压缩任务时复用的任务记忆摘要。",


### PR DESCRIPTION
## Summary
- clarify that the Project Memory toggle only controls reading saved memory into task context
- explain that project memory learning and writes remain enabled regardless of the toggle state
- add localized tooltip copy for English, Chinese, Japanese, and Korean

## Screenshot

![Project Memory toggle tooltip](https://pochi-file-uploads.getpochi.com/blob-1785477426149.?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=6014c18302705bffb21520cf4f865c2b%2F20260731%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260731T055706Z&X-Amz-Expires=561600&X-Amz-Signature=05b74e0b07d907a961c62a1b76f8736b894b2ea6fc601f9639817a0f85240e59&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Test plan
- [x] Run `bun check`
- [x] Run `bun tsc`
- [x] Verify the Project Memory toggle tooltip displays the clarification

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0c57243dc8fa4ad5b00efcdcc5b50893)