### PR TITLE
feat(skills): support invocation controls

### DIFF
--- a/packages/cli/src/lib/__tests__/match-slash-command.test.ts
+++ b/packages/cli/src/lib/__tests__/match-slash-command.test.ts
@@ -90,6 +90,13 @@ describe("match-slash-command", () => {
         instructions: "This is a test skill",
         filePath: ".pochi/skills/test-skill/SKILL.md",
       },
+      {
+        name: "model-only-skill",
+        description: "A skill that users cannot invoke",
+        instructions: "This is a model-only skill",
+        filePath: ".pochi/skills/model-only-skill/SKILL.md",
+        userInvocable: false,
+      },
     ];
 
     it("should replace agent references with content", async () => {
@@ -124,6 +131,16 @@ describe("match-slash-command", () => {
       expect(result).toBe(
         'Use <custom-agent id="test-agent" path=".pochi/agents/test-agent.md">Please use the newTask tool to run test-agent to complete the following request:\n</custom-agent> and then <skill id="test-skill" path=".pochi/skills/test-skill/SKILL.md">Please use the useSkill tool to run test-skill to complete the following request:\n</skill>',
       );
+    });
+
+    it("should not replace skills that are not user invocable", async () => {
+      const prompt = "Please use /model-only-skill for this task";
+      const { prompt: result } = await replaceSlashCommandReferences(prompt, {
+        customAgents,
+        skills,
+      });
+
+      expect(result).toBe(prompt);
     });
   });
 });

--- a/packages/cli/src/lib/match-slash-command.ts
+++ b/packages/cli/src/lib/match-slash-command.ts
@@ -107,7 +107,7 @@ export async function replaceSlashCommandReferences(
               (x) => x.name === commandName,
             );
             const skill = slashCommandContext.skills.find(
-              (x) => x.name === commandName,
+              (x) => x.name === commandName && x.userInvocable !== false,
             );
 
             if (agent?.name) {

--- a/packages/common/src/base/agents/guide/references/llms-txt.md
+++ b/packages/common/src/base/agents/guide/references/llms-txt.md
@@ -487,128 +487,6 @@ Pochi will include your recent edits together with your message and use them as 
 This lets the agent build directly on top of what you already adjusted, without you needing to re-explain those changes in chat.
 
 
-# GitHub
-URL: /github
-
-***
-
-title: GitHub
-icon: "Github"
---------------
-
-# GitHub
-
-Use Pochi's AI assistant directly in your GitHub repository by commenting on pull requests to perform code reviews, explain changes, and suggest improvements.
-
-<Callout type="info" title="How it works">
-  This integration runs inside a GitHub Actions runner. It temporarily installs
-  the pochi CLI and executes tasks in the context of your repository. Progress
-  is continuously updated under the triggering comment, and a final result
-  (✅/❌) is posted when finished.
-</Callout>
-
-## Getting Your API Keys
-
-1. Log in to your Pochi account and go to **API Keys** from your user menu
-
-![User button overview](../assets/images/api-overview.png)
-
-2. Create a new API key with a descriptive name
-3. Copy the generated key (it's only shown once)
-
-![API page interface](../assets/images/api-page-interface.png)
-
-4. Add it to your GitHub repository as a secret named `POCHI_API_KEY`. See [GitHub's official guide](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets) for detailed steps:
-   * Go to **Settings** → **Secrets and variables** → **Actions**
-   * Click **"New repository secret"**
-   * Name: `POCHI_API_KEY`, Value: your API key
-
-## Setup
-
-Create a workflow file `.github/workflows/pochi.yml` in your repository:
-
-```yaml
-name: pochi
-
-on:
-  issue_comment:
-    types: [created]
-
-jobs:
-  pochi:
-    if: startsWith(github.event.comment.body, '/pochi')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run pochi
-        uses: tabbyml/pochi/packages/github-action@main
-        env:
-          # Required: Pochi session token (get it from app.getpochi.com and add as a repository secret)
-          POCHI_API_KEY: ${{ secrets.POCHI_API_KEY }}
-          # Optional: custom model (defaults to CLI's default model if not set)
-          # See the Models page for model options and configuration
-          # POCHI_MODEL: google/gemini-3-pro
-```
-
-Notes:
-
-* Triggered by `issue_comment` (created) and runs only if the comment body starts with `/pochi`
-* Requires write permissions to read changes, post comments, and add reactions to PRs
-* Provide `POCHI_API_KEY` via env; optionally set `POCHI_MODEL` to customize the model
-* By default, the action uses GitHub's built-in `GITHUB_TOKEN` (github-actions bot). You can customize this by setting a custom `GITHUB_TOKEN` environment variable with your own Personal Access Token (PAT)
-
-## Usage
-
-Comment on a PR with `/pochi` followed by your request, e.g. `/pochi review this code`, `/pochi explain the changes in this PR`, `/pochi suggest improvements`.
-
-![Comment example](../assets/images/github-comment.png)
-
-Once triggered:
-
-* Pochi reacts to your comment with 👀 to indicate it's running
-* A progress comment is updated every 15 seconds
-* When finished, it posts the final result and reacts with 🚀 (success) or −1 (failure)
-
-![Progress example](../assets/images/github-progress.png)
-
-![Actions run example](../assets/images/github-action-run.png)
-
-Permission requirement: Only users with write/admin permission can trigger execution. Otherwise, an error will be posted as a comment.
-
-## Advanced configuration
-
-### Use a custom GitHub token (optional)
-
-By default, the action uses the GitHub-provided `GITHUB_TOKEN`. For cross-repo or higher-privileged operations, you can override it with a PAT:
-
-```yaml
-- name: Run pochi
-  uses: tabbyml/pochi/packages/github-action@main
-  env:
-    GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }} # Your PAT
-    POCHI_API_KEY: ${{ secrets.POCHI_API_KEY }}
-```
-
-### Permissions
-
-Ensure the workflow includes these permissions:
-
-```yaml
-permissions:
-  contents: write # Read repo contents and commit changes if needed
-  issues: write # Comment on issues/PRs
-  pull-requests: write # Access PR information and status
-```
-
-
 # Getting Started
 URL: /
 Welcome to Pochi - Full-Stack AI Teammate Guide
@@ -661,7 +539,6 @@ With Pochi, you can use any LLM provider by configuring their API keys. Use the 
 
 * Pochi's managed LLM models
 * Shared task histories and team management
-* Integrations with GitHub and Slack for a collaborative workflow
 
 To use these features, sign up at [app.getpochi.com](http://app.getpochi.com) and log in to your VS Code extension.
 
@@ -1421,10 +1298,12 @@ IMPORTANT: Only create the issue, do not attempt to fix it.
 
 Each skill must start with YAML frontmatter containing at least a `name` and `description`.
 
-| Field         | Description                                     |
-| ------------- | ----------------------------------------------- |
-| `name`        | Unique identifier (lowercase, hyphens allowed). |
-| `description` | Brief explanation of what the skill does.       |
+| Field                      | Description                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------ |
+| `name`                     | Unique identifier (lowercase, hyphens allowed).                                      |
+| `description`              | Brief explanation of what the skill does.                                            |
+| `disable-model-invocation` | Set to `true` to hide the skill from automatic model discovery. Defaults to `false`. |
+| `user-invocable`           | Set to `false` to hide the skill from the slash command menu. Defaults to `true`.    |
 
 ## Discovery
 
@@ -1466,71 +1345,6 @@ You can explicitly specify which skill to use by typing a slash command followed
 ![Slash Command Usage](../assets/images/skill-slash-command.png)
 
 
-# Slack
-URL: /slack
-Pochi's integration with Slack
-***
-
-title: Slack
-description: Pochi's integration with Slack
-icon: "Slack"
--------------
-
-# Slack
-
-Pochi's Slack integration allows you to use Pochi directly within your Slack workspace, bringing AI-powered development assistance to your team conversations.
-Start tasks in Slack and seamlessly switch to the Cloud IDE when you need the full development experience.
-
-<Callout type="info" title="Cloud IDE">
-  When you send messages to Pochi in Slack, tasks are executed in remote environment running in the cloud. You can switch to the Cloud IDE to continue working on the task.
-</Callout>
-
-## Getting Started
-
-### Adding Pochi to Your Workspace
-
-1. **Install the Integration**: Add Pochi to your Slack workspace through the `Add to Slack` button on the [homepage](https://app.getpochi.com/home)
-   ![Slack Installation](../assets/images/slack-install-home.png)
-2. **Authorize Access**: Grant the necessary permissions for Pochi to interact with your Slack channels
-   ![Slack Authorization](../assets/images/slack-authorize.png)
-3. **Start Collaborating**: Begin using Pochi in any channel or direct message where it's been added. If using channels, please make sure to invite Pochi to the channel before creating a task.
-
-### Basic Usage
-
-Once Pochi is added to your workspace:
-
-1. \[Optional] **Invite Pochi to Channels**: If you want to interact with Pochi in channels, simply send `@Pochi` in the channel, and you will be prompted to invite Pochi to the channel.
-2. \[Optional] **Default Github Repository**: Set the repository in the Channel Topic, so Pochi knows which repository to work on by default.
-   * Format: `[repo:OWNER/REPO]`, for example, `[repo:TabbyML/pochi]`
-3. **Start Task**: Send a task prompt to Pochi in Direct Messages or channels using the following format:
-   * If a default repository is set: `/newtask PROMPT`, for example, `/newtask What are recent commits`
-   * If no default repository is set or you want to run Pochi with another repository : `/newtask [OWNER/REPO] PROMPT`, for example, `/newtask [TabbyML/tabby] What are recent commits`
-4. **Real-time Updates**: Watch as Pochi executes tasks and provides updates directly in Slack.
-5. **Follow-up**: After the task is completed, Pochi might ask some follow-up questions, or you can provide responses clicking the option buttons or the Reply button.
-
-![Slack Task](../assets/images/slack-task.png)
-
-### Continue in Cloud IDE
-
-When you need the full IDE experience:
-
-1. **Access Task Page**: Click on the `See Details` button to navigate to the task in Pochi's web interface.
-2. **Click Remote Icon**: Look for the remote/external link icon in the task interface.
-   ![Slack Remote Button](../assets/images/slack-remote-button.png)
-3. **Continue Development**: Pick up exactly where you left off.
-   ![Slack VSCode Web](../assets/images/slack-vscode-web.png)
-
-## Frequently Asked Questions
-
-### Why do I get a `not_in_channel` error when creating a task in a channel?
-
-Verify that Pochi has been properly added to the channel. If Pochi is not invited to the channel, mention @Pochi in the channel to invite it.
-
-### Why can't I access the Cloud IDE?
-
-Only the Task Owner has permission to access the Cloud IDE. Make sure you are the Task Owner and logged in to Pochi with the same account in your browser.
-
-
 # Tab Completion
 URL: /tab-completion
 Inline code completion
@@ -1542,6 +1356,8 @@ icon: "Code"
 ------------
 
 # Tab Completion
+
+> **Unavailable:** Tab Completion and Next Edit Suggestions are turned off in current releases. Pochi does not provide editor predictions or display the associated status bar indicator. The documentation below is retained for reference.
 
 **Tab Completion** is Pochi's in-editor inline code completion feature that provides AI-powered suggestions as you type, helping you write code faster and more efficiently.
 

--- a/packages/common/src/base/skills/create-skill.md
+++ b/packages/common/src/base/skills/create-skill.md
@@ -37,12 +37,16 @@ The `SKILL.md` file has two parts:
 
 ```yaml
 ---
-name: my-skill           # required: kebab-case identifier
-description: |           # required: when to trigger and what it does
+name: my-skill                    # required: kebab-case identifier
+description: |                    # required: when to trigger and what it does
   One or two sentences. Include specific trigger phrases.
-compatibility: node      # optional: runtime requirements (node, python, bun, etc.)
+compatibility: node               # optional: runtime requirements (node, python, bun, etc.)
+disable-model-invocation: false   # optional: true makes the skill manual-only
+user-invocable: true              # optional: false hides the skill from slash commands
 ---
 ```
+
+Invocation settings default to `disable-model-invocation: false` and `user-invocable: true`. Use `disable-model-invocation: true` for workflows that should only run when selected by the user. Use `user-invocable: false` for background knowledge that only the model should select.
 
 **Description writing tips:**
 - Include both what the skill does AND when to use it

--- a/packages/common/src/base/skills/widget-guidelines/SKILL.md
+++ b/packages/common/src/base/skills/widget-guidelines/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: widget-guidelines
 description: Use before renderWidget when the user needs a visual widget, SVG diagram, UI mockup, chart, local interactive explainer, or generative art.
+user-invocable: false
 ---
 
 # Widget Guidelines

--- a/packages/common/src/tool-utils/__tests__/skill-parser.test.ts
+++ b/packages/common/src/tool-utils/__tests__/skill-parser.test.ts
@@ -10,6 +10,8 @@ description: A test skill
 license: MIT
 compatibility: Node.js >= 18
 allowed-tools: readFile writeFile
+disable-model-invocation: true
+user-invocable: false
 metadata:
   author: test-author
   version: 1.0.0
@@ -29,6 +31,8 @@ Follow the instructions carefully.`;
     expect(validResult.license).toBe("MIT");
     expect(validResult.compatibility).toBe("Node.js >= 18");
     expect(validResult.allowedTools).toBe("readFile writeFile");
+    expect(validResult.disableModelInvocation).toBe(true);
+    expect(validResult.userInvocable).toBe(false);
     expect(validResult.metadata).toEqual({
       author: "test-author",
       version: "1.0.0",
@@ -62,10 +66,30 @@ This is a minimal skill with just the required fields.`;
     expect(validResult.license).toBeUndefined();
     expect(validResult.compatibility).toBeUndefined();
     expect(validResult.allowedTools).toBeUndefined();
+    expect(validResult.disableModelInvocation).toBeUndefined();
+    expect(validResult.userInvocable).toBeUndefined();
     expect(validResult.metadata).toBeUndefined();
     expect(validResult.instructions).toContain(
       "This is a minimal skill with just the required fields.",
     );
+  });
+
+  it("should reject non-boolean invocation settings", async () => {
+    const content = `---
+name: invalid-invocation-settings
+description: A skill with invalid invocation settings
+disable-model-invocation: "true"
+user-invocable: always
+---
+
+Content with invalid invocation settings.`;
+
+    const result = await parseSkillFile(
+      "invalid-invocation-settings/skill.md",
+      () => Promise.resolve(content),
+    );
+
+    expect(result).toHaveProperty("error", "validationError");
   });
 
   it("should return an error for invalid frontmatter", async () => {

--- a/packages/common/src/tool-utils/skill-parser.ts
+++ b/packages/common/src/tool-utils/skill-parser.ts
@@ -13,6 +13,8 @@ const SkillFrontmatter = z.object({
   compatibility: z.string().optional(),
   metadata: z.record(z.string(), z.string()).optional(),
   "allowed-tools": z.string().optional(),
+  "disable-model-invocation": z.boolean().optional(),
+  "user-invocable": z.boolean().optional(),
 });
 
 const EmptyFrontmatterMessage =
@@ -71,6 +73,8 @@ export async function parseSkillFile(
     compatibility: frontmatterData.compatibility,
     metadata: frontmatterData.metadata,
     allowedTools: frontmatterData["allowed-tools"],
+    disableModelInvocation: frontmatterData["disable-model-invocation"],
+    userInvocable: frontmatterData["user-invocable"],
     instructions,
   } satisfies ValidSkillFile;
 }

--- a/packages/docs/content/docs/skills.mdx
+++ b/packages/docs/content/docs/skills.mdx
@@ -49,10 +49,12 @@ IMPORTANT: Only create the issue, do not attempt to fix it.
 
 Each skill must start with YAML frontmatter containing at least a `name` and `description`.
 
-| Field         | Description                                     |
-| ------------- | ----------------------------------------------- |
-| `name`        | Unique identifier (lowercase, hyphens allowed). |
-| `description` | Brief explanation of what the skill does.       |
+| Field                       | Description                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `name`                      | Unique identifier (lowercase, hyphens allowed).                                                  |
+| `description`               | Brief explanation of what the skill does.                                                        |
+| `disable-model-invocation`  | Set to `true` to hide the skill from automatic model discovery. Defaults to `false`.             |
+| `user-invocable`            | Set to `false` to hide the skill from the slash command menu. Defaults to `true`.                 |
 
 ## Discovery
 

--- a/packages/tools/src/__test__/use-skill.test.ts
+++ b/packages/tools/src/__test__/use-skill.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../use-skill";
+import { createSkillTool } from "../use-skill";
+
+const skills: Skill[] = [
+  {
+    name: "model-skill",
+    description: "A skill the model can discover",
+    filePath: ".pochi/skills/model-skill/SKILL.md",
+    instructions: "Model skill instructions",
+  },
+  {
+    name: "user-only-skill",
+    description: "A skill only users can invoke",
+    filePath: ".pochi/skills/user-only-skill/SKILL.md",
+    instructions: "User-only skill instructions",
+    disableModelInvocation: true,
+  },
+];
+
+describe("createSkillTool", () => {
+  it("hides skills with model invocation disabled from the tool description", () => {
+    const tool = createSkillTool(skills);
+
+    expect(tool.description).toContain("model-skill");
+    expect(tool.description).not.toContain("user-only-skill");
+  });
+
+  it("allows explicitly invoked hidden skills through skill markers", () => {
+    const tool = createSkillTool(skills);
+
+    expect(tool.description).toContain(
+      "unless the user's prompt explicitly invokes a skill through a <skill> marker",
+    );
+  });
+});

--- a/packages/tools/src/use-skill.ts
+++ b/packages/tools/src/use-skill.ts
@@ -22,18 +22,29 @@ export const Skill = z.object({
     .string()
     .optional()
     .describe("Space-delimited list of pre-approved tools"),
+  disableModelInvocation: z
+    .boolean()
+    .optional()
+    .describe("Whether the skill is hidden from automatic model invocation"),
+  userInvocable: z
+    .boolean()
+    .optional()
+    .describe("Whether the skill is available as a user slash command"),
   instructions: z.string().describe("The skill's instructions."),
 });
 
 export type Skill = z.infer<typeof Skill>;
 
 function makeSkillToolDescription(skills?: Skill[]) {
-  if (!skills || skills.length === 0)
+  const modelInvocableSkills = skills?.filter(
+    (skill) => skill.disableModelInvocation !== true,
+  );
+  if (!modelInvocableSkills || modelInvocableSkills.length === 0)
     return "No skills are available in the workspace.";
 
   return `Available skills:
 
-${skills
+${modelInvocableSkills
   .map((skill) => {
     const compatibilityInfo = skill.compatibility
       ? ` [Compatibility: ${skill.compatibility}]`
@@ -71,7 +82,7 @@ Important:
 - For general questions about available skills, simply refer to the "Available skills" list below without calling this tool
 - NEVER just announce or mention a skill in your text response without actually calling this tool (except for general skill listing requests)
 - This is a BLOCKING REQUIREMENT: invoke the relevant Skill tool BEFORE generating any other response about a specific skill or task
-- Only use skills listed in "Available skills" below
+- Only use skills listed in "Available skills" below, unless the user's prompt explicitly invokes a skill through a <skill> marker
 - Check compatibility requirements before using a skill - ensure the skill is compatible with the current OS/environment
 - After calling this tool, follow the returned instructions step by step
 - The skill file location is shown in the [Location: filepath] section of each skill listing below - use this information to understand where the skill is defined

--- a/packages/vscode-webui/src/components/prompt-form/__tests__/slash-candidates.test.ts
+++ b/packages/vscode-webui/src/components/prompt-form/__tests__/slash-candidates.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { createSlashCandidates } from "../slash-mention/slash-candidates";
 
 describe("createSlashCandidates", () => {
-  it("omits widget-guidelines from user slash command skill candidates", () => {
+  it("omits skills that are not user invocable", () => {
     const customAgents: CustomAgentFile[] = [
       {
         name: "reviewer",
@@ -28,6 +28,7 @@ describe("createSlashCandidates", () => {
         instructions: "Widget instructions",
         filePath: "/built-in/widget-guidelines/SKILL.md",
         isBuiltIn: true,
+        userInvocable: false,
       },
     ];
 

--- a/packages/vscode-webui/src/components/prompt-form/slash-mention/slash-candidates.ts
+++ b/packages/vscode-webui/src/components/prompt-form/slash-mention/slash-candidates.ts
@@ -6,8 +6,6 @@ import {
 } from "@getpochi/common/vscode-webui-bridge";
 import type { SlashCandidate } from "./mention-list";
 
-const HiddenSlashSkillNames = new Set(["widget-guidelines"]);
-
 export function createSlashCandidates(
   customAgents: CustomAgentFile[],
   skills: SkillFile[],
@@ -25,7 +23,7 @@ export function createSlashCandidates(
       })),
     ...skills
       .filter((x) => isValidSkillFile(x))
-      .filter((x) => !HiddenSlashSkillNames.has(x.name))
+      .filter((x) => x.userInvocable !== false)
       .map((x) => ({
         type: "skill" as const,
         id: x.name,


### PR DESCRIPTION
## Summary
- parse `disable-model-invocation` and exclude those skills from model-facing discovery while preserving explicit slash invocation
- parse `user-invocable` and hide disabled skills from VS Code and CLI slash-command handling
- document the invocation controls, migrate `widget-guidelines`, refresh generated guide references, and add focused tests

## Test plan
- [x] Run common skill parser tests
- [x] Run tools skill-description tests
- [x] Run VS Code web UI slash-candidate tests
- [x] Run CLI unit tests
- [x] Run `bun check`
- [x] Run `bun tsc`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1055b48e22c948efbb47a49287cad1a5)