### PR TITLE
feat: add terminal text selection as chat context

### DIFF
--- a/packages/common/src/base/prompts/__tests__/__snapshots__/active-selection.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/active-selection.test.ts.snap
@@ -13,10 +13,10 @@ const x = 1;
 exports[`renderTerminalTextSelection renders the terminal name and content 1`] = `
 "The user has selected text in their integrated terminal. This context is provided to help you understand what the user is currently focused on or referring to.
 
-<terminal-selection terminal="bash">
+<active-terminal-selection terminal="bash" backgroundJobId="term-1">
 \`\`\`
 npm run build
 Build succeeded.
 \`\`\`
-</terminal-selection>"
+</active-terminal-selection>"
 `;

--- a/packages/common/src/base/prompts/__tests__/__snapshots__/terminal-context.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/terminal-context.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderTerminalContext renders a single selection 1`] = `
+"The user has explicitly attached the following text selection(s) from their integrated terminal(s) as context for this message.
+
+<terminal-context-selection terminal="bash" backgroundJobId="term-1">
+\`\`\`
+npm run build
+Build succeeded.
+\`\`\`
+</terminal-context-selection>"
+`;
+
+exports[`renderTerminalContext renders multiple selections and skips empty ones 1`] = `
+"The user has explicitly attached the following text selection(s) from their integrated terminal(s) as context for this message.
+
+<terminal-context-selection terminal="bash" backgroundJobId="term-1">
+\`\`\`
+npm run build
+Build succeeded.
+\`\`\`
+</terminal-context-selection>
+
+<terminal-context-selection terminal="zsh" backgroundJobId="term-2">
+\`\`\`
+git status
+\`\`\`
+</terminal-context-selection>"
+`;

--- a/packages/common/src/base/prompts/__tests__/terminal-context.test.ts
+++ b/packages/common/src/base/prompts/__tests__/terminal-context.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import { renderTerminalContext } from "../terminal-context";
+
+test("renderTerminalContext returns empty string for undefined selections", () => {
+  expect(renderTerminalContext(undefined)).toBe("");
+});
+
+test("renderTerminalContext returns empty string for an empty array", () => {
+  expect(renderTerminalContext([])).toBe("");
+});
+
+test("renderTerminalContext returns empty string when all selections are empty", () => {
+  expect(
+    renderTerminalContext([{ terminalName: "bash", content: "   " }]),
+  ).toBe("");
+});
+
+test("renderTerminalContext renders a single selection", () => {
+  expect(
+    renderTerminalContext([
+      {
+        terminalName: "bash",
+        backgroundJobId: "term-1",
+        content: "npm run build\nBuild succeeded.",
+      },
+    ]),
+  ).toMatchSnapshot();
+});
+
+test("renderTerminalContext renders multiple selections and skips empty ones", () => {
+  expect(
+    renderTerminalContext([
+      {
+        terminalName: "bash",
+        backgroundJobId: "term-1",
+        content: "npm run build\nBuild succeeded.",
+      },
+      {
+        terminalName: "zsh",
+        content: "   ",
+      },
+      {
+        terminalName: "zsh",
+        backgroundJobId: "term-2",
+        content: "git status",
+      },
+    ]),
+  ).toMatchSnapshot();
+});

--- a/packages/common/src/base/prompts/active-selection.ts
+++ b/packages/common/src/base/prompts/active-selection.ts
@@ -25,7 +25,7 @@ export function renderTerminalTextSelection(
   if (!selection) {
     return "";
   }
-  const { terminalName, content } = selection;
+  const { terminalName, backgroundJobId, content } = selection;
   if (!content || content.trim() === "") {
     return "";
   }
@@ -33,5 +33,17 @@ export function renderTerminalTextSelection(
   const header =
     "The user has selected text in their integrated terminal. This context is provided to help you understand what the user is currently focused on or referring to.";
 
-  return `${header}\n\n<terminal-selection terminal="${terminalName}">\n\`\`\`\n${content}\n\`\`\`\n</terminal-selection>`;
+  const attrs = renderTerminalSelectionAttrs(terminalName, backgroundJobId);
+
+  return `${header}\n\n<active-terminal-selection ${attrs}>\n\`\`\`\n${content}\n\`\`\`\n</active-terminal-selection>`;
+}
+
+/** @internal exported for reuse by terminal-context.ts */
+export function renderTerminalSelectionAttrs(
+  terminalName: string,
+  backgroundJobId: string | undefined,
+): string {
+  return backgroundJobId
+    ? `terminal="${terminalName}" backgroundJobId="${backgroundJobId}"`
+    : `terminal="${terminalName}"`;
 }

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -28,6 +28,7 @@ import {
   buildMemoryExtractionDirective,
   taskMemoryTemplate,
 } from "./task-memory";
+import { renderTerminalContext } from "./terminal-context";
 import { renderUserEdits } from "./user-edits";
 
 export { parseEnvironmentInfo } from "./environment";
@@ -51,6 +52,7 @@ export const prompts = {
   renderReviewComments,
   renderActiveSelection,
   renderTerminalTextSelection,
+  renderTerminalContext,
   renderUserEdits,
   renderBashOutputs,
   fixMermaidError,

--- a/packages/common/src/base/prompts/terminal-context.ts
+++ b/packages/common/src/base/prompts/terminal-context.ts
@@ -1,0 +1,37 @@
+import type { TerminalTextSelection } from "../message";
+import { renderTerminalSelectionAttrs } from "./active-selection";
+
+/**
+ * Renders text selections that the user explicitly attached to a message via
+ * the "Add to Chat" terminal context menu action. Unlike
+ * {@link renderTerminalTextSelection} (which renders whatever happens to be
+ * selected in the terminal at submit time), these selections were
+ * deliberately picked by the user and can accumulate multiple entries across
+ * one or more terminals.
+ */
+export function renderTerminalContext(
+  selections: TerminalTextSelection[] | undefined,
+): string {
+  if (!selections || selections.length === 0) {
+    return "";
+  }
+
+  const blocks = selections
+    .filter((selection) => selection.content.trim() !== "")
+    .map((selection) => {
+      const attrs = renderTerminalSelectionAttrs(
+        selection.terminalName,
+        selection.backgroundJobId,
+      );
+      return `<terminal-context-selection ${attrs}>\n\`\`\`\n${selection.content}\n\`\`\`\n</terminal-context-selection>`;
+    });
+
+  if (blocks.length === 0) {
+    return "";
+  }
+
+  const header =
+    "The user has explicitly attached the following text selection(s) from their integrated terminal(s) as context for this message.";
+
+  return `${header}\n\n${blocks.join("\n\n")}`;
+}

--- a/packages/common/src/vscode-webui-bridge/types/task.ts
+++ b/packages/common/src/vscode-webui-bridge/types/task.ts
@@ -26,6 +26,7 @@ export type PochiTaskParams = { cwd: string } & (
       files?: FileUIPart[];
       activeSelection?: ActiveSelection;
       activeTerminalTextSelection?: TerminalTextSelection;
+      terminalContextSelections?: TerminalTextSelection[];
       mcpConfigOverride?: McpConfigOverride;
     }
   | {

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -565,6 +565,10 @@ export interface WebviewHostApi {
    * context" list, so it shows up attached to the next outgoing chat
    * message. Invoked from the VS Code side (e.g. the terminal right-click
    * "Add to Chat" command).
+   *
+   * Resolves once the selection has been handed off to the webview's
+   * terminal context state (awaiting readiness rather than dropping it if
+   * the webview hasn't finished initializing yet).
    */
-  addTerminalContext(selection: TerminalTextSelection): void;
+  addTerminalContext(selection: TerminalTextSelection): Promise<void>;
 }

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -559,4 +559,12 @@ export interface WebviewHostApi {
   readStoreFile(filePath: string): Promise<string | null>;
 
   readTaskOutput(taskId: string): Promise<ExecuteCommandResult>;
+
+  /**
+   * Pushes a terminal text selection into the webview's pending "terminal
+   * context" list, so it shows up attached to the next outgoing chat
+   * message. Invoked from the VS Code side (e.g. the terminal right-click
+   * "Add to Chat" command).
+   */
+  addTerminalContext(selection: TerminalTextSelection): void;
 }

--- a/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
+++ b/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
@@ -66,7 +66,7 @@ describe("convertDataPartToText", () => {
     const result = convertDataPartToText(part) as { type: string; text: string }[];
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe("text");
-    expect(result[0].text).toContain("terminal-selection");
+    expect(result[0].text).toContain("active-terminal-selection");
     expect(result[0].text).toContain("echo hello");
   });
 
@@ -94,5 +94,34 @@ describe("convertDataPartToText", () => {
     expect(result).toHaveLength(2);
     expect(result[0].text).toContain("active-selection");
     expect(result[1].text).toContain("terminal-selection");
+  });
+
+  it("returns no parts when data-terminal-context has no selections", () => {
+    const part = {
+      type: "data-terminal-context",
+      data: { textSelections: [] },
+    } as unknown as MessagePart;
+
+    expect(convertDataPartToText(part)).toEqual([]);
+  });
+
+  it("converts data-terminal-context into a single text part with all selections", () => {
+    const part = {
+      type: "data-terminal-context",
+      data: {
+        textSelections: [
+          { terminalName: "bash", backgroundJobId: "term-1", content: "echo hello" },
+          { terminalName: "zsh", content: "git status" },
+        ],
+      },
+    } as unknown as MessagePart;
+
+    const result = convertDataPartToText(part) as { type: string; text: string }[];
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("text");
+    expect(result[0].text).toContain("terminal-context-selection terminal=\"bash\"");
+    expect(result[0].text).toContain("echo hello");
+    expect(result[0].text).toContain("terminal-context-selection terminal=\"zsh\"");
+    expect(result[0].text).toContain("git status");
   });
 });

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -472,6 +472,10 @@ export function convertDataPartToText(
     ].filter((text): text is string => !!text);
     return texts.map((text) => ({ type: "text" as const, text }));
   }
+  if (part.type === "data-terminal-context") {
+    const text = prompts.renderTerminalContext(part.data.textSelections);
+    return text ? [{ type: "text" as const, text }] : [];
+  }
   if (part.type === "data-bash-outputs") {
     return {
       type: "text" as const,

--- a/packages/livekit/src/types.ts
+++ b/packages/livekit/src/types.ts
@@ -30,6 +30,9 @@ export type DataParts = {
     activeSelection?: ActiveSelection;
     activeTerminalTextSelection?: TerminalTextSelection;
   };
+  "terminal-context": {
+    textSelections: TerminalTextSelection[];
+  };
   "bash-outputs": {
     bashOutputs: BashOutputs;
   };

--- a/packages/vscode-webui/src/components/message/__stories__/user-message-complex.stories.tsx
+++ b/packages/vscode-webui/src/components/message/__stories__/user-message-complex.stories.tsx
@@ -183,3 +183,85 @@ export const TerminalSelectionOnly: Story = {
     },
   },
 };
+
+// Explicitly attached terminal context ("Add to Chat" flow) — a single
+// selection, distinct from the implicit `activeTerminalTextSelection` above.
+const terminalContextSingleMessage: Message = {
+  id: "msg-terminal-context-single",
+  role: "user",
+  parts: [
+    {
+      type: "text",
+      text: "I attached the build output for reference.",
+    },
+    {
+      type: "data-terminal-context",
+      data: {
+        textSelections: [
+          {
+            terminalName: "bash",
+            backgroundJobId: "term-story-context-1",
+            content: "$ npm run build\n> tsc && vite build\n✓ built in 1.2s",
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export const TerminalContextSingle: Story = {
+  args: {
+    messages: [terminalContextSingleMessage],
+    isLoading: false,
+    user: {
+      name: "Developer",
+      image: "https://github.com/shadcn.png",
+    },
+  },
+};
+
+// Multiple explicitly attached terminal selections across different
+// terminals. Note: when the user has manually attached terminal context like
+// this, the implicit "currently selected" terminal text capture is skipped
+// at submit time (mutually exclusive), so `data-active-selection` with an
+// `activeTerminalTextSelection` would not also appear on a message like this
+// in practice.
+const terminalContextMultipleMessage: Message = {
+  id: "msg-terminal-context-multiple",
+  role: "user",
+  parts: [
+    {
+      type: "text",
+      text: "Here are a few terminal snippets I manually attached for reference.",
+    },
+    {
+      type: "data-terminal-context",
+      data: {
+        textSelections: [
+          {
+            terminalName: "bash",
+            backgroundJobId: "term-story-context-2",
+            content: "$ npm run build\n> tsc && vite build\n✓ built in 1.2s",
+          },
+          {
+            terminalName: "zsh",
+            backgroundJobId: "term-story-context-3",
+            content:
+              "$ git status\nOn branch main\nnothing to commit, working tree clean",
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export const TerminalContextMultiple: Story = {
+  args: {
+    messages: [terminalContextMultipleMessage],
+    isLoading: false,
+    user: {
+      name: "Developer",
+      image: "https://github.com/shadcn.png",
+    },
+  },
+};

--- a/packages/vscode-webui/src/components/message/active-selection.tsx
+++ b/packages/vscode-webui/src/components/message/active-selection.tsx
@@ -136,7 +136,7 @@ export const TerminalSelectionPart: React.FC<TerminalSelectionProps> = ({
  * Counts the number of lines in the given text, ignoring a single trailing
  * newline (so `"a\nb\n"` is treated as 2 lines, not 3).
  */
-function getLineCount(content: string): number {
+export function getLineCount(content: string): number {
   const trimmed = content.endsWith("\n") ? content.slice(0, -1) : content;
   return trimmed.length === 0 ? 0 : trimmed.split("\n").length;
 }

--- a/packages/vscode-webui/src/components/message/index.tsx
+++ b/packages/vscode-webui/src/components/message/index.tsx
@@ -1,3 +1,4 @@
 export { MessageMarkdown } from "./markdown";
 export { MessageAttachments } from "./attachments";
 export { CodeBlock } from "./code-block";
+export { getLineCount } from "./active-selection";

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -190,7 +190,7 @@ export const MessageList: React.FC<{
                 </div>
                 {/* Display attachments at the bottom of the message */}
                 <UserAttachments message={m} />
-                <UserActiveSelections message={m} />
+                <UserSelections message={m} />
               </div>
               {messageIndex < renderMessages.length - 1 ? (
                 <SeparatorWithCheckpoint
@@ -245,7 +245,7 @@ function UserAttachments({ message }: { message: Message }) {
   }
 }
 
-function UserActiveSelections({ message }: { message: Message }) {
+function UserSelections({ message }: { message: Message }) {
   const selectionParts = message.parts.filter(
     (part) => part.type === "data-active-selection",
   ) as {
@@ -256,26 +256,48 @@ function UserActiveSelections({ message }: { message: Message }) {
     };
   }[];
 
-  if (message.role === "user" && selectionParts.length) {
-    return (
-      <div className="mt-2 flex flex-wrap gap-2">
-        {selectionParts.map((part, index) => (
-          <Fragment key={index}>
-            {part.data.activeSelection && (
-              <ActiveSelectionPart
-                activeSelection={part.data.activeSelection}
-              />
-            )}
-            {part.data.activeTerminalTextSelection && (
-              <TerminalSelectionPart
-                terminalTextSelection={part.data.activeTerminalTextSelection}
-              />
-            )}
-          </Fragment>
-        ))}
-      </div>
-    );
+  const terminalContextParts = message.parts.filter(
+    (part) => part.type === "data-terminal-context",
+  ) as {
+    type: "data-terminal-context";
+    data: {
+      textSelections: TerminalTextSelection[];
+    };
+  }[];
+
+  const terminalContextSelections = terminalContextParts.flatMap(
+    (part) => part.data.textSelections,
+  );
+
+  if (
+    message.role !== "user" ||
+    (!selectionParts.length && !terminalContextSelections.length)
+  ) {
+    return;
   }
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-2">
+      {selectionParts.map((part, index) => (
+        <Fragment key={index}>
+          {part.data.activeSelection && (
+            <ActiveSelectionPart activeSelection={part.data.activeSelection} />
+          )}
+          {part.data.activeTerminalTextSelection && (
+            <TerminalSelectionPart
+              terminalTextSelection={part.data.activeTerminalTextSelection}
+            />
+          )}
+        </Fragment>
+      ))}
+      {terminalContextSelections.map((textSelection, index) => (
+        <TerminalSelectionPart
+          key={index}
+          terminalTextSelection={textSelection}
+        />
+      ))}
+    </div>
+  );
 }
 
 function Part({
@@ -372,6 +394,10 @@ function Part({
   }
 
   if (part.type === "data-active-selection") {
+    return null;
+  }
+
+  if (part.type === "data-terminal-context") {
     return null;
   }
 

--- a/packages/vscode-webui/src/components/prompt-form/terminal-context-badges.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/terminal-context-badges.tsx
@@ -1,0 +1,108 @@
+import { CodeBlock, getLineCount } from "@/components/message";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { useVisibleTerminals } from "@/lib/hooks/use-visible-terminals";
+import { cn } from "@/lib/utils";
+import { isVSCodeEnvironment } from "@/lib/vscode";
+import type { TerminalTextSelection } from "@getpochi/common/vscode-webui-bridge";
+import { TerminalIcon, X } from "lucide-react";
+import type React from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "../ui/button";
+
+interface TerminalContextBadgesProps {
+  selections: TerminalTextSelection[];
+  onRemove?: (index: number) => void;
+  className?: string;
+}
+
+/**
+ * Renders the terminal selections the user explicitly attached via the
+ * "Add to Chat" terminal context menu action, one removable badge per
+ * selection. Unlike `TerminalSelectionPart` (read-only, used in rendered
+ * messages), each badge here exposes a hover-revealed remove button, mirroring
+ * the pattern used by `UserEdits`.
+ */
+export const TerminalContextBadges: React.FC<TerminalContextBadgesProps> = ({
+  selections,
+  onRemove,
+  className,
+}) => {
+  const { t } = useTranslation();
+  const { openBackgroundJobTerminal } = useVisibleTerminals();
+
+  if (!selections.length) {
+    return null;
+  }
+
+  return (
+    <>
+      {selections.map((selection, index) => {
+        const { terminalName, backgroundJobId, content } = selection;
+        const lineCount = getLineCount(content);
+
+        const onClick = () => {
+          if (!isVSCodeEnvironment() || !backgroundJobId) return;
+          openBackgroundJobTerminal?.(backgroundJobId);
+        };
+
+        return (
+          <HoverCard key={index} openDelay={300} closeDelay={200}>
+            <HoverCardTrigger asChild>
+              <div
+                className={cn(
+                  "group inline-flex h-[1.7rem] max-w-full cursor-pointer items-center gap-1 overflow-hidden truncate rounded-sm border border-[var(--vscode-chat-requestBorder)] px-1 hover:bg-accent/40",
+                  className,
+                )}
+                onClick={onClick}
+              >
+                {onRemove ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={t("terminalContextBadge.remove")}
+                    className="relative size-3.5 shrink-0 p-0 hover:bg-transparent"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onRemove(index);
+                    }}
+                  >
+                    <TerminalIcon className="absolute size-3.5 transition-opacity duration-150 group-focus-within:opacity-0 group-hover:opacity-0" />
+                    <X className="absolute size-3.5 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100" />
+                  </Button>
+                ) : (
+                  <TerminalIcon className="size-3.5 shrink-0" />
+                )}
+                <span className="truncate text-sm">
+                  {terminalName}
+                  <span className="text-zinc-500 dark:text-zinc-400">
+                    :{lineCount}
+                  </span>
+                </span>
+              </div>
+            </HoverCardTrigger>
+            <HoverCardContent className="w-auto max-w-[90vw] p-0" align="start">
+              <div className="flex max-w-[300px] items-center gap-1.5 truncate border-b px-2 py-1.5 font-medium text-xs">
+                <TerminalIcon className="size-3.5 shrink-0" />
+                <span className="truncate">{terminalName}</span>
+              </div>
+              <div className="max-h-[60vh] overflow-auto">
+                <CodeBlock
+                  language="shell"
+                  value={content}
+                  isMinimalView={true}
+                  className="m-0 border-none"
+                />
+              </div>
+            </HoverCardContent>
+          </HoverCard>
+        );
+      })}
+    </>
+  );
+};

--- a/packages/vscode-webui/src/components/terminal-context-state-initializer.tsx
+++ b/packages/vscode-webui/src/components/terminal-context-state-initializer.tsx
@@ -1,0 +1,25 @@
+import { useTerminalContextState } from "@/features/chat";
+import { setAddTerminalContext } from "@/lib/vscode";
+import { useEffect } from "react";
+
+/**
+ * Resolves the placeholder registered in `@/lib/vscode` with the actual
+ * `useTerminalContextState` store once the React tree has mounted.
+ *
+ * `useTerminalContextState` lives in "@/features/chat", which transitively
+ * imports "@/lib/vscode". Importing it eagerly at the top of "@/lib/vscode"
+ * (a module that is evaluated very early, before React initializes) creates
+ * an import cycle that can leave other modules partially initialized. To
+ * avoid that, "@/lib/vscode" only keeps a placeholder function that is
+ * resolved here, from within the React tree.
+ */
+export function TerminalContextStateInitializer() {
+  useEffect(() => {
+    setAddTerminalContext(useTerminalContextState.getState().addSelection);
+    return () => {
+      setAddTerminalContext(null);
+    };
+  }, []);
+
+  return null;
+}

--- a/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-input-form.tsx
@@ -10,9 +10,14 @@ import type { UseChatHelpers } from "@ai-sdk/react";
 import type { Message } from "@getpochi/livekit";
 
 import { ReviewBadges } from "@/components/prompt-form/review-badges";
+import { TerminalContextBadges } from "@/components/prompt-form/terminal-context-badges";
 import { UserEdits } from "@/components/prompt-form/user-edits";
 import { useActiveSelection } from "@/lib/hooks/use-active-selection";
-import type { FileDiff, Review } from "@getpochi/common/vscode-webui-bridge";
+import type {
+  FileDiff,
+  Review,
+  TerminalTextSelection,
+} from "@getpochi/common/vscode-webui-bridge";
 import type { ReactNode } from "@tanstack/react-router";
 import type { ChatInput } from "../hooks/use-chat-input-state";
 import type { DraftMessage } from "../hooks/use-chat-submit";
@@ -37,6 +42,8 @@ interface ChatInputFormProps {
   userEdits?: FileDiff[];
   lastCheckpointHash?: string;
   onRemoveUserEdits?: () => void;
+  terminalContextSelections?: TerminalTextSelection[];
+  onRemoveTerminalContextSelection?: (index: number) => void;
   onSwitchSubmitMode?: () => void;
   isPlanMode?: boolean;
   onSelectTodoMode?: () => void;
@@ -76,6 +83,8 @@ export const ChatInputForm = forwardRef<
     userEdits = [],
     lastCheckpointHash,
     onRemoveUserEdits,
+    terminalContextSelections = [],
+    onRemoveTerminalContextSelection,
     children,
     onSwitchSubmitMode,
     onSelectTodoMode,
@@ -145,6 +154,10 @@ export const ChatInputForm = forwardRef<
           todoModeDisabled={todoModeDisabled}
         />
         <ActiveSelectionBadge />
+        <TerminalContextBadges
+          selections={terminalContextSelections}
+          onRemove={onRemoveTerminalContextSelection}
+        />
         {userEdits.length > 0 && lastCheckpointHash && (
           <UserEdits
             userEdits={userEdits}

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -278,4 +278,15 @@ describe("ChatToolbar", () => {
       }),
     );
   });
+
+  it("passes the accumulated terminal context selections (empty by default) to useChatSubmit", () => {
+    renderToolbar(false);
+
+    expect(chatSubmitMocks.useChatSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalContextSelections: [],
+        clearTerminalContextSelections: expect.any(Function),
+      }),
+    );
+  });
 });

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -54,6 +54,7 @@ import { useInlineCompactTask } from "../hooks/use-inline-compact-task";
 import { useNewCompactTask } from "../hooks/use-new-compact-task";
 import { useShowCompleteSubtaskButton } from "../hooks/use-subtask-completed";
 import type { SubtaskInfo } from "../hooks/use-subtask-info";
+import { useTerminalContextState } from "../hooks/use-terminal-context-state";
 import { ChatInputForm } from "./chat-input-form";
 import { ErrorMessageView } from "./error-message-view";
 import { SubmitReviewsButton } from "./submit-review-button";
@@ -204,6 +205,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   } = attachmentUpload;
 
   const reviews = useReviews();
+  const {
+    selections: terminalContextSelections,
+    removeSelection: removeTerminalContextSelection,
+    clearSelections: clearTerminalContextSelections,
+  } = useTerminalContextState();
 
   const { inlineCompactTask, inlineCompactTaskPending } = useInlineCompactTask({
     sendMessage,
@@ -241,6 +247,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     isInputEmpty: !input.text.trim() && queuedMessages.length === 0,
     isFilesEmpty: files.length === 0,
     isReviewsEmpty: reviews.length === 0,
+    isTerminalContextEmpty: terminalContextSelections.length === 0,
     isUploadingAttachments,
     blockingState,
     taskStatus: task?.status,
@@ -272,6 +279,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     setQueuedMessages,
     reviews,
     userEdits: includedUserEdits,
+    terminalContextSelections,
+    clearTerminalContextSelections,
     taskId,
     isTodoMode: todoModeSelected,
     canCreateTodo: !todoModeDisabled,
@@ -436,6 +445,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
           onRemoveUserEdits={() =>
             setExcludedUserEditsContext(userEditsContext)
           }
+          terminalContextSelections={terminalContextSelections}
+          onRemoveTerminalContextSelection={removeTerminalContextSelection}
           queuedMessages={queuedMessages}
           onRemoveQueuedMessage={handleRemoveQueuedMessage}
           onSteerQueuedMessage={handleSteerQueuedMessage}

--- a/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
+++ b/packages/vscode-webui/src/features/chat/components/create-task-input.tsx
@@ -19,6 +19,7 @@ import type { GitWorktree, Review } from "@getpochi/common/vscode-webui-bridge";
 import { type Todo, initTodoModeTodos } from "@getpochi/tools";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTerminalContextState } from "../hooks/use-terminal-context-state";
 import { ChatInputForm, type ChatInputFormHandle } from "./chat-input-form";
 
 interface CreateTaskInputProps {
@@ -41,6 +42,11 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
   deletingWorktreePaths,
 }) => {
   const activeSelection = useActiveSelection();
+  const {
+    selections: terminalContextSelections,
+    removeSelection: removeTerminalContextSelection,
+    clearSelections: clearTerminalContextSelections,
+  } = useTerminalContextState();
   const { draft: input, setDraft: setInput, clearDraft } = useTaskInputDraft();
   const [planMode, setPlanMode] = useState(false);
   const [todoModeSelected, setTodoModeSelected] = useState(false);
@@ -180,9 +186,13 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
 
       // Terminal selection can only be read on demand (there's no reactive
       // VS Code API for it), so capture it once at task-creation time.
-      const activeTerminalTextSelection = isVSCodeEnvironment()
-        ? await vscodeHost.readTerminalSelection()
-        : undefined;
+      // If the user has manually attached terminal context via the "Add to
+      // Chat" flow, skip this implicit capture so the same terminal content
+      // isn't duplicated on the message via two different mechanisms.
+      const activeTerminalTextSelection =
+        terminalContextSelections.length === 0 && isVSCodeEnvironment()
+          ? await vscodeHost.readTerminalSelection()
+          : undefined;
 
       vscodeHost.openTaskInPanel(
         {
@@ -193,6 +203,10 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
           files: uploadedFiles,
           activeSelection: activeSelection ?? undefined,
           activeTerminalTextSelection,
+          terminalContextSelections:
+            terminalContextSelections.length > 0
+              ? terminalContextSelections
+              : undefined,
           mcpConfigOverride:
             Object.keys(mcpConfigOverride).length > 0
               ? mcpConfigOverride
@@ -204,6 +218,10 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       // Clear files if they were uploaded
       if (uploadedFiles && uploadedFiles.length > 0) {
         clearFiles();
+      }
+
+      if (terminalContextSelections.length > 0) {
+        clearTerminalContextSelections();
       }
 
       resetMcpTools();
@@ -222,6 +240,8 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       resetMcpTools,
       globalMcpConfig,
       activeSelection,
+      terminalContextSelections,
+      clearTerminalContextSelections,
     ],
   );
 
@@ -246,7 +266,12 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       let content = input.text.trim();
 
       // Disallow empty submissions
-      if (content.length === 0 && files.length === 0) return;
+      if (
+        content.length === 0 &&
+        files.length === 0 &&
+        terminalContextSelections.length === 0
+      )
+        return;
 
       if (shouldCreatePlan) {
         // Use built-in planner agent
@@ -306,6 +331,7 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
       createWorktreeAndOpenTask,
       planMode,
       todoModeSelected,
+      terminalContextSelections,
     ],
   );
 
@@ -352,6 +378,8 @@ export const CreateTaskInput: React.FC<CreateTaskInputProps> = ({
         isSubTask={false}
         onFocus={onFocus}
         reviews={emptyReviews}
+        terminalContextSelections={terminalContextSelections}
+        onRemoveTerminalContextSelection={removeTerminalContextSelection}
         onSwitchSubmitMode={switchSubmitMode}
         isPlanMode={planMode}
         onSelectTodoMode={selectTodoMode}

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
@@ -76,6 +76,22 @@ describe("QueuedMessages", () => {
     ).toBeTruthy();
   });
 
+  it("shows the terminal context count alongside other counts", () => {
+    const { getByText } = render(
+      <QueuedMessages
+        messages={[
+          queuedMessage({
+            text: "  ",
+            terminalContextCount: 2,
+          }),
+        ]}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(getByText("chat.terminalContextCount:2")).toBeTruthy();
+  });
+
   it("renders a minimal icon-only preview for the active editor selection captured at queue time", () => {
     const activeSelection: ActiveSelection = {
       filepath: "/workspace/foo.ts",
@@ -158,6 +174,7 @@ function queuedMessage({
   filesCount = 0,
   reviewsCount = 0,
   userEditsCount = 0,
+  terminalContextCount = 0,
   activeSelection,
   activeTerminalTextSelection,
 }: {
@@ -166,6 +183,7 @@ function queuedMessage({
   filesCount?: number;
   reviewsCount?: number;
   userEditsCount?: number;
+  terminalContextCount?: number;
   activeSelection?: ActiveSelection;
   activeTerminalTextSelection?: TerminalTextSelection;
 }): DraftMessage {
@@ -176,6 +194,7 @@ function queuedMessage({
       filesCount,
       reviewsCount,
       userEditsCount,
+      terminalContextCount,
       isTodoMode,
       activeSelection,
       activeTerminalTextSelection,

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
@@ -59,6 +59,7 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
         filesCount = 0,
         reviewsCount = 0,
         userEditsCount = 0,
+        terminalContextCount = 0,
         isTodoMode,
         activeSelection,
         activeTerminalTextSelection,
@@ -69,6 +70,9 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
         reviewsCount > 0 ? t("chat.reviewCount", { count: reviewsCount }) : "",
         userEditsCount > 0
           ? t("chat.userEditCount", { count: userEditsCount })
+          : "",
+        terminalContextCount > 0
+          ? t("chat.terminalContextCount", { count: terminalContextCount })
           : "",
       ].filter(Boolean);
 

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-initialization.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-initialization.ts
@@ -51,6 +51,7 @@ export function useChatInitialization({
 
       const activeSelection = info.activeSelection;
       const activeTerminalTextSelection = info.activeTerminalTextSelection;
+      const terminalContextSelections = info.terminalContextSelections;
       const files = info.files?.map((file) => ({
         type: "file" as const,
         filename: file.name,
@@ -60,7 +61,8 @@ export function useChatInitialization({
       const shouldUseParts =
         (files?.length ?? 0) > 0 ||
         !!activeSelection ||
-        !!activeTerminalTextSelection;
+        !!activeTerminalTextSelection ||
+        (terminalContextSelections?.length ?? 0) > 0;
 
       if (shouldUseParts) {
         chatKit.init(cwd, {
@@ -73,6 +75,7 @@ export function useChatInitialization({
             undefined,
             activeSelection,
             activeTerminalTextSelection,
+            terminalContextSelections,
           ),
         });
       } else {

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-status.ts
@@ -11,6 +11,7 @@ interface UseChatStatusProps {
   isInputEmpty: boolean;
   isFilesEmpty: boolean;
   isReviewsEmpty: boolean;
+  isTerminalContextEmpty: boolean;
   isUploadingAttachments: boolean;
   blockingState: BlockingState;
   taskStatus: Task["status"] | undefined;
@@ -22,6 +23,7 @@ export function useChatStatus({
   isInputEmpty,
   isFilesEmpty,
   isReviewsEmpty,
+  isTerminalContextEmpty,
   isUploadingAttachments,
   blockingState,
   taskStatus,
@@ -44,7 +46,10 @@ export function useChatStatus({
   // `submit`: send or queue message
   const isSubmitEnabled =
     !isUploadingAttachments &&
-    (!isInputEmpty || !isFilesEmpty || !isReviewsEmpty);
+    (!isInputEmpty ||
+      !isFilesEmpty ||
+      !isReviewsEmpty ||
+      !isTerminalContextEmpty);
 
   // `stop`: stop chat streaming or tool execution
   const isStopEnabled =

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -453,6 +453,7 @@ describe("useChatSubmit", () => {
       [],
       sendTimeActiveSelection,
       sendTimeTerminalSelection,
+      [],
     );
   });
 
@@ -482,6 +483,7 @@ describe("useChatSubmit", () => {
       [],
       undefined,
       undefined,
+      [],
     );
   });
 
@@ -511,6 +513,7 @@ describe("useChatSubmit", () => {
       [],
       undefined,
       undefined,
+      [],
     );
 
     expect(context.queuedMessages).toEqual([
@@ -552,7 +555,73 @@ describe("useChatSubmit", () => {
       queuedUserEdits,
       undefined,
       undefined,
+      [],
     );
+  });
+
+  it("allows submitting with no text when terminal context selections are attached", async () => {
+    const terminalContextSelections: TerminalTextSelection[] = [
+      { terminalName: "bash", content: "echo hi" },
+    ];
+    const context = setup({
+      isLoading: false,
+      inputText: "",
+      terminalContextSelections,
+    });
+
+    await act(async () => {
+      await context.result.current.handleSubmit();
+    });
+
+    expect(context.sendMessage).toHaveBeenCalledWith({
+      parts: ["text:"],
+    });
+  });
+
+  it("skips the implicit active-terminal-selection capture when terminal context selections are attached, and clears them after sending", async () => {
+    const terminalContextSelections: TerminalTextSelection[] = [
+      { terminalName: "bash", content: "echo hi" },
+    ];
+    vscodeMocks.isVSCodeEnvironment.value = true;
+
+    const context = setup({
+      isLoading: false,
+      terminalContextSelections,
+    });
+
+    await act(async () => {
+      await context.result.current.handleSubmit();
+    });
+
+    expect(vscodeMocks.readTerminalSelection).not.toHaveBeenCalled();
+    expect(messageUtilsMocks.prepareMessageParts).toHaveBeenCalledWith(
+      expect.any(Function),
+      "follow up",
+      [],
+      [],
+      [],
+      undefined,
+      undefined,
+      terminalContextSelections,
+    );
+    expect(context.clearTerminalContextSelections).toHaveBeenCalledOnce();
+  });
+
+  it("still reads the implicit active-terminal-selection when no terminal context selections are attached", async () => {
+    vscodeMocks.isVSCodeEnvironment.value = true;
+    vscodeMocks.readTerminalSelection.mockResolvedValue({
+      terminalName: "bash",
+      content: "implicit capture",
+    });
+
+    const context = setup({ isLoading: false });
+
+    await act(async () => {
+      await context.result.current.handleSubmit();
+    });
+
+    expect(vscodeMocks.readTerminalSelection).toHaveBeenCalledOnce();
+    expect(context.clearTerminalContextSelections).not.toHaveBeenCalled();
   });
 });
 
@@ -563,6 +632,7 @@ function setup({
   files = [],
   reviews = [],
   includeUserEdits: initialIncludeUserEdits = true,
+  terminalContextSelections = [],
   isTodoMode = false,
   canCreateTodo = true,
   onTodoModeQueued,
@@ -574,6 +644,7 @@ function setup({
   files?: File[];
   reviews?: Review[];
   includeUserEdits?: boolean;
+  terminalContextSelections?: TerminalTextSelection[];
   isTodoMode?: boolean;
   canCreateTodo?: boolean;
   onTodoModeQueued?: () => void;
@@ -583,6 +654,7 @@ function setup({
   const stopChat = vi.fn();
   const clearInput = vi.fn();
   const clearFiles = vi.fn();
+  const clearTerminalContextSelections = vi.fn();
 
   const upload = vi.fn(() => Promise.resolve([]));
 
@@ -611,7 +683,12 @@ function setup({
       const isInputEmpty = !initialInputText.trim();
       const isFilesEmpty = files.length === 0;
       const isReviewsEmpty = reviews.length === 0;
-      const isSubmitEnabled = !isInputEmpty || !isFilesEmpty || !isReviewsEmpty;
+      const isTerminalContextEmpty = terminalContextSelections.length === 0;
+      const isSubmitEnabled =
+        !isInputEmpty ||
+        !isFilesEmpty ||
+        !isReviewsEmpty ||
+        !isTerminalContextEmpty;
       const isStopEnabled = isRunning;
       const allowSendMessage = !isRunning;
       const allowSteer = true;
@@ -641,6 +718,8 @@ function setup({
         setQueuedMessages,
         reviews,
         userEdits: props.includeUserEdits ? userEditsMocks.userEdits : [],
+        terminalContextSelections,
+        clearTerminalContextSelections,
         taskId: "task-1",
         isTodoMode,
         canCreateTodo,
@@ -678,6 +757,7 @@ function setup({
     },
     clearInput,
     clearFiles,
+    clearTerminalContextSelections,
     upload,
     sendMessage,
     stopChat,
@@ -689,6 +769,7 @@ function draftMessage({
   filesCount = 0,
   reviewsCount = 0,
   userEditsCount = 0,
+  terminalContextCount = 0,
   isTodoMode = false,
   activeSelection,
   activeTerminalTextSelection,
@@ -697,6 +778,7 @@ function draftMessage({
   filesCount?: number;
   reviewsCount?: number;
   userEditsCount?: number;
+  terminalContextCount?: number;
   isTodoMode?: boolean;
   activeSelection?: ActiveSelection;
   activeTerminalTextSelection?: TerminalTextSelection;
@@ -708,6 +790,7 @@ function draftMessage({
       filesCount,
       reviewsCount,
       userEditsCount,
+      terminalContextCount,
       isTodoMode,
       activeSelection,
       activeTerminalTextSelection,

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -36,6 +36,7 @@ export interface DraftMessage {
     filesCount?: number;
     reviewsCount?: number;
     userEditsCount?: number;
+    terminalContextCount?: number;
     isTodoMode?: boolean;
     activeSelection?: ActiveSelection;
     activeTerminalTextSelection?: TerminalTextSelection;
@@ -58,6 +59,8 @@ interface UseChatSubmitProps {
   setQueuedMessages: React.Dispatch<React.SetStateAction<DraftMessage[]>>;
   reviews: Review[];
   userEdits: FileDiff[];
+  terminalContextSelections: TerminalTextSelection[];
+  clearTerminalContextSelections: () => void;
   taskId: string;
   isTodoMode?: boolean;
   canCreateTodo?: boolean;
@@ -85,6 +88,8 @@ export function useChatSubmit({
   setQueuedMessages,
   reviews,
   userEdits,
+  terminalContextSelections,
+  clearTerminalContextSelections,
   taskId,
   isTodoMode = false,
   canCreateTodo = true,
@@ -166,11 +171,13 @@ export function useChatSubmit({
     const text = input.text.trim();
     const currentFiles = [...files];
     const currentReviews = [...reviews];
+    const currentTerminalContextSelections = [...terminalContextSelections];
 
     if (
       text.length === 0 &&
       currentFiles.length === 0 &&
-      currentReviews.length === 0
+      currentReviews.length === 0 &&
+      currentTerminalContextSelections.length === 0
     ) {
       return undefined;
     }
@@ -181,9 +188,13 @@ export function useChatSubmit({
 
     // Terminal selection can only be read on demand (there's no reactive
     // VS Code API for it), so this is the only chance to snapshot it.
-    const currentTerminalTextSelection = isVSCodeEnvironment()
-      ? await vscodeHost.readTerminalSelection()
-      : undefined;
+    // If the user has manually attached terminal context via the "Add to
+    // Chat" flow, skip this implicit capture so the same terminal content
+    // isn't duplicated on the message via two different mechanisms.
+    const currentTerminalTextSelection =
+      currentTerminalContextSelections.length === 0 && isVSCodeEnvironment()
+        ? await vscodeHost.readTerminalSelection()
+        : undefined;
 
     let uploadedAttachments: FileUIPart[] = [];
     if (currentFiles.length > 0) {
@@ -203,12 +214,16 @@ export function useChatSubmit({
     if (currentReviews.length > 0) {
       vscodeHost.deleteReviews(currentReviews.map((review) => review.id));
     }
+    if (currentTerminalContextSelections.length > 0) {
+      clearTerminalContextSelections();
+    }
 
     const raw = {
       text,
       filesCount: currentFiles.length,
       reviewsCount: currentReviews.length,
       userEditsCount: currentUserEdits.length,
+      terminalContextCount: currentTerminalContextSelections.length,
       isTodoMode,
       activeSelection: currentSelection,
       activeTerminalTextSelection: currentTerminalTextSelection,
@@ -221,6 +236,7 @@ export function useChatSubmit({
       currentUserEdits,
       currentSelection,
       currentTerminalTextSelection,
+      currentTerminalContextSelections,
     );
 
     return { parts, raw };
@@ -230,6 +246,8 @@ export function useChatSubmit({
     files,
     reviews,
     userEdits,
+    terminalContextSelections,
+    clearTerminalContextSelections,
     activeSelection,
     upload,
     clearFiles,

--- a/packages/vscode-webui/src/features/chat/hooks/use-terminal-context-state.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-terminal-context-state.ts
@@ -1,0 +1,29 @@
+import type { TerminalTextSelection } from "@getpochi/common/vscode-webui-bridge";
+import { create } from "zustand";
+
+/**
+ * Accumulates terminal text selections that the user explicitly attaches to
+ * the next outgoing message via the "Add to Chat" terminal context menu
+ * action (pushed from the VS Code host). This is intentionally kept separate
+ * from the implicit "currently selected terminal text" capture performed at
+ * submit time (see `useActiveSelection` / `readTerminalSelection`).
+ */
+export interface TerminalContextState {
+  selections: TerminalTextSelection[];
+  addSelection: (selection: TerminalTextSelection) => void;
+  removeSelection: (index: number) => void;
+  clearSelections: () => void;
+}
+
+export const useTerminalContextState = create<TerminalContextState>()(
+  (set) => ({
+    selections: [],
+    addSelection: (selection) =>
+      set((state) => ({ selections: [...state.selections, selection] })),
+    removeSelection: (index) =>
+      set((state) => ({
+        selections: state.selections.filter((_, i) => i !== index),
+      })),
+    clearSelections: () => set({ selections: [] }),
+  }),
+);

--- a/packages/vscode-webui/src/features/chat/index.ts
+++ b/packages/vscode-webui/src/features/chat/index.ts
@@ -44,6 +44,11 @@ export {
   type SubtaskInfo,
 } from "./hooks/use-subtask-info";
 
+export {
+  useTerminalContextState,
+  type TerminalContextState,
+} from "./hooks/use-terminal-context-state";
+
 export { useRenderWidgetStore } from "./hooks/use-render-widget-store";
 
 export {

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -48,7 +48,10 @@
     "steer": "Steer",
     "copyImage": "Copy Image",
     "openImage": "Open Image",
-    "pleaseCheckFiles": "Please check these attachments.",
+    "contextLabelFiles": "files",
+    "contextLabelReviews": "reviews",
+    "contextLabelTerminalSelections": "terminal selections",
+    "pleaseCheckAttachedContext": "Please check the attached {{items}}.",
     "chatToolbar": {
       "diffWorktreeWith": "Diff worktree with {{branch}}",
       "openInTerminal": "Open in Integrated Terminal"

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -44,6 +44,7 @@
     "fileCount": "{{count}} files",
     "reviewCount": "{{count}} reviews",
     "userEditCount": "{{count}} edits",
+    "terminalContextCount": "{{count}} terminal selections",
     "steer": "Steer",
     "copyImage": "Copy Image",
     "openImage": "Open Image",
@@ -448,6 +449,9 @@
     "cell": "Cell",
     "addContext": "Add Context",
     "terminal": "Terminal"
+  },
+  "terminalContextBadge": {
+    "remove": "Remove terminal selection from context"
   },
   "todoModeBadge": {
     "remove": "Remove todo mode"

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -47,7 +47,10 @@
     "steer": "介入",
     "copyImage": "画像をコピー",
     "openImage": "画像を開く",
-    "pleaseCheckFiles": "これらの添付ファイルを確認してください。",
+    "contextLabelFiles": "添付ファイル",
+    "contextLabelReviews": "レビュー",
+    "contextLabelTerminalSelections": "ターミナル選択",
+    "pleaseCheckAttachedContext": "添付された{{items}}を確認してください。",
     "chatToolbar": {
       "diffWorktreeWith": "ワークツリーを {{branch}} と比較",
       "openInTerminal": "統合ターミナルで開く"

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -43,6 +43,7 @@
     "fileCount": "{{count}} 件のファイル",
     "reviewCount": "{{count}} 件のレビュー",
     "userEditCount": "{{count}} 件の編集",
+    "terminalContextCount": "{{count}} 件のターミナル選択",
     "steer": "介入",
     "copyImage": "画像をコピー",
     "openImage": "画像を開く",
@@ -442,6 +443,9 @@
     "cell": "セル",
     "addContext": "コンテキストを追加",
     "terminal": "ターミナル"
+  },
+  "terminalContextBadge": {
+    "remove": "ターミナル選択をコンテキストから削除"
   },
   "todoModeBadge": {
     "remove": "Todoモードを削除"

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -42,6 +42,7 @@
     "fileCount": "파일 {{count}}개",
     "reviewCount": "리뷰 {{count}}개",
     "userEditCount": "편집 {{count}}개",
+    "terminalContextCount": "터미널 선택 {{count}}개",
     "steer": "개입",
     "copyImage": "이미지 복사",
     "openImage": "이미지 열기",
@@ -440,6 +441,9 @@
     "cell": "셀",
     "addContext": "컨텍스트 추가",
     "terminal": "터미널"
+  },
+  "terminalContextBadge": {
+    "remove": "컨텍스트에서 터미널 선택 제거"
   },
   "todoModeBadge": {
     "remove": "Todo 모드 제거"

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -46,7 +46,10 @@
     "steer": "개입",
     "copyImage": "이미지 복사",
     "openImage": "이미지 열기",
-    "pleaseCheckFiles": "이 첨부 파일들을 확인해 주세요.",
+    "contextLabelFiles": "첨부 파일",
+    "contextLabelReviews": "리뷰",
+    "contextLabelTerminalSelections": "터미널 선택",
+    "pleaseCheckAttachedContext": "첨부된 다음 항목을 확인해 주세요: {{items}}",
     "chatToolbar": {
       "diffWorktreeWith": "{{branch}}와(과) 워크트리 비교",
       "openInTerminal": "통합 터미널에서 열기"

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -46,7 +46,10 @@
     "steer": "介入",
     "copyImage": "复制图片",
     "openImage": "打开图片",
-    "pleaseCheckFiles": "请检查这些附件。",
+    "contextLabelFiles": "附件",
+    "contextLabelReviews": "评审",
+    "contextLabelTerminalSelections": "终端选区",
+    "pleaseCheckAttachedContext": "请检查已附加的{{items}}。",
     "chatToolbar": {
       "diffWorktreeWith": "将工作树与 {{branch}} 进行比较",
       "openInTerminal": "在集成终端中打开"

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -42,6 +42,7 @@
     "fileCount": "{{count}} 个文件",
     "reviewCount": "{{count}} 条评审",
     "userEditCount": "{{count}} 处编辑",
+    "terminalContextCount": "{{count}} 个终端选区",
     "steer": "介入",
     "copyImage": "复制图片",
     "openImage": "打开图片",
@@ -440,6 +441,9 @@
     "cell": "单元格",
     "addContext": "添加上下文",
     "terminal": "终端"
+  },
+  "terminalContextBadge": {
+    "remove": "从上下文中移除终端选区"
   },
   "todoModeBadge": {
     "remove": "移除 Todo 模式"

--- a/packages/vscode-webui/src/lib/message-utils.ts
+++ b/packages/vscode-webui/src/lib/message-utils.ts
@@ -8,7 +8,6 @@ import type {
 import type { Message } from "@getpochi/livekit";
 import type { FileUIPart } from "ai";
 import type { TFunction } from "i18next";
-import i18n from "../i18n/config";
 import { vscodeHost } from "./vscode";
 
 export function prepareMessageParts(
@@ -78,7 +77,11 @@ export function prepareMessageParts(
 
   let fallbackPrompt = "";
   if (attachedContextLabels.length) {
-    const items = new Intl.ListFormat(i18n.language, {
+    // Use the runtime's default locale (rather than importing the i18next
+    // singleton) to avoid pulling i18n/config.ts - and its side-effecting
+    // `.use(initReactI18next)` init call - into this module, which breaks
+    // tests that partially mock "react-i18next".
+    const items = new Intl.ListFormat(undefined, {
       style: "long",
       type: "conjunction",
     }).format(attachedContextLabels);

--- a/packages/vscode-webui/src/lib/message-utils.ts
+++ b/packages/vscode-webui/src/lib/message-utils.ts
@@ -8,6 +8,7 @@ import type {
 import type { Message } from "@getpochi/livekit";
 import type { FileUIPart } from "ai";
 import type { TFunction } from "i18next";
+import i18n from "../i18n/config";
 import { vscodeHost } from "./vscode";
 
 export function prepareMessageParts(
@@ -62,9 +63,26 @@ export function prepareMessageParts(
     });
   }
 
-  let fallbackPrompt = "";
+  const attachedContextLabels: string[] = [];
   if (files.length) {
-    fallbackPrompt = t("chat.pleaseCheckFiles") as string;
+    attachedContextLabels.push(t("chat.contextLabelFiles") as string);
+  }
+  if (reviews.length) {
+    attachedContextLabels.push(t("chat.contextLabelReviews") as string);
+  }
+  if (terminalContextSelections?.length) {
+    attachedContextLabels.push(
+      t("chat.contextLabelTerminalSelections") as string,
+    );
+  }
+
+  let fallbackPrompt = "";
+  if (attachedContextLabels.length) {
+    const items = new Intl.ListFormat(i18n.language, {
+      style: "long",
+      type: "conjunction",
+    }).format(attachedContextLabels);
+    fallbackPrompt = t("chat.pleaseCheckAttachedContext", { items }) as string;
   }
 
   const finalPrompt = prompt || fallbackPrompt;

--- a/packages/vscode-webui/src/lib/message-utils.ts
+++ b/packages/vscode-webui/src/lib/message-utils.ts
@@ -18,6 +18,7 @@ export function prepareMessageParts(
   userEdits?: UserEdits,
   activeSelection?: ActiveSelection,
   activeTerminalTextSelection?: TerminalTextSelection,
+  terminalContextSelections?: TerminalTextSelection[],
 ) {
   const parts: Message["parts"] = [];
   for (const x of files) {
@@ -51,6 +52,13 @@ export function prepareMessageParts(
     parts.push({
       type: "data-active-selection",
       data: { activeSelection, activeTerminalTextSelection },
+    });
+  }
+
+  if (terminalContextSelections && terminalContextSelections.length > 0) {
+    parts.push({
+      type: "data-terminal-context",
+      data: { textSelections: terminalContextSelections },
     });
   }
 

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -1,6 +1,6 @@
-import { useTerminalContextState } from "@/features/chat";
 import { type AutoMemoryManager, getLogger } from "@getpochi/common";
 import { validateTaskFilePath } from "@getpochi/common/pochi-file-system";
+import type { TerminalTextSelection } from "@getpochi/common/vscode-webui-bridge";
 import {
   type ExecuteCommandResult,
   type VSCodeHostApi,
@@ -26,6 +26,34 @@ export function setGlobalStore(
   store: ReturnType<typeof useDefaultStore> | null,
 ) {
   globalStore = store;
+}
+
+// `useTerminalContextState` lives in "@/features/chat", which (transitively)
+// imports this module. Importing it eagerly here at module scope would
+// create an import cycle that can leave other modules partially
+// initialized (e.g. the default selected model logic), so instead we keep a
+// placeholder that gets resolved once the React tree mounts.
+// See `TerminalContextStateInitializer`. Calls made before it's ready are
+// queued (via `addTerminalContextReady`) rather than dropped.
+type AddTerminalContextFn = (selection: TerminalTextSelection) => void;
+let addTerminalContextImpl: AddTerminalContextFn | null = null;
+let resolveAddTerminalContextReady:
+  | ((impl: AddTerminalContextFn) => void)
+  | null = null;
+let addTerminalContextReady = new Promise<AddTerminalContextFn>((resolve) => {
+  resolveAddTerminalContextReady = resolve;
+});
+
+export function setAddTerminalContext(impl: AddTerminalContextFn | null) {
+  addTerminalContextImpl = impl;
+  if (impl) {
+    resolveAddTerminalContextReady?.(impl);
+  } else {
+    // Reset so future calls wait again until it's resolved.
+    addTerminalContextReady = new Promise<AddTerminalContextFn>((resolve) => {
+      resolveAddTerminalContextReady = resolve;
+    });
+  }
 }
 
 let vscodeApi: WebviewApi<unknown> | undefined | null = undefined;
@@ -142,8 +170,10 @@ function createVSCodeHost(): VSCodeHostApi {
         "readTaskChangedFiles",
       ],
       exports: {
-        addTerminalContext(selection) {
-          useTerminalContextState.getState().addSelection(selection);
+        async addTerminalContext(selection) {
+          const impl =
+            addTerminalContextImpl ?? (await addTerminalContextReady);
+          impl(selection);
         },
 
         openTaskList() {

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -1,3 +1,4 @@
+import { useTerminalContextState } from "@/features/chat";
 import { type AutoMemoryManager, getLogger } from "@getpochi/common";
 import { validateTaskFilePath } from "@getpochi/common/pochi-file-system";
 import {
@@ -141,6 +142,10 @@ function createVSCodeHost(): VSCodeHostApi {
         "readTaskChangedFiles",
       ],
       exports: {
+        addTerminalContext(selection) {
+          useTerminalContextState.getState().addSelection(selection);
+        },
+
         openTaskList() {
           window.router.navigate({
             to: "/",

--- a/packages/vscode-webui/src/routes/index.tsx
+++ b/packages/vscode-webui/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { TerminalContextStateInitializer } from "@/components/terminal-context-state-initializer";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { WelcomeScreen } from "@/components/welcome-screen";
 import { WorkspaceRequiredPlaceholder } from "@/components/workspace-required-placeholder";
@@ -76,6 +77,7 @@ function Tasks() {
 
   return (
     <div className="flex h-screen w-screen flex-col">
+      <TerminalContextStateInitializer />
       <div className="w-full px-4 pt-3">
         <CreateTaskInput
           cwd={cwd}

--- a/packages/vscode-webui/src/routes/task.tsx
+++ b/packages/vscode-webui/src/routes/task.tsx
@@ -1,6 +1,7 @@
 import "@/components/prompt-form/prompt-form.css";
 
 import { GlobalStoreInitializer } from "@/components/global-store-initializer";
+import { TerminalContextStateInitializer } from "@/components/terminal-context-state-initializer";
 import { WelcomeScreen } from "@/components/welcome-screen";
 import { ChatPage, ChatSkeleton } from "@/features/chat";
 import { useModelList } from "@/lib/hooks/use-model-list";
@@ -67,6 +68,7 @@ function RouteComponent() {
   const chatPage = (
     <>
       <GlobalStoreInitializer />
+      <TerminalContextStateInitializer />
       <ChatPage key={key} user={users?.pochi} uid={uid} info={info} />
     </>
   );

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -233,6 +233,11 @@
         "title": "Cancel",
         "icon": "$(close)",
         "category": "Pochi"
+      },
+      {
+        "command": "pochi.terminal.addToChat",
+        "title": "Add Selection to Pochi Chat",
+        "category": "Pochi"
       }
     ],
     "menus": {
@@ -341,6 +346,10 @@
         {
           "command": "pochi.comments.cancelEditComment",
           "when": "false"
+        },
+        {
+          "command": "pochi.terminal.addToChat",
+          "when": "terminalFocus && terminalTextSelected"
         }
       ],
       "view/title": [
@@ -353,6 +362,13 @@
           "command": "pochi.webui.navigate.settings",
           "when": "view == pochiSidebarDark || view == pochiSidebarLight",
           "group": "navigation@2"
+        }
+      ],
+      "terminal/context": [
+        {
+          "command": "pochi.terminal.addToChat",
+          "when": "terminalTextSelected",
+          "group": "navigation"
         }
       ],
       "comments/commentThread/context": [

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -349,7 +349,7 @@
         },
         {
           "command": "pochi.terminal.addToChat",
-          "when": "terminalFocus && terminalTextSelected"
+          "when": "terminalTextSelected"
         }
       ],
       "view/title": [

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -28,7 +28,7 @@ import { CommandManager } from "./integrations/command";
 import { DiffChangesContentProvider } from "./integrations/editor/diff-changes-content-provider";
 import { PochiFileSystemProvider } from "./integrations/editor/pochi-file-system-provider";
 import { WorktreeManager } from "./integrations/git/worktree";
-import { LayoutManager } from "./integrations/layout";
+import { LayoutManager, PochiTaskTabMonitor } from "./integrations/layout";
 import { createMcpHub } from "./integrations/mcp";
 import { ReviewController } from "./integrations/review-controller";
 import { StatusBarItem } from "./integrations/status-bar-item";
@@ -105,6 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
     container.resolve(TabCompletionManager);
   }
   container.resolve(LayoutManager);
+  container.resolve(PochiTaskTabMonitor);
 }
 
 // This method is called when your extension is deactivated

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -26,7 +26,10 @@ import {
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { McpHub } from "@getpochi/common/mcp-utils";
 import { getVendor } from "@getpochi/common/vendor";
-import type { PochiTaskParams } from "@getpochi/common/vscode-webui-bridge";
+import type {
+  PochiTaskParams,
+  TerminalTextSelection,
+} from "@getpochi/common/vscode-webui-bridge";
 import { getServerBaseUrl } from "@getpochi/common/vscode-webui-bridge";
 import { container, inject, injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
@@ -51,7 +54,13 @@ import {
   ReviewController,
   type Thread,
 } from "./review-controller";
-import { PochiTaskEditorProvider } from "./webview/webview-panel";
+import { readTerminalSelection as readTerminalSelectionFromClipboard } from "./terminal/read-terminal-selection";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { TerminalState } from "./terminal/terminal-state";
+import {
+  PochiTaskEditorProvider,
+  PochiWebviewPanel,
+} from "./webview/webview-panel";
 
 const logger = getLogger("CommandManager");
 
@@ -73,6 +82,7 @@ export class CommandManager implements vscode.Disposable {
     private readonly worktreeInfoProvider: GitWorktreeInfoProvider,
     private readonly reviewController: ReviewController,
     private readonly layoutManager: LayoutManager,
+    private readonly terminalState: TerminalState,
   ) {
     this.registerCommands();
     if (EditorPredictionsAvailable) {
@@ -641,7 +651,42 @@ export class CommandManager implements vscode.Disposable {
           await this.reviewController.cancelEditComment(comment);
         },
       ),
+
+      vscode.commands.registerCommand("pochi.terminal.addToChat", async () => {
+        const terminal = vscode.window.activeTerminal;
+        if (!terminal) return;
+
+        const selection = await readTerminalSelectionFromClipboard(
+          terminal,
+          this.terminalState.getTerminalId(terminal),
+        );
+        if (!selection) return;
+
+        await this.sendTerminalContextToActiveChat(selection);
+      }),
     );
+  }
+
+  /**
+   * Sends a terminal text selection to the currently active Pochi chat tab
+   * and brings it to the foreground. Falls back to the sidebar (focusing
+   * it) if no chat tab is currently open.
+   */
+  private async sendTerminalContextToActiveChat(
+    selection: TerminalTextSelection,
+  ): Promise<void> {
+    const activeTab = findActivePochiTaskTab();
+    const uid = activeTab
+      ? PochiTaskEditorProvider.parseTaskUri(activeTab.input.uri)?.uid
+      : undefined;
+
+    if (uid && PochiWebviewPanel.addTerminalContext(uid, selection)) {
+      return;
+    }
+
+    await this.focusSidebar();
+    const webviewHost = await this.pochiWebviewSidebar.retrieveWebviewHost();
+    webviewHost.addTerminalContext(selection);
   }
 
   private registerEditorPredictionCommands(): vscode.Disposable[] {

--- a/packages/vscode/src/integrations/layout/index.ts
+++ b/packages/vscode/src/integrations/layout/index.ts
@@ -17,4 +17,4 @@ export function createTerminal(
 }
 
 export { LayoutManager };
-export { findActivePochiTaskTab } from "./tab-utils";
+export { findActivePochiTaskTab, PochiTaskTabMonitor } from "./tab-utils";

--- a/packages/vscode/src/integrations/layout/tab-utils.ts
+++ b/packages/vscode/src/integrations/layout/tab-utils.ts
@@ -126,8 +126,44 @@ function findTaskTabByUri(uri: vscode.Uri): PochiTaskTab | undefined {
     );
 }
 
+// Picks the preferred tab among a list of candidate pochi task tab
+// candidates: prefer the one matching the last actually active task tab (if
+// any), otherwise prefer one that's in a pochi-panel typed group, otherwise
+// just return the first candidate.
+function pickPreferredTaskTab(
+  candidates: readonly PochiTaskTab[],
+  lastActiveTab: PochiTaskTab | undefined,
+): PochiTaskTab | undefined {
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  const matchedTab =
+    lastActiveTab &&
+    candidates.find((tab) => isSameTabInput(tab.input, lastActiveTab.input));
+  if (matchedTab) {
+    return matchedTab;
+  }
+
+  const tabInPochiPanelGroup = candidates.find(
+    (tab) => getTabGroupType(tab.group.tabs) === "pochi-panel",
+  );
+  if (tabInPochiPanelGroup) {
+    return tabInPochiPanelGroup;
+  }
+
+  return candidates[0];
+}
+
 export function findActivePochiTaskTab(): PochiTaskTab | undefined {
   const tabGroups = vscode.window.tabGroups;
+
+  // Fast path: the active tab of the active group is almost always what we
+  // want, so check it first before scanning every group below.
+  const activeTab = tabGroups.activeTabGroup.activeTab;
+  if (activeTab && isPochiTaskTab(activeTab)) {
+    return activeTab;
+  }
 
   // Find pochi task tabs that are the active tab of their own group, across
   // every group (this covers both the active group and any other groups).
@@ -138,49 +174,25 @@ export function findActivePochiTaskTab(): PochiTaskTab | undefined {
   if (activeTaskTabs.length === 1) {
     return activeTaskTabs[0];
   }
+
+  const lastActiveTab = container
+    .resolve(PochiTaskTabMonitor)
+    .getLastActiveTaskTab();
+
   if (activeTaskTabs.length > 1) {
     // Multiple groups have an active pochi task tab (e.g. side-by-side task
-    // editors). Disambiguate using the last actually active one.
-    const lastActiveTab = container
-      .resolve(PochiTaskTabMonitor)
-      .getLastActiveTaskTab();
-    const matchedTab =
-      lastActiveTab &&
-      activeTaskTabs.find((tab) =>
-        isSameTabInput(tab.input, lastActiveTab.input),
-      );
-    if (matchedTab) {
-      return matchedTab;
-    }
-
-    // Otherwise, prefer an active task tab that's in a pochi-panel typed
-    // group.
-    const panelActiveTab = activeTaskTabs.find(
-      (tab) => getTabGroupType(tab.group.tabs) === "pochi-panel",
-    );
-    if (panelActiveTab) {
-      return panelActiveTab;
-    }
-
-    // Otherwise, fallback to the first active task tab found.
-    return activeTaskTabs[0];
+    // editors). Disambiguate using the last actually active one, otherwise
+    // prefer one in a pochi-panel typed group, otherwise just pick one.
+    return pickPreferredTaskTab(activeTaskTabs, lastActiveTab);
   }
 
-  // Otherwise, falling back to checking non-active tabs
-  // Check a pochi-panel typed group first
-  for (const group of tabGroups.all) {
-    if (getTabGroupType(group.tabs) === "pochi-panel") {
-      const tab = group.tabs.find((tab) => isPochiTaskTab(tab));
-      if (tab) {
-        return tab;
-      }
-    }
-  }
-
-  // Otherwise, fallback to the first task tab found anywhere.
-  return tabGroups.all
+  // Otherwise, fallback to checking non-active tabs, using the same
+  // preference order.
+  const nonActiveTaskTabs = tabGroups.all
     .flatMap((group) => group.tabs)
-    .find((tab): tab is PochiTaskTab => isPochiTaskTab(tab));
+    .filter((tab): tab is PochiTaskTab => !tab.isActive && isPochiTaskTab(tab));
+
+  return pickPreferredTaskTab(nonActiveTaskTabs, lastActiveTab);
 }
 
 export function isSameTabInput(

--- a/packages/vscode/src/integrations/layout/tab-utils.ts
+++ b/packages/vscode/src/integrations/layout/tab-utils.ts
@@ -1,14 +1,17 @@
+import { container, injectable, singleton } from "tsyringe";
 import * as vscode from "vscode";
 import { PochiTaskEditorProvider } from "../webview/webview-panel";
 
 const MainThreadWebviewPrefix = "mainThreadWebview-";
 const PochiPanelViewTypePrefix = "pochi.";
 
-export function isPochiTaskTab(tab: vscode.Tab): tab is vscode.Tab & {
+export type PochiTaskTab = vscode.Tab & {
   input: vscode.TabInputCustom & {
     viewType: typeof PochiTaskEditorProvider.viewType;
   };
-} {
+};
+
+export function isPochiTaskTab(tab: vscode.Tab): tab is PochiTaskTab {
   return (
     tab.input instanceof vscode.TabInputCustom &&
     tab.input.viewType === PochiTaskEditorProvider.viewType
@@ -114,35 +117,58 @@ export function getTabGroupType(tabs: readonly vscode.Tab[]) {
   return "editor";
 }
 
-export function findActivePochiTaskTab():
-  | (vscode.Tab & {
-      input: vscode.TabInputCustom & {
-        viewType: typeof PochiTaskEditorProvider.viewType;
-      };
-    })
-  | undefined {
+function findTaskTabByUri(uri: vscode.Uri): PochiTaskTab | undefined {
+  return vscode.window.tabGroups.all
+    .flatMap((group) => group.tabs)
+    .find(
+      (tab): tab is PochiTaskTab =>
+        isPochiTaskTab(tab) && tab.input.uri.toString() === uri.toString(),
+    );
+}
+
+export function findActivePochiTaskTab(): PochiTaskTab | undefined {
   const tabGroups = vscode.window.tabGroups;
 
-  // Try find active tab in active group
-  const activeTab = tabGroups.activeTabGroup.activeTab;
-  if (activeTab && isPochiTaskTab(activeTab)) {
-    return activeTab;
+  // Find pochi task tabs that are the active tab of their own group, across
+  // every group (this covers both the active group and any other groups).
+  const activeTaskTabs = tabGroups.all
+    .map((group) => group.activeTab)
+    .filter((tab): tab is PochiTaskTab => !!tab && isPochiTaskTab(tab));
+
+  if (activeTaskTabs.length === 1) {
+    return activeTaskTabs[0];
   }
-  // Otherwise find active tab in other groups
-  const group = tabGroups.all.find(
-    (group) => group.activeTab && isPochiTaskTab(group.activeTab),
-  );
-  if (group?.activeTab && isPochiTaskTab(group.activeTab)) {
-    return group.activeTab;
+  if (activeTaskTabs.length > 1) {
+    // Multiple groups have an active pochi task tab (e.g. side-by-side task
+    // editors). Disambiguate using the last actually active one.
+    const lastActiveTab = container
+      .resolve(PochiTaskTabMonitor)
+      .getLastActiveTaskTab();
+    const matchedTab =
+      lastActiveTab &&
+      activeTaskTabs.find((tab) =>
+        isSameTabInput(tab.input, lastActiveTab.input),
+      );
+    if (matchedTab) {
+      return matchedTab;
+    }
   }
-  // Otherwise find first task tab
-  const tab = tabGroups.all
+
+  // Otherwise, fallback to the first task tab found in a pochi-panel typed
+  // group.
+  for (const group of tabGroups.all) {
+    if (getTabGroupType(group.tabs) === "pochi-panel") {
+      const tab = group.tabs.find((tab) => isPochiTaskTab(tab));
+      if (tab) {
+        return tab;
+      }
+    }
+  }
+
+  // Otherwise, fallback to the first task tab found anywhere.
+  return tabGroups.all
     .flatMap((group) => group.tabs)
-    .find((tab) => isPochiTaskTab(tab));
-  if (tab) {
-    return tab;
-  }
-  return undefined;
+    .find((tab): tab is PochiTaskTab => isPochiTaskTab(tab));
 }
 
 export function isSameTabInput(
@@ -254,4 +280,52 @@ export function countOtherTabs(tabGroups: TabGroupShape) {
         .length,
     0,
   );
+}
+
+/**
+ * Monitors the last pochi task tab that was actually active, i.e. it was the
+ * `activeTab` of the `activeTabGroup` at some point. This is tracked by uri
+ * (rather than holding onto the `Tab` object itself) so that we always
+ * resolve back to the live `Tab` instance, and can detect when the tab has
+ * since been closed.
+ *
+ * This is registered as a singleton and eagerly resolved on extension
+ * activation (see `extension.ts`), so that the listeners start running as
+ * soon as the extension starts, rather than lazily on first import/use.
+ */
+@injectable()
+@singleton()
+export class PochiTaskTabMonitor implements vscode.Disposable {
+  private disposables: vscode.Disposable[] = [];
+  private lastActiveTaskTabUri: vscode.Uri | undefined;
+
+  constructor() {
+    this.disposables.push(
+      vscode.window.tabGroups.onDidChangeTabGroups(this.update),
+      vscode.window.tabGroups.onDidChangeTabs(this.update),
+    );
+    // Initialize eagerly in case a pochi task tab is already active.
+    this.update();
+  }
+
+  private update = () => {
+    const activeGroup = vscode.window.tabGroups.activeTabGroup;
+    const activeTab = activeGroup?.activeTab;
+    if (activeGroup && activeTab && isPochiTaskTab(activeTab)) {
+      this.lastActiveTaskTabUri = activeTab.input.uri;
+    }
+  };
+
+  getLastActiveTaskTab(): PochiTaskTab | undefined {
+    return this.lastActiveTaskTabUri
+      ? findTaskTabByUri(this.lastActiveTaskTabUri)
+      : undefined;
+  }
+
+  dispose() {
+    for (const disposable of this.disposables) {
+      disposable.dispose();
+    }
+    this.disposables = [];
+  }
 }

--- a/packages/vscode/src/integrations/layout/tab-utils.ts
+++ b/packages/vscode/src/integrations/layout/tab-utils.ts
@@ -152,10 +152,22 @@ export function findActivePochiTaskTab(): PochiTaskTab | undefined {
     if (matchedTab) {
       return matchedTab;
     }
+
+    // Otherwise, prefer an active task tab that's in a pochi-panel typed
+    // group.
+    const panelActiveTab = activeTaskTabs.find(
+      (tab) => getTabGroupType(tab.group.tabs) === "pochi-panel",
+    );
+    if (panelActiveTab) {
+      return panelActiveTab;
+    }
+
+    // Otherwise, fallback to the first active task tab found.
+    return activeTaskTabs[0];
   }
 
-  // Otherwise, fallback to the first task tab found in a pochi-panel typed
-  // group.
+  // Otherwise, falling back to checking non-active tabs
+  // Check a pochi-panel typed group first
   for (const group of tabGroups.all) {
     if (getTabGroupType(group.tabs) === "pochi-panel") {
       const tab = group.tabs.find((tab) => isPochiTaskTab(tab));

--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -407,6 +407,7 @@ export abstract class WebviewBase implements vscode.Disposable {
           "writeStoreFile",
           "readStoreFile",
           "readTaskOutput",
+          "addTerminalContext",
         ],
       },
     );

--- a/packages/vscode/src/integrations/webview/webview-panel.ts
+++ b/packages/vscode/src/integrations/webview/webview-panel.ts
@@ -9,6 +9,7 @@ import {
   type PochiTaskInfo,
   type PochiTaskParams,
   type ResourceURI,
+  type TerminalTextSelection,
   type VSCodeHostApi,
   getTaskDisplayTitle,
 } from "@getpochi/common/vscode-webui-bridge";
@@ -120,6 +121,28 @@ export class PochiWebviewPanel
     return PochiWebviewPanel.panels
       .get(taskId)
       ?.webviewHost?.readTaskOutput(taskId);
+  }
+
+  /**
+   * Pushes a terminal text selection into the panel identified by `uid`'s
+   * webview and brings the panel to the foreground. Returns `false` if no
+   * panel is currently open for that task (in which case callers should
+   * fall back to the sidebar).
+   */
+  static addTerminalContext(
+    uid: string,
+    selection: TerminalTextSelection,
+  ): boolean {
+    const panelInstance = PochiWebviewPanel.panels.get(uid);
+    if (!panelInstance) return false;
+
+    panelInstance.webviewHost?.addTerminalContext(selection);
+    panelInstance.reveal();
+    return true;
+  }
+
+  reveal(): void {
+    this.panel.reveal();
   }
 
   dispose(): void {


### PR DESCRIPTION
## Summary
- Adds a "Add Selection to Pochi Chat" terminal context-menu command that lets users explicitly attach one or more terminal text selections to the next outgoing chat message (accumulated via a small zustand store, rendered as removable badges).
- Introduces `renderTerminalContext` to render these explicitly-attached selections separately from the existing implicit "currently selected terminal text" capture (`renderTerminalTextSelection`), avoiding double-inclusion when both are present.
- Renames the implicit selection's rendered tag to `<active-terminal-selection>` and adds an optional `backgroundJobId` attribute (shared via a new `renderTerminalSelectionAttrs` helper) so the model/UI can link a selection back to its originating terminal.
- Wires the new state through `useChatSubmit`, `CreateTaskInput`, message rendering (`data-terminal-context` part), queued message counts, and i18n strings (en/jp/ko/zh).
- Fixes a regression (introduced by the terminal-context work) where the default selected model was affected by a module import cycle between `@/lib/vscode` and `@/features/chat`; resolved via a lazily-registered `setAddTerminalContext` implementation and a mount-time `TerminalContextStateInitializer`.

## Test plan
- [x] `bun run test` (root, all 17 tasks/344+111 tests passing)
- [x] `bun tsc` (root) and `bun tsc` in `packages/vscode`
- [x] `bun check`
- [x] `bun run test` in `packages/vscode` (190 mocha tests passing)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e06a80760513425995fb212d15cc2cc0)