### PR TITLE
feat(vscode): show details for terminal output reads

### DIFF
--- a/packages/tools/src/read-background-job-output.ts
+++ b/packages/tools/src/read-background-job-output.ts
@@ -26,6 +26,18 @@ const toolDef = {
       .boolean()
       .optional()
       .describe("Whether the output was truncated"),
+    terminalName: z
+      .string()
+      .optional()
+      .describe(
+        "For user-opened terminals (term-), the terminal's display name at read time.",
+      ),
+    lastCommand: z
+      .string()
+      .optional()
+      .describe(
+        "For user-opened terminals (term-), the last command run in the terminal at read time.",
+      ),
   }),
 };
 

--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -9,6 +9,7 @@ import { useBackgroundJobInfo } from "@/features/chat";
 import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { useVisibleTerminals } from "@/lib/hooks/use-visible-terminals";
+import { formatTerminalDisplayName } from "@/lib/terminal-display-name";
 import { cn } from "@/lib/utils";
 import { isVSCodeEnvironment } from "@/lib/vscode";
 import {
@@ -129,6 +130,34 @@ const BackgroundJobIdButton: FC<{
   );
 };
 
+const OpenTerminalButton: FC<{
+  name: string;
+  isActive?: boolean;
+  onClick: () => void;
+}> = ({ name, isActive, onClick }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          size="sm"
+          className={cn("size-[16px] rounded-sm ring-primary", {
+            "ring-1": isActive,
+          })}
+          variant="secondary"
+          onClick={onClick}
+        >
+          <TerminalIcon className="size-3" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>{t("commandExecutionPanel.openTerminal", { name })}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
 export const CommandPanelContainer: FC<{
   icon: React.ReactNode;
   title: React.ReactNode;
@@ -195,22 +224,34 @@ export const CommandPanelContainer: FC<{
 export const BackgroundJobPanel: FC<{
   backgroundJobId: string;
   output?: string;
-}> = ({ backgroundJobId, output }) => {
+  /** Terminal name snapshot from the tool output (term- ids only). */
+  terminalName?: string;
+  /** Last command run in the terminal, from the tool output (term- ids only). */
+  lastCommand?: string;
+}> = ({ backgroundJobId, output, terminalName, lastCommand }) => {
+  const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const toggleExpanded = () => setExpanded((prev) => !prev);
   const info = useBackgroundJobInfo(backgroundJobId);
   const { terminals, openBackgroundJobTerminal } = useVisibleTerminals();
-  const hasCommand = Boolean(info?.command);
-  const title = info?.command ?? backgroundJobId;
-  const isActive = useMemo(
-    () =>
-      backgroundJobId
-        ? terminals?.some(
-            (t) => t.backgroundJobId === backgroundJobId && t.isActive,
-          )
-        : false,
+  const isUserTerminal = backgroundJobId.startsWith("term-");
+  // Live name wins over the snapshot: the terminal may have been renamed
+  // since the read. The snapshot keeps historical reads meaningful after the
+  // terminal is closed.
+  const liveTerminal = useMemo(
+    () => terminals?.find((tm) => tm.backgroundJobId === backgroundJobId),
     [backgroundJobId, terminals],
   );
+  const hasCommand = Boolean(info?.command);
+  const copyCommand = info?.command ?? lastCommand;
+  const displayTerminalName = formatTerminalDisplayName(
+    liveTerminal?.name ?? terminalName,
+    lastCommand,
+  );
+  const title = isUserTerminal
+    ? (displayTerminalName ?? t("commandExecutionPanel.userTerminal"))
+    : (info?.command ?? backgroundJobId);
+  const isActive = liveTerminal?.isActive ?? false;
 
   const openTerminal = useCallback(() => {
     openBackgroundJobTerminal?.(backgroundJobId);
@@ -219,14 +260,22 @@ export const BackgroundJobPanel: FC<{
   return (
     <CommandPanelContainer
       icon={
-        hasCommand &&
-        info?.displayId && (
-          <BackgroundJobIdButton
-            displayId={info.displayId}
-            isActive={isActive}
-            onClick={openTerminal}
-          />
-        )
+        isUserTerminal
+          ? liveTerminal && (
+              <OpenTerminalButton
+                name={liveTerminal.name}
+                isActive={isActive}
+                onClick={openTerminal}
+              />
+            )
+          : hasCommand &&
+            info?.displayId && (
+              <BackgroundJobIdButton
+                displayId={info.displayId}
+                isActive={isActive}
+                onClick={openTerminal}
+              />
+            )
       }
       title={title}
       expanded={output !== undefined && expanded}
@@ -235,7 +284,7 @@ export const BackgroundJobPanel: FC<{
           {output && (
             <ToggleExpandButton expanded={expanded} onToggle={toggleExpanded} />
           )}
-          {info?.command && <CopyCommandButton command={info?.command} />}
+          {copyCommand && <CopyCommandButton command={copyCommand} />}
         </>
       }
       output={output}

--- a/packages/vscode-webui/src/features/tools/components/read-background-job-output.tsx
+++ b/packages/vscode-webui/src/features/tools/components/read-background-job-output.tsx
@@ -1,5 +1,7 @@
+import { formatTerminalDisplayName } from "@/lib/terminal-display-name";
 import { useTranslation } from "react-i18next";
 import { BackgroundJobPanel } from "./command-execution-panel";
+import { HighlightedText } from "./highlight-text";
 import { StatusIcon } from "./status-icon";
 import { ExpandableToolContainer } from "./tool-container";
 import type { ToolProps } from "./types";
@@ -10,6 +12,12 @@ export const ReadBackgroundJobOutputTool: React.FC<
   const { t } = useTranslation();
   const { backgroundJobId } = tool.input || {};
   const isUserTerminal = backgroundJobId?.startsWith("term-");
+  const terminalName = isUserTerminal ? tool.output?.terminalName : undefined;
+  const lastCommand = isUserTerminal ? tool.output?.lastCommand : undefined;
+  const terminalDisplayName = formatTerminalDisplayName(
+    terminalName,
+    lastCommand,
+  );
   const title = (
     <>
       <StatusIcon isExecuting={isExecuting} tool={tool} />
@@ -18,6 +26,12 @@ export const ReadBackgroundJobOutputTool: React.FC<
           ? t("toolInvocation.readTerminal")
           : t("toolInvocation.readBackground")}
       </span>
+      {terminalDisplayName && (
+        <>
+          {" "}
+          <HighlightedText>{terminalDisplayName}</HighlightedText>
+        </>
+      )}
     </>
   );
 
@@ -32,6 +46,8 @@ export const ReadBackgroundJobOutputTool: React.FC<
           <BackgroundJobPanel
             backgroundJobId={finalJobId}
             output={tool.output?.output}
+            terminalName={terminalName}
+            lastCommand={lastCommand}
           />
         ) : null
       }

--- a/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
@@ -1,3 +1,4 @@
+import { formatTerminalDisplayName } from "@/lib/terminal-display-name";
 import { cn } from "@/lib/utils";
 import { formatPochiFileDisplayPath } from "@getpochi/common/pochi-file-system";
 import type { UITools } from "@getpochi/livekit";
@@ -222,6 +223,12 @@ const ReadBackgroundJobTool = ({
   const { t } = useTranslation();
   const { backgroundJobId } = tool.input || {};
   const isUserTerminal = backgroundJobId?.startsWith("term-");
+  const terminalDisplayName = isUserTerminal
+    ? formatTerminalDisplayName(
+        tool.output?.terminalName,
+        tool.output?.lastCommand,
+      )
+    : undefined;
   return (
     <>
       <span className="ml-2">
@@ -229,6 +236,12 @@ const ReadBackgroundJobTool = ({
           ? t("toolInvocation.readTerminal")
           : t("toolInvocation.readBackground")}
       </span>
+      {terminalDisplayName && (
+        <>
+          {" "}
+          <HighlightedText>{terminalDisplayName}</HighlightedText>
+        </>
+      )}
     </>
   );
 };

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -516,6 +516,8 @@
     "collapse": "Collapse",
     "expand": "Expand",
     "openJob": "Open Job {{displayId}}",
+    "openTerminal": "Open terminal {{name}}",
+    "userTerminal": "User terminal",
     "stop": "STOP"
   },
   "devModeButton": {

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -510,6 +510,8 @@
     "collapse": "折りたたむ",
     "expand": "展開",
     "openJob": "ジョブ {{displayId}} を開く",
+    "openTerminal": "ターミナル {{name}} を開く",
+    "userTerminal": "ユーザーターミナル",
     "stop": "停止"
   },
   "liveSubTask": {

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -508,6 +508,8 @@
     "collapse": "접기",
     "expand": "펼치기",
     "openJob": "작업 {{displayId}} 열기",
+    "openTerminal": "터미널 {{name}} 열기",
+    "userTerminal": "사용자 터미널",
     "stop": "중지"
   },
   "devModeButton": {

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -508,6 +508,8 @@
     "collapse": "收起",
     "expand": "展开",
     "openJob": "打开任务 {{displayId}}",
+    "openTerminal": "打开终端 {{name}}",
+    "userTerminal": "用户终端",
     "stop": "停止"
   },
   "liveSubTask": {

--- a/packages/vscode-webui/src/lib/__tests__/terminal-display-name.test.ts
+++ b/packages/vscode-webui/src/lib/__tests__/terminal-display-name.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { formatTerminalDisplayName } from "../terminal-display-name";
+
+describe("formatTerminalDisplayName", () => {
+  it("appends the last command to a bare shell name", () => {
+    expect(formatTerminalDisplayName("zsh", "npm run dev")).toBe(
+      "zsh · npm run dev",
+    );
+    expect(formatTerminalDisplayName("bash", "ls -la")).toBe("bash · ls -la");
+    expect(formatTerminalDisplayName("pwsh.exe", "dir")).toBe(
+      "pwsh.exe · dir",
+    );
+    expect(formatTerminalDisplayName("Zsh", "make")).toBe("Zsh · make");
+  });
+
+  it("keeps a bare shell name when there is no last command", () => {
+    expect(formatTerminalDisplayName("zsh", undefined)).toBe("zsh");
+  });
+
+  it("shows informative names as-is", () => {
+    expect(formatTerminalDisplayName("npm: dev", "npm run dev")).toBe(
+      "npm: dev",
+    );
+    expect(formatTerminalDisplayName("my-renamed-tab", "ls")).toBe(
+      "my-renamed-tab",
+    );
+    // A shell name embedded in a longer title is not a bare shell name.
+    expect(formatTerminalDisplayName("zsh - server", "ls")).toBe(
+      "zsh - server",
+    );
+  });
+
+  it("falls back to the last command when the name is missing", () => {
+    expect(formatTerminalDisplayName(undefined, "npm run dev")).toBe(
+      "npm run dev",
+    );
+    expect(formatTerminalDisplayName(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/packages/vscode-webui/src/lib/terminal-display-name.ts
+++ b/packages/vscode-webui/src/lib/terminal-display-name.ts
@@ -1,0 +1,24 @@
+/**
+ * Bare shell process names as produced by the default
+ * `terminal.integrated.tabs.title` (`${process}`) when the shell is idle.
+ * These carry no information about what the terminal is used for.
+ */
+const PlainShellNameRegex =
+  /^(zsh|bash|sh|dash|fish|ksh|tcsh|csh|nu|nushell|pwsh|powershell|cmd)(\.exe)?$/i;
+
+/**
+ * Formats a user terminal's display name. A bare shell name ("zsh", "bash",
+ * …) is disambiguated by appending the last command run in the terminal;
+ * any other name (task terminals, renamed tabs, OSC titles) is informative
+ * on its own and shown as-is.
+ */
+export function formatTerminalDisplayName(
+  name: string | undefined,
+  lastCommand: string | undefined,
+): string | undefined {
+  if (!name) return lastCommand;
+  if (lastCommand && PlainShellNameRegex.test(name.trim())) {
+    return `${name} · ${lastCommand}`;
+  }
+  return name;
+}

--- a/packages/vscode/src/integrations/terminal/terminal-history.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-history.ts
@@ -51,6 +51,16 @@ export class TerminalHistoryManager {
   private lastReadLength = 0; // tracks byte length, not character length
   private lastReadAt = 0;
 
+  /**
+   * The terminal's display name, refreshed on each command start. A snapshot:
+   * VS Code terminal names follow `terminal.integrated.tabs.title` (default
+   * `${process}`) and there is no stable API event for name changes.
+   */
+  terminalName?: string;
+
+  /** The most recent command run in the terminal. */
+  lastCommand?: string;
+
   private constructor(public readonly id: string) {}
 
   static getOrCreate(id: string): TerminalHistoryManager {
@@ -76,6 +86,7 @@ export class TerminalHistoryManager {
    * (added separately via {@link addChunk}).
    */
   beginCommand(command: string, cwd?: string): void {
+    this.lastCommand = command;
     const header = cwd ? `${cwd}$ ${command}\n` : `$ ${command}\n`;
     this.addChunk(header);
   }

--- a/packages/vscode/src/integrations/terminal/terminal-state.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-state.ts
@@ -117,6 +117,7 @@ export class TerminalState implements vscode.Disposable {
     // time, the same way it would look in the terminal itself, instead of
     // being wiped out by the next command.
     const history = TerminalHistoryManager.getOrCreate(id);
+    history.terminalName = event.terminal.name;
     const cwd = event.terminal.shellIntegration?.cwd?.fsPath;
     history.beginCommand(command, cwd);
 

--- a/packages/vscode/src/tools/read-background-job-output.ts
+++ b/packages/vscode/src/tools/read-background-job-output.ts
@@ -23,6 +23,8 @@ export const readBackgroundJobOutput: ToolFunctionType<
       isTruncated: output.isTruncated,
       status: output.status,
       error: output.error,
+      terminalName: history.terminalName,
+      lastCommand: history.lastCommand,
     };
   }
 


### PR DESCRIPTION
## Summary
- capture terminal display names and latest commands when reading user-opened terminal output
- show descriptive terminal labels in full and compact tool cards, with live terminal names taking precedence over snapshots
- allow reopening active user terminals and copying their latest command

## Test plan
- [x] Run `bun check`
- [x] Run `bun tsc`
- [x] Run terminal display-name unit tests
- [x] Run `TerminalHistoryManager` extension tests

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-67aa56e88cb94d0ab518fc82c154a3f0)