### PR TITLE
feat: support content-filtering metadata extraction and retry handling

### DIFF
--- a/packages/common/src/base/message.ts
+++ b/packages/common/src/base/message.ts
@@ -14,6 +14,7 @@ export const MessageMetadata = z.discriminatedUnion("kind", [
     contentFilter: z
       .object({
         provider: z.enum(["anthropic", "google"]),
+        reason: z.string().optional(),
         details: z.unknown().optional(),
       })
       .optional(),

--- a/packages/common/src/base/message.ts
+++ b/packages/common/src/base/message.ts
@@ -11,6 +11,12 @@ export const MessageMetadata = z.discriminatedUnion("kind", [
     // calibration to only trust actual provider usage.
     totalTokensIsEstimated: z.boolean().optional(),
     finishReason: z.custom<FinishReason>(),
+    contentFilter: z
+      .object({
+        provider: z.enum(["anthropic", "google"]),
+        details: z.unknown().optional(),
+      })
+      .optional(),
     startedAt: z.coerce.date().optional(),
     finishedAt: z.coerce.date().optional(),
     totalStreamingDuration: z.number().optional(),

--- a/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
+++ b/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
@@ -115,9 +115,11 @@ describe("extractContentFilterMetadata", () => {
           },
         },
         "content-filter",
+        "refusal",
       ),
     ).toEqual({
       provider: "anthropic",
+      reason: "refusal",
       details: {
         type: "refusal",
         category: "bio",
@@ -135,8 +137,9 @@ describe("extractContentFilterMetadata", () => {
           },
         },
         "content-filter",
+        "refusal",
       ),
-    ).toEqual({ provider: "anthropic" });
+    ).toEqual({ provider: "anthropic", reason: "refusal" });
   });
 
   it("keeps only Google safety details", () => {
@@ -151,9 +154,11 @@ describe("extractContentFilterMetadata", () => {
           },
         },
         "content-filter",
+        "SAFETY",
       ),
     ).toEqual({
       provider: "google",
+      reason: "SAFETY",
       details: {
         promptFeedback: { blockReason: "SAFETY" },
         safetyRatings: [{ category: "HARM_CATEGORY_DANGEROUS_CONTENT" }],
@@ -173,9 +178,11 @@ describe("extractContentFilterMetadata", () => {
           },
         },
         "content-filter",
+        "BLOCKLIST",
       ),
     ).toEqual({
       provider: "google",
+      reason: "BLOCKLIST",
       details: {
         promptFeedback: { blockReason: "BLOCKLIST" },
         safetyRatings: [],

--- a/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
+++ b/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { convertDataPartToText } from "../flexible-chat-transport";
 import type { Message } from "../../types";
+import {
+  convertDataPartToText,
+  extractContentFilterMetadata,
+} from "../flexible-chat-transport";
 
 type MessagePart = Message["parts"][number];
 
@@ -94,5 +97,127 @@ describe("convertDataPartToText", () => {
     expect(result).toHaveLength(2);
     expect(result[0].text).toContain("active-selection");
     expect(result[1].text).toContain("terminal-selection");
+  });
+});
+
+describe("extractContentFilterMetadata", () => {
+  it("keeps Anthropic stop details without the rest of provider metadata", () => {
+    expect(
+      extractContentFilterMetadata(
+        {
+          anthropic: {
+            stopDetails: {
+              type: "refusal",
+              category: "bio",
+              explanation: "Request blocked by the safety classifier.",
+            },
+            usage: { input_tokens: 100 },
+          },
+        },
+        "content-filter",
+      ),
+    ).toEqual({
+      provider: "anthropic",
+      details: {
+        type: "refusal",
+        category: "bio",
+        explanation: "Request blocked by the safety classifier.",
+      },
+    });
+  });
+
+  it("records the Anthropic provider when stop details are unavailable", () => {
+    expect(
+      extractContentFilterMetadata(
+        {
+          anthropic: {
+            usage: { input_tokens: 100 },
+          },
+        },
+        "content-filter",
+      ),
+    ).toEqual({ provider: "anthropic" });
+  });
+
+  it("keeps only Google safety details", () => {
+    expect(
+      extractContentFilterMetadata(
+        {
+          google: {
+            promptFeedback: { blockReason: "SAFETY" },
+            safetyRatings: [{ category: "HARM_CATEGORY_DANGEROUS_CONTENT" }],
+            finishMessage: "Blocked for safety reasons.",
+            groundingMetadata: { searchEntryPoint: "unrelated" },
+          },
+        },
+        "content-filter",
+      ),
+    ).toEqual({
+      provider: "google",
+      details: {
+        promptFeedback: { blockReason: "SAFETY" },
+        safetyRatings: [{ category: "HARM_CATEGORY_DANGEROUS_CONTENT" }],
+        finishMessage: "Blocked for safety reasons.",
+      },
+    });
+  });
+
+  it("reads Google safety details from Vertex metadata", () => {
+    expect(
+      extractContentFilterMetadata(
+        {
+          vertex: {
+            promptFeedback: { blockReason: "BLOCKLIST" },
+            safetyRatings: [],
+            finishMessage: "Blocked by Vertex safety settings.",
+          },
+        },
+        "content-filter",
+      ),
+    ).toEqual({
+      provider: "google",
+      details: {
+        promptFeedback: { blockReason: "BLOCKLIST" },
+        safetyRatings: [],
+        finishMessage: "Blocked by Vertex safety settings.",
+      },
+    });
+  });
+
+  it("recognizes a prompt-level Google block reported with finish reason other", () => {
+    expect(
+      extractContentFilterMetadata(
+        {
+          google: {
+            promptFeedback: { blockReason: "SAFETY" },
+            safetyRatings: [],
+            finishMessage: null,
+          },
+        },
+        "other",
+      ),
+    ).toEqual({
+      provider: "google",
+      details: {
+        promptFeedback: { blockReason: "SAFETY" },
+        safetyRatings: [],
+        finishMessage: null,
+      },
+    });
+  });
+
+  it("ignores normal Google metadata reported with finish reason other", () => {
+    expect(
+      extractContentFilterMetadata(
+        {
+          google: {
+            promptFeedback: { safetyRatings: [] },
+            safetyRatings: [],
+            finishMessage: null,
+          },
+        },
+        "other",
+      ),
+    ).toBeUndefined();
   });
 });

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -79,6 +79,7 @@ type ContentFilterMetadata = NonNullable<
 export function extractContentFilterMetadata(
   providerMetadata: ProviderMetadata | undefined,
   finishReason: FinishReason,
+  rawFinishReason?: string,
 ): ContentFilterMetadata | undefined {
   const anthropic = providerMetadata?.anthropic;
   if (
@@ -87,6 +88,7 @@ export function extractContentFilterMetadata(
   ) {
     return {
       provider: "anthropic",
+      ...(rawFinishReason !== undefined && { reason: rawFinishReason }),
       ...(anthropic.stopDetails !== undefined && {
         details: anthropic.stopDetails,
       }),
@@ -103,6 +105,7 @@ export function extractContentFilterMetadata(
   if (google && (finishReason === "content-filter" || hasPromptBlockReason)) {
     return {
       provider: "google",
+      ...(rawFinishReason !== undefined && { reason: rawFinishReason }),
       details: {
         promptFeedback: google.promptFeedback,
         safetyRatings: google.safetyRatings,
@@ -352,6 +355,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
             contentFilterMetadata = extractContentFilterMetadata(
               part.providerMetadata,
               part.finishReason,
+              part.rawFinishReason,
             );
           }
 

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -22,7 +22,9 @@ import {
   APICallError,
   type ChatRequestOptions,
   type ChatTransport,
+  type FinishReason,
   type ModelMessage,
+  type ProviderMetadata,
   type UIMessageChunk,
   convertToModelMessages,
   streamText,
@@ -69,6 +71,46 @@ export type FinishedRequestSnapshot = {
    */
   calibrationFactor: number;
 };
+
+type ContentFilterMetadata = NonNullable<
+  Extract<MessageMetadata, { kind: "assistant" }>["contentFilter"]
+>;
+
+export function extractContentFilterMetadata(
+  providerMetadata: ProviderMetadata | undefined,
+  finishReason: FinishReason,
+): ContentFilterMetadata | undefined {
+  const anthropic = providerMetadata?.anthropic;
+  if (
+    anthropic &&
+    (finishReason === "content-filter" || anthropic.stopDetails != null)
+  ) {
+    return {
+      provider: "anthropic",
+      ...(anthropic.stopDetails !== undefined && {
+        details: anthropic.stopDetails,
+      }),
+    };
+  }
+
+  const google = providerMetadata?.google ?? providerMetadata?.vertex;
+  const promptFeedback = google?.promptFeedback;
+  const hasPromptBlockReason =
+    typeof promptFeedback === "object" &&
+    promptFeedback !== null &&
+    "blockReason" in promptFeedback &&
+    promptFeedback.blockReason != null;
+  if (google && (finishReason === "content-filter" || hasPromptBlockReason)) {
+    return {
+      provider: "google",
+      details: {
+        promptFeedback: google.promptFeedback,
+        safetyRatings: google.safetyRatings,
+        finishMessage: google.finishMessage,
+      },
+    };
+  }
+}
 
 function createAbortAwareUIStreamTransform(
   abortSignal: AbortSignal | undefined,
@@ -261,6 +303,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     )) as ModelMessage[];
 
     const requestStartedAt = new Date();
+    let contentFilterMetadata: ContentFilterMetadata | undefined;
     // Anthropic cache breakpoints are applied server-side based on `useCase`.
     const stream = streamText({
       providerOptions: {
@@ -305,6 +348,13 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
         },
         originalMessages: preparedMessages,
         messageMetadata: ({ part }) => {
+          if (part.type === "finish-step") {
+            contentFilterMetadata = extractContentFilterMetadata(
+              part.providerMetadata,
+              part.finishReason,
+            );
+          }
+
           if (part.type === "finish") {
             const now = new Date();
             const duration = now.getTime() - requestStartedAt.getTime();
@@ -337,6 +387,10 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
               );
             }
 
+            const isContentFiltered =
+              part.finishReason === "content-filter" ||
+              contentFilterMetadata !== undefined;
+
             return {
               kind: "assistant",
               // The client only consumes the aggregated total token count here.
@@ -348,7 +402,10 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
               // our heuristic fallback. Only set when true; keep undefined
               // otherwise so it's omitted.
               totalTokensIsEstimated: totalTokens ? undefined : true,
-              finishReason: part.finishReason,
+              finishReason: isContentFiltered
+                ? "content-filter"
+                : part.finishReason,
+              contentFilter: contentFilterMetadata,
               startedAt: requestStartedAt,
               finishedAt: now,
               totalStreamingDuration:

--- a/packages/vscode-webui/src/features/approval/components/__tests__/retry-approval-button.test.tsx
+++ b/packages/vscode-webui/src/features/approval/components/__tests__/retry-approval-button.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { ReadyForRetryError } from "@/features/retry";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RetryApprovalButton } from "../retry-approval-button";
+
+vi.mock("@/features/chat", () => ({
+  useAutoApproveGuard: () => ({ current: "stop" }),
+  useHandleChatEvents: () => undefined,
+}));
+
+vi.mock("@/lib/hooks/use-debounce-state", () => ({
+  useDebounceState: () => [true, vi.fn()],
+}));
+
+vi.mock("@/lib/hooks/use-reviews", () => ({
+  useReviews: () => [],
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === "toolInvocation.retry" ? "Retry" : key),
+  }),
+}));
+
+describe("RetryApprovalButton", () => {
+  it("retries a content-filtered response instead of sending a queued message", () => {
+    const retry = vi.fn();
+    const onContinueWithQueuedMessage = vi.fn();
+    const error = new ReadyForRetryError("content-filter");
+
+    render(
+      <RetryApprovalButton
+        pendingApproval={{
+          name: "retry",
+          error,
+          attempts: 0,
+          delay: undefined,
+          countdown: undefined,
+          stopCountdown: vi.fn(),
+        }}
+        retry={retry}
+        hasQueuedMessages
+        onContinueWithQueuedMessage={onContinueWithQueuedMessage}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(retry).toHaveBeenCalledWith(error);
+    expect(onContinueWithQueuedMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx
+++ b/packages/vscode-webui/src/features/approval/components/retry-approval-button.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect } from "react";
 
 import { Button } from "@/components/ui/button";
 import { useAutoApproveGuard, useHandleChatEvents } from "@/features/chat";
+import { ReadyForRetryError } from "@/features/retry";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { useReviews } from "@/lib/hooks/use-reviews";
 import { useTranslation } from "react-i18next";
@@ -32,17 +33,26 @@ export const RetryApprovalButton: React.FC<RetryApprovalButtonProps> = ({
 }) => {
   const { t } = useTranslation();
   const reviews = useReviews();
+  const isContentFilter =
+    pendingApproval.error instanceof ReadyForRetryError &&
+    pendingApproval.error.kind === "content-filter";
 
   const handleContinue = useCallback(() => {
     pendingApproval.stopCountdown();
-    if (hasQueuedMessages && onContinueWithQueuedMessage) {
+    if (!isContentFilter && hasQueuedMessages && onContinueWithQueuedMessage) {
       // A message is already queued, so continue the chat by sending it
       // instead of retrying / regenerating the previous turn.
       onContinueWithQueuedMessage();
       return;
     }
     retry(pendingApproval.error);
-  }, [retry, pendingApproval, hasQueuedMessages, onContinueWithQueuedMessage]);
+  }, [
+    retry,
+    pendingApproval,
+    isContentFilter,
+    hasQueuedMessages,
+    onContinueWithQueuedMessage,
+  ]);
 
   useEffect(() => {
     if (pendingApproval.countdown === 0) {
@@ -80,7 +90,11 @@ export const RetryApprovalButton: React.FC<RetryApprovalButtonProps> = ({
           ? t("toolInvocation.continueInSeconds", {
               seconds: pendingApproval.countdown,
             })
-          : t("toolInvocation.continue")}
+          : t(
+              isContentFilter
+                ? "toolInvocation.retry"
+                : "toolInvocation.continue",
+            )}
       </Button>
       {pendingApproval.countdown !== undefined && (
         <Button onClick={pendingApproval.stopCountdown} variant="secondary">

--- a/packages/vscode-webui/src/features/chat/components/error-message-view.tsx
+++ b/packages/vscode-webui/src/features/chat/components/error-message-view.tsx
@@ -1,4 +1,5 @@
 import { ErrorMessage } from "@/components/error-message";
+import { ReadyForRetryError } from "@/features/retry";
 import { useDebounceState } from "@/lib/hooks/use-debounce-state";
 import { PochiApiErrors } from "@getpochi/vendor-pochi/edge";
 import { ExternalLinkIcon } from "lucide-react";
@@ -57,6 +58,13 @@ export function ErrorMessageView({
       error={debouncedError}
       collapsible
       formatter={(e) => {
+        if (
+          debouncedError instanceof ReadyForRetryError &&
+          debouncedError.kind === "content-filter"
+        ) {
+          return t("errorMessageView.contentFilter");
+        }
+
         if (e.message === PochiApiErrors.ReachedCreditLimit) {
           return (
             <span>

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-notifications.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-notifications.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import type { Message, Task } from "@getpochi/livekit";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useChatNotifications } from "./use-chat-notifications";
+
+const sendNotificationMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hooks/use-mcp", () => ({
+  useMcp: () => ({ toolset: {} }),
+}));
+
+vi.mock("@/features/settings", () => ({
+  getPendingToolcallApproval: vi.fn(),
+  isToolAutoApproved: vi.fn(),
+}));
+
+vi.mock("@/features/retry", () => ({
+  getReadyForRetryError: () => new Error("content-filter"),
+  isRetryableError: () => false,
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  vscodeHost: {
+    onTaskRunning: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/chat-state", () => ({
+  useRetryCount: () => ({ retryCount: undefined }),
+}));
+
+vi.mock("../lib/use-send-task-notification", () => ({
+  useSendTaskNotification: () => ({
+    sendNotification: sendNotificationMock,
+    clearNotification: vi.fn(),
+  }),
+}));
+
+describe("useChatNotifications", () => {
+  it("notifies for content filtering even when automatic retries are enabled", () => {
+    const { result } = renderHook(() =>
+      useChatNotifications({
+        uid: "task-1",
+        task: { id: "task-1", cwd: "/workspace" } as Task,
+        isSubTask: false,
+        autoApproveGuard: { current: "auto" } as never,
+        autoApproveActive: true,
+        autoApproveSettings: {
+          retry: true,
+          maxRetryLimit: 3,
+        } as never,
+      }),
+    );
+
+    const messages = [
+      {
+        id: "assistant-content-filtered",
+        role: "assistant",
+        parts: [{ type: "text", text: "Request refused." }],
+        metadata: {
+          kind: "assistant",
+          totalTokens: 10,
+          finishReason: "content-filter",
+        },
+      } as Message,
+    ];
+
+    act(() => {
+      result.current.onStreamFinish.current({
+        id: "task-1",
+        cwd: "/workspace",
+        status: "pending-input",
+        messages,
+      });
+    });
+
+    expect(sendNotificationMock).toHaveBeenCalledWith("pending-input", {
+      uid: "task-1",
+      isSubTask: false,
+    });
+  });
+});

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-notifications.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-notifications.ts
@@ -110,7 +110,9 @@ export function useChatNotifications({
         if (!readyForRetryError) return;
 
         const retryLimit =
-          autoApproveActive && autoApproveSettings.retry
+          isRetryableError(readyForRetryError) &&
+          autoApproveActive &&
+          autoApproveSettings.retry
             ? autoApproveSettings.maxRetryLimit
             : 0;
 

--- a/packages/vscode-webui/src/features/retry/hooks/use-ready-for-retry-error.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-ready-for-retry-error.ts
@@ -8,7 +8,7 @@ import type { Message } from "@getpochi/livekit";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { useMemo } from "react";
 
-type RetryKind = "ready" | "tool-calls" | "no-tool-calls";
+type RetryKind = "ready" | "tool-calls" | "no-tool-calls" | "content-filter";
 
 export class ReadyForRetryError extends Error {
   kind: RetryKind;
@@ -33,6 +33,13 @@ export function useMixinReadyForRetryError(
 export function getReadyForRetryError(messages: Message[]) {
   const lastMessage = messages.at(-1);
   if (!lastMessage) return;
+  if (
+    lastMessage.role === "assistant" &&
+    lastMessage.metadata?.kind === "assistant" &&
+    lastMessage.metadata.finishReason === "content-filter"
+  ) {
+    return new ReadyForRetryError("content-filter");
+  }
   const attemptTodoCompletionPart =
     getLastAttemptTodoCompletionPart(lastMessage);
   if (attemptTodoCompletionPart) {

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
@@ -2,7 +2,11 @@ import type { Message } from "@getpochi/livekit";
 // @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getReadyForRetryError } from "./use-ready-for-retry-error";
+import { isRetryableError } from "../lib/is-retryable-error";
+import {
+  ReadyForRetryError,
+  getReadyForRetryError,
+} from "./use-ready-for-retry-error";
 import { useRetry } from "./use-retry";
 
 function createRetryableAssistantMessage(): Message {
@@ -125,9 +129,62 @@ describe("useRetry", () => {
       setMessages.mock.invocationCallOrder[0],
     );
   });
+
+  it("regenerates a content-filtered assistant response", async () => {
+    const setMessages = vi.fn();
+    const sendMessage = vi.fn();
+    const regenerate = vi.fn();
+    const message = {
+      id: "assistant-content-filtered",
+      role: "assistant",
+      parts: [{ type: "text", text: "Request refused." }],
+      metadata: {
+        kind: "assistant",
+        totalTokens: 10,
+        finishReason: "content-filter",
+      },
+    } as Message;
+
+    const { result } = renderHook(() =>
+      useRetry({
+        messages: [message],
+        setMessages,
+        sendMessage,
+        regenerate,
+      }),
+    );
+
+    await act(async () => {
+      await result.current(new ReadyForRetryError("content-filter"));
+    });
+
+    expect(regenerate).toHaveBeenCalledWith({
+      messageId: "assistant-content-filtered",
+    });
+    expect(setMessages).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
 });
 
 describe("getReadyForRetryError", () => {
+  it("requires manual retry when the provider filters the response", () => {
+    const error = getReadyForRetryError([
+      {
+        id: "assistant-content-filtered",
+        role: "assistant",
+        parts: [{ type: "text", text: "Request refused." }],
+        metadata: {
+          kind: "assistant",
+          totalTokens: 10,
+          finishReason: "content-filter",
+        },
+      } as Message,
+    ]);
+
+    expect(error).toMatchObject({ kind: "content-filter" });
+    expect(isRetryableError(error as Error)).toBe(false);
+  });
+
   it("does not retry a successful attemptTodoCompletion subtask", () => {
     expect(
       getReadyForRetryError([

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.test.tsx
@@ -130,14 +130,26 @@ describe("useRetry", () => {
     );
   });
 
-  it("regenerates a content-filtered assistant response", async () => {
+  it("continues from a content-filtered assistant response", async () => {
+    const clearFileStateCache = vi.fn();
     const setMessages = vi.fn();
     const sendMessage = vi.fn();
     const regenerate = vi.fn();
     const message = {
       id: "assistant-content-filtered",
       role: "assistant",
-      parts: [{ type: "text", text: "Request refused." }],
+      parts: [
+        { type: "step-start" },
+        {
+          type: "tool-readFile",
+          toolCallId: "call-read-file",
+          state: "output-available",
+          input: { path: "src/app.ts" },
+          output: { content: "const answer = 42;", isTruncated: false },
+        },
+        { type: "step-start" },
+        { type: "text", text: "Request refused." },
+      ],
       metadata: {
         kind: "assistant",
         totalTokens: 10,
@@ -151,6 +163,7 @@ describe("useRetry", () => {
         setMessages,
         sendMessage,
         regenerate,
+        clearFileStateCache,
       }),
     );
 
@@ -158,11 +171,10 @@ describe("useRetry", () => {
       await result.current(new ReadyForRetryError("content-filter"));
     });
 
-    expect(regenerate).toHaveBeenCalledWith({
-      messageId: "assistant-content-filtered",
-    });
-    expect(setMessages).not.toHaveBeenCalled();
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(setMessages).toHaveBeenCalledWith([message]);
+    expect(sendMessage).toHaveBeenCalledWith(undefined);
+    expect(clearFileStateCache).not.toHaveBeenCalled();
+    expect(regenerate).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
@@ -30,15 +30,6 @@ export function useRetry({
 
       if (
         error instanceof ReadyForRetryError &&
-        error.kind === "content-filter"
-      ) {
-        return regenerate({
-          messageId: lastMessage.id,
-        });
-      }
-
-      if (
-        error instanceof ReadyForRetryError &&
         error.kind === "no-tool-calls"
       ) {
         return sendMessage({

--- a/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
+++ b/packages/vscode-webui/src/features/retry/hooks/use-retry.ts
@@ -30,6 +30,15 @@ export function useRetry({
 
       if (
         error instanceof ReadyForRetryError &&
+        error.kind === "content-filter"
+      ) {
+        return regenerate({
+          messageId: lastMessage.id,
+        });
+      }
+
+      if (
+        error instanceof ReadyForRetryError &&
         error.kind === "no-tool-calls"
       ) {
         return sendMessage({

--- a/packages/vscode-webui/src/features/retry/lib/is-retryable-error.ts
+++ b/packages/vscode-webui/src/features/retry/lib/is-retryable-error.ts
@@ -1,7 +1,12 @@
 import { PochiApiErrors } from "@getpochi/vendor-pochi/edge";
 import { APICallError } from "ai";
+import { ReadyForRetryError } from "../hooks/use-ready-for-retry-error";
 
 export function isRetryableError(error: Error) {
+  if (error instanceof ReadyForRetryError && error.kind === "content-filter") {
+    return false;
+  }
+
   if (Object.values(PochiApiErrors).includes(error.message)) {
     return false;
   }

--- a/packages/vscode-webui/src/features/tools/hooks/__tests__/use-live-sub-task.test.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/__tests__/use-live-sub-task.test.tsx
@@ -1,6 +1,7 @@
+import { ReadyForRetryError } from "@/features/retry";
 import type { Todo } from "@getpochi/tools";
 // @vitest-environment jsdom
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useLiveSubTask } from "../use-live-sub-task";
 
@@ -13,6 +14,19 @@ const storeMock = vi.hoisted(() => ({
     status: "pending-model",
   })),
 }));
+const retryErrorMock = vi.hoisted<{ current: Error | undefined }>(() => ({
+  current: undefined,
+}));
+const retryImplMock = vi.hoisted(() => vi.fn());
+const streamingResultMock = vi.hoisted<{
+  current:
+    | {
+        toolName: string;
+        abortSignal: AbortSignal;
+        throws: ReturnType<typeof vi.fn>;
+      }
+    | undefined;
+}>(() => ({ current: undefined }));
 
 vi.mock("@/features/chat", () => ({
   useBatchExecuteManager: () => ({
@@ -23,15 +37,21 @@ vi.mock("@/features/chat", () => ({
   useLiveChatKitGetters: useLiveChatKitGettersMock,
   useToolCallLifeCycle: () => ({
     getToolCallLifeCycle: () => ({
-      streamingResult: undefined,
+      streamingResult: streamingResultMock.current,
     }),
   }),
 }));
 
 vi.mock("@/features/retry", () => ({
-  ReadyForRetryError: class ReadyForRetryError extends Error {},
-  useMixinReadyForRetryError: () => undefined,
-  useRetry: () => vi.fn(),
+  ReadyForRetryError: class ReadyForRetryError extends Error {
+    constructor(public kind = "ready") {
+      super();
+    }
+  },
+  isRetryableError: (error: Error & { kind?: string }) =>
+    error.kind !== "content-filter",
+  useMixinReadyForRetryError: () => retryErrorMock.current,
+  useRetry: () => retryImplMock,
 }));
 
 vi.mock("@/lib/hooks/use-custom-agents", () => ({
@@ -123,6 +143,9 @@ describe("useLiveSubTask", () => {
   beforeEach(() => {
     useLiveChatKitGettersMock.mockClear();
     storeMock.useQuery.mockClear();
+    retryErrorMock.current = undefined;
+    retryImplMock.mockClear();
+    streamingResultMock.current = undefined;
   });
 
   it("passes audit todos to attemptTodoCompletion subtasks", () => {
@@ -157,5 +180,30 @@ describe("useLiveSubTask", () => {
         }),
       }),
     );
+  });
+
+  it("does not automatically retry a content-filtered subtask", async () => {
+    vi.useFakeTimers();
+    retryErrorMock.current = new ReadyForRetryError("content-filter");
+    streamingResultMock.current = {
+      toolName: "newTask",
+      abortSignal: new AbortController().signal,
+      throws: vi.fn(),
+    };
+
+    renderHook(() =>
+      useLiveSubTask(
+        { tool: makeTool("planner"), isExecuting: true },
+        makeToolCallStatusRegistry(),
+      ),
+    );
+
+    retryImplMock.mockClear();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(retryImplMock).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-live-sub-task.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/features/chat";
 import {
   ReadyForRetryError,
+  isRetryableError,
   useMixinReadyForRetryError,
   useRetry,
 } from "@/features/retry";
@@ -252,8 +253,12 @@ export function useLiveSubTask(
     if (!isExecuting || !streamingResult) {
       return;
     }
-    if (pendingErrorForRetry) {
-      setDebouncedPendingErrorForRetry(undefined);
+    if (!pendingErrorForRetry) {
+      return;
+    }
+
+    setDebouncedPendingErrorForRetry(undefined);
+    if (isRetryableError(pendingErrorForRetry)) {
       retryWithCount(pendingErrorForRetry);
     }
   }, [

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -319,6 +319,7 @@
     "reading": "Reading ",
     "writing": "Writing ",
     "continue": "Continue",
+    "retry": "Retry",
     "cancel": "Cancel",
     "continueInSeconds": "Continue in {{seconds}}s",
     "save": "Save",
@@ -473,6 +474,7 @@
     "complete": "Complete"
   },
   "errorMessageView": {
+    "contentFilter": "The model declined to respond because the request was blocked by the provider's safety filter. Revise your request or retry.",
     "reachedCreditLimit": "You have reached your spending limit.",
     "seeMore": "See More",
     "teamReachedCreditLimit": "Your team has reached the spending limit.",

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -474,7 +474,7 @@
     "complete": "Complete"
   },
   "errorMessageView": {
-    "contentFilter": "The provider's safety filter prevented a response. Revise your request or retry.",
+    "contentFilter": "A safety filter stopped the response. Try rephrasing your message or retry.",
     "reachedCreditLimit": "You have reached your spending limit.",
     "seeMore": "See More",
     "teamReachedCreditLimit": "Your team has reached the spending limit.",

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -474,7 +474,7 @@
     "complete": "Complete"
   },
   "errorMessageView": {
-    "contentFilter": "The model declined to respond because the request was blocked by the provider's safety filter. Revise your request or retry.",
+    "contentFilter": "The provider's safety filter prevented a response. Revise your request or retry.",
     "reachedCreditLimit": "You have reached your spending limit.",
     "seeMore": "See More",
     "teamReachedCreditLimit": "Your team has reached the spending limit.",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -468,7 +468,7 @@
     "complete": "完了"
   },
   "errorMessageView": {
-    "contentFilter": "プロバイダーの安全フィルターにより応答が停止されました。リクエストを修正するか、再試行してください。",
+    "contentFilter": "安全フィルターにより応答が停止されました。メッセージを言い換えるか、再試行してください。",
     "reachedCreditLimit": "支出限度額に達しました。",
     "seeMore": "詳細を見る",
     "teamReachedCreditLimit": "チームが支出限度額に達しました。",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -315,6 +315,7 @@
 
     "writing": "書き込み中 ",
     "continue": "続行",
+    "retry": "再試行",
     "cancel": "キャンセル",
     "continueInSeconds": "{{seconds}}秒後に続行",
     "save": "保存",
@@ -467,6 +468,7 @@
     "complete": "完了"
   },
   "errorMessageView": {
+    "contentFilter": "プロバイダーの安全フィルターによってリクエストがブロックされたため、モデルは応答できませんでした。リクエストを修正するか、再試行してください。",
     "reachedCreditLimit": "支出限度額に達しました。",
     "seeMore": "詳細を見る",
     "teamReachedCreditLimit": "チームが支出限度額に達しました。",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -468,7 +468,7 @@
     "complete": "完了"
   },
   "errorMessageView": {
-    "contentFilter": "プロバイダーの安全フィルターによってリクエストがブロックされたため、モデルは応答できませんでした。リクエストを修正するか、再試行してください。",
+    "contentFilter": "プロバイダーの安全フィルターにより応答が停止されました。リクエストを修正するか、再試行してください。",
     "reachedCreditLimit": "支出限度額に達しました。",
     "seeMore": "詳細を見る",
     "teamReachedCreditLimit": "チームが支出限度額に達しました。",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -313,6 +313,7 @@
     "reading": "읽는 중 ",
     "writing": "쓰는 중 ",
     "continue": "계속",
+    "retry": "재시도",
     "cancel": "취소",
     "continueInSeconds": "{{seconds}}초 후 계속",
     "save": "저장",
@@ -465,6 +466,7 @@
     "complete": "완료"
   },
   "errorMessageView": {
+    "contentFilter": "제공업체의 안전 필터가 요청을 차단하여 모델이 응답하지 못했습니다. 요청을 수정하거나 다시 시도하세요.",
     "reachedCreditLimit": "지출 한도에 도달했습니다.",
     "seeMore": "더 보기",
     "teamReachedCreditLimit": "팀이 지출 한도에 도달했습니다.",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -466,7 +466,7 @@
     "complete": "완료"
   },
   "errorMessageView": {
-    "contentFilter": "제공업체의 안전 필터로 인해 응답이 차단되었습니다. 요청을 수정하거나 다시 시도하세요.",
+    "contentFilter": "안전 필터로 인해 응답이 중단되었습니다. 메시지를 바꿔 표현하거나 다시 시도해 보세요.",
     "reachedCreditLimit": "지출 한도에 도달했습니다.",
     "seeMore": "더 보기",
     "teamReachedCreditLimit": "팀이 지출 한도에 도달했습니다.",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -466,7 +466,7 @@
     "complete": "완료"
   },
   "errorMessageView": {
-    "contentFilter": "제공업체의 안전 필터가 요청을 차단하여 모델이 응답하지 못했습니다. 요청을 수정하거나 다시 시도하세요.",
+    "contentFilter": "제공업체의 안전 필터로 인해 응답이 차단되었습니다. 요청을 수정하거나 다시 시도하세요.",
     "reachedCreditLimit": "지출 한도에 도달했습니다.",
     "seeMore": "더 보기",
     "teamReachedCreditLimit": "팀이 지출 한도에 도달했습니다.",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -466,7 +466,7 @@
     "complete": "完成"
   },
   "errorMessageView": {
-    "contentFilter": "模型未能回答，因为请求触发了服务提供商的安全过滤。你可以修改请求或重试。",
+    "contentFilter": "服务提供商的安全过滤阻止了此次回答。你可以修改请求或重试。",
     "reachedCreditLimit": "您已达到消费限额。",
     "seeMore": "查看更多",
     "teamReachedCreditLimit": "您的团队已达到消费限额。",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -466,7 +466,7 @@
     "complete": "完成"
   },
   "errorMessageView": {
-    "contentFilter": "服务提供商的安全过滤阻止了此次回答。你可以修改请求或重试。",
+    "contentFilter": "安全过滤阻止了此次回答。请尝试换一种方式表达，或重试。",
     "reachedCreditLimit": "您已达到消费限额。",
     "seeMore": "查看更多",
     "teamReachedCreditLimit": "您的团队已达到消费限额。",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -313,6 +313,7 @@
 
     "writing": "正在写入 ",
     "continue": "继续",
+    "retry": "重试",
     "cancel": "取消",
     "continueInSeconds": "{{seconds}}秒后继续",
     "save": "保存",
@@ -465,6 +466,7 @@
     "complete": "完成"
   },
   "errorMessageView": {
+    "contentFilter": "模型未能回答，因为请求触发了服务提供商的安全过滤。你可以修改请求或重试。",
     "reachedCreditLimit": "您已达到消费限额。",
     "seeMore": "查看更多",
     "teamReachedCreditLimit": "您的团队已达到消费限额。",


### PR DESCRIPTION
## Summary
* Extracted content filter metadata from chat completions when the finish reason is `content-filter` or when Anthropic/Google content blocks are present.
* Disabled automatic retries for content-filtered errors and displayed localized safety filter warnings to the user.
* Updated UI components (like the retry approval button, error message view, and live subtasks) to support explicit manual retry instead of "Continue" or automatic retries.

## Screenshot
<img width="1892" height="950" alt="image" src="https://github.com/user-attachments/assets/627e7c5c-495e-4b2d-b270-f9442a8b9548" />


## Test plan
- [x] Verified unit tests in `packages/livekit` (`flexible-chat-transport.test.ts`) using `bun test` to ensure content filter metadata is correctly extracted.
- [x] Verified unit tests in `packages/vscode-webui` (including `use-retry.test.tsx` and `use-live-sub-task.test.tsx`) under Node-based `npx vitest` run, and all 12/12 unit tests pass successfully.

🤖 Generated with [Pochi](https://getpochi.com)