### PR TITLE
fix(vscode-webui): preserve ordered list start values

### DIFF
--- a/packages/vscode-webui/src/components/message/__tests__/markdown-list.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/markdown-list.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MessageMarkdown } from "../markdown";
+
+vi.mock("@/features/chat", () => ({
+  useReplaceJobIdsInContent: () => (content: string) => content,
+}));
+
+vi.mock("@/features/tools", () => ({
+  FileBadge: ({ path }: { path: string }) => <span>{path}</span>,
+  IssueBadge: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  isVSCodeEnvironment: () => false,
+  vscodeHost: {},
+}));
+
+describe("MessageMarkdown", () => {
+  it("preserves the start of a nested ordered list", () => {
+    const { container } = render(
+      <MessageMarkdown>{"1. 5. 这是第五条"}</MessageMarkdown>,
+    );
+
+    expect(container.querySelectorAll("ol")[1].start).toBe(5);
+  });
+});

--- a/packages/vscode-webui/src/components/message/markdown.tsx
+++ b/packages/vscode-webui/src/components/message/markdown.tsx
@@ -410,6 +410,7 @@ export function MessageMarkdown({
                 skill: ["path", "id"],
                 issue: ["id", "url", "title"],
                 ...mathSanitizeConfig.attributes,
+                ol: [...(defaultSchema.attributes?.ol ?? []), "start"],
               },
             },
           ],


### PR DESCRIPTION
## Summary
- preserve the semantic `start` attribute on ordered lists after applying the custom math sanitizer schema
- add a regression test for nested Markdown ordered lists such as `1. 5. 这是第五条`

## Screenshot
<img width="746" height="290" alt="image" src="https://github.com/user-attachments/assets/5f02ad8f-1301-45ec-be13-e14523da41c4" />


## Test plan
- [x] `bun run test -- src/components/message/__tests__/markdown-list.test.tsx`
- [x] `bun check`
- [x] `bun tsc`
- [x] pre-push repository checks (17/17 tasks successful)

🤖 Generated with [Pochi](https://getpochi.com)