### PR TITLE
fix(vscode-webui): show default badge when newTask agentType is empty

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
@@ -82,7 +82,7 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
   const agent = tool.input?.agentType;
   const description = tool.input?.description ?? "";
   const agentType = tool.input?.agentType;
-  const toolTitle = agentType ?? "Subtask";
+  const toolTitle = agentType?.trim() || "Subtask";
   const completed =
     tool.state === "output-available" &&
     "result" in tool.output &&
@@ -114,7 +114,7 @@ function NewTaskToolView(props: NewTaskToolViewProps) {
         <TaskThread
           source={taskThreadSource}
           showMessageList={showMessageList}
-          assistant={{ name: agent ?? "Pochi" }}
+          assistant={{ name: agent?.trim() || "Pochi" }}
         />
       </FixedStateChatContextProvider>
     ) : undefined;

--- a/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/sub-agent-view.tsx
@@ -39,7 +39,7 @@ export function SubAgentView({
   footerActions,
   taskSource,
   toolCallStatusRegistryRef,
-  assistantName = tool.input?.agentType ?? "Pochi",
+  assistantName = tool.input?.agentType?.trim() || "Pochi",
   showToolCall,
   showTaskThread = true,
 }: SubAgentViewProps) {
@@ -59,7 +59,7 @@ export function SubAgentView({
   const hasContent = children != null || !!showFooter;
   const navigate = useNavigate();
   const store = useDefaultStore();
-  const toolTitle = tool.input?.agentType;
+  const toolTitle = tool.input?.agentType?.trim() || "Subtask";
   const description = tool.input?.description;
 
   useEffect(() => {

--- a/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
+++ b/packages/vscode-webui/src/features/tools/components/tool-call-lite.tsx
@@ -347,7 +347,7 @@ const NewTaskTool = ({ tool }: ToolCallLiteViewProps<"newTask">) => {
   const description = tool.input?.description ?? "";
 
   const agentType = tool.input?.agentType;
-  const toolTitle = agentType ?? "Subtask";
+  const toolTitle = agentType?.trim() || "Subtask";
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Fixes the newTask tool-call card missing its agent-type Badge (e.g. "Subtask") when `agentType` is an empty or whitespace-only string.
- Root cause: `agentType ?? "Subtask"` only falls back for `null`/`undefined`, not for `""`, which some models emit instead of omitting the field.
- Replaced `?? fallback` with `?.trim() || fallback` at all newTask badge/assistant-name display sites in `new-task/index.tsx`, `new-task/sub-agent-view.tsx`, and `tool-call-lite.tsx`. Also added a missing fallback for `SubAgentView`'s `toolTitle`, which previously had none at all.

## Test plan
- [x] `bun tsc` passes across affected packages
- [x] `bun check` (biome) passes with no issues
- [x] Manually verified via Storybook that the badge now renders "Subtask"/"Pochi" when `agentType: ""` is passed, instead of a blank badge

🤖 Generated with [Pochi](https://getpochi.com)