### PR TITLE
chore(vscode): bump version to 0.63.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.61.0-dev",
+  "version": "0.63.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- bump the VS Code extension development version from `0.61.0-dev` to `0.63.0-dev`
- prepare the extension manifest for the next development cycle

## Test plan
- [x] Confirm the manifest-only version change

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-2e71b53fc2e0426aaa25422874ee8b60)