### PR TITLE
fix(vscode-webui): hide background job detail panel on read failure

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/__tests__/read-background-job-output.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/read-background-job-output.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ReadBackgroundJobOutputTool } from "../read-background-job-output";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("../status-icon", () => ({
+  StatusIcon: () => <div data-testid="status-icon" />,
+}));
+
+vi.mock("../command-execution-panel", () => ({
+  BackgroundJobPanel: () => <div data-testid="background-job-panel" />,
+}));
+
+function makeTool(overrides: Record<string, unknown>) {
+  return {
+    type: "tool-readBackgroundJobOutput",
+    toolCallId: "call-1",
+    input: { backgroundJobId: "bgjob-1" },
+    ...overrides,
+  } as never;
+}
+
+describe("ReadBackgroundJobOutputTool", () => {
+  it("shows the detail panel when the read succeeds", () => {
+    render(
+      <ReadBackgroundJobOutputTool
+        tool={makeTool({
+          state: "output-available",
+          output: { output: "hello" },
+        })}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.getByTestId("background-job-panel")).toBeTruthy();
+  });
+
+  it("hides the detail panel when the tool call state is output-error", () => {
+    render(
+      <ReadBackgroundJobOutputTool
+        tool={makeTool({
+          state: "output-error",
+          errorText: "Background job not found.",
+        })}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByTestId("background-job-panel")).toBeNull();
+  });
+
+  it("hides the detail panel when output-available carries an error field", () => {
+    render(
+      <ReadBackgroundJobOutputTool
+        tool={makeTool({
+          state: "output-available",
+          output: {
+            error:
+              'No output available for terminal "term-1". It may have been closed.',
+          },
+        })}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByTestId("background-job-panel")).toBeNull();
+  });
+
+  it("hides the detail panel while input is still streaming", () => {
+    render(
+      <ReadBackgroundJobOutputTool
+        tool={makeTool({
+          state: "input-streaming",
+        })}
+        isExecuting={true}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    expect(screen.queryByTestId("background-job-panel")).toBeNull();
+  });
+});

--- a/packages/vscode-webui/src/features/tools/components/read-background-job-output.tsx
+++ b/packages/vscode-webui/src/features/tools/components/read-background-job-output.tsx
@@ -1,4 +1,5 @@
 import { formatTerminalDisplayName } from "@/lib/terminal-display-name";
+import { getToolPartError } from "@/lib/tool-call-error";
 import { useTranslation } from "react-i18next";
 import { BackgroundJobPanel } from "./command-execution-panel";
 import { HighlightedText } from "./highlight-text";
@@ -35,8 +36,9 @@ export const ReadBackgroundJobOutputTool: React.FC<
     </>
   );
 
+  const hasError = getToolPartError(tool) !== undefined;
   const finalJobId =
-    tool.state !== "input-streaming" ? backgroundJobId : undefined;
+    tool.state !== "input-streaming" && !hasError ? backgroundJobId : undefined;
 
   return (
     <ExpandableToolContainer


### PR DESCRIPTION
## Summary
- Hide the background job detail panel when a read fails (either via `output-error` tool state or an `error` field in `output-available`), instead of showing a stale/empty panel.
- Add tests covering success, `output-error`, `output-available` with an error field, and `input-streaming` states.

## Test plan
- [x] `bun run test` in `packages/vscode-webui` covering the new `read-background-job-output.test.tsx` cases

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8bdd68af5d40433e98a4ca2fb06844de)