### PR TITLE
feat: add recommended setting for terminal right-click behavior

### DIFF
--- a/packages/common/src/vscode-webui-bridge/types/vscode-settings.ts
+++ b/packages/common/src/vscode-webui-bridge/types/vscode-settings.ts
@@ -8,6 +8,6 @@ export interface VSCodeSettings {
   autoSaveDisabled: boolean;
   commentsOpenViewDisabled: boolean;
   githubCopilotCodeCompletionEnabled: boolean;
-  terminalRightClickBehaviorDefault: boolean;
+  terminalRightClickContextMenuEnabled: boolean;
   reviewAgent?: boolean;
 }

--- a/packages/common/src/vscode-webui-bridge/types/vscode-settings.ts
+++ b/packages/common/src/vscode-webui-bridge/types/vscode-settings.ts
@@ -8,5 +8,6 @@ export interface VSCodeSettings {
   autoSaveDisabled: boolean;
   commentsOpenViewDisabled: boolean;
   githubCopilotCodeCompletionEnabled: boolean;
+  terminalRightClickBehaviorDefault: boolean;
   reviewAgent?: boolean;
 }

--- a/packages/vscode-webui/src/components/__stories__/recommend-settings.stories.tsx
+++ b/packages/vscode-webui/src/components/__stories__/recommend-settings.stories.tsx
@@ -8,7 +8,7 @@ const defaultSettings: VSCodeSettings = {
   autoSaveDisabled: false,
   commentsOpenViewDisabled: false,
   githubCopilotCodeCompletionEnabled: true,
-  terminalRightClickBehaviorDefault: false,
+  terminalRightClickContextMenuEnabled: false,
   pochiLayout: {
     enabled: false,
   },
@@ -70,7 +70,7 @@ export const AllConfigured: Story = {
       autoSaveDisabled: true,
       commentsOpenViewDisabled: true,
       githubCopilotCodeCompletionEnabled: false,
-      terminalRightClickBehaviorDefault: true,
+      terminalRightClickContextMenuEnabled: true,
       pochiLayout: {
         enabled: true,
       },

--- a/packages/vscode-webui/src/components/__stories__/recommend-settings.stories.tsx
+++ b/packages/vscode-webui/src/components/__stories__/recommend-settings.stories.tsx
@@ -8,6 +8,7 @@ const defaultSettings: VSCodeSettings = {
   autoSaveDisabled: false,
   commentsOpenViewDisabled: false,
   githubCopilotCodeCompletionEnabled: true,
+  terminalRightClickBehaviorDefault: false,
   pochiLayout: {
     enabled: false,
   },
@@ -69,6 +70,7 @@ export const AllConfigured: Story = {
       autoSaveDisabled: true,
       commentsOpenViewDisabled: true,
       githubCopilotCodeCompletionEnabled: false,
+      terminalRightClickBehaviorDefault: true,
       pochiLayout: {
         enabled: true,
       },

--- a/packages/vscode-webui/src/components/recommend-settings.tsx
+++ b/packages/vscode-webui/src/components/recommend-settings.tsx
@@ -13,14 +13,15 @@ type Options =
   | "disableAutoSave"
   | "disableCommentsOpenView"
   | "disableGithubCopilotCodeCompletion"
-  | "terminalRightClickBehaviorDefault";
+  | "terminalRightClickContextMenuEnabled";
 
 const OptionsToSettingsKey = {
   enablePochiLayout: "pochi.advanced",
   disableAutoSave: "files.autoSave",
   disableCommentsOpenView: "comments.openView",
   disableGithubCopilotCodeCompletion: "github.copilot.enable",
-  terminalRightClickBehaviorDefault: "terminal.integrated.rightClickBehavior",
+  terminalRightClickContextMenuEnabled:
+    "terminal.integrated.rightClickBehavior",
 };
 
 function openSettingsLink(option: Options) {
@@ -36,7 +37,7 @@ export function RecommendSettings() {
     autoSaveDisabled: true,
     commentsOpenViewDisabled: true,
     githubCopilotCodeCompletionEnabled: false,
-    terminalRightClickBehaviorDefault: true,
+    terminalRightClickContextMenuEnabled: true,
   };
 
   const options: { id: Options; checked: boolean }[] = useMemo(() => {
@@ -58,8 +59,8 @@ export function RecommendSettings() {
         checked: !vscodeSettings.githubCopilotCodeCompletionEnabled,
       },
       {
-        id: "terminalRightClickBehaviorDefault",
-        checked: !!vscodeSettings.terminalRightClickBehaviorDefault,
+        id: "terminalRightClickContextMenuEnabled",
+        checked: !!vscodeSettings.terminalRightClickContextMenuEnabled,
       },
     ];
   }, [vscodeSettings]);
@@ -83,8 +84,8 @@ export function RecommendSettings() {
         case "disableGithubCopilotCodeCompletion":
           params.githubCopilotCodeCompletionEnabled = !checked;
           break;
-        case "terminalRightClickBehaviorDefault":
-          params.terminalRightClickBehaviorDefault = checked;
+        case "terminalRightClickContextMenuEnabled":
+          params.terminalRightClickContextMenuEnabled = checked;
           break;
       }
       await vscodeHost.updateVSCodeSettings(params);

--- a/packages/vscode-webui/src/components/recommend-settings.tsx
+++ b/packages/vscode-webui/src/components/recommend-settings.tsx
@@ -12,13 +12,15 @@ type Options =
   | "enablePochiLayout"
   | "disableAutoSave"
   | "disableCommentsOpenView"
-  | "disableGithubCopilotCodeCompletion";
+  | "disableGithubCopilotCodeCompletion"
+  | "terminalRightClickBehaviorDefault";
 
 const OptionsToSettingsKey = {
   enablePochiLayout: "pochi.advanced",
   disableAutoSave: "files.autoSave",
   disableCommentsOpenView: "comments.openView",
   disableGithubCopilotCodeCompletion: "github.copilot.enable",
+  terminalRightClickBehaviorDefault: "terminal.integrated.rightClickBehavior",
 };
 
 function openSettingsLink(option: Options) {
@@ -34,6 +36,7 @@ export function RecommendSettings() {
     autoSaveDisabled: true,
     commentsOpenViewDisabled: true,
     githubCopilotCodeCompletionEnabled: false,
+    terminalRightClickBehaviorDefault: true,
   };
 
   const options: { id: Options; checked: boolean }[] = useMemo(() => {
@@ -53,6 +56,10 @@ export function RecommendSettings() {
       {
         id: "disableGithubCopilotCodeCompletion",
         checked: !vscodeSettings.githubCopilotCodeCompletionEnabled,
+      },
+      {
+        id: "terminalRightClickBehaviorDefault",
+        checked: !!vscodeSettings.terminalRightClickBehaviorDefault,
       },
     ];
   }, [vscodeSettings]);
@@ -75,6 +82,9 @@ export function RecommendSettings() {
           break;
         case "disableGithubCopilotCodeCompletion":
           params.githubCopilotCodeCompletionEnabled = !checked;
+          break;
+        case "terminalRightClickBehaviorDefault":
+          params.terminalRightClickBehaviorDefault = checked;
           break;
       }
       await vscodeHost.updateVSCodeSettings(params);

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -593,7 +593,8 @@
       "enablePochiLayout": "Enable Pochi Layout",
       "disableAutoSave": "Disable Auto-Save",
       "disableCommentsOpenView": "Disable Auto-Opening of Comments Panel",
-      "disableGithubCopilotCodeCompletion": "Disable GitHub Copilot Code Completion"
+      "disableGithubCopilotCodeCompletion": "Disable GitHub Copilot Code Completion",
+      "terminalRightClickBehaviorDefault": "Show Context Menu on Terminal Right Click"
     }
   },
   "mermaid": {

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -594,7 +594,7 @@
       "disableAutoSave": "Disable Auto-Save",
       "disableCommentsOpenView": "Disable Auto-Opening of Comments Panel",
       "disableGithubCopilotCodeCompletion": "Disable GitHub Copilot Code Completion",
-      "terminalRightClickBehaviorDefault": "Show Context Menu on Terminal Right Click"
+      "terminalRightClickContextMenuEnabled": "Show Context Menu on Terminal Right Click"
     }
   },
   "mermaid": {

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -593,7 +593,7 @@
       "disableAutoSave": "自動保存を無効にする",
       "disableCommentsOpenView": "コメントパネルの自動表示を無効にする",
       "disableGithubCopilotCodeCompletion": "GitHub Copilot のコード補完を無効にする",
-      "terminalRightClickBehaviorDefault": "ターミナルの右クリックでコンテキストメニューを表示する"
+      "terminalRightClickContextMenuEnabled": "ターミナルの右クリックでコンテキストメニューを表示する"
     }
   },
   "mermaid": {

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -592,7 +592,8 @@
       "enablePochiLayout": "Pochi レイアウトを有効にする",
       "disableAutoSave": "自動保存を無効にする",
       "disableCommentsOpenView": "コメントパネルの自動表示を無効にする",
-      "disableGithubCopilotCodeCompletion": "GitHub Copilot のコード補完を無効にする"
+      "disableGithubCopilotCodeCompletion": "GitHub Copilot のコード補完を無効にする",
+      "terminalRightClickBehaviorDefault": "ターミナルの右クリックでコンテキストメニューを表示する"
     }
   },
   "mermaid": {

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -585,7 +585,8 @@
       "enablePochiLayout": "Pochi 레이아웃 활성화",
       "disableAutoSave": "자동 저장 비활성화",
       "disableCommentsOpenView": "주석 패널 자동 열기 비활성화",
-      "disableGithubCopilotCodeCompletion": "GitHub Copilot 코드 완성 비활성화"
+      "disableGithubCopilotCodeCompletion": "GitHub Copilot 코드 완성 비활성화",
+      "terminalRightClickBehaviorDefault": "터미널 우클릭 시 상황에 맞는 메뉴 표시"
     }
   },
   "mermaid": {

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -586,7 +586,7 @@
       "disableAutoSave": "자동 저장 비활성화",
       "disableCommentsOpenView": "주석 패널 자동 열기 비활성화",
       "disableGithubCopilotCodeCompletion": "GitHub Copilot 코드 완성 비활성화",
-      "terminalRightClickBehaviorDefault": "터미널 우클릭 시 상황에 맞는 메뉴 표시"
+      "terminalRightClickContextMenuEnabled": "터미널 우클릭 시 상황에 맞는 메뉴 표시"
     }
   },
   "mermaid": {

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -590,7 +590,8 @@
       "enablePochiLayout": "启用 Pochi 布局",
       "disableAutoSave": "禁用自动保存",
       "disableCommentsOpenView": "禁用自动打开评论面板",
-      "disableGithubCopilotCodeCompletion": "禁用 GitHub Copilot 代码补全"
+      "disableGithubCopilotCodeCompletion": "禁用 GitHub Copilot 代码补全",
+      "terminalRightClickBehaviorDefault": "终端右键显示上下文菜单"
     }
   },
   "mermaid": {

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -591,7 +591,7 @@
       "disableAutoSave": "禁用自动保存",
       "disableCommentsOpenView": "禁用自动打开评论面板",
       "disableGithubCopilotCodeCompletion": "禁用 GitHub Copilot 代码补全",
-      "terminalRightClickBehaviorDefault": "终端右键显示上下文菜单"
+      "terminalRightClickContextMenuEnabled": "终端右键显示上下文菜单"
     }
   },
   "mermaid": {

--- a/packages/vscode/src/integrations/configuration.ts
+++ b/packages/vscode/src/integrations/configuration.ts
@@ -28,8 +28,8 @@ export class PochiConfiguration implements vscode.Disposable {
   readonly githubCopilotCodeCompletionEnabled = signal(
     getGithubCopilotCodeCompletionEnabled(),
   );
-  readonly terminalRightClickBehaviorDefault = signal(
-    getTerminalRightClickBehaviorDefault(),
+  readonly terminalRightClickContextMenuEnabled = signal(
+    getTerminalRightClickContextMenuEnabled(),
   );
   readonly detectWorktreesLimit = signal(getDetectWorktreesLimit());
 
@@ -55,8 +55,8 @@ export class PochiConfiguration implements vscode.Disposable {
         }
 
         if (e.affectsConfiguration("terminal.integrated.rightClickBehavior")) {
-          this.terminalRightClickBehaviorDefault.value =
-            getTerminalRightClickBehaviorDefault();
+          this.terminalRightClickContextMenuEnabled.value =
+            getTerminalRightClickContextMenuEnabled();
         }
 
         if (e.affectsConfiguration("git.detectWorktreesLimit")) {
@@ -97,11 +97,13 @@ export class PochiConfiguration implements vscode.Disposable {
         ),
       },
       {
-        dispose: this.terminalRightClickBehaviorDefault.subscribe((value) => {
-          if (value !== getTerminalRightClickBehaviorDefault()) {
-            updateTerminalRightClickBehaviorDefault(value);
-          }
-        }),
+        dispose: this.terminalRightClickContextMenuEnabled.subscribe(
+          (value) => {
+            if (value !== getTerminalRightClickContextMenuEnabled()) {
+              updateTerminalRightClickContextMenuEnabled(value);
+            }
+          },
+        ),
       },
     );
   }
@@ -302,7 +304,7 @@ function updateCommentsOpenViewDisabled(value: boolean) {
     .update("openView", target, true);
 }
 
-function getTerminalRightClickBehaviorDefault() {
+function getTerminalRightClickContextMenuEnabled() {
   const rightClickBehavior = vscode.workspace
     .getConfiguration("terminal.integrated")
     .get<string>("rightClickBehavior");
@@ -310,7 +312,13 @@ function getTerminalRightClickBehaviorDefault() {
   return rightClickBehavior === "default";
 }
 
-function updateTerminalRightClickBehaviorDefault(value: boolean) {
+function updateTerminalRightClickContextMenuEnabled(value: boolean) {
+  // Unlike other recommended settings, VS Code's built-in default for
+  // `rightClickBehavior` is platform-dependent (e.g. "copyPaste" on Windows,
+  // "selectWord" on macOS, "default" on Linux), so there's no single fixed
+  // value to fall back to. Clearing the override (setting `undefined`)
+  // restores whichever value the user had configured before opting in, or
+  // VS Code's platform default if they had none.
   const target = value ? "default" : undefined;
   return vscode.workspace
     .getConfiguration("terminal.integrated")

--- a/packages/vscode/src/integrations/configuration.ts
+++ b/packages/vscode/src/integrations/configuration.ts
@@ -28,6 +28,9 @@ export class PochiConfiguration implements vscode.Disposable {
   readonly githubCopilotCodeCompletionEnabled = signal(
     getGithubCopilotCodeCompletionEnabled(),
   );
+  readonly terminalRightClickBehaviorDefault = signal(
+    getTerminalRightClickBehaviorDefault(),
+  );
   readonly detectWorktreesLimit = signal(getDetectWorktreesLimit());
 
   constructor() {
@@ -49,6 +52,11 @@ export class PochiConfiguration implements vscode.Disposable {
         if (e.affectsConfiguration("github.copilot")) {
           this.githubCopilotCodeCompletionEnabled.value =
             getGithubCopilotCodeCompletionEnabled();
+        }
+
+        if (e.affectsConfiguration("terminal.integrated.rightClickBehavior")) {
+          this.terminalRightClickBehaviorDefault.value =
+            getTerminalRightClickBehaviorDefault();
         }
 
         if (e.affectsConfiguration("git.detectWorktreesLimit")) {
@@ -87,6 +95,13 @@ export class PochiConfiguration implements vscode.Disposable {
             }
           },
         ),
+      },
+      {
+        dispose: this.terminalRightClickBehaviorDefault.subscribe((value) => {
+          if (value !== getTerminalRightClickBehaviorDefault()) {
+            updateTerminalRightClickBehaviorDefault(value);
+          }
+        }),
       },
     );
   }
@@ -285,6 +300,21 @@ function updateCommentsOpenViewDisabled(value: boolean) {
   return vscode.workspace
     .getConfiguration("comments")
     .update("openView", target, true);
+}
+
+function getTerminalRightClickBehaviorDefault() {
+  const rightClickBehavior = vscode.workspace
+    .getConfiguration("terminal.integrated")
+    .get<string>("rightClickBehavior");
+
+  return rightClickBehavior === "default";
+}
+
+function updateTerminalRightClickBehaviorDefault(value: boolean) {
+  const target = value ? "default" : undefined;
+  return vscode.workspace
+    .getConfiguration("terminal.integrated")
+    .update("rightClickBehavior", target, true);
 }
 
 function getDetectWorktreesLimit() {

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1006,8 +1006,8 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
             this.pochiConfiguration.commentsOpenViewDisabled.value,
           githubCopilotCodeCompletionEnabled:
             this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value,
-          terminalRightClickBehaviorDefault:
-            this.pochiConfiguration.terminalRightClickBehaviorDefault.value,
+          terminalRightClickContextMenuEnabled:
+            this.pochiConfiguration.terminalRightClickContextMenuEnabled.value,
           reviewAgent:
             this.pochiConfiguration.advancedSettings.value.reviewAgent,
         };
@@ -1037,9 +1037,9 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value =
         params.githubCopilotCodeCompletionEnabled;
     }
-    if (params.terminalRightClickBehaviorDefault !== undefined) {
-      this.pochiConfiguration.terminalRightClickBehaviorDefault.value =
-        params.terminalRightClickBehaviorDefault;
+    if (params.terminalRightClickContextMenuEnabled !== undefined) {
+      this.pochiConfiguration.terminalRightClickContextMenuEnabled.value =
+        params.terminalRightClickContextMenuEnabled;
     }
   };
 

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1006,6 +1006,8 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
             this.pochiConfiguration.commentsOpenViewDisabled.value,
           githubCopilotCodeCompletionEnabled:
             this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value,
+          terminalRightClickBehaviorDefault:
+            this.pochiConfiguration.terminalRightClickBehaviorDefault.value,
           reviewAgent:
             this.pochiConfiguration.advancedSettings.value.reviewAgent,
         };
@@ -1034,6 +1036,10 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     if (params.githubCopilotCodeCompletionEnabled !== undefined) {
       this.pochiConfiguration.githubCopilotCodeCompletionEnabled.value =
         params.githubCopilotCodeCompletionEnabled;
+    }
+    if (params.terminalRightClickBehaviorDefault !== undefined) {
+      this.pochiConfiguration.terminalRightClickBehaviorDefault.value =
+        params.terminalRightClickBehaviorDefault;
     }
   };
 


### PR DESCRIPTION
## Summary
- Add a "Show Context Menu on Terminal Right Click" recommended setting, backed by `terminal.integrated.rightClickBehavior`, alongside the existing recommended settings (auto-save, comments panel, Copilot completion).
- On enable, sets `rightClickBehavior` to `"default"`; on disable, clears the override so VS Code falls back to the user's prior value or its platform-specific default (behavior differs by OS and has no single fixed fallback).
- Wire the new setting through `PochiConfiguration`, `VSCodeHostApi` (read/update), and the `RecommendSettings` webview component, with i18n strings for en/jp/ko/zh.

## Test plan
- [ ] In VS Code, open the Pochi sidebar settings panel and toggle "Show Context Menu on Terminal Right Click"; verify `terminal.integrated.rightClickBehavior` setting updates accordingly.
- [ ] Right-click in the integrated terminal to confirm the context menu shows/hides per the toggle.
- [ ] Disable the setting and confirm the underlying VS Code setting is cleared (not forced to a specific value).
- [ ] Run `bun run storybook` (or view `recommend-settings.stories.tsx`) to confirm the new option renders correctly in both default and all-configured states.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9e234f11392b4a39ab187d81d7c4ce2b)