### PR TITLE
fix(vscode-webui): fix memory leaks in sub-task runtimes and autocomplete

### DIFF
--- a/packages/vscode-webui/src/components/task-thread.tsx
+++ b/packages/vscode-webui/src/components/task-thread.tsx
@@ -4,13 +4,15 @@ import { cn } from "@/lib/utils";
 import { formatters } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
 export type TaskThreadSource = {
   messages: Message[];
   todos: Todo[];
   isLoading?: boolean;
 };
+
+const EmptyMessages: Message[] = [];
 
 export const TaskThread: React.FC<{
   source: TaskThreadSource;
@@ -37,19 +39,16 @@ export const TaskThread: React.FC<{
   scrollAreaClassName,
   instantAutoScroll = false,
 }) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [messages, setMessages] = useState<Message[]>([]);
+  const isLoading = source?.isLoading ?? false;
+  const messages = source?.messages ?? EmptyMessages;
 
-  useEffect(() => {
-    if (!source) {
-      return;
-    }
-
-    setIsLoading(source.isLoading ?? false);
-    setMessages(source.messages);
-  }, [source]);
-
-  const renderMessages = useMemo(() => prepareForRender(messages), [messages]);
+  // Only materialize the transformed copy while the thread is expanded. Holding
+  // a second copy of every sub task history for the whole session is a large,
+  // avoidable memory cost in conversations with many sub tasks.
+  const renderMessages = useMemo(
+    () => (showMessageList ? prepareForRender(messages) : EmptyMessages),
+    [messages, showMessageList],
+  );
   const newTaskContainer = useRef<HTMLDivElement>(null);
   const { isAtBottom, scrollToBottom } = useIsAtBottom(newTaskContainer);
   const isAtBottomRef = useRef(isAtBottom);

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -58,6 +58,7 @@ import { useNewCompactTask } from "../hooks/use-new-compact-task";
 import { useShowCompleteSubtaskButton } from "../hooks/use-subtask-completed";
 import type { SubtaskInfo } from "../hooks/use-subtask-info";
 import { useTerminalContextState } from "../hooks/use-terminal-context-state";
+import { collectAutoCompleteTokens } from "../lib/auto-complete-tokens";
 import { ChatInputForm, type ChatInputFormHandle } from "./chat-input-form";
 import { ErrorMessageView } from "./error-message-view";
 import { SubmitReviewsButton } from "./submit-review-button";
@@ -390,8 +391,11 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     newCompactTaskPending,
   };
 
+  // Only the word-like tokens are consumed by the prompt editor's
+  // autocompletion, so collect those directly instead of retaining a serialized
+  // copy of the whole conversation.
   const messageContent = useMemo(
-    () => JSON.stringify(messages, null, 2),
+    () => collectAutoCompleteTokens(messages),
     [messages],
   );
 

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/auto-complete-tokens.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/auto-complete-tokens.test.ts
@@ -1,0 +1,99 @@
+import type { Message } from "@getpochi/livekit";
+import { describe, expect, it } from "vitest";
+import { collectAutoCompleteTokens } from "../auto-complete-tokens";
+
+function makeTextMessage(id: string, text: string): Message {
+  return {
+    id,
+    role: "assistant",
+    parts: [{ type: "text", text }],
+  } as unknown as Message;
+}
+
+describe("collectAutoCompleteTokens", () => {
+  it("returns an empty string for no messages", () => {
+    expect(collectAutoCompleteTokens([])).toBe("");
+  });
+
+  it("collects word tokens from message text", () => {
+    const tokens = collectAutoCompleteTokens([
+      makeTextMessage("1", "update collectAutoCompleteTokens in chat_toolbar"),
+    ]).split(" ");
+
+    expect(tokens).toContain("update");
+    expect(tokens).toContain("collectAutoCompleteTokens");
+    expect(tokens).toContain("chat_toolbar");
+  });
+
+  it("skips tokens shorter than three characters", () => {
+    const tokens = collectAutoCompleteTokens([
+      makeTextMessage("1", "a bc def"),
+    ]).split(" ");
+
+    expect(tokens).not.toContain("a");
+    expect(tokens).not.toContain("bc");
+    expect(tokens).toContain("def");
+  });
+
+  it("dedupes repeated tokens", () => {
+    const tokens = collectAutoCompleteTokens([
+      makeTextMessage("1", "foo foo foo"),
+    ]).split(" ");
+
+    expect(tokens.filter((token) => token === "foo")).toHaveLength(1);
+  });
+
+  it("walks nested tool inputs and outputs", () => {
+    const message = {
+      id: "1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-readFile",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { path: "packages/nested_path.ts" },
+          output: { content: "exportedSymbol" },
+        },
+      ],
+    } as unknown as Message;
+
+    const tokens = collectAutoCompleteTokens([message]).split(" ");
+    expect(tokens).toContain("nested_path");
+    expect(tokens).toContain("exportedSymbol");
+  });
+
+  it("caps the number of collected tokens", () => {
+    const words = Array.from({ length: 5000 }, (_, i) => `token${i}`).join(" ");
+    const tokens = collectAutoCompleteTokens([
+      makeTextMessage("1", words),
+    ]).split(" ");
+
+    expect(tokens.length).toBe(2500);
+  });
+
+  it("prefers the newest messages when the budget is exhausted", () => {
+    const olderWords = Array.from(
+      { length: 5000 },
+      (_, i) => `older${i}`,
+    ).join(" ");
+
+    const tokens = collectAutoCompleteTokens([
+      makeTextMessage("1", olderWords),
+      makeTextMessage("2", "newestToken"),
+    ]).split(" ");
+
+    expect(tokens).toContain("newestToken");
+  });
+
+  it("does not scan unbounded amounts of text", () => {
+    // A single huge tool output must not force a full scan of the transcript.
+    const huge = "x".repeat(1024 * 1024);
+    const tokens = collectAutoCompleteTokens([
+      makeTextMessage("1", "shouldNotBeReached"),
+      makeTextMessage("2", huge),
+    ]).split(" ");
+
+    expect(tokens).not.toContain("shouldNotBeReached");
+  });
+});

--- a/packages/vscode-webui/src/features/chat/lib/auto-complete-tokens.ts
+++ b/packages/vscode-webui/src/features/chat/lib/auto-complete-tokens.ts
@@ -1,0 +1,71 @@
+import type { Message } from "@getpochi/livekit";
+
+/**
+ * The autocompletion candidate list is capped at 2500 entries downstream
+ * (see `createFuzzySearcher`), so there is no point collecting more than that.
+ */
+const MaxTokens = 2500;
+
+/**
+ * Upper bound on how much message text is scanned per computation. Tool outputs
+ * can be megabytes large; without a budget a single long conversation would
+ * dominate both CPU and memory every time a chunk streams in.
+ */
+const MaxScannedChars = 256 * 1024;
+
+const MinTokenLength = 3;
+
+/**
+ * Collect word-like tokens from the conversation to seed the prompt editor's
+ * autocompletion.
+ *
+ * This replaces the previous `JSON.stringify(messages, null, 2)`, which
+ * retained a serialized copy of the whole conversation (often tens of MB) in
+ * component state and rebuilt it on every streaming update. Only the deduped
+ * tokens are actually consumed, so we build them directly and keep the result
+ * bounded.
+ *
+ * Messages are visited newest-first so that the most recent context wins when
+ * the token budget is exhausted.
+ */
+export function collectAutoCompleteTokens(messages: Message[]): string {
+  const tokens = new Set<string>();
+  const tokenPattern = new RegExp(`[\\w_]{${MinTokenLength},}`, "g");
+  let scannedChars = 0;
+
+  const visitString = (value: string): boolean => {
+    scannedChars += value.length;
+    tokenPattern.lastIndex = 0;
+    let match = tokenPattern.exec(value);
+    while (match !== null) {
+      tokens.add(match[0]);
+      if (tokens.size >= MaxTokens) return false;
+      match = tokenPattern.exec(value);
+    }
+    return scannedChars < MaxScannedChars;
+  };
+
+  const visit = (value: unknown): boolean => {
+    if (typeof value === "string") {
+      return visitString(value);
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (!visit(item)) return false;
+      }
+      return true;
+    }
+    if (value && typeof value === "object") {
+      for (const item of Object.values(value)) {
+        if (!visit(item)) return false;
+      }
+    }
+    return true;
+  };
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (!visit(messages[i])) break;
+  }
+
+  return [...tokens].join(" ");
+}

--- a/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/new-task/index.tsx
@@ -13,6 +13,7 @@ import { type RefObject, useEffect, useMemo, useRef } from "react";
 import { useThrottle } from "react-use";
 import { useInlinedSubTask } from "../../hooks/use-inlined-sub-task";
 import { useLiveSubTask } from "../../hooks/use-live-sub-task";
+import { useStoredSubTask } from "../../hooks/use-stored-sub-task";
 import { StatusIcon } from "../status-icon";
 import { ExpandableToolContainer } from "../tool-container";
 import type { ToolProps } from "../types";
@@ -30,7 +31,7 @@ interface NewTaskToolProps extends ToolProps<"newTask"> {
 }
 
 export const newTaskTool: React.FC<NewTaskToolProps> = (props) => {
-  const { tool, taskThreadSource } = props;
+  const { tool, isExecuting, taskThreadSource } = props;
   const uid = tool.input?._meta?.uid;
 
   let taskSource: (TaskThreadSource & { parentId?: string }) | undefined =
@@ -43,7 +44,14 @@ export const newTaskTool: React.FC<NewTaskToolProps> = (props) => {
   }
 
   if (!inlinedTaskSource && uid && isVSCodeEnvironment()) {
-    return <LiveSubTaskToolView {...props} uid={uid} />;
+    // Only drive a sub task through a full chat runtime while it is actually
+    // running. Finished sub tasks are read straight from the store so that a
+    // long conversation does not accumulate one live chat runtime per sub task.
+    return isExecuting ? (
+      <LiveSubTaskToolView {...props} uid={uid} />
+    ) : (
+      <StoredSubTaskToolView {...props} uid={uid} />
+    );
   }
 
   return <NewTaskToolView {...props} taskSource={taskSource} uid={uid} />;
@@ -66,6 +74,13 @@ function LiveSubTaskToolView(props: NewTaskToolProps & { uid: string }) {
       toolCallStatusRegistryRef={subTaskToolCallStatusRegistry}
     />
   );
+}
+
+function StoredSubTaskToolView(props: NewTaskToolProps & { uid: string }) {
+  const { uid } = props;
+  const taskSource = useStoredSubTask(uid);
+
+  return <NewTaskToolView {...props} taskSource={taskSource} uid={uid} />;
 }
 
 export interface NewTaskToolViewProps extends ToolProps<"newTask"> {

--- a/packages/vscode-webui/src/features/tools/hooks/use-stored-sub-task.tsx
+++ b/packages/vscode-webui/src/features/tools/hooks/use-stored-sub-task.tsx
@@ -1,0 +1,39 @@
+import type { TaskThreadSource } from "@/components/task-thread";
+import { useDefaultStore } from "@/lib/use-default-store";
+import { type Message, catalog } from "@getpochi/livekit";
+import { useMemo } from "react";
+
+/**
+ * Read-only view of a sub task that is no longer running.
+ *
+ * Unlike `useLiveSubTask`, this does not build a `LiveChatKit` (chat transport,
+ * background task executor, memory adaptors), a `useChat` instance, retry
+ * timers or an abort controller. A parent task that spawned many sub tasks
+ * would otherwise keep one full chat runtime alive per sub task for the whole
+ * lifetime of the webview, which is a major contributor to renderer memory
+ * pressure (all Pochi task panes share a single renderer process).
+ */
+export function useStoredSubTask(
+  uid: string,
+): (TaskThreadSource & { parentId: string }) | undefined {
+  const store = useDefaultStore();
+  const task = store.useQuery(catalog.queries.makeTaskQuery(uid));
+  const messageRows = store.useQuery(catalog.queries.makeMessagesQuery(uid));
+
+  const messages = useMemo(
+    () => messageRows.map((row) => row.data as Message),
+    [messageRows],
+  );
+
+  if (!task?.parentId) {
+    // The task is not found in store (or is not a sub task).
+    return undefined;
+  }
+
+  return {
+    parentId: task.parentId,
+    messages,
+    todos: [],
+    isLoading: false,
+  };
+}


### PR DESCRIPTION
## Summary
- Avoid mounting live chat runtimes for finished sub-tasks by splitting `NewTaskToolView` into `LiveSubTaskToolView` and `StoredSubTaskToolView` components.
- Optimize `TaskThread` memory consumption by pruning redundant state mirroring and deferring message list compilation until the thread is expanded.
- Replace heavy autocomplete `JSON.stringify(messages)` with a highly efficient, bounded word-token collector `collectAutoCompleteTokens`.

## Test plan
- Run webui unit and integration tests: `bunx vitest run src/features/tools src/components` and `src/features/chat/lib/__tests__/auto-complete-tokens.test.ts`. All pass successfully.
- Verify sub-task component rendering in different environments (VS Code vs Web/CLI).

🤖 Generated with [Pochi](https://getpochi.com)