### PR TITLE
fix(vscode): prefer sidebar for terminal Add to Chat when more recently focused

### DIFF
--- a/packages/common/src/vscode-webui-bridge/webview-stub.ts
+++ b/packages/common/src/vscode-webui-bridge/webview-stub.ts
@@ -48,6 +48,9 @@ const VSCodeHostStub = {
   readCurrentWorkspace: async () => {
     return Promise.resolve({ cwd: null, workspacePath: null });
   },
+  notifyFocusChanged: async (_focused: boolean): Promise<void> => {
+    return Promise.resolve();
+  },
   readResourceURI: (): Promise<ResourceURI> => {
     return Promise.resolve({} as ResourceURI);
   },

--- a/packages/common/src/vscode-webui-bridge/webview.ts
+++ b/packages/common/src/vscode-webui-bridge/webview.ts
@@ -231,6 +231,16 @@ export interface VSCodeHostApi {
     workspacePath: string | null;
   }>;
 
+  /**
+   * Reports that this webview's window gained or lost focus. Used to track,
+   * per Pochi surface (sidebar vs. a task tab's panel), when it was last
+   * focused by the user. There is no VS Code host-native signal for "the
+   * sidebar view gained keyboard focus" (unlike editor tabs, which are
+   * tracked via `vscode.window.tabGroups`), so the webview reports it
+   * directly via this method.
+   */
+  notifyFocusChanged(focused: boolean): Promise<void>;
+
   readCustomAgents(): Promise<ThreadSignalSerialization<CustomAgentFile[]>>;
 
   readSkills(): Promise<ThreadSignalSerialization<SkillFile[]>>;

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -170,6 +170,7 @@ function createVSCodeHost(): VSCodeHostApi {
         "readTaskPinned",
         "readLang",
         "readTaskChangedFiles",
+        "notifyFocusChanged",
       ],
       exports: {
         async addTerminalContext(selection) {
@@ -293,6 +294,20 @@ function createVSCodeHost(): VSCodeHostApi {
   );
 
   const vscodeHostApi: VSCodeHostApi = thread.imports;
+
+  // Report focus changes so the extension host can tell, in retrospect,
+  // which Pochi surface (this webview vs. e.g. a different task tab) the
+  // user last focused. Seed the initial state in case this webview is
+  // already focused when it finishes loading (window "focus"/"blur" only
+  // fire on subsequent transitions).
+  void vscodeHostApi.notifyFocusChanged(window.document.hasFocus());
+  window.addEventListener("focus", () => {
+    void vscodeHostApi.notifyFocusChanged(true);
+  });
+  window.addEventListener("blur", () => {
+    void vscodeHostApi.notifyFocusChanged(false);
+  });
+
   const openFile: VSCodeHostApi["openFile"] = async (filePath, options) => {
     return vscodeHostApi.openFile(
       resolvePochiUri(filePath, globalStore?.storeId ?? ""),

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -33,7 +33,7 @@ import { createMcpHub } from "./integrations/mcp";
 import { ReviewController } from "./integrations/review-controller";
 import { StatusBarItem } from "./integrations/status-bar-item";
 import { TerminalLinkProvider } from "./integrations/terminal-link-provider";
-import { PochiWebviewSidebar } from "./integrations/webview";
+import { PochiFocusTracker, PochiWebviewSidebar } from "./integrations/webview";
 import { PochiTaskEditorProvider } from "./integrations/webview/webview-panel";
 import { type AuthClient, createAuthClient } from "./lib/auth-client";
 import "./lib/file-logger";
@@ -106,6 +106,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
   container.resolve(LayoutManager);
   container.resolve(PochiTaskTabMonitor);
+  container.resolve(PochiFocusTracker);
 }
 
 // This method is called when your extension is deactivated

--- a/packages/vscode/src/integrations/command.ts
+++ b/packages/vscode/src/integrations/command.ts
@@ -57,6 +57,8 @@ import {
 import { readTerminalSelection as readTerminalSelectionFromClipboard } from "./terminal/read-terminal-selection";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { TerminalState } from "./terminal/terminal-state";
+// biome-ignore lint/style/useImportType: needed for dependency injection
+import { PochiFocusTracker } from "./webview/focus-tracker";
 import {
   PochiTaskEditorProvider,
   PochiWebviewPanel,
@@ -83,6 +85,7 @@ export class CommandManager implements vscode.Disposable {
     private readonly reviewController: ReviewController,
     private readonly layoutManager: LayoutManager,
     private readonly terminalState: TerminalState,
+    private readonly focusTracker: PochiFocusTracker,
   ) {
     this.registerCommands();
     if (EditorPredictionsAvailable) {
@@ -680,7 +683,16 @@ export class CommandManager implements vscode.Disposable {
       ? PochiTaskEditorProvider.parseTaskUri(activeTab.input.uri)?.uid
       : undefined;
 
-    if (uid && PochiWebviewPanel.addTerminalContext(uid, selection)) {
+    // Even if a task tab exists, prefer the sidebar when the user was more
+    // recently focused there than on any Pochi task tab (e.g. they were
+    // chatting in the sidebar, then selected text in the terminal).
+    const preferSidebar = this.focusTracker.wasSidebarMoreRecentlyFocused();
+
+    if (
+      uid &&
+      !preferSidebar &&
+      PochiWebviewPanel.addTerminalContext(uid, selection)
+    ) {
       return;
     }
 

--- a/packages/vscode/src/integrations/webview/base.ts
+++ b/packages/vscode/src/integrations/webview/base.ts
@@ -459,10 +459,21 @@ export abstract class WebviewBase implements vscode.Disposable {
         this.sessionState = { ...this.sessionState, ...state };
       },
       readResourceURI: this.getReadResourceURI(),
+      notifyFocusChanged: async (focused) => {
+        this.onFocusChanged(focused);
+      },
     };
 
     return wrapper;
   }
+
+  /**
+   * Called whenever this webview's window focus state changes (see
+   * `notifyFocusChanged` on `VSCodeHostApi`). No-op by default; subclasses
+   * that need to react to focus changes (e.g. the sidebar, for
+   * `PochiFocusTracker`) should override this.
+   */
+  protected onFocusChanged(_focused: boolean): void {}
 
   // Abstract methods to be implemented by subclasses
   protected abstract getReadResourceURI(): VSCodeHostApi["readResourceURI"];

--- a/packages/vscode/src/integrations/webview/focus-tracker.ts
+++ b/packages/vscode/src/integrations/webview/focus-tracker.ts
@@ -1,0 +1,74 @@
+import { injectable, singleton } from "tsyringe";
+import * as vscode from "vscode";
+import { isPochiTaskTab } from "../layout/tab-utils";
+
+/**
+ * Tracks the relative recency of focus between the Pochi sidebar webview and
+ * any Pochi task tab open in the editor area.
+ *
+ * This exists to disambiguate "which Pochi surface did the user leave last"
+ * for actions triggered from *outside* any Pochi webview (e.g. the terminal
+ * "Add to Chat" command). By the time such an action fires, focus has
+ * already moved to the terminal, so neither surface can be asked "are you
+ * focused right now?" — we need to remember which one was focused most
+ * recently instead.
+ *
+ * - Task tab focus is derived from `vscode.window.tabGroups`, the same
+ *   native signal `PochiTaskTabMonitor` uses: becoming the active tab of the
+ *   active group is treated as "focused".
+ * - There is no equivalent host-native signal for the sidebar (a
+ *   `WebviewView` only exposes `onDidChangeVisibility`, which fires on
+ *   show/hide, not on focus-within-an-already-visible view), so the sidebar
+ *   webview itself reports focus gain over the webview thread (see
+ *   `WebviewBase.onFocusChanged` / `PochiWebviewSidebar`).
+ *
+ * This is a best-effort signal only, not a precise focus tracker.
+ */
+@injectable()
+@singleton()
+export class PochiFocusTracker implements vscode.Disposable {
+  private disposables: vscode.Disposable[] = [];
+  private sidebarFocusedAt = 0;
+  private taskTabFocusedAt = 0;
+
+  constructor() {
+    this.disposables.push(
+      vscode.window.tabGroups.onDidChangeTabs(this.updateTaskTabFocusedAt),
+      vscode.window.tabGroups.onDidChangeTabGroups(this.updateTaskTabFocusedAt),
+    );
+    // Initialize eagerly in case a pochi task tab is already active.
+    this.updateTaskTabFocusedAt();
+  }
+
+  private updateTaskTabFocusedAt = () => {
+    const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+    if (activeTab && isPochiTaskTab(activeTab)) {
+      this.taskTabFocusedAt = Date.now();
+    }
+  };
+
+  /**
+   * Called by the sidebar webview whenever its window focus state changes.
+   */
+  markSidebarFocused(focused: boolean): void {
+    if (focused) {
+      this.sidebarFocusedAt = Date.now();
+    }
+  }
+
+  /**
+   * Returns true if the sidebar was more recently focused than any Pochi
+   * task tab. Ties (e.g. neither has ever reported focus) resolve to false,
+   * preserving the "prefer the active task tab" default behavior.
+   */
+  wasSidebarMoreRecentlyFocused(): boolean {
+    return this.sidebarFocusedAt > this.taskTabFocusedAt;
+  }
+
+  dispose(): void {
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+    this.disposables = [];
+  }
+}

--- a/packages/vscode/src/integrations/webview/index.ts
+++ b/packages/vscode/src/integrations/webview/index.ts
@@ -1,2 +1,3 @@
+export { PochiFocusTracker } from "./focus-tracker";
 export { PochiWebviewPanel } from "./webview-panel";
 export { PochiWebviewSidebar } from "./webview-sidebar";

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -257,6 +257,12 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
     );
   };
 
+  notifyFocusChanged = async (_focused: boolean): Promise<void> => {
+    throw new Error(
+      "notifyFocusChanged should be called on the webview-specific wrapper, not the singleton",
+    );
+  };
+
   getWorkspaceState = async <K extends keyof WorkspaceState>(
     key: K,
     defaultValue?: WorkspaceState[K],

--- a/packages/vscode/src/integrations/webview/webview-sidebar.ts
+++ b/packages/vscode/src/integrations/webview/webview-sidebar.ts
@@ -11,6 +11,8 @@ import * as vscode from "vscode";
 import { PochiConfiguration } from "../configuration";
 import { WebviewBase } from "./base";
 // biome-ignore lint/style/useImportType: needed for dependency injection
+import { PochiFocusTracker } from "./focus-tracker";
+// biome-ignore lint/style/useImportType: needed for dependency injection
 import { VSCodeHostImpl } from "./vscode-host-impl";
 
 type SidebarViewType = "pochiSidebarDark" | "pochiSidebarLight";
@@ -46,6 +48,7 @@ export class PochiWebviewSidebar
     events: AuthEvents,
     pochiConfiguration: PochiConfiguration,
     vscodeHost: VSCodeHostImpl,
+    private readonly focusTracker: PochiFocusTracker,
   ) {
     super("sidebar-default", context, events, pochiConfiguration, vscodeHost);
 
@@ -104,6 +107,10 @@ export class PochiWebviewSidebar
 
       return this.buildResourceURI(this.view.webview);
     };
+  }
+
+  protected onFocusChanged(focused: boolean): void {
+    this.focusTracker.markSidebarFocused(focused);
   }
 
   public getSiderbarViewType(


### PR DESCRIPTION
## Summary
- Adds `PochiFocusTracker`, which records the relative recency of focus between the Pochi sidebar webview and any open Pochi task tab (task tabs via `vscode.window.tabGroups`, sidebar via a new `notifyFocusChanged` webview → host message).
- The terminal "Add to Chat" command now checks `wasSidebarMoreRecentlyFocused()` and routes context to the sidebar instead of an open task tab when the user was more recently focused on the sidebar (e.g. chatting in the sidebar, then selecting text in the terminal).

## Test plan
- [x] `biome check` passes on all changed files
- [x] `turbo tsc` passes for `pochi`, `@getpochi/common`, `@getpochi/vscode-webui`
- [x] Pre-push hook (full test suite) passed
- [ ] Manual: open a task tab and the sidebar, focus the sidebar, select text in a terminal, run "Add to Chat" — context should land in the sidebar
- [ ] Manual: focus a task tab, select text in a terminal, run "Add to Chat" — context should land in that task tab (existing behavior)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8558f13f9a3f43b495773a5d2c0d9e39)