### PR TITLE
fix(vscode-webui): prevent checkpoint UI bounce before auto-approved tool execution

### DIFF
--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -8,6 +8,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import {
   BackgroundJobContextProvider,
+  useAutoApproveGuard,
   useToolCallLifeCycle,
 } from "@/features/chat";
 import { ToolInvocationPart } from "@/features/tools";
@@ -20,7 +21,7 @@ import type {
   ActiveSelection,
   TerminalTextSelection,
 } from "@getpochi/common/vscode-webui-bridge";
-import type { Message } from "@getpochi/livekit";
+import type { Message, Task } from "@getpochi/livekit";
 import { type FileUIPart, type TextUIPart, isStaticToolUIPart } from "ai";
 import { memo, useEffect, useMemo } from "react";
 import { CheckpointUI, CompactCheckpointUI } from "../checkpoint-ui";
@@ -61,6 +62,7 @@ export const MessageList: React.FC<{
   repairMermaid?: MermaidContext["repairMermaid"];
   repairingChart?: string | null;
   showLastStepDuration?: boolean;
+  taskStatus?: Task["status"];
 }> = ({
   messages: renderMessages,
   isLoading,
@@ -78,6 +80,7 @@ export const MessageList: React.FC<{
   repairMermaid,
   repairingChart,
   showLastStepDuration,
+  taskStatus,
 }) => {
   const [debouncedIsLoading, setDebouncedIsLoading] = useDebounceState(
     isLoading,
@@ -88,8 +91,17 @@ export const MessageList: React.FC<{
     setDebouncedIsLoading(isLoading);
   }, [isLoading, setDebouncedIsLoading]);
 
-  const { executingToolCalls } = useToolCallLifeCycle();
+  const { executingToolCalls, completeToolCalls } = useToolCallLifeCycle();
   const isExecuting = executingToolCalls.length > 0;
+  const autoApproveGuard = useAutoApproveGuard();
+  const isAboutToExecuteWithAutoApprove =
+    !isLoading &&
+    !isExecuting &&
+    taskStatus === "pending-tool" &&
+    autoApproveGuard.current === "auto" &&
+    completeToolCalls.length === 0;
+  const shouldCheckpointUseLoading =
+    isLoading || isExecuting || isAboutToExecuteWithAutoApprove;
   const assistantName = assistant?.name ?? "Pochi";
   const latestCheckpoint = useLatestCheckpoint();
   const toolCallCheckpoints = useMemo(
@@ -177,7 +189,7 @@ export const MessageList: React.FC<{
                       partIndex={index}
                       part={part}
                       isLoading={isLoading}
-                      isExecuting={isExecuting}
+                      shouldCheckpointUseLoading={shouldCheckpointUseLoading}
                       messages={renderMessages}
                       forkTask={forkTask}
                       isSubTask={isSubTask}
@@ -198,7 +210,7 @@ export const MessageList: React.FC<{
                   messageIndex={messageIndex}
                   message={m}
                   nextMessage={renderMessages[messageIndex + 1]}
-                  isLoading={isLoading || isExecuting}
+                  isLoading={shouldCheckpointUseLoading}
                   forkTask={forkTask}
                   isSubTask={isSubTask}
                   latestCheckpoint={latestCheckpoint}
@@ -206,7 +218,7 @@ export const MessageList: React.FC<{
                 />
               ) : (
                 showLastStepDuration &&
-                !(isLoading || isExecuting) && (
+                !shouldCheckpointUseLoading && (
                   <OptionalSeparatorWithExecutionDuration
                     duration={computeExecutionDuration(m)}
                   />
@@ -304,7 +316,7 @@ function Part({
   messageId,
   isLastPartInMessages,
   isLoading,
-  isExecuting,
+  shouldCheckpointUseLoading,
   messages,
   forkTask,
   isSubTask,
@@ -320,7 +332,7 @@ function Part({
   part: NonNullable<Message["parts"]>[number];
   isLastPartInMessages: boolean;
   isLoading: boolean;
-  isExecuting: boolean;
+  shouldCheckpointUseLoading: boolean;
   messages: Message[];
   forkTask?: (commitId: string) => Promise<void>;
   isSubTask?: boolean;
@@ -364,7 +376,7 @@ function Part({
       return (
         <CheckpointUI
           checkpoint={part.data}
-          isLoading={isLoading || isExecuting}
+          isLoading={shouldCheckpointUseLoading}
           forkTask={forkTask}
           isRestored={
             lastCheckpointInMessage !== part.data.commit &&

--- a/packages/vscode-webui/src/features/chat/components/chat-area.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.tsx
@@ -2,7 +2,7 @@ import { EmptyChatPlaceholder } from "@/components/empty-chat-placeholder";
 import type { MermaidContext } from "@/components/message/mermaid-context";
 import { MessageList } from "@/components/message/message-list";
 import { useResourceURI } from "@/lib/hooks/use-resource-uri";
-import type { Message } from "@getpochi/livekit";
+import type { Message, Task } from "@getpochi/livekit";
 import type React from "react";
 
 interface ChatAreaProps {
@@ -18,6 +18,7 @@ interface ChatAreaProps {
   repairMermaid?: MermaidContext["repairMermaid"];
   repairingChart?: string | null;
   showLastStepDuration?: boolean;
+  taskStatus?: Task["status"];
 }
 
 export function ChatArea({
@@ -33,6 +34,7 @@ export function ChatArea({
   repairMermaid,
   repairingChart,
   showLastStepDuration,
+  taskStatus,
 }: ChatAreaProps) {
   const resourceUri = useResourceURI();
   return (
@@ -57,6 +59,7 @@ export function ChatArea({
         repairMermaid={repairMermaid}
         repairingChart={repairingChart}
         showLastStepDuration={showLastStepDuration}
+        taskStatus={taskStatus}
       />
     </>
   );

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -471,6 +471,7 @@ function Chat({ user, uid, info }: ChatProps) {
         repairMermaid={repairMermaid}
         repairingChart={repairingChart}
         showLastStepDuration={task?.status === "completed"}
+        taskStatus={task?.status}
       />
       <div className={ChatToolbarContainerClassName}>
         <ChatToolbar


### PR DESCRIPTION
## Summary
- Bridge the brief window where assistant streaming has finished but an auto-approved tool call hasn't started executing yet, so the checkpoint badge no longer flashes visible before hiding again when a tool runs.
- Add `isAboutToExecuteWithAutoApprove` detection (mirroring the existing gating logic in `useChatStatus`) and derive a new `shouldCheckpointUseLoading` flag consumed by `MessageList`/`CheckpointUI`.
- Thread a new optional `taskStatus` prop through `ChatArea` → `MessageList` so it can be evaluated against `"pending-tool"`.

## Test plan
- [x] `bun tsc` (vscode-webui) — no type errors
- [x] `bun check` — biome/ast-grep/i18n checks pass
- [x] `turbo test` (pre-push hook) — all 17 tasks pass, including 370 vscode-webui tests
- [ ] Manual: enable auto-approve, send a message that triggers a tool call, and confirm the checkpoint indicator no longer flickers between the end of streaming and the start of tool execution

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-50e8d247f6c049fa90f7ba4e4cb75fb2)