### PR TITLE
fix(vscode-webui): resolve markdown list rerender and attribute leak

### DIFF
--- a/packages/vscode-webui/src/components/message/__tests__/markdown-list.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/markdown-list.test.tsx
@@ -24,9 +24,34 @@ vi.mock("@/lib/vscode", () => ({
 describe("MessageMarkdown", () => {
   it("preserves the start of a nested ordered list", () => {
     const { container } = render(
-      <MessageMarkdown>{"1. 5. 这是第五条"}</MessageMarkdown>,
+      <MessageMarkdown>{"1. 5. the fifth item"}</MessageMarkdown>,
     );
 
     expect(container.querySelectorAll("ol")[1].start).toBe(5);
+  });
+
+  it("does not leak the markdown node onto list elements", () => {
+    const { container } = render(
+      <MessageMarkdown>{"- 1. the first item"}</MessageMarkdown>,
+    );
+
+    for (const selector of ["ul", "ol", "li"]) {
+      for (const element of container.querySelectorAll(selector)) {
+        expect(element.getAttributeNames()).not.toContain("node");
+      }
+    }
+  });
+
+  // Guards against memoizing the list components again: a memo comparator that
+  // ignores `children` (they are rebuilt on every render, so comparing them is
+  // pointless) freezes the whole `ul > li > ol` subtree on rerender.
+  it("updates a nested ordered list on rerender", () => {
+    const { container, rerender } = render(
+      <MessageMarkdown>{"- 1. x"}</MessageMarkdown>,
+    );
+    expect(container.querySelector("ol")?.start).toBe(1);
+
+    rerender(<MessageMarkdown>{"- 9. x"}</MessageMarkdown>);
+    expect(container.querySelector("ol")?.start).toBe(9);
   });
 });

--- a/packages/vscode-webui/src/components/message/markdown.tsx
+++ b/packages/vscode-webui/src/components/message/markdown.tsx
@@ -331,19 +331,25 @@ type WithNode<T> = T & {
 };
 type LiProps = WithNode<JSX.IntrinsicElements["li"]>;
 
+// For the list components below: `node` is not a valid DOM attribute, so it
+// must be destructured out; and the comparators must check `children`, since
+// the source position can stay stable while the list content changes.
 const MemoLi = memo<LiProps>(
-  ({ children, className, ...props }: LiProps) => (
+  ({ children, className, node: _node, ...props }: LiProps) => (
     <li className={className} data-streamdown="list-item" {...props}>
       {children}
     </li>
   ),
-  (p, n) => p.className === n.className && sameNodePosition(p.node, n.node),
+  (p, n) =>
+    p.className === n.className &&
+    sameNodePosition(p.node, n.node) &&
+    p.children === n.children,
 );
 MemoLi.displayName = "MarkdownLi";
 
 type UlProps = WithNode<JSX.IntrinsicElements["ul"]>;
 const MemoUl = memo<UlProps>(
-  ({ children, className, ...props }: UlProps) => (
+  ({ children, className, node: _node, ...props }: UlProps) => (
     <ul
       className={cn("list-outside list-disc whitespace-normal", className)}
       data-streamdown="unordered-list"
@@ -352,13 +358,13 @@ const MemoUl = memo<UlProps>(
       {children}
     </ul>
   ),
-  (p, n) => sameClassAndNode(p, n),
+  (p, n) => sameClassAndNode(p, n) && p.children === n.children,
 );
 MemoUl.displayName = "MarkdownUl";
 
 type OlProps = WithNode<JSX.IntrinsicElements["ol"]>;
 const MemoOl = memo<OlProps>(
-  ({ children, className, ...props }: OlProps) => (
+  ({ children, className, node: _node, ...props }: OlProps) => (
     <ol
       className={cn("list-outside list-decimal whitespace-normal", className)}
       data-streamdown="ordered-list"
@@ -367,7 +373,8 @@ const MemoOl = memo<OlProps>(
       {children}
     </ol>
   ),
-  (p, n) => sameClassAndNode(p, n),
+  (p, n) =>
+    sameClassAndNode(p, n) && p.children === n.children && p.start === n.start,
 );
 MemoOl.displayName = "MarkdownOl";
 


### PR DESCRIPTION
## Summary
- Destructures the `node` prop from list components (`MemoLi`, `MemoUl`, `MemoOl`) to prevent it from leaking into the DOM as an invalid attribute.
- Updates memo comparators to check `children` and `start` props to ensure nested list components correctly rerender when their content/start index changes.

## Test plan
- Verified that all unit tests in `packages/vscode-webui` pass (`bun run test` in `packages/vscode-webui`).
- Added new test cases in `markdown-list.test.tsx` to guard against DOM attribute leak and memoization bugs causing list items not to update.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9f976436c8604d6bbe2d849209510666)