### PR TITLE
docs: add isolated-workspaces video to weekly update #36

### DIFF
--- a/packages/docs/content/docs/developer-updates/2026-07-30-weekly-update-36.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-07-30-weekly-update-36.mdx
@@ -15,6 +15,18 @@ More below!
 
   This gives review agents a safe place for deeper validation, and also helps when your current workspace has pending work but you want Pochi to handle something else in parallel. [**#1820**](https://github.com/TabbyML/pochi/pull/1820)
 
+  <video
+    controls
+    style={{
+      width: "100%",
+      borderRadius: "8px",
+      boxShadow: "0 4px 12px rgba(0, 0, 0, 0.15)",
+    }}
+  >
+    <source src="https://assets.docs.getpochi.com/docs/33/3379128f66f39fbab3b88f39843ebd4d396ee51d520346be24716b761d4b09c5.mp4" type="video/mp4" />
+    Your browser does not support the video tag.
+  </video>
+
 ### ✨ Enhancements
 
 - **Remove your edits from message context:** Manual file edits detected by Pochi now have a remove action in the chat input, letting you leave unrelated changes out before sending. Switching branches also clears stale edits so changes from the previous branch do not silently follow your next message. [**#1818**](https://github.com/TabbyML/pochi/pull/1818), [**#1846**](https://github.com/TabbyML/pochi/pull/1846), [**#1851**](https://github.com/TabbyML/pochi/pull/1851)


### PR DESCRIPTION
Adds the isolated-workspaces demo video to the already-published Weekly Update #36 (the entry was missing its #1820 media). Video hosted on R2. No other content changes.