### PR TITLE
feat(vscode-webui): display input and cache-read tokens in dev mode

### DIFF
--- a/packages/common/src/base/__tests__/message.test.ts
+++ b/packages/common/src/base/__tests__/message.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { MessageMetadata } from "../message";
+
+describe("MessageMetadata", () => {
+  it("preserves assistant input and cache-read token usage", () => {
+    const metadata = MessageMetadata.parse({
+      kind: "assistant",
+      totalTokens: 12,
+      inputTokens: 0,
+      cacheReadTokens: 0,
+      finishReason: "stop",
+    });
+
+    expect(metadata).toMatchObject({
+      inputTokens: 0,
+      cacheReadTokens: 0,
+    });
+  });
+});

--- a/packages/common/src/base/message.ts
+++ b/packages/common/src/base/message.ts
@@ -5,6 +5,8 @@ export const MessageMetadata = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("assistant"),
     totalTokens: z.number(),
+    inputTokens: z.number().optional(),
+    cacheReadTokens: z.number().optional(),
     // True when `totalTokens` falls back to our heuristic estimate because
     // the provider did not report usage; false/undefined means it's the real
     // token count reported by the provider. Used to gate token-estimate

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -369,7 +369,8 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
                 ? lastMessage.metadata
                 : undefined;
 
-            const { inputTokens, totalTokens } = part.totalUsage;
+            const { inputTokens, inputTokenDetails, totalTokens } =
+              part.totalUsage;
             if (inputTokens) {
               // Calibrate using *input* tokens only, against the raw
               // (uncalibrated) estimate of exactly the input content sent
@@ -397,11 +398,11 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
 
             return {
               kind: "assistant",
-              // The client only consumes the aggregated total token count here.
-              // Detailed usage shape differences are a server/protocol concern.
               totalTokens:
                 totalTokens ||
                 estimateTotalTokens(llmMessages, calibrationFactor),
+              inputTokens,
+              cacheReadTokens: inputTokenDetails.cacheReadTokens,
               // Lets downstream consumers tell apart real provider usage from
               // our heuristic fallback. Only set when true; keep undefined
               // otherwise so it's omitted.

--- a/packages/vscode-webui/src/components/__tests__/token-usage.test.tsx
+++ b/packages/vscode-webui/src/components/__tests__/token-usage.test.tsx
@@ -1,0 +1,145 @@
+import type { DisplayModel } from "@getpochi/common/vscode-webui-bridge";
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TokenUsage } from "../token-usage";
+
+const { devModeState } = vi.hoisted(() => ({
+  devModeState: { enabled: true },
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => children,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => children,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/features/settings", () => ({
+  useIsDevMode: () => [devModeState.enabled, vi.fn()] as const,
+}));
+
+vi.mock("@/features/tools", () => ({
+  FileList: () => null,
+}));
+
+vi.mock("@/lib/hooks/use-auto-memory-enabled", () => ({
+  useAutoMemoryEnabled: () => ({
+    autoMemoryEnabled: false,
+    setAutoMemoryEnabled: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-effective-context-window", () => ({
+  useEffectiveContextWindow: () => undefined,
+}));
+
+vi.mock("@/lib/hooks/use-rules", () => ({
+  useRules: () => ({ rules: [] }),
+}));
+
+vi.mock("@/lib/hooks/use-task-context-window-usage", () => ({
+  useTaskContextWindowUsage: () => ({ contextWindowUsage: undefined }),
+}));
+
+vi.mock("@/lib/hooks/use-task-memory-state", () => ({
+  useTaskMemoryState: () => ({
+    taskMemoryState: { extractionCount: 0 },
+  }),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  vscodeAutoMemoryManager: {
+    readContext: vi.fn().mockResolvedValue(undefined),
+    clearProjectMemory: vi.fn(),
+  },
+  vscodeHost: {
+    openFile: vi.fn(),
+    showInformationMessage: vi.fn(),
+  },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const selectedModel = {
+  type: "provider",
+  options: { contextWindow: 200_000 },
+} as DisplayModel;
+
+function renderTokenUsage(
+  props: Partial<React.ComponentProps<typeof TokenUsage>> = {},
+) {
+  return render(
+    <TokenUsage
+      taskId="task-id"
+      selectedModel={selectedModel}
+      totalTokens={12_000}
+      {...props}
+    />,
+  );
+}
+
+describe("TokenUsage development metadata", () => {
+  it("shows input and cache-read tokens in development mode", () => {
+    devModeState.enabled = true;
+
+    renderTokenUsage({ inputTokens: 10_000, cacheReadTokens: 8_000 });
+
+    expect(screen.getByText("tokenUsage.inputTokens")).not.toBeNull();
+    expect(screen.getByText("10k")).not.toBeNull();
+    expect(screen.getByText("tokenUsage.cacheReadTokens")).not.toBeNull();
+    expect(screen.getByText("8k")).not.toBeNull();
+  });
+
+  it("shows cache-read then input metadata after the context window progress bar", () => {
+    devModeState.enabled = true;
+
+    const { container } = renderTokenUsage({
+      inputTokens: 10_000,
+      cacheReadTokens: 8_000,
+    });
+    const progress = container.querySelector('[data-slot="progress"]');
+    const cacheReadTokens = screen.getByText("tokenUsage.cacheReadTokens");
+    const inputTokens = screen.getByText("tokenUsage.inputTokens");
+
+    expect(progress).not.toBeNull();
+    expect(progress?.compareDocumentPosition(cacheReadTokens) ?? 0).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(cacheReadTokens.compareDocumentPosition(inputTokens)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("preserves zero-valued metadata", () => {
+    devModeState.enabled = true;
+
+    renderTokenUsage({ inputTokens: 0, cacheReadTokens: 0 });
+
+    expect(screen.getAllByText("0")).toHaveLength(2);
+  });
+
+  it("shows N/A when metadata is undefined", () => {
+    devModeState.enabled = true;
+
+    renderTokenUsage();
+
+    expect(screen.getAllByText("N/A")).toHaveLength(2);
+  });
+
+  it("hides detailed metadata outside development mode", () => {
+    devModeState.enabled = false;
+
+    renderTokenUsage({ inputTokens: 10_000, cacheReadTokens: 8_000 });
+
+    expect(screen.queryByText("tokenUsage.inputTokens")).toBeNull();
+    expect(screen.queryByText("tokenUsage.cacheReadTokens")).toBeNull();
+  });
+});

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -3,6 +3,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { formatTokens } from "@/features/chat";
 import { useIsDevMode } from "@/features/settings";
 import { FileList } from "@/features/tools";
 import { cn } from "@/lib/utils";
@@ -573,40 +574,4 @@ function formatPercentage(value: number): string {
     return "<0.1%";
   }
   return `${rounded}%`;
-}
-
-function formatTokens(tokens: number | null | undefined): string {
-  if (tokens == null || tokens === 0) {
-    return "0";
-  }
-  const k = 1000;
-  const m = k * 1000;
-  const g = m * 1000;
-  // Add T, P, E if needed
-
-  let value: number;
-  let unit: string;
-
-  if (tokens >= g) {
-    value = tokens / g;
-    unit = "G";
-  } else if (tokens >= m) {
-    value = tokens / m;
-    unit = "M";
-  } else if (tokens >= k) {
-    value = tokens / k;
-    unit = "k";
-  } else {
-    return tokens.toString(); // Return the number as is if less than 1k
-  }
-
-  // Format to one decimal place
-  let formattedValue = value.toFixed(1);
-
-  // If it ends with .0, remove .0
-  if (formattedValue.endsWith(".0")) {
-    formattedValue = formattedValue.substring(0, formattedValue.length - 2);
-  }
-
-  return `${formattedValue}${unit}`;
 }

--- a/packages/vscode-webui/src/components/token-usage.tsx
+++ b/packages/vscode-webui/src/components/token-usage.tsx
@@ -3,6 +3,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { useIsDevMode } from "@/features/settings";
 import { FileList } from "@/features/tools";
 import { cn } from "@/lib/utils";
 
@@ -33,6 +34,8 @@ interface Props {
   taskId: string;
   selectedModel: DisplayModel;
   totalTokens: number;
+  inputTokens?: number;
+  cacheReadTokens?: number;
   className?: string;
   compact?: {
     inlineCompactTaskPending: boolean;
@@ -46,10 +49,13 @@ interface Props {
 export function TokenUsage({
   taskId,
   totalTokens,
+  inputTokens,
+  cacheReadTokens,
   className,
   compact,
   selectedModel,
 }: Props) {
+  const [isDevMode] = useIsDevMode();
   const { contextWindowUsage } = useTaskContextWindowUsage(taskId);
   const { taskMemoryState } = useTaskMemoryState(taskId);
   const hasTaskMemory = taskMemoryState.extractionCount > 0;
@@ -269,6 +275,26 @@ export function TokenUsage({
                 </TooltipProvider>
               )}
             </div>
+            {isDevMode && (
+              <div className="mb-2 flex flex-col gap-y-1 text-muted-foreground">
+                <div className="flex justify-between">
+                  <span>{t("tokenUsage.cacheReadTokens")}</span>
+                  <span>
+                    {cacheReadTokens === undefined
+                      ? "N/A"
+                      : formatTokens(cacheReadTokens)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span>{t("tokenUsage.inputTokens")}</span>
+                  <span>
+                    {inputTokens === undefined
+                      ? "N/A"
+                      : formatTokens(inputTokens)}
+                  </span>
+                </div>
+              </div>
+            )}
 
             <div className="mt-1 flex flex-col gap-y-3">
               {showSystemSection && (

--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BackgroundTaskDebugPanel } from "./background-task-debug-panel";
 
 const task = {
@@ -12,6 +12,8 @@ const task = {
   todos: [],
   error: { message: "A detailed failure message" },
 };
+
+let messageRows: Array<{ data: unknown }> = [];
 
 vi.mock("@/components/task-thread", () => ({
   TaskThread: ({
@@ -78,16 +80,28 @@ vi.mock("@/lib/use-default-store", () => ({
     useQuery: (query: string) => {
       if (query === "backgroundTasks") return [task];
       if (query === "task") return task;
+      if (query === "messages") return messageRows;
       return [];
     },
   }),
 }));
 
-describe("BackgroundTaskDebugPanel", () => {
-  it("uses a single borderless scroll area that fills the remaining height", () => {
-    render(<BackgroundTaskDebugPanel />);
+function openTaskDetail() {
+  render(<BackgroundTaskDebugPanel />);
+  fireEvent.click(screen.getByText("Background task"));
+}
 
-    fireEvent.click(screen.getByText("Background task"));
+function getDetailValue(label: string): string | null | undefined {
+  return screen.getByText(label).parentElement?.lastElementChild?.textContent;
+}
+
+describe("BackgroundTaskDebugPanel", () => {
+  beforeEach(() => {
+    messageRows = [];
+  });
+
+  it("uses a single borderless scroll area that fills the remaining height", () => {
+    openTaskDetail();
 
     const taskThread = screen.getByTestId("task-thread");
     expect(taskThread.classList.contains("min-h-0")).toBe(true);
@@ -107,5 +121,78 @@ describe("BackgroundTaskDebugPanel", () => {
     expect(detailBodyClasses?.contains("flex-col")).toBe(true);
     expect(detailBodyClasses?.contains("overflow-hidden")).toBe(true);
     expect(taskThread.dataset.scrollAreaClassName).not.toContain("100vh");
+  });
+
+  it("shows formatted token usage from the latest assistant request", () => {
+    messageRows = [
+      {
+        data: {
+          id: "assistant-1",
+          role: "assistant",
+          metadata: {
+            kind: "assistant",
+            totalTokens: 1_500,
+            cacheReadTokens: 800,
+            inputTokens: 700,
+          },
+          parts: [],
+        },
+      },
+      {
+        data: {
+          id: "user-1",
+          role: "user",
+          metadata: { kind: "user" },
+          parts: [],
+        },
+      },
+      {
+        data: {
+          id: "assistant-2",
+          role: "assistant",
+          metadata: {
+            kind: "assistant",
+            totalTokens: 12_345,
+            cacheReadTokens: 0,
+            inputTokens: 12_345,
+          },
+          parts: [],
+        },
+      },
+    ];
+
+    openTaskDetail();
+
+    expect(getDetailValue("Cache Read Tokens")).toBe("0");
+    expect(getDetailValue("Input Tokens")).toBe("12.3k");
+
+    const statusRow = screen.getByText("Status").parentElement;
+    const updatedRow = screen.getByText("Updated").parentElement;
+    const cacheReadRow = screen.getByText("Cache Read Tokens").parentElement;
+    const inputRow = screen.getByText("Input Tokens").parentElement;
+    expect(statusRow?.nextElementSibling).toBe(updatedRow);
+    expect(updatedRow?.nextElementSibling).toBe(cacheReadRow);
+    expect(cacheReadRow?.nextElementSibling).toBe(inputRow);
+  });
+
+  it("shows a dash when the latest assistant request has no detailed usage", () => {
+    messageRows = [
+      {
+        data: {
+          id: "assistant-1",
+          role: "assistant",
+          metadata: {
+            kind: "assistant",
+            totalTokens: 100,
+          },
+          parts: [],
+        },
+      },
+    ];
+
+    openTaskDetail();
+
+    expect(getDetailValue("Cache Read Tokens")).toBe("-");
+    expect(getDetailValue("Input Tokens")).toBe("-");
   });
 });

--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
@@ -33,6 +33,7 @@ import {
   X,
 } from "lucide-react";
 import { useMemo, useState } from "react";
+import { formatTokens } from "../lib/format-tokens";
 
 export function BackgroundTaskDebugPanel() {
   const [isDevMode] = useIsDevMode();
@@ -228,6 +229,14 @@ function BackgroundTaskDetail({
     }),
     [messageRows, task?.todos, task?.status],
   );
+  const latestAssistantMessage = source.messages.findLast(
+    (message) =>
+      message.role === "assistant" && message.metadata?.kind === "assistant",
+  );
+  const latestAssistantMetadata =
+    latestAssistantMessage?.metadata?.kind === "assistant"
+      ? latestAssistantMessage.metadata
+      : undefined;
 
   return (
     <div
@@ -265,6 +274,14 @@ function BackgroundTaskDetail({
         <DetailRow
           label="Updated"
           value={task ? formatRelative(task.updatedAt) : undefined}
+        />
+        <DetailRow
+          label="Cache Read Tokens"
+          value={formatDetailedTokens(latestAssistantMetadata?.cacheReadTokens)}
+        />
+        <DetailRow
+          label="Input Tokens"
+          value={formatDetailedTokens(latestAssistantMetadata?.inputTokens)}
         />
         {backgroundTaskState?.useCase && (
           <DetailRow label="Use case" value={backgroundTaskState.useCase} />
@@ -324,6 +341,10 @@ function DetailRow({
       </span>
     </div>
   );
+}
+
+function formatDetailedTokens(tokens: number | undefined): string {
+  return tokens === undefined ? "-" : formatTokens(tokens);
 }
 
 function formatRelative(date: Date | string | number): string {

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -124,6 +124,14 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   const { messages, sendMessage, addToolOutput, status } = chat;
   const isLoading = status === "streaming" || status === "submitted";
   const totalTokens = task?.totalTokens || 0;
+  const latestAssistantMessage = messages.findLast(
+    (message) =>
+      message.role === "assistant" && message.metadata?.kind === "assistant",
+  );
+  const latestAssistantMetadata =
+    latestAssistantMessage?.metadata?.kind === "assistant"
+      ? latestAssistantMessage.metadata
+      : undefined;
 
   const { input, setInput, clearInput } = useChatInputState();
   const { skills, isLoading: isSkillsLoading } = useSkills(true);
@@ -516,6 +524,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
             <TokenUsage
               taskId={taskId}
               totalTokens={totalTokens}
+              inputTokens={latestAssistantMetadata?.inputTokens}
+              cacheReadTokens={latestAssistantMetadata?.cacheReadTokens}
               className="mr-5"
               compact={compactOptions}
               selectedModel={selectedModel}

--- a/packages/vscode-webui/src/features/chat/index.ts
+++ b/packages/vscode-webui/src/features/chat/index.ts
@@ -15,6 +15,7 @@ export {
   useHandleChatEvents,
 } from "./lib/chat-events";
 export { useLiveChatKitGetters } from "./lib/use-live-chat-kit-getters";
+export { formatTokens } from "./lib/format-tokens";
 export {
   useBackgroundJobInfo,
   useReplaceJobIdsInContent,

--- a/packages/vscode-webui/src/features/chat/lib/format-tokens.ts
+++ b/packages/vscode-webui/src/features/chat/lib/format-tokens.ts
@@ -1,0 +1,28 @@
+export function formatTokens(tokens: number | null | undefined): string {
+  if (tokens == null || tokens === 0) {
+    return "0";
+  }
+
+  const k = 1000;
+  const m = k * 1000;
+  const g = m * 1000;
+
+  let value: number;
+  let unit: string;
+
+  if (tokens >= g) {
+    value = tokens / g;
+    unit = "G";
+  } else if (tokens >= m) {
+    value = tokens / m;
+    unit = "M";
+  } else if (tokens >= k) {
+    value = tokens / k;
+    unit = "k";
+  } else {
+    return tokens.toString();
+  }
+
+  const formattedValue = value.toFixed(1).replace(/\.0$/, "");
+  return `${formattedValue}${unit}`;
+}

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -72,6 +72,8 @@
     "minTokensRequired": "At least {{minTokens}} tokens are required to compact the conversation",
     "defaultContextWindowWarning": "The context window value is a default and may not be accurate for your custom model. For precise token management, please adjust it in the settings according to your model provider's documentation.",
     "tokensUsed": "{{used}} / {{total}} tokens",
+    "inputTokens": "Input Tokens",
+    "cacheReadTokens": "Cache Read Tokens",
     "system": "System",
     "systemInstructions": "System Instructions",
     "toolDefinitions": "Tool Definitions",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -72,6 +72,8 @@
     "minTokensRequired": "会話を圧縮するには少なくとも {{minTokens}} tokens が必要です",
     "defaultContextWindowWarning": "コンテキストウィンドウの値はデフォルトであり、カスタムモデルには正確でない場合があります。正確な token 管理のために、モデルプロバイダーのドキュメントに従って設定で調整してください。",
     "tokensUsed": "{{used}} / {{total}} tokens",
+    "inputTokens": "入力 Tokens",
+    "cacheReadTokens": "キャッシュ読み取り Tokens",
     "system": "システム",
     "systemInstructions": "システム指示",
     "toolDefinitions": "ツール定義",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -71,6 +71,8 @@
     "minTokensRequired": "대화를 압축하려면 최소 {{minTokens}} tokens 이상 필요합니다",
     "defaultContextWindowWarning": "컨텍스트 창 값은 기본값이며 사용자 지정 모델에 대해 정확하지 않을 수 있습니다. 정확한 token 관리를 위해 모델 공급자의 설명서에 따라 설정에서 조정하십시오.",
     "tokensUsed": "{{used}} / {{total}} tokens",
+    "inputTokens": "입력 Tokens",
+    "cacheReadTokens": "캐시 읽기 Tokens",
     "system": "시스템",
     "systemInstructions": "시스템 지침",
     "toolDefinitions": "도구 정의",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -71,6 +71,8 @@
     "minTokensRequired": "至少需要 {{minTokens}} 个 token 才能压缩对话",
     "defaultContextWindowWarning": "上下文窗口值是默认值，对于您的自定义模型可能不准确。为了精确的 token 管理，请根据您的模型提供商的文档在设置中进行调整。",
     "tokensUsed": "已使用 {{used}} / {{total}} tokens",
+    "inputTokens": "输入 Tokens",
+    "cacheReadTokens": "缓存读取 Tokens",
     "system": "系统",
     "systemInstructions": "系统指令",
     "toolDefinitions": "工具定义",


### PR DESCRIPTION
## Summary
- Add `inputTokens` and `cacheReadTokens` to the assistant message metadata.
- Display cache read tokens and input tokens in the TokenUsage popover when in developer mode.
- Add localization keys and unit tests for the metadata and token usage components.

## Screenshot
<img width="552" height="316" alt="image" src="https://github.com/user-attachments/assets/b4e6fdfb-0f0d-4bde-8e50-eff6ea290c9c" />

<img width="860" height="318" alt="image" src="https://github.com/user-attachments/assets/9b50b832-9c8e-4ba1-b77e-44ecbf63bf45" />


## Test plan
- Run unit tests to verify metadata extraction and token usage rendering: `bun run test`
- Manually verify that the detailed input and cache read tokens are displayed in the token usage popup when dev mode is enabled.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4039c3988a1544bfb115272a1f0c85a0)