### PR TITLE
refactor(vscode-webui): rename cache read tokens to cache input tokens

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.test.tsx
@@ -163,12 +163,12 @@ describe("BackgroundTaskDebugPanel", () => {
 
     openTaskDetail();
 
-    expect(getDetailValue("Cache Read Tokens")).toBe("0");
+    expect(getDetailValue("Cache Input Tokens")).toBe("0");
     expect(getDetailValue("Input Tokens")).toBe("12.3k");
 
     const statusRow = screen.getByText("Status").parentElement;
     const updatedRow = screen.getByText("Updated").parentElement;
-    const cacheReadRow = screen.getByText("Cache Read Tokens").parentElement;
+    const cacheReadRow = screen.getByText("Cache Input Tokens").parentElement;
     const inputRow = screen.getByText("Input Tokens").parentElement;
     expect(statusRow?.nextElementSibling).toBe(updatedRow);
     expect(updatedRow?.nextElementSibling).toBe(cacheReadRow);
@@ -192,7 +192,7 @@ describe("BackgroundTaskDebugPanel", () => {
 
     openTaskDetail();
 
-    expect(getDetailValue("Cache Read Tokens")).toBe("-");
+    expect(getDetailValue("Cache Input Tokens")).toBe("-");
     expect(getDetailValue("Input Tokens")).toBe("-");
   });
 });

--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
@@ -276,7 +276,7 @@ function BackgroundTaskDetail({
           value={task ? formatRelative(task.updatedAt) : undefined}
         />
         <DetailRow
-          label="Cache Read Tokens"
+          label="Cache Input Tokens"
           value={formatDetailedTokens(latestAssistantMetadata?.cacheReadTokens)}
         />
         <DetailRow

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -73,7 +73,7 @@
     "defaultContextWindowWarning": "The context window value is a default and may not be accurate for your custom model. For precise token management, please adjust it in the settings according to your model provider's documentation.",
     "tokensUsed": "{{used}} / {{total}} tokens",
     "inputTokens": "Input Tokens",
-    "cacheReadTokens": "Cache Read Tokens",
+    "cacheReadTokens": "Cache Input Tokens",
     "system": "System",
     "systemInstructions": "System Instructions",
     "toolDefinitions": "Tool Definitions",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -73,7 +73,7 @@
     "defaultContextWindowWarning": "コンテキストウィンドウの値はデフォルトであり、カスタムモデルには正確でない場合があります。正確な token 管理のために、モデルプロバイダーのドキュメントに従って設定で調整してください。",
     "tokensUsed": "{{used}} / {{total}} tokens",
     "inputTokens": "入力 Tokens",
-    "cacheReadTokens": "キャッシュ読み取り Tokens",
+    "cacheReadTokens": "キャッシュ入力 Tokens",
     "system": "システム",
     "systemInstructions": "システム指示",
     "toolDefinitions": "ツール定義",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -72,7 +72,7 @@
     "defaultContextWindowWarning": "컨텍스트 창 값은 기본값이며 사용자 지정 모델에 대해 정확하지 않을 수 있습니다. 정확한 token 관리를 위해 모델 공급자의 설명서에 따라 설정에서 조정하십시오.",
     "tokensUsed": "{{used}} / {{total}} tokens",
     "inputTokens": "입력 Tokens",
-    "cacheReadTokens": "캐시 읽기 Tokens",
+    "cacheReadTokens": "캐시 입력 Tokens",
     "system": "시스템",
     "systemInstructions": "시스템 지침",
     "toolDefinitions": "도구 정의",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -72,7 +72,7 @@
     "defaultContextWindowWarning": "上下文窗口值是默认值，对于您的自定义模型可能不准确。为了精确的 token 管理，请根据您的模型提供商的文档在设置中进行调整。",
     "tokensUsed": "已使用 {{used}} / {{total}} tokens",
     "inputTokens": "输入 Tokens",
-    "cacheReadTokens": "缓存读取 Tokens",
+    "cacheReadTokens": "缓存输入 Tokens",
     "system": "系统",
     "systemInstructions": "系统指令",
     "toolDefinitions": "工具定义",


### PR DESCRIPTION
## Summary
- Renamed "Cache Read Tokens" to "Cache Input Tokens" in the background task debug panel and all translation files (en, zh, jp, ko).
- Updated the corresponding unit tests to reflect the label change.

## Test plan
- Run the unit tests for the background task debug panel: `bun --cwd packages/vscode-webui vitest --run src/features/chat/components/background-task-debug-panel.test.tsx` and verify that all tests pass.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-946bdc69342941c7a7ee624c211491ca)