### PR TITLE
feat(vscode-webui): add copy action to attempt-completion tool

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/__tests__/attempt-completion.test.ts
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/attempt-completion.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
+  getAttemptCompletionResultCopyText,
   getAttemptCompletionResultDisplay,
   isAttemptTodoCompletionUnsuccessful,
 } from "../tool-result-display";
+
+describe("getAttemptCompletionResultCopyText", () => {
+  it("keeps string results unchanged", () => {
+    expect(getAttemptCompletionResultCopyText('{"success":true}')).toBe(
+      '{"success":true}',
+    );
+  });
+
+  it("formats object results as JSON", () => {
+    expect(
+      getAttemptCompletionResultCopyText({ success: true, summary: "Done." }),
+    ).toBe('{\n  "success": true,\n  "summary": "Done."\n}');
+  });
+});
 
 describe("getAttemptCompletionResultDisplay", () => {
   it("formats JSON object string results as json", () => {

--- a/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
+++ b/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
@@ -1,10 +1,20 @@
 import { CodeBlock, MessageMarkdown } from "@/components/message";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 import { isStaticToolUIPart } from "ai";
-import { Check } from "lucide-react";
+import { Check, CheckIcon, CopyIcon } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { CreatePrAction } from "./create-pr-action";
-import { getAttemptCompletionResultDisplay } from "./tool-result-display";
+import {
+  getAttemptCompletionResultCopyText,
+  getAttemptCompletionResultDisplay,
+} from "./tool-result-display";
 import type { ToolProps } from "./types";
 
 export const AttemptCompletionTool: React.FC<
@@ -41,11 +51,10 @@ export const AttemptCompletionTool: React.FC<
           <Check className="size-4" />
           {t("toolInvocation.taskCompleted")}
         </span>
-        {isLastPart && !isSubTask && (
-          <div className="flex items-center gap-1">
-            <CreatePrAction />
-          </div>
-        )}
+        <div className="flex items-center gap-1">
+          <AttemptCompletionCopyAction result={result} />
+          {isLastPart && !isSubTask ? <CreatePrAction /> : null}
+        </div>
       </div>
       {resultContent.type === "json" ? (
         <CodeBlock language="json" value={resultContent.content} />
@@ -55,3 +64,37 @@ export const AttemptCompletionTool: React.FC<
     </div>
   );
 };
+
+function AttemptCompletionCopyAction({ result }: { result: unknown }) {
+  const { t } = useTranslation();
+  const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 });
+  const label = isCopied
+    ? t("commandExecutionPanel.copied")
+    : t("codeBlock.copy");
+
+  const onCopy = () => {
+    if (isCopied) return;
+    copyToClipboard(getAttemptCompletionResultCopyText(result));
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 text-muted-foreground"
+          aria-label={label}
+          onClick={onCopy}
+        >
+          {isCopied ? (
+            <CheckIcon className="size-3.5" />
+          ) : (
+            <CopyIcon className="size-3.5" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/vscode-webui/src/features/tools/components/tool-result-display.ts
+++ b/packages/vscode-webui/src/features/tools/components/tool-result-display.ts
@@ -10,6 +10,14 @@ export type ToolResultDisplay =
       content: string;
     };
 
+export function getAttemptCompletionResultCopyText(result: unknown): string {
+  if (typeof result === "string") {
+    return result;
+  }
+
+  return JSON.stringify(result, null, 2) ?? "";
+}
+
 export function getAttemptCompletionResultDisplay(
   result: unknown,
 ): ToolResultDisplay {


### PR DESCRIPTION
## Summary
- Add a copy button to the `AttemptCompletionTool` component to allow users to copy the result to their clipboard.
- Introduce `getAttemptCompletionResultCopyText` helper to format object results as JSON while keeping string results unchanged.
- Include unit tests to verify copying behavior for both string and object results.

## Screenshot
<img width="1014" height="380" alt="image" src="https://github.com/user-attachments/assets/fa34b275-d8fb-4542-b3ee-5d39a203f929" />


## Test plan
- [x] Run `bun test packages/vscode-webui/src/features/tools/components/__tests__/attempt-completion.test.ts` to verify the copy action utility works as expected.
- [x] Run `bun check` and `bun tsc` to verify formatting and TypeScript compilation.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7d7c5fb185944a88a7fd5c0edbaa4223)