### PR TITLE
fix(vscode-webui): move edit summary to the right of hover buttons

### DIFF
--- a/packages/vscode-webui/src/components/diff-summary.tsx
+++ b/packages/vscode-webui/src/components/diff-summary.tsx
@@ -159,13 +159,6 @@ export function DiffSummary({
                     </div>
 
                     <div className="flex shrink-0 items-center gap-3">
-                      <EditSummary
-                        editSummary={{
-                          added: file.added,
-                          removed: file.removed,
-                        }}
-                        className="text-sm"
-                      />
                       <div className="hidden items-center gap-1 group-hover:flex">
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -222,6 +215,13 @@ export function DiffSummary({
                           </TooltipContent>
                         </Tooltip>
                       </div>
+                      <EditSummary
+                        editSummary={{
+                          added: file.added,
+                          removed: file.removed,
+                        }}
+                        className="text-sm"
+                      />
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Move the `EditSummary` component to the right of the hover action buttons in `DiffSummary`
- This ensures that the persistent edit summary metadata (+N -M) does not shift horizontally when hover actions are displayed.

## Screenshot
<img width="906" height="154" alt="image" src="https://github.com/user-attachments/assets/c0255b17-86f7-4d95-81e1-8ffdbf10b13d" />


## Test plan
- Verify that hovering over a file item in the DiffSummary displays the hover buttons on the left of the `+N -M` EditSummary, and that the EditSummary itself remains vertically aligned and does not shift.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-a793d0dcb6034c2580169ab87a0b8c8c)