### PR TITLE
fix(livekit): repair mermaid charts embedded in any markdown string

### DIFF
--- a/packages/livekit/src/chat/__tests__/repair-mermaid.test.ts
+++ b/packages/livekit/src/chat/__tests__/repair-mermaid.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const generateTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    generateText: generateTextMock,
+  };
+});
+
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { LiveKitStore, Message } from "../../types";
+import { repairMermaid } from "../llm/repair-mermaid";
+
+const BrokenChart = "graph TD\n  A --> ";
+const FixedChart = "graph TD\n  A --> B";
+
+function brokenBlock(chart = BrokenChart) {
+  return `\`\`\`mermaid\n${chart}\n\`\`\``;
+}
+
+function createStore() {
+  return {
+    storeId: "store-1",
+    commit: vi.fn(),
+  } as unknown as LiveKitStore & { commit: ReturnType<typeof vi.fn> };
+}
+
+async function runRepair(messages: Message[]) {
+  const store = createStore();
+  await repairMermaid({
+    store,
+    taskId: "task-1",
+    model: {} as LanguageModelV3,
+    messages,
+    chart: BrokenChart,
+    error: "Parse error",
+  });
+  return store;
+}
+
+function repairedParts(store: { commit: ReturnType<typeof vi.fn> }) {
+  const event = store.commit.mock.calls[0]?.[0];
+  return event?.args?.repairs as { id: string; parts: unknown[] }[];
+}
+
+describe("repairMermaid", () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      text: `\`\`\`mermaid\n${FixedChart}\n\`\`\``,
+    });
+  });
+
+  it("repairs charts in text parts", async () => {
+    const messages = [
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [{ type: "text", text: `Here you go:\n\n${brokenBlock()}\n` }],
+      },
+    ] as unknown as Message[];
+
+    const store = await runRepair(messages);
+
+    expect(repairedParts(store)).toEqual([
+      {
+        id: "m1",
+        parts: [
+          {
+            type: "text",
+            text: `Here you go:\n\n${brokenBlock(FixedChart)}\n`,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("repairs charts in attemptCompletion inputs", async () => {
+    const messages = [
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-attemptCompletion",
+            toolCallId: "t1",
+            state: "input-available",
+            input: { result: `Done\n\n${brokenBlock()}` },
+          },
+        ],
+      },
+    ] as unknown as Message[];
+
+    const store = await runRepair(messages);
+
+    expect(repairedParts(store)[0].parts[0]).toMatchObject({
+      type: "tool-attemptCompletion",
+      toolCallId: "t1",
+      input: { result: `Done\n\n${brokenBlock(FixedChart)}` },
+    });
+  });
+
+  it("repairs charts nested in askFollowupQuestion inputs", async () => {
+    const messages = [
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-askFollowupQuestion",
+            toolCallId: "t1",
+            state: "input-available",
+            input: {
+              questions: [
+                {
+                  header: "Approach",
+                  question: `Which flow?\n\n${brokenBlock()}`,
+                  options: [{ label: "A" }, { label: "B" }],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ] as unknown as Message[];
+
+    const store = await runRepair(messages);
+
+    expect(repairedParts(store)[0].parts[0]).toMatchObject({
+      type: "tool-askFollowupQuestion",
+      toolCallId: "t1",
+      input: {
+        questions: [
+          {
+            header: "Approach",
+            question: `Which flow?\n\n${brokenBlock(FixedChart)}`,
+            options: [{ label: "A" }, { label: "B" }],
+          },
+        ],
+      },
+    });
+  });
+
+  it("repairs every occurrence across messages and parts", async () => {
+    const messages = [
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: `${brokenBlock()}\nand again\n${brokenBlock()}`,
+          },
+          { type: "text", text: "untouched" },
+        ],
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        parts: [{ type: "reasoning", text: brokenBlock() }],
+      },
+    ] as unknown as Message[];
+
+    const store = await runRepair(messages);
+
+    const repairs = repairedParts(store);
+    expect(repairs).toHaveLength(2);
+    expect(repairs[0].parts).toEqual([
+      {
+        type: "text",
+        text: `${brokenBlock(FixedChart)}\nand again\n${brokenBlock(FixedChart)}`,
+      },
+      { type: "text", text: "untouched" },
+    ]);
+    expect(repairs[1].parts).toEqual([
+      { type: "reasoning", text: brokenBlock(FixedChart) },
+    ]);
+  });
+
+  it("keeps `$` sequences of the fixed chart verbatim", async () => {
+    const chartWithDollar = 'graph TD\n  A["$&"] --> B';
+    generateTextMock.mockResolvedValue({
+      text: `\`\`\`mermaid\n${chartWithDollar}\n\`\`\``,
+    });
+
+    const messages = [
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [{ type: "text", text: brokenBlock() }],
+      },
+    ] as unknown as Message[];
+
+    const store = await runRepair(messages);
+
+    expect(repairedParts(store)[0].parts[0]).toEqual({
+      type: "text",
+      text: brokenBlock(chartWithDollar),
+    });
+  });
+
+  it("throws when no message holds the chart", async () => {
+    const messages = [
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [{ type: "text", text: "no diagram here" }],
+      },
+    ] as unknown as Message[];
+
+    await expect(runRepair(messages)).rejects.toThrow(
+      "Message containing mermaid chart not found",
+    );
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/livekit/src/chat/llm/repair-mermaid.ts
+++ b/packages/livekit/src/chat/llm/repair-mermaid.ts
@@ -30,17 +30,11 @@ export async function repairMermaid({
 }): Promise<void> {
   // Find all messages containing the mermaid diagram by searching through all parts
   // This is more reliable than using messageId since messages may be transformed in UI/DB
+  // Any string in a part might be rendered as markdown (message text, reasoning,
+  // tool inputs such as `attemptCompletion.result` or `askFollowupQuestion.questions[].question`),
+  // so the whole part is walked recursively.
   const messagesWithMermaid = messages.filter((msg) =>
-    msg.parts.some(
-      (part) =>
-        ((part.type === "text" || part.type === "reasoning") &&
-          part.text.includes("```mermaid") &&
-          part.text.includes(chart)) ||
-        (part.type === "tool-attemptCompletion" &&
-          typeof part.input?.result === "string" &&
-          part.input.result.includes("```mermaid") &&
-          part.input.result.includes(chart)),
-    ),
+    msg.parts.some((part) => containsMermaidChart(part, chart)),
   );
 
   if (messagesWithMermaid.length === 0) {
@@ -67,64 +61,25 @@ export async function repairMermaid({
     // Collect all updated messages
     const updatedMessages: Message[] = [];
 
+    const mermaidPattern = buildMermaidPattern(chart);
+    const fixedMermaidBlock = `\`\`\`mermaid\n${fixedMermaid}\n\`\`\``;
+
     // Update all messages containing the chart
     for (const messageWithMermaid of messagesWithMermaid) {
       // Find and update the part with mermaid code, creating new objects to trigger updates
       let replaced = false;
 
       const updatedParts = messageWithMermaid.parts.map((part) => {
-        if (
-          (part.type === "text" || part.type === "reasoning") &&
-          part.text.includes(chart)
-        ) {
-          // Escape special regex characters in the chart content
-          const escapedChart = chart.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          // Create a regex pattern that matches the exact mermaid block with this chart
-          const mermaidPattern = new RegExp(
-            `\`\`\`mermaid\\s*\\n${escapedChart}\\s*\\n\`\`\``,
-            "s",
-          );
-          // Replace the old mermaid code with the new one
-          const newText = part.text.replace(
-            mermaidPattern,
-            `\`\`\`mermaid\n${fixedMermaid}\n\`\`\``,
-          );
-          if (newText !== part.text) {
-            replaced = true;
-            logger.debug("Replaced mermaid in message part", newText);
-            return { ...part, text: newText };
-          }
+        const updatedPart = replaceMermaidChart(
+          part,
+          mermaidPattern,
+          fixedMermaidBlock,
+        );
+        if (updatedPart !== part) {
+          replaced = true;
+          logger.debug(`Replaced mermaid in ${part.type} part`);
         }
-        if (
-          part.type === "tool-attemptCompletion" &&
-          typeof part.input?.result === "string" &&
-          part.input?.result?.includes(chart)
-        ) {
-          // Escape special regex characters in the chart content
-          const escapedChart = chart.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          // Create a regex pattern that matches the exact mermaid block with this chart
-          const mermaidPattern = new RegExp(
-            `\`\`\`mermaid\\s*\\n${escapedChart}\\s*\\n\`\`\``,
-            "s",
-          );
-          // Replace the old mermaid code with the new one
-          const newText = part.input.result.replace(
-            mermaidPattern,
-            `\`\`\`mermaid\n${fixedMermaid}\n\`\`\``,
-          );
-          if (newText !== part.input.result) {
-            replaced = true;
-            logger.debug("Replaced mermaid in tool completion input", newText);
-            return {
-              ...part,
-              input: {
-                ...part.input,
-                result: newText,
-              },
-            };
-          }
-        }
-        return part;
+        return updatedPart;
       });
 
       if (!replaced) {
@@ -158,6 +113,89 @@ export async function repairMermaid({
     logger.warn("Failed to repair mermaid", err);
     throw err;
   }
+}
+
+/**
+ * Builds a regex matching the exact mermaid code block holding `chart`.
+ */
+function buildMermaidPattern(chart: string) {
+  // Escape special regex characters in the chart content
+  const escapedChart = chart.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\`\`\`mermaid\\s*\\n${escapedChart}\\s*\\n\`\`\``, "gs");
+}
+
+/**
+ * Only plain objects are walked, so exotic values (Date, Map, ...) are kept as-is.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Checks whether `value` holds - at any depth - a string containing the mermaid chart.
+ *
+ * Charts may live in plain text / reasoning parts, but also in tool call inputs
+ * (e.g. `attemptCompletion.result` or `askFollowupQuestion.questions[].question`),
+ * which are rendered as markdown as well.
+ */
+function containsMermaidChart(value: unknown, chart: string): boolean {
+  if (typeof value === "string") {
+    return value.includes("```mermaid") && value.includes(chart);
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsMermaidChart(item, chart));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.values(value).some((item) =>
+      containsMermaidChart(item, chart),
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Recursively replaces every mermaid block matching `pattern` with `replacement`.
+ *
+ * Returns the original reference when nothing changed, so callers can detect
+ * updates with a simple identity check and avoid pointless re-renders.
+ */
+function replaceMermaidChart<T>(
+  value: T,
+  pattern: RegExp,
+  replacement: string,
+): T {
+  if (typeof value === "string") {
+    // Use a replacer function so that `$` sequences in the fixed chart are kept as-is
+    const replaced = value.replace(pattern, () => replacement);
+    return (replaced === value ? value : replaced) as T;
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const items = value.map((item) => {
+      const updated = replaceMermaidChart(item, pattern, replacement);
+      if (updated !== item) changed = true;
+      return updated;
+    });
+    return (changed ? items : value) as T;
+  }
+
+  if (isPlainObject(value)) {
+    let changed = false;
+    const entries = Object.entries(value).map(([key, item]) => {
+      const updated = replaceMermaidChart(item, pattern, replacement);
+      if (updated !== item) changed = true;
+      return [key, updated] as const;
+    });
+    return (changed ? Object.fromEntries(entries) : value) as T;
+  }
+
+  return value;
 }
 
 async function generateFixedMermaid(


### PR DESCRIPTION
## Summary
- Walk message parts recursively so mermaid repair finds charts in any string, not just `text`/`reasoning` parts and `attemptCompletion.result` (e.g. `askFollowupQuestion.questions[].question`).
- Replace every occurrence of the broken block (global regex) and use a replacer function so `$` sequences in the fixed chart are kept verbatim.
- Add unit tests for `repairMermaid` covering text parts, tool inputs, nested inputs, multiple occurrences, `$` escaping and the not-found error.

## Test plan
- [ ] `bun run test` in `packages/livekit`
- [ ] Manually trigger a broken mermaid chart rendered from an `askFollowupQuestion` / `attemptCompletion` payload and verify it gets repaired in the UI

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-0e499a43f92b4c1abf855b5deeed5d39)