### PR TITLE
fix(vscode): dedupe changed files that differ only by path form

### DIFF
--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1567,6 +1567,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
           files,
           checkpoint,
           this.checkpointService,
+          this.cwd,
         );
       },
       acceptChangedFile: async (

--- a/packages/vscode/src/lib/__test__/task-changed-files-manager.test.ts
+++ b/packages/vscode/src/lib/__test__/task-changed-files-manager.test.ts
@@ -1,0 +1,158 @@
+import * as assert from "node:assert";
+import * as path from "node:path";
+import type { TaskChangedFile } from "@getpochi/common/vscode-webui-bridge";
+import { describe, it } from "mocha";
+import type { CheckpointService } from "../../integrations/checkpoint/checkpoint-service";
+import type { TaskActivityTracker } from "../../integrations/editor/task-activity-tracker";
+import type { TaskDataStore } from "../task-data-store";
+import { TaskChangedFilesManager } from "../task-changed-files-manager";
+
+const taskId = "task-1";
+const checkpoint = "checkpoint-1";
+
+function createChangedFile(filepath: string): TaskChangedFile {
+  return {
+    filepath,
+    added: 1,
+    removed: 0,
+    content: { type: "checkpoint", commit: checkpoint },
+    deleted: false,
+    state: "pending",
+  };
+}
+
+function createManager(currentFiles: TaskChangedFile[]) {
+  let savedFiles: TaskChangedFile[] = [];
+  const taskDataStore = {
+    getChangedFiles: () => currentFiles,
+    setChangedFiles: async (_taskId: string, files: TaskChangedFile[]) => {
+      savedFiles = files;
+    },
+  } as unknown as TaskDataStore;
+  const taskActivityTracker = {} as TaskActivityTracker;
+  const checkpointService = {
+    diffChangedFiles: async (files: TaskChangedFile[]) => files,
+  } as CheckpointService;
+
+  return {
+    manager: new TaskChangedFilesManager(taskDataStore, taskActivityTracker),
+    checkpointService,
+    getSavedFiles: () => savedFiles,
+  };
+}
+
+describe("TaskChangedFilesManager", () => {
+  it("does not append a relative alias for an existing absolute path", async () => {
+    const cwd = path.join(path.sep, "workspace", "project");
+    const relativePath = path.join("packages", "vscode", "package.json");
+    const absolutePath = path.join(cwd, relativePath);
+    const { manager, checkpointService, getSavedFiles } = createManager([
+      createChangedFile(absolutePath),
+    ]);
+
+    await manager.updateChangedFiles(
+      taskId,
+      [relativePath],
+      checkpoint,
+      checkpointService,
+      cwd,
+    );
+
+    assert.deepStrictEqual(
+      getSavedFiles().map((file) => file.filepath),
+      [absolutePath],
+    );
+  });
+
+  it("deduplicates aliases added in the same update without rewriting the first path", async () => {
+    const cwd = path.join(path.sep, "workspace", "project");
+    const relativePath = path.join("packages", "vscode", "package.json");
+    const absolutePath = path.join(cwd, relativePath);
+    const { manager, checkpointService, getSavedFiles } = createManager([]);
+
+    await manager.updateChangedFiles(
+      taskId,
+      [absolutePath, relativePath],
+      checkpoint,
+      checkpointService,
+      cwd,
+    );
+
+    assert.deepStrictEqual(
+      getSavedFiles().map((file) => file.filepath),
+      [absolutePath],
+    );
+  });
+
+  it("leaves existing aliases unchanged", async () => {
+    const cwd = path.join(path.sep, "workspace", "project");
+    const relativePath = path.join("src", "index.ts");
+    const firstFile = {
+      ...createChangedFile(path.join(cwd, relativePath)),
+      added: 3,
+      state: "accepted" as const,
+    };
+    const laterAlias = {
+      ...createChangedFile(relativePath),
+      added: 7,
+      content: { type: "text" as const, text: "later alias" },
+    };
+    const { manager, checkpointService, getSavedFiles } = createManager([
+      firstFile,
+      laterAlias,
+    ]);
+
+    await manager.updateChangedFiles(
+      taskId,
+      [],
+      checkpoint,
+      checkpointService,
+      cwd,
+    );
+
+    assert.deepStrictEqual(getSavedFiles(), [firstFile, laterAlias]);
+  });
+
+  it("preserves raw strings for paths outside cwd", async () => {
+    const cwd = path.join(path.sep, "workspace", "project");
+    const absolutePath = path.join(path.sep, "workspace", "external", "file.ts");
+    const relativePath = path.join("..", "external", "file.ts");
+    const { manager, checkpointService, getSavedFiles } = createManager([
+      createChangedFile(absolutePath),
+    ]);
+
+    await manager.updateChangedFiles(
+      taskId,
+      [relativePath],
+      checkpoint,
+      checkpointService,
+      cwd,
+    );
+
+    assert.deepStrictEqual(
+      getSavedFiles().map((file) => file.filepath),
+      [absolutePath, relativePath],
+    );
+  });
+
+  it("preserves raw strings when cwd is unavailable", async () => {
+    const absolutePath = path.join(path.sep, "workspace", "project", "file.ts");
+    const relativePath = "file.ts";
+    const { manager, checkpointService, getSavedFiles } = createManager([
+      createChangedFile(absolutePath),
+    ]);
+
+    await manager.updateChangedFiles(
+      taskId,
+      [relativePath],
+      checkpoint,
+      checkpointService,
+      null,
+    );
+
+    assert.deepStrictEqual(
+      getSavedFiles().map((file) => file.filepath),
+      [absolutePath, relativePath],
+    );
+  });
+});

--- a/packages/vscode/src/lib/task-changed-files-manager.ts
+++ b/packages/vscode/src/lib/task-changed-files-manager.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { getLogger } from "@getpochi/common";
 import type {
   ChangedFileContent,
@@ -82,21 +83,26 @@ export class TaskChangedFilesManager {
    * @param files The file paths to add
    * @param checkpoint The checkpoint commit hash
    * @param checkpointService The checkpoint service instance (container-scoped)
+   * @param cwd The task working directory
    */
   async updateChangedFiles(
     taskId: string,
     files: string[],
     checkpoint: string,
     checkpointService: CheckpointService,
+    cwd: string | null,
   ): Promise<void> {
     const currentFiles = this.getChangedFiles(taskId);
     const updatedChangedFiles = [...currentFiles];
+    const knownPaths = new Set(
+      currentFiles.map((file) => getComparisonKey(file.filepath, cwd)),
+    );
 
     for (const filePath of files) {
-      const currentFile = currentFiles.find((f) => f.filepath === filePath);
+      const comparisonKey = getComparisonKey(filePath, cwd);
 
       // first time seeing this file change
-      if (!currentFile) {
+      if (!knownPaths.has(comparisonKey)) {
         updatedChangedFiles.push({
           filepath: filePath,
           added: 0,
@@ -105,6 +111,7 @@ export class TaskChangedFilesManager {
           deleted: false,
           state: "pending",
         });
+        knownPaths.add(comparisonKey);
       }
     }
 
@@ -253,4 +260,22 @@ export class TaskChangedFilesManager {
     const title = filepath ? `Changes in ${filepath}` : "Changed Files";
     return await showDiffChanges(changes, title, cwd, true);
   }
+}
+
+// Returns a cwd-relative key for comparison without changing the stored path.
+function getComparisonKey(filepath: string, cwd: string | null): string {
+  if (!cwd) {
+    return filepath;
+  }
+
+  const relativePath = path.relative(cwd, path.resolve(cwd, filepath));
+  if (
+    path.isAbsolute(relativePath) ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`)
+  ) {
+    return filepath;
+  }
+
+  return relativePath;
 }


### PR DESCRIPTION
## Summary
- `updateChangedFiles` compared incoming tool paths with `===`, so the same file reported once as an absolute path and once as a cwd-relative path produced two entries in the task changed-files list.
- Compare using a cwd-relative key (`getComparisonKey`) instead, and dedupe within a single update batch too. Stored paths stay exactly as reported, so existing records and their diff/undo behavior are unchanged.
- Paths outside cwd (or when `cwd` is unavailable) fall back to raw-string comparison.
- `VSCodeHostImpl` now passes `this.cwd` into `updateChangedFiles`.

## Test plan
- [x] Added `packages/vscode/src/lib/__test__/task-changed-files-manager.test.ts` covering: existing absolute path vs new relative alias, same-batch aliases, pre-existing aliases left untouched, paths outside cwd, and missing cwd.
- [ ] `cd packages/vscode && bun run test`
- [ ] Manually verify the changed-files panel shows one entry per file during a task that mixes absolute and relative tool paths.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3d25294f63d144b197fda74722404733)