### PR TITLE
fix(vscode-webui): close suggestion popups when caret moves

### DIFF
--- a/packages/vscode-webui/src/components/prompt-form/__tests__/suggestion-activation.test.ts
+++ b/packages/vscode-webui/src/components/prompt-form/__tests__/suggestion-activation.test.ts
@@ -1,0 +1,84 @@
+import Document from "@tiptap/extension-document";
+import Paragraph from "@tiptap/extension-paragraph";
+import Text from "@tiptap/extension-text";
+import { Editor } from "@tiptap/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  PromptFormSlashExtension,
+  SlashMentionPluginKey,
+} from "../slash-mention/extension";
+import {
+  TextUpdateTrackerExtension,
+  createMentionSuggestionAllow,
+} from "../suggestion-activation";
+
+let editor: Editor | undefined;
+
+function createEditor() {
+  return new Editor({
+    extensions: [
+      TextUpdateTrackerExtension,
+      Document,
+      Paragraph,
+      Text,
+      PromptFormSlashExtension.configure({
+        suggestion: {
+          char: "/",
+          pluginKey: SlashMentionPluginKey,
+          allow: createMentionSuggestionAllow(PromptFormSlashExtension.name),
+        },
+      }),
+    ],
+    content: "<p>f</p>",
+  });
+}
+
+function isSuggestionActive(instance: Editor) {
+  return !!SlashMentionPluginKey.getState(instance.state)?.active;
+}
+
+/** Types the trigger char to the left of the existing `f`, giving `/f`. */
+function typeTriggerBeforeText(instance: Editor) {
+  instance.view.dispatch(instance.state.tr.insertText("/", 1));
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = undefined;
+});
+
+describe("suggestion activation", () => {
+  it("opens the suggestion when the trigger char is typed", () => {
+    editor = createEditor();
+    typeTriggerBeforeText(editor);
+
+    expect(isSuggestionActive(editor)).toBe(true);
+  });
+
+  it("keeps the suggestion open while text is typed", () => {
+    editor = createEditor();
+    typeTriggerBeforeText(editor);
+    editor.view.dispatch(editor.state.tr.insertText("a", 2));
+
+    expect(isSuggestionActive(editor)).toBe(true);
+  });
+
+  it("keeps the suggestion open on metadata only transactions", () => {
+    editor = createEditor();
+    typeTriggerBeforeText(editor);
+    editor.view.dispatch(editor.state.tr.setMeta("forceUpdate", true));
+
+    expect(isSuggestionActive(editor)).toBe(true);
+  });
+
+  it("closes the suggestion when the caret moves without a text update", () => {
+    editor = createEditor();
+    typeTriggerBeforeText(editor);
+    expect(isSuggestionActive(editor)).toBe(true);
+
+    // Arrow right: the caret stays inside `/f`, so the query would still match.
+    editor.commands.setTextSelection(3);
+
+    expect(isSuggestionActive(editor)).toBe(false);
+  });
+});

--- a/packages/vscode-webui/src/components/prompt-form/context-mention/mention-config.ts
+++ b/packages/vscode-webui/src/components/prompt-form/context-mention/mention-config.ts
@@ -8,7 +8,12 @@ import type {
 import { findSuggestionMatch } from "@tiptap/suggestion";
 import tippy from "tippy.js";
 import type { MentionListActions } from "../shared";
-import { fileMentionPluginKey, fileMentionPreviewPluginKey } from "./extension";
+import { createMentionSuggestionAllow } from "../suggestion-activation";
+import {
+  PromptFormMentionExtension,
+  fileMentionPluginKey,
+  fileMentionPreviewPluginKey,
+} from "./extension";
 import { MentionList, type MentionListProps } from "./mention-list";
 
 const logger = getLogger("mention-config");
@@ -208,6 +213,7 @@ export function createFileMentionConfig<T extends { filepath: string }>({
       items,
       render,
       findSuggestionMatch: findSuggestionMatchFn,
+      allow: createMentionSuggestionAllow(PromptFormMentionExtension.name),
     },
   };
 }

--- a/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
+++ b/packages/vscode-webui/src/components/prompt-form/form-editor.tsx
@@ -59,6 +59,10 @@ import {
 } from "./slash-mention/mention-list";
 import { createSlashCandidates } from "./slash-mention/slash-candidates";
 import { SubmitHistoryExtension } from "./submit-history-extension";
+import {
+  TextUpdateTrackerExtension,
+  createMentionSuggestionAllow,
+} from "./suggestion-activation";
 import { createPlainTextSlice, shouldPasteAsPlainText } from "./utils";
 
 const newLineCharacter = "\n";
@@ -187,6 +191,8 @@ export function FormEditor({
   const editor = useEditor(
     {
       extensions: [
+        // Backs the `allow` callbacks of the mention suggestions below.
+        TextUpdateTrackerExtension,
         Document,
         Paragraph,
         Text,
@@ -309,6 +315,9 @@ export function FormEditor({
                 allowSpaces: isIssueMentionComposingRef.current,
               });
             },
+            allow: createMentionSuggestionAllow(
+              PromptFormIssueMentionExtension.name,
+            ),
           },
         }),
         // Use the already configured PromptFormWorkflowExtension
@@ -406,6 +415,7 @@ export function FormEditor({
                 allowSpaces: isCommandMentionComposingRef.current,
               });
             },
+            allow: createMentionSuggestionAllow(PromptFormSlashExtension.name),
           },
         }),
         History.configure({

--- a/packages/vscode-webui/src/components/prompt-form/suggestion-activation.ts
+++ b/packages/vscode-webui/src/components/prompt-form/suggestion-activation.ts
@@ -1,0 +1,74 @@
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Extension } from "@tiptap/react";
+import type { SuggestionOptions } from "@tiptap/suggestion";
+
+const textUpdatePluginKey = new PluginKey<boolean>("textUpdate");
+
+/**
+ * Tracks whether the latest transaction changed the document (typing, deleting,
+ * pasting, inserting a node) or only moved the caret. Transactions that do
+ * neither keep the previous value.
+ */
+const textUpdatePlugin = new Plugin<boolean>({
+  key: textUpdatePluginKey,
+  state: {
+    init: () => false,
+    apply: (tr, prev) => {
+      // `docChanged` must be checked first: text input sets both flags.
+      if (tr.docChanged) {
+        return true;
+      }
+      if (tr.selectionSet) {
+        return false;
+      }
+      // Metadata only transactions (async item fetches, forced updates, ...)
+      // keep the previous value so open popups are not closed by them.
+      return prev;
+    },
+  },
+});
+
+/**
+ * Provides the state read by {@link createMentionSuggestionAllow}.
+ *
+ * ProseMirror computes plugin state fields in plugin order, and a field is only
+ * readable once it has been computed. The high `priority` therefore matters:
+ * tiptap sorts extensions by priority (descending) before collecting their
+ * plugins, so this plugin always runs before the suggestion plugins of the
+ * mention extensions (`@tiptap/extension-mention` uses `priority: 101`),
+ * independently of the order of the `extensions` array.
+ */
+export const TextUpdateTrackerExtension = Extension.create({
+  name: "textUpdateTracker",
+  priority: 1000,
+  addProseMirrorPlugins() {
+    return [textUpdatePlugin];
+  },
+});
+
+/**
+ * Builds a `suggestion.allow` callback that blocks activation when the caret
+ * moved without the document changing, so that arrow keys and clicks dismiss
+ * the popup even when the query below the caret still matches. Document changes
+ * activate, metadata only transactions keep whatever the previous transaction
+ * decided, and an ongoing IME composition always activates.
+ *
+ * @param nodeName name of the mention node the suggestion inserts.
+ */
+export function createMentionSuggestionAllow(
+  nodeName: string,
+): NonNullable<SuggestionOptions["allow"]> {
+  return ({ editor, state, range }) => {
+    // `state` is the state being built, while `editor.state` still is the
+    // previous one and would therefore lag one transaction behind.
+    if (!textUpdatePluginKey.getState(state) && !editor.view.composing) {
+      return false;
+    }
+
+    // Preserves the default `allow` of @tiptap/extension-mention, which is
+    // replaced as soon as `suggestion.allow` is configured.
+    const $from = state.doc.resolve(range.from);
+    const type = state.schema.nodes[nodeName];
+    return !!$from.parent.type.contentMatch.matchType(type);
+  };
+}


### PR DESCRIPTION
## Summary
- Introduce `TextUpdateTrackerExtension` and `createMentionSuggestionAllow` to distinguish text changes from caret-only moves.
- Configure all suggestion popups (`/`, `@`, `@#`, Tab autocomplete) to use the new `allow` callback.
- Add unit tests validating that typing keeps popups open while caret-only moves close them.

## Test plan
- Run unit tests in `packages/vscode-webui`: `bun run test` (all tests passed).
- Verify in the editor that arrow key movements and mouse clicks dismiss active slash/mention suggestions.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-4eaf6f4c86ce4512ac01dea34390547b)