### PR TITLE
feat(livekit): send compact count in provider options

### DIFF
--- a/packages/common/src/base/__tests__/provider-options.test.ts
+++ b/packages/common/src/base/__tests__/provider-options.test.ts
@@ -13,6 +13,19 @@ describe("PochiProviderOptions", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a compact sequence", () => {
+    const result = PochiProviderOptions.safeParse({
+      taskId: "task-1",
+      storeId: "store-1",
+      client: "vscode",
+      useCase: "agent",
+      compactSequence: 2,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.compactSequence).toBe(2);
+  });
+
   it("rejects unknown request use cases", () => {
     const result = PochiProviderOptions.safeParse({
       taskId: "task-1",

--- a/packages/common/src/base/__tests__/provider-options.test.ts
+++ b/packages/common/src/base/__tests__/provider-options.test.ts
@@ -13,17 +13,17 @@ describe("PochiProviderOptions", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts a compact sequence", () => {
+  it("accepts a number of compacts", () => {
     const result = PochiProviderOptions.safeParse({
       taskId: "task-1",
       storeId: "store-1",
       client: "vscode",
       useCase: "agent",
-      compactSequence: 2,
+      numCompacts: 2,
     });
 
     expect(result.success).toBe(true);
-    expect(result.data?.compactSequence).toBe(2);
+    expect(result.data?.numCompacts).toBe(2);
   });
 
   it("rejects unknown request use cases", () => {

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -80,6 +80,7 @@ export const PochiProviderOptions = z.object({
   storeId: z.string(),
   client: z.string(),
   useCase: PochiRequestUseCase,
+  compactSequence: z.number().int().positive().optional(),
 });
 
 export type PochiProviderOptions = z.infer<typeof PochiProviderOptions>;

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -80,7 +80,7 @@ export const PochiProviderOptions = z.object({
   storeId: z.string(),
   client: z.string(),
   useCase: PochiRequestUseCase,
-  compactSequence: z.number().int().positive().optional(),
+  numCompacts: z.number().int().positive().optional(),
 });
 
 export type PochiProviderOptions = z.infer<typeof PochiProviderOptions>;

--- a/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
+++ b/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
@@ -3,6 +3,7 @@ import type { Message } from "../../types";
 import {
   convertDataPartToText,
   extractContentFilterMetadata,
+  getCompactSequence,
 } from "../flexible-chat-transport";
 
 type MessagePart = Message["parts"][number];
@@ -237,5 +238,32 @@ describe("extractContentFilterMetadata", () => {
         "other",
       ),
     ).toBeUndefined();
+  });
+});
+
+describe("getCompactSequence", () => {
+  it("counts persisted compact blocks before LLM message trimming", () => {
+    const messages = [
+      {
+        id: "checkpoint-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "<compact>first summary</compact>" },
+          { type: "text", text: "continue" },
+        ],
+      },
+      {
+        id: "checkpoint-2",
+        role: "user",
+        parts: [{ type: "text", text: "<compact>second summary</compact>" }],
+      },
+      {
+        id: "new-message",
+        role: "user",
+        parts: [{ type: "text", text: "continue" }],
+      },
+    ] as Message[];
+
+    expect(getCompactSequence(messages)).toBe(2);
   });
 });

--- a/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
+++ b/packages/livekit/src/chat/__tests__/flexible-chat-transport.test.ts
@@ -3,7 +3,7 @@ import type { Message } from "../../types";
 import {
   convertDataPartToText,
   extractContentFilterMetadata,
-  getCompactSequence,
+  getNumCompacts,
 } from "../flexible-chat-transport";
 
 type MessagePart = Message["parts"][number];
@@ -241,7 +241,7 @@ describe("extractContentFilterMetadata", () => {
   });
 });
 
-describe("getCompactSequence", () => {
+describe("getNumCompacts", () => {
   it("counts persisted compact blocks before LLM message trimming", () => {
     const messages = [
       {
@@ -264,6 +264,6 @@ describe("getCompactSequence", () => {
       },
     ] as Message[];
 
-    expect(getCompactSequence(messages)).toBe(2);
+    expect(getNumCompacts(messages)).toBe(2);
   });
 });

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -176,8 +176,8 @@ export type ChatTransportOptions = {
   onRequestFinished?: (snapshot: FinishedRequestSnapshot) => MaybePromise<void>;
 };
 
-export function getCompactSequence(messages: Message[]): number | undefined {
-  const compactSequence = messages.reduce(
+export function getNumCompacts(messages: Message[]): number | undefined {
+  const numCompacts = messages.reduce(
     (count, message) =>
       count +
       message.parts.filter(
@@ -185,7 +185,7 @@ export function getCompactSequence(messages: Message[]): number | undefined {
       ).length,
     0,
   );
-  return compactSequence > 0 ? compactSequence : undefined;
+  return numCompacts > 0 ? numCompacts : undefined;
 }
 
 export class FlexibleChatTransport implements ChatTransport<Message> {
@@ -227,7 +227,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     messages,
     abortSignal,
   }) => {
-    const compactSequence = getCompactSequence(messages);
+    const numCompacts = getNumCompacts(messages);
     const llm = await this.getters.getLLM();
     const environment = await this.getters.getEnvironment?.();
     const autoMemory = await this.getters.getAutoMemory?.();
@@ -328,7 +328,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
           storeId: this.store.storeId,
           client: globalThis.POCHI_CLIENT,
           useCase: this.requestUseCase,
-          compactSequence,
+          numCompacts,
         } satisfies PochiProviderOptions,
       },
       system: systemPrompt,

--- a/packages/livekit/src/chat/flexible-chat-transport.ts
+++ b/packages/livekit/src/chat/flexible-chat-transport.ts
@@ -176,6 +176,18 @@ export type ChatTransportOptions = {
   onRequestFinished?: (snapshot: FinishedRequestSnapshot) => MaybePromise<void>;
 };
 
+export function getCompactSequence(messages: Message[]): number | undefined {
+  const compactSequence = messages.reduce(
+    (count, message) =>
+      count +
+      message.parts.filter(
+        (part) => part.type === "text" && prompts.isCompact(part.text),
+      ).length,
+    0,
+  );
+  return compactSequence > 0 ? compactSequence : undefined;
+}
+
 export class FlexibleChatTransport implements ChatTransport<Message> {
   private readonly onStart?: OnStartCallback;
   private readonly getters: PrepareRequestGetters;
@@ -215,6 +227,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
     messages,
     abortSignal,
   }) => {
+    const compactSequence = getCompactSequence(messages);
     const llm = await this.getters.getLLM();
     const environment = await this.getters.getEnvironment?.();
     const autoMemory = await this.getters.getAutoMemory?.();
@@ -315,6 +328,7 @@ export class FlexibleChatTransport implements ChatTransport<Message> {
           storeId: this.store.storeId,
           client: globalThis.POCHI_CLIENT,
           useCase: this.requestUseCase,
+          compactSequence,
         } satisfies PochiProviderOptions,
       },
       system: systemPrompt,


### PR DESCRIPTION
## Summary
- Add optional positive-integer `numCompacts` to `PochiProviderOptions` to report the number of prior compactions.
- Implement `getNumCompacts` in `flexible-chat-transport.ts` to count persisted `<compact>` blocks in active chat messages.
- Pass `numCompacts` in provider options when initiating a chat request.

## Test plan
- Verified that all unit tests in `provider-options.test.ts` and `flexible-chat-transport.test.ts` pass successfully.
- Ran `bun check` and `bun tsc` to ensure code style and type safety are maintained.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-aaec3e260f2e4a66872286c419d8d2c8)