### PR TITLE
chore(vscode): bump version to 0.65.0-dev

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.63.0-dev",
+  "version": "0.65.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump `packages/vscode` version from `0.63.0-dev` to `0.65.0-dev` to start the next development cycle.

## Test plan
- [ ] CI passes

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-e460e13f3af44c6ab627b1b19e27dbf5)