### PR TITLE
fix(tools): stop polling empty background command output

### DIFF
--- a/packages/common/src/base/__tests__/background-job-notification.test.ts
+++ b/packages/common/src/base/__tests__/background-job-notification.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { renderBackgroundJobNotification } from "../prompts/background-job-notification";
+
+describe("renderBackgroundJobNotification", () => {
+  it("directs the agent to read output after the final status arrives", () => {
+    const prompt = renderBackgroundJobNotification({
+      notificationId: "notification-1",
+      backgroundJobId: "bgjob-cmd-test",
+      outputFile: "/tmp/bgjob-cmd-test.log",
+      command: "false",
+      status: "failed",
+      summary: 'Background command "false" failed with exit code 1',
+      exitCode: 1,
+      finishedAt: 1,
+    });
+
+    expect(prompt).toContain("<status>failed</status>");
+    expect(prompt).toContain(
+      "<output-file>/tmp/bgjob-cmd-test.log</output-file>",
+    );
+    expect(prompt).toContain("Read the output file");
+    expect(prompt).toContain("status above is final");
+  });
+});

--- a/packages/common/src/base/prompts/background-job-notification.ts
+++ b/packages/common/src/base/prompts/background-job-notification.ts
@@ -17,5 +17,6 @@ export function renderBackgroundJobNotification(
   <output-file>${escapeXml(notification.outputFile)}</output-file>
   <status>${notification.status}</status>
   <summary>${escapeXml(notification.summary)}</summary>
+  <instruction>The background job has finished. Read the output file when its output is needed. If the file is empty, the command produced no captured output; do not wait or poll because the status above is final.</instruction>
 </background-job-notification>`;
 }

--- a/packages/tools/src/__test__/execute-command.test.ts
+++ b/packages/tools/src/__test__/execute-command.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createBackgroundCommandResult } from "../execute-command";
 
 describe("createBackgroundCommandResult", () => {
-  it("describes the job ID and output file in the public output", () => {
+  it("provides the output path without treating it as a status signal", () => {
     const result = createBackgroundCommandResult(
       "bgjob-cmd-test",
       "/tmp/bgjob-cmd-test.log",
@@ -10,6 +10,11 @@ describe("createBackgroundCommandResult", () => {
 
     expect(result.output).toContain("bgjob-cmd-test");
     expect(result.output).toContain("/tmp/bgjob-cmd-test.log");
-    expect(result._meta).toEqual({ backgroundJobId: "bgjob-cmd-test" });
+    expect(result.output).toContain("Do not infer job status");
+    expect(result.output).toContain("read the output file if needed");
+    expect(result._meta).toEqual({
+      backgroundJobId: "bgjob-cmd-test",
+      outputFile: "/tmp/bgjob-cmd-test.log",
+    });
   });
 });

--- a/packages/tools/src/__test__/select-agent-tools.test.ts
+++ b/packages/tools/src/__test__/select-agent-tools.test.ts
@@ -198,6 +198,27 @@ describe("selectAgentTools", () => {
     );
   });
 
+  it("does not expose background commands to subtasks", () => {
+    const topLevelTools = selectAgentTools({ isSubTask: false });
+    const subTaskTools = selectAgentTools({ isSubTask: true });
+    const topLevelSchema = topLevelTools.executeCommand
+      ?.inputSchema as z.ZodObject;
+    const subTaskSchema = subTaskTools.executeCommand
+      ?.inputSchema as z.ZodObject;
+
+    expect(topLevelSchema.shape).toHaveProperty("background");
+    expect(subTaskSchema.shape).not.toHaveProperty("background");
+    expect(topLevelTools.executeCommand?.description).toContain(
+      "Do not infer status from empty or partial file contents",
+    );
+    expect(subTaskTools.executeCommand?.description).not.toContain(
+      "background command",
+    );
+    expect(topLevelTools.attemptCompletion?.description).toContain(
+      "if they are still running and no independent work remains",
+    );
+  });
+
   it("exposes declared review source tools to reviewer agents", () => {
     const reviewerTools = selectAgentTools({
       agent: createAgent({

--- a/packages/tools/src/attempt-completion.ts
+++ b/packages/tools/src/attempt-completion.ts
@@ -14,7 +14,9 @@ export const attemptCompletionSchema = z.object({
 
 const toolDef = {
   description:
-    `Once you've received the results of tool uses and can confirm that the task is complete, use this tool to present the result of your work to the user.
+    `Use this tool to end the current agent turn and present its result to the user. Normally, call it only after receiving all tool results and confirming the task is complete.
+
+Exception for background commands: if they are still running and no independent work remains, call this tool now instead of reading their output, polling, or waiting. Do not claim that a background command succeeded or failed before its completion notification arrives. The notification will resume the task with its final status.
 
 You MUST NOT generate any text before this tool call. All conclusion text must be included within the result parameter of the attemptCompletion tool.
 Never use this tool with a question or request to engage in further conversation! Formulate the end of your result in a way that is final and does not require further input from the user.

--- a/packages/tools/src/execute-command.ts
+++ b/packages/tools/src/execute-command.ts
@@ -26,9 +26,17 @@ function resolveExecuteCommandDefaultTimeoutSec(): number {
 export const ExecuteCommandDefaultTimeoutSec =
   resolveExecuteCommandDefaultTimeoutSec();
 
-const toolDef = {
-  description:
-    `Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
+function createToolDef(isSubTask: boolean) {
+  const backgroundUsageNotes = isSubTask
+    ? ""
+    : `- Set background to true for commands that should continue running without blocking the task. The initial result includes the job ID and output file, but only confirms that the job started; it does not report whether the command succeeded or failed.
+- The completion notification is the authoritative job status and reports completed, failed, or stopped. Do not infer status from empty or partial file contents, and do not wait or poll with commands such as sleep.
+- Continue independent work after starting a background command. If no other work remains, use attemptCompletion to end the current turn; the completion notification will resume the task.
+- After receiving the completion notification, read the output file when you need the command output. If it is empty, the command produced no captured output; the notification status is still final.`;
+
+  return {
+    description:
+      `Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
 
 IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO NOT use it for file operations (reading, writing, editing, searching, finding files) - use the specialized tools for this instead.
 
@@ -50,8 +58,7 @@ Before executing the command, please follow these steps:
 
 Usage notes:
 - The command argument is required.
-- Set background to true for commands that should continue running without blocking the task. The returned output describes the background job ID and output file; read that file with readFile and use killBackgroundJob with the ID if the process must be stopped.
-- Background commands do not use the foreground timeout. When they finish, a notification reports completed, failed, or stopped status.
+${backgroundUsageNotes}
 - For foreground commands, you can specify an optional timeout in seconds (up to 300s). If not specified, commands will timeout after ${ExecuteCommandDefaultTimeoutSec}s.
 - If the output exceeds 30000 characters, output will be truncated before being returned to you.
 - When issuing multiple commands:
@@ -156,61 +163,70 @@ Important:
   - gh api repos/foo/bar/pulls/123/comments
   - gh pr view --comments
 `.trim(),
-  inputSchema: z.object({
-    command: z
-      .string()
-      .describe(
-        "The CLI command to execute. This should be valid for the current operating system.",
-      ),
-    cwd: z
-      .string()
-      .optional()
-      .describe("The working directory to execute the command in."),
-    background: z
-      .boolean()
-      .optional()
-      .describe(
-        "Run the command in the background and return immediately. The output describes the background job ID and output file.",
-      ),
-    timeout: z
-      .number()
-      .min(1)
-      .max(60 * 5)
-      .optional()
-      .describe(
-        `Optional timeout in seconds, max 300 seconds. By default the timeout is ${ExecuteCommandDefaultTimeoutSec} seconds.`,
-      ),
-  }),
-  outputSchema: z.object({
-    output: z
-      .string()
-      .describe(
-        "The command result. For foreground execution, this contains stdout and stderr. For background execution, this describes the background job ID and output file.",
-      ),
-    isTruncated: z
-      .boolean()
-      .optional()
-      .describe("Whether the output was truncated"),
-    _meta: z
-      .object({
-        backgroundJobId: z.string(),
-      })
-      .optional()
-      .describe(
-        "Metadata removed before sending the result to the LLM and used to render a background command in the UI.",
-      ),
-  }),
-};
+    inputSchema: z.object({
+      command: z
+        .string()
+        .describe(
+          "The CLI command to execute. This should be valid for the current operating system.",
+        ),
+      cwd: z
+        .string()
+        .optional()
+        .describe("The working directory to execute the command in."),
+      ...(isSubTask
+        ? {}
+        : {
+            background: z
+              .boolean()
+              .optional()
+              .describe(
+                "Run the command in the background and return immediately. The output describes the background job ID and output file.",
+              ),
+          }),
+      timeout: z
+        .number()
+        .min(1)
+        .max(60 * 5)
+        .optional()
+        .describe(
+          `Optional timeout in seconds, max 300 seconds. By default the timeout is ${ExecuteCommandDefaultTimeoutSec} seconds.`,
+        ),
+    }),
+    outputSchema: z.object({
+      output: z
+        .string()
+        .describe(
+          "The command result. For foreground execution, this contains stdout and stderr. For background execution, this describes the background job ID and output file.",
+        ),
+      isTruncated: z
+        .boolean()
+        .optional()
+        .describe("Whether the output was truncated"),
+      _meta: z
+        .object({
+          backgroundJobId: z.string(),
+          // Optional: results persisted before this field existed have no path.
+          outputFile: z.string().optional(),
+        })
+        .optional()
+        .describe(
+          "Metadata removed before sending the result to the LLM and used to render a background command in the UI.",
+        ),
+    }),
+  };
+}
 
 export function createBackgroundCommandResult(
   backgroundJobId: string,
   outputFile: string,
 ) {
   return {
-    output: `Background command started with ID "${backgroundJobId}". Output is being written to "${outputFile}"; use readFile to read it.`,
+    output: `Background command "${backgroundJobId}" started. Its output is written to "${outputFile}". Do not infer job status from empty or partial output, and do not sleep or poll. Continue independent work, or use attemptCompletion if nothing else remains. After the completion notification resumes the task with its final status, read the output file if needed.`,
     isTruncated: false,
-    _meta: { backgroundJobId },
+    _meta: { backgroundJobId, outputFile },
   };
 }
 
-export const executeCommand = defineClientTool(toolDef);
+export function createExecuteCommandTool(isSubTask = false) {
+  return defineClientTool(createToolDef(isSubTask));
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -18,7 +18,7 @@ import { applyDiff } from "./apply-diff";
 import { askFollowupQuestion } from "./ask-followup-question";
 import { createAttemptCompletionTool } from "./attempt-completion";
 import { createReview } from "./create-review";
-import { executeCommand } from "./execute-command";
+import { createExecuteCommandTool } from "./execute-command";
 import { globFiles } from "./glob-files";
 import { listFiles } from "./list-files";
 import type { multiApplyDiff } from "./multi-apply-diff";
@@ -139,6 +139,7 @@ export interface CreateClientToolOptions {
   contentType?: string[];
   attemptCompletionSchema?: z.ZodType;
   agent?: CustomAgent;
+  isSubTask?: boolean;
 }
 
 const HiddenNewTaskAgentNames = new Set(["attemptTodoCompletion"]);
@@ -155,7 +156,7 @@ const createCliTools = (options?: CreateClientToolOptions) => ({
   attemptCompletion: createAttemptCompletionTool(
     options?.attemptCompletionSchema,
   ),
-  executeCommand,
+  executeCommand: createExecuteCommandTool(options?.isSubTask),
   globFiles,
   listFiles,
   readFile: createReadFileTool(options?.contentType),
@@ -252,10 +253,10 @@ export const selectAgentTools = (
   options: SelectAgentToolsOptions,
 ): AgentTools => {
   const { agent, mcpTools, isSubTask, ...toolOptions } = options;
-  const allowList = getAgentToolAllowList(agent, options.isSubTask);
+  const allowList = getAgentToolAllowList(agent, isSubTask);
 
   const avaliableTools: AgentTools = {
-    ...createClientTools(toolOptions),
+    ...createClientTools({ ...toolOptions, isSubTask }),
     ...(mcpTools ?? {}),
   };
 

--- a/packages/vscode-webui/src/features/tools/__stories__/tool-gallery.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/tool-gallery.stories.tsx
@@ -131,10 +131,11 @@ const executeCommandBackgroundProps: ExecuteCommandProp["tool"] = {
   },
   output: {
     output:
-      'Background command started with ID "bgjob-cmd-123". Output is being written to "/tmp/bgjob-cmd-123.log"; use readFile to read it.',
+      'Background command "bgjob-cmd-123" started. Its output is written to "/tmp/bgjob-cmd-123.log". Do not infer job status from empty or partial output, and do not sleep or poll. Continue independent work, or use attemptCompletion if nothing else remains. After the completion notification resumes the task with its final status, read the output file if needed.',
     isTruncated: false,
     _meta: {
       backgroundJobId: "bgjob-cmd-123",
+      outputFile: "/tmp/bgjob-cmd-123.log",
     },
   },
 };

--- a/packages/vscode-webui/src/features/tools/components/__tests__/execute-command.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/execute-command.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { executeCommandTool as ExecuteCommandTool } from "../execute-command";
+
+vi.mock("@/features/chat", () => ({
+  useToolCallLifeCycle: () => ({
+    getToolCallLifeCycle: () => ({
+      abort: vi.fn(),
+      streamingResult: undefined,
+    }),
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("../status-icon", () => ({
+  StatusIcon: () => <div data-testid="status-icon" />,
+}));
+
+vi.mock("../tool-container", () => ({
+  ExpandableToolContainer: ({
+    title,
+    detail,
+  }: {
+    title: React.ReactNode;
+    detail?: React.ReactNode;
+  }) => (
+    <div>
+      {title}
+      {detail}
+    </div>
+  ),
+}));
+
+vi.mock("../command-execution-panel", () => ({
+  BackgroundJobPanel: ({
+    backgroundJobId,
+    outputFile,
+  }: {
+    backgroundJobId: string;
+    outputFile?: string;
+  }) => (
+    <div
+      data-testid="background-job-panel"
+      data-job-id={backgroundJobId}
+      data-output-file={outputFile}
+    />
+  ),
+  CommandExecutionPanel: () => null,
+  CommandPanelContainer: () => null,
+  CopyCommandButton: () => null,
+}));
+
+describe("executeCommandTool", () => {
+  it("passes a background command output file to the job panel", () => {
+    render(
+      <ExecuteCommandTool
+        tool={{
+          type: "tool-executeCommand",
+          toolCallId: "execute-call",
+          state: "output-available",
+          input: {
+            command: "bun run dev",
+            cwd: "/workspace",
+            background: true,
+            timeout: 60,
+          },
+          output: {
+            output: "Background command started",
+            isTruncated: false,
+            _meta: {
+              backgroundJobId: "bgjob-cmd-test",
+              outputFile: "/tmp/bgjob-cmd-test.log",
+            },
+          },
+        }}
+        isExecuting={false}
+        isLoading={false}
+        messages={[]}
+      />,
+    );
+
+    const panel = screen.getByTestId("background-job-panel");
+    expect(panel.dataset.jobId).toBe("bgjob-cmd-test");
+    expect(panel.dataset.outputFile).toBe("/tmp/bgjob-cmd-test.log");
+  });
+});

--- a/packages/vscode-webui/src/features/tools/components/__tests__/legacy-background-tools.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/legacy-background-tools.test.tsx
@@ -19,11 +19,17 @@ vi.mock("../command-execution-panel", () => ({
   BackgroundJobPanel: ({
     backgroundJobId,
     command,
+    outputFile,
   }: {
     backgroundJobId: string;
     command?: string;
+    outputFile?: string;
   }) => (
-    <div data-command={command} data-testid="background-job-panel">
+    <div
+      data-command={command}
+      data-output-file={outputFile}
+      data-testid="background-job-panel"
+    >
       {backgroundJobId}
     </div>
   ),
@@ -78,6 +84,9 @@ describe("legacy background tool renderers", () => {
     );
     expect(screen.getByTestId("background-job-panel").dataset.command).toBe(
       "npm run dev",
+    );
+    expect(screen.getByTestId("background-job-panel").dataset.outputFile).toBe(
+      "/tmp/legacy-job.log",
     );
   });
 

--- a/packages/vscode-webui/src/features/tools/components/__tests__/read-file.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/read-file.test.tsx
@@ -36,17 +36,20 @@ vi.mock("../command-execution-panel", () => ({
   BackgroundJobPanel: ({
     backgroundJobId,
     output,
+    outputFile,
     terminalName,
     lastCommand,
   }: {
     backgroundJobId: string;
     output?: string;
+    outputFile?: string;
     terminalName?: string;
     lastCommand?: string;
   }) => (
     <div
       data-testid="background-job-panel"
       data-job-id={backgroundJobId}
+      data-output-file={outputFile}
       data-terminal-name={terminalName}
       data-last-command={lastCommand}
     >
@@ -153,6 +156,9 @@ describe("readFileTool", () => {
     expect(
       getByTestId("background-job-panel").getAttribute("data-job-id"),
     ).toBe("bgjob-cmd-test");
+    expect(
+      getByTestId("background-job-panel").getAttribute("data-output-file"),
+    ).toBe("pochi://~/background-jobs/bgjob-cmd-test.log");
     expect(getByTestId("background-job-panel").textContent).toBe("job output");
   });
 

--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -407,20 +407,20 @@ const BackgroundJobStatus: FC<{
 
 const OpenOutputFileButton: FC<{ outputFile: string }> = ({ outputFile }) => {
   const { t } = useTranslation();
+  const label = t("backgroundJobNotifications.openOutput");
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
           size="xs"
           variant="ghost"
+          aria-label={label}
           onClick={() => vscodeHost.openFile(outputFile)}
         >
           <FileText className="size-4" />
         </Button>
       </TooltipTrigger>
-      <TooltipContent>
-        {t("backgroundJobNotifications.openOutput")}
-      </TooltipContent>
+      <TooltipContent>{label}</TooltipContent>
     </Tooltip>
   );
 };

--- a/packages/vscode-webui/src/features/tools/components/execute-command.tsx
+++ b/packages/vscode-webui/src/features/tools/components/execute-command.tsx
@@ -54,10 +54,8 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
   }
 
   if (background) {
-    const backgroundJobId =
-      tool.state === "output-available"
-        ? tool.output._meta?.backgroundJobId
-        : undefined;
+    const backgroundJobMetadata =
+      tool.state === "output-available" ? tool.output._meta : undefined;
     const availableCommand =
       tool.state === "input-available" || tool.state === "output-available"
         ? tool.input.command
@@ -67,8 +65,11 @@ export const executeCommandTool: React.FC<ToolProps<"executeCommand">> = ({
       <ExpandableToolContainer
         title={title}
         detail={
-          backgroundJobId ? (
-            <BackgroundJobPanel backgroundJobId={backgroundJobId} />
+          backgroundJobMetadata ? (
+            <BackgroundJobPanel
+              backgroundJobId={backgroundJobMetadata.backgroundJobId}
+              outputFile={backgroundJobMetadata.outputFile}
+            />
           ) : availableCommand ? (
             <CommandPanelContainer
               icon={<TerminalIcon className="mt-[2px] size-4 flex-shrink-0" />}

--- a/packages/vscode-webui/src/features/tools/components/read-file.tsx
+++ b/packages/vscode-webui/src/features/tools/components/read-file.tsx
@@ -63,6 +63,7 @@ export const readFileTool: React.FC<ToolProps<"readFile">> = ({
             <BackgroundJobPanel
               backgroundJobId={finalJobId}
               output={output}
+              outputFile={path}
               terminalName={terminalName}
               lastCommand={lastCommand}
             />

--- a/packages/vscode-webui/src/features/tools/components/start-background-job.tsx
+++ b/packages/vscode-webui/src/features/tools/components/start-background-job.tsx
@@ -21,8 +21,8 @@ export const StartBackgroundJobTool: React.FC<
       ? tool.input.command
       : undefined;
 
-  const backgroundJobId =
-    tool.state === "output-available" ? tool.output.backgroundJobId : undefined;
+  const backgroundJob =
+    tool.state === "output-available" ? tool.output : undefined;
 
   const cwdNode = cwd ? (
     <span>
@@ -44,10 +44,11 @@ export const StartBackgroundJobTool: React.FC<
     <ExpandableToolContainer
       title={title}
       detail={
-        backgroundJobId ? (
+        backgroundJob ? (
           <BackgroundJobPanel
-            backgroundJobId={backgroundJobId}
+            backgroundJobId={backgroundJob.backgroundJobId}
             command={command}
+            outputFile={backgroundJob.outputFile}
           />
         ) : command ? (
           <CommandPanelContainer

--- a/packages/vscode-webui/src/lib/vscode.ts
+++ b/packages/vscode-webui/src/lib/vscode.ts
@@ -240,7 +240,7 @@ function createVSCodeHost(): VSCodeHostApi {
           if (status !== "completed") {
             return {
               content:
-                "The task is currently running. You can continue with other operations while it executes in the background. If you need to wait for the task to complete, you can use the `executeCommand` tool with `sleep`.",
+                "The task is currently running. Do not wait for or poll it; continue with other work until its completion notification arrives.",
               status,
               isTruncated: false,
             };

--- a/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
@@ -59,10 +59,14 @@ function createHarness(options?: { read?: () => AsyncIterable<string> }) {
   const shellIntegration: FakeShellIntegration = {
     executeCommand: () => execution,
   };
+  let terminalDisposeCalls = 0;
   const terminal: FakeTerminal = {
     shellIntegration,
     show: () => {},
-    dispose: () => closeEmitter.fire(terminal),
+    dispose: () => {
+      terminalDisposeCalls++;
+      closeEmitter.fire(terminal);
+    },
   };
   const finalizeCalls: Array<TestExecutionError | undefined> = [];
   const lifecycle: string[] = [];
@@ -154,6 +158,9 @@ function createHarness(options?: { read?: () => AsyncIterable<string> }) {
     job,
     lifecycle,
     terminal,
+    get terminalDisposeCalls() {
+      return terminalDisposeCalls;
+    },
   };
 }
 
@@ -172,26 +179,24 @@ interface FakeTerminal {
 }
 
 describe("TerminalJob", () => {
-  it("keeps a completed job registered until its terminal closes", async () => {
-    const {
-      TerminalJob,
-      execution,
-      executionEndEmitter,
-      finalizeCalls,
-      finishEvents,
-      job,
-      lifecycle,
-      terminal,
-    } = createHarness();
+  it("closes the terminal after a background command completes", async () => {
+    const harness = createHarness();
 
     await flushPromises();
-    executionEndEmitter.fire({ execution, exitCode: 0 });
+    harness.executionEndEmitter.fire({
+      execution: harness.execution,
+      exitCode: 0,
+    });
     await flushPromises();
 
-    assert.strictEqual(finalizeCalls.length, 1);
-    assert.strictEqual(finalizeCalls[0], undefined);
-    assert.deepStrictEqual(lifecycle, ["file-closed", "event-fired"]);
-    assert.deepStrictEqual(finishEvents, [
+    assert.strictEqual(harness.finalizeCalls.length, 1);
+    assert.strictEqual(harness.finalizeCalls[0], undefined);
+    assert.deepStrictEqual(harness.lifecycle, [
+      "output:$ sleep 10\n",
+      "file-closed",
+      "event-fired",
+    ]);
+    assert.deepStrictEqual(harness.finishEvents, [
       {
         taskId: "task-test",
         backgroundJobId: "bgjob-cmd-test",
@@ -199,16 +204,11 @@ describe("TerminalJob", () => {
         status: "completed",
         command: "sleep 10",
         exitCode: 0,
-        finishedAt: finishEvents[0]?.finishedAt,
+        finishedAt: harness.finishEvents[0]?.finishedAt,
       },
     ]);
-    assert.strictEqual(TerminalJob.get(job.id), job);
-
-    terminal.dispose();
-    await flushPromises();
-
-    assert.strictEqual(TerminalJob.get(job.id), undefined);
-    assert.strictEqual(finalizeCalls.length, 1);
+    assert.strictEqual(harness.terminalDisposeCalls, 1);
+    assert.strictEqual(harness.TerminalJob.get(harness.job.id), undefined);
   });
 
   it("finalizes a running job when its terminal closes", async () => {
@@ -246,13 +246,14 @@ describe("TerminalJob", () => {
     await flushPromises();
 
     assert.strictEqual(harness.finishEvents.length, 0);
-    assert.deepStrictEqual(harness.lifecycle, []);
+    assert.deepStrictEqual(harness.lifecycle, ["output:$ sleep 10\n"]);
 
     releaseOutput?.();
     await flushPromises();
     await flushPromises();
 
     assert.deepStrictEqual(harness.lifecycle, [
+      "output:$ sleep 10\n",
       "output:failure details",
       "file-closed",
       "event-fired",
@@ -261,7 +262,7 @@ describe("TerminalJob", () => {
     assert.strictEqual(harness.finishEvents[0]?.exitCode, 1);
   });
 
-  it("notifies when a background command fails without output", async () => {
+  it("notifies when a background command fails without command output", async () => {
     const harness = createHarness();
 
     await flushPromises();
@@ -272,7 +273,11 @@ describe("TerminalJob", () => {
     await flushPromises();
 
     assert.strictEqual(harness.finalizeCalls.length, 1);
-    assert.deepStrictEqual(harness.lifecycle, ["file-closed", "event-fired"]);
+    assert.deepStrictEqual(harness.lifecycle, [
+      "output:$ sleep 10\n",
+      "file-closed",
+      "event-fired",
+    ]);
     assert.strictEqual(harness.finishEvents.length, 1);
     assert.strictEqual(harness.finishEvents[0]?.status, "failed");
     assert.strictEqual(harness.finishEvents[0]?.exitCode, 2);
@@ -280,5 +285,7 @@ describe("TerminalJob", () => {
       harness.finishEvents[0]?.error ?? "",
       /exited with code 2/,
     );
+    assert.strictEqual(harness.terminalDisposeCalls, 1);
+    assert.strictEqual(harness.TerminalJob.get(harness.job.id), undefined);
   });
 });

--- a/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
@@ -260,4 +260,25 @@ describe("TerminalJob", () => {
     assert.strictEqual(harness.finishEvents[0]?.status, "failed");
     assert.strictEqual(harness.finishEvents[0]?.exitCode, 1);
   });
+
+  it("notifies when a background command fails without output", async () => {
+    const harness = createHarness();
+
+    await flushPromises();
+    harness.executionEndEmitter.fire({
+      execution: harness.execution,
+      exitCode: 2,
+    });
+    await flushPromises();
+
+    assert.strictEqual(harness.finalizeCalls.length, 1);
+    assert.deepStrictEqual(harness.lifecycle, ["file-closed", "event-fired"]);
+    assert.strictEqual(harness.finishEvents.length, 1);
+    assert.strictEqual(harness.finishEvents[0]?.status, "failed");
+    assert.strictEqual(harness.finishEvents[0]?.exitCode, 2);
+    assert.match(
+      harness.finishEvents[0]?.error ?? "",
+      /exited with code 2/,
+    );
+  });
 });

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -98,10 +98,8 @@ export class TerminalJob implements vscode.Disposable {
       this.rejectTerminalClosed = reject;
     });
 
-    // Keep the job registered (and thus its terminal <-> backgroundJobId
-    // association) alive as long as the terminal is open, so the UI can keep
-    // highlighting the active terminal and jump to it even after the command
-    // has finished executing.
+    // Keep the terminal and job lifecycle synchronized when the user closes
+    // the terminal before execution finishes.
     this.closeListener = vscode.window.onDidCloseTerminal((terminal) => {
       if (terminal === this.terminal) {
         this.stopRequested = true;
@@ -127,6 +125,8 @@ export class TerminalJob implements vscode.Disposable {
   async execute(): Promise<void> {
     let executionError: ExecutionError | undefined;
     try {
+      await this.outputWriter.append(`$ ${this.config.command}\n`);
+
       // Wait for shell integration if not available
       const shellIntegration = await Promise.race([
         this.waitForShellIntegration(),
@@ -167,15 +167,12 @@ export class TerminalJob implements vscode.Disposable {
       }
       this.outputManager.finalize(executionError);
       await this.finish(executionError);
-      // Only tear down the execution-scoped listeners here. The job itself
-      // stays registered until the terminal is closed (see closeListener),
-      // so the UI can still highlight and reopen the terminal.
       this.cleanupExecution();
     }
   }
 
   /**
-   * Dispose of the execution-scoped listeners while keeping the job registered.
+   * Dispose of execution-scoped listeners.
    */
   private cleanupExecution(): void {
     for (const d of this.disposables) {
@@ -384,5 +381,10 @@ export class TerminalJob implements vscode.Disposable {
       ...(finalError ? { error: finalError.message } : {}),
       finishedAt: Date.now(),
     });
+
+    if (!this.disposed) {
+      this.terminal.dispose();
+      this.dispose();
+    }
   }
 }

--- a/packages/vscode/src/tools/__test__/execute-command.test.ts
+++ b/packages/vscode/src/tools/__test__/execute-command.test.ts
@@ -12,7 +12,6 @@ type SignalValue = {
 
 describe("executeCommand Tool", () => {
   it("persists failed command output before completing", async () => {
-    const clock = sinon.useFakeTimers();
     const maybePersistToolResult = sinon.stub().resolves({
       output: "persisted preview",
       isTruncated: true,
@@ -26,99 +25,95 @@ describe("executeCommand Tool", () => {
       throw new Error("Command exited with code 1");
     });
 
-    try {
-      const { executeCommand } = proxyquire.noCallThru().load(
-        "../execute-command",
-        {
-          "@/integrations/layout": {
-            getViewColumnForTerminal: sinon.stub(),
-          },
-          "@/integrations/terminal/terminal-job": {
-            TerminalJob: { create: sinon.stub() },
-          },
-          "@/lib/background-job-terminal-name": {
-            getBackgroundJobTerminalName: sinon.stub(),
-          },
-          "@getpochi/common": {
-            getLogger: () => ({
-              warn: sinon.stub(),
+    const { executeCommand } = proxyquire.noCallThru().load(
+      "../execute-command",
+      {
+        "@/integrations/layout": {
+          getViewColumnForTerminal: sinon.stub(),
+        },
+        "@/integrations/terminal/terminal-job": {
+          TerminalJob: { create: sinon.stub() },
+        },
+        "@/lib/background-job-terminal-name": {
+          getBackgroundJobTerminalName: sinon.stub(),
+        },
+        "@getpochi/common": {
+          getLogger: () => ({
+            warn: sinon.stub(),
+          }),
+        },
+        "@getpochi/common/tool-utils": {
+          getShellPath: () => undefined,
+          maybePersistToolResult,
+        },
+        "@getpochi/tools": {
+          validateExecuteCommandRules: sinon.stub(),
+        },
+        "@quilted/threads/signals": {
+          ThreadSignal: {
+            serialize: (signal: {
+              value: SignalValue;
+              subscribe: (subscriber: (value: SignalValue) => void) => () => void;
+            }) => ({
+              get value() {
+                return signal.value;
+              },
+              start(subscriber: (value: SignalValue) => void) {
+                return signal.subscribe(subscriber);
+              },
             }),
           },
-          "@getpochi/common/tool-utils": {
-            getShellPath: () => undefined,
-            maybePersistToolResult,
-          },
-          "@getpochi/tools": {
-            validateExecuteCommandRules: sinon.stub(),
-          },
-          "@quilted/threads/signals": {
-            ThreadSignal: {
-              serialize: (signal: {
-                value: SignalValue;
-                subscribe: (subscriber: (value: SignalValue) => void) => () => void;
-              }) => ({
-                get value() {
-                  return signal.value;
-                },
-                start(subscriber: (value: SignalValue) => void) {
-                  return signal.subscribe(subscriber);
-                },
-              }),
-            },
-          },
-          "../integrations/terminal/execute-command-with-node": {
-            executeCommandWithNode,
-          },
-          "../integrations/terminal/execute-command-with-pty": {
-            PtySpawnError: class PtySpawnError extends Error {},
-            executeCommandWithPty: sinon.stub(),
-          },
         },
-      ) as typeof import("../execute-command");
-
-      const resultPromise = executeCommand(
-        { command: "false" },
-        {
-          abortSignal: new AbortController().signal,
-          cwd: process.cwd(),
-          messages: [],
-          toolCallId: "call-1",
-          taskId: "task-1",
+        "../integrations/terminal/execute-command-with-node": {
+          executeCommandWithNode,
         },
-      );
-
-      const result = await resultPromise;
-      const values: unknown[] = [];
-      (
-        (result as unknown as { streamingOutput: unknown }).streamingOutput as {
-          start: (subscriber: (value: SignalValue) => void) => () => void;
-        }
-      ).start((value) => {
-        values.push(value);
-      });
-      await clock.runAllAsync();
-
-      assert.ok(maybePersistToolResult.calledOnce);
-      assert.deepStrictEqual(maybePersistToolResult.firstCall.args, [
-        "executeCommand",
-        "call-1",
-        "task-1",
-        {
-          output: "raw noisy output",
-          isTruncated: true,
-          error: "Command exited with code 1",
+        "../integrations/terminal/execute-command-with-pty": {
+          PtySpawnError: class PtySpawnError extends Error {},
+          executeCommandWithPty: sinon.stub(),
         },
-      ]);
+      },
+    ) as typeof import("../execute-command");
 
-      assert.deepStrictEqual(values.at(-1), {
-        content: "persisted preview",
-        status: "completed",
+    const resultPromise = executeCommand(
+      { command: "false" },
+      {
+        abortSignal: new AbortController().signal,
+        cwd: process.cwd(),
+        messages: [],
+        toolCallId: "call-1",
+        taskId: "task-1",
+      },
+    );
+
+    const result = await resultPromise;
+    const values: unknown[] = [];
+    (
+      (result as unknown as { streamingOutput: unknown }).streamingOutput as {
+        start: (subscriber: (value: SignalValue) => void) => () => void;
+      }
+    ).start((value) => {
+      values.push(value);
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.ok(maybePersistToolResult.calledOnce);
+    assert.deepStrictEqual(maybePersistToolResult.firstCall.args, [
+      "executeCommand",
+      "call-1",
+      "task-1",
+      {
+        output: "raw noisy output",
         isTruncated: true,
         error: "Command exited with code 1",
-      });
-    } finally {
-      clock.restore();
-    }
+      },
+    ]);
+
+    assert.deepStrictEqual(values.at(-1), {
+      content: "persisted preview",
+      status: "completed",
+      isTruncated: true,
+      error: "Command exited with code 1",
+    });
   });
 
   it("cancels pending throttled output after completion", async () => {
@@ -272,10 +267,11 @@ describe("executeCommand Tool", () => {
 
     assert.deepStrictEqual(result, {
       output:
-        'Background command started with ID "bgjob-cmd-test". Output is being written to "/tmp/bgjob-cmd-test.log"; use readFile to read it.',
+        'Background command "bgjob-cmd-test" started. Its output is written to "/tmp/bgjob-cmd-test.log". Do not infer job status from empty or partial output, and do not sleep or poll. Continue independent work, or use attemptCompletion if nothing else remains. After the completion notification resumes the task with its final status, read the output file if needed.',
       isTruncated: false,
       _meta: {
         backgroundJobId: "bgjob-cmd-test",
+        outputFile: "/tmp/bgjob-cmd-test.log",
       },
     });
     assert.ok(


### PR DESCRIPTION
## Summary
- separate background command lifecycle status from captured output so empty or partial logs cannot trigger polling or sleeps
- preserve output-file paths for model diagnostics and UI access after the authoritative completion notification
- prevent subtasks from starting detached commands and add zero-output failure coverage

## Test plan
- [x] `bun run test -- src/base/__tests__/background-job-notification.test.ts` (packages/common)
- [x] `bun run test -- src/__test__/execute-command.test.ts src/__test__/select-agent-tools.test.ts` (packages/tools)
- [x] `bun run test -- --grep "executeCommand Tool"` (packages/vscode)
- [x] focused VS Code WebUI component tests
- [x] `bun check`
- [x] `bun tsc`
- [ ] `bun turbo test:integration` — blocked before WDIO startup by the existing nested `minimatch` / `brace-expansion` default-export dependency error

🤖 Generated with [Pochi](https://getpochi.com)