### PR TITLE
feat(vscode-webui): implement message list pagination to prevent OOM

### DIFF
--- a/packages/vscode-webui/src/__stories__/perf/__tests__/perf-data.test.ts
+++ b/packages/vscode-webui/src/__stories__/perf/__tests__/perf-data.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  appendTaskHistoryTurn,
   makeAddedFilePatch,
   makeFileMatches,
   makeReplaceFilePatch,
+  makeTaskHistoryMessages,
   makeWriteToFileTool,
+  summarizeMessageRange,
+  summarizeTaskHistory,
+  updateTaskHistoryStream,
 } from "../perf-data";
 
 describe("perf data", () => {
@@ -50,5 +55,118 @@ describe("perf data", () => {
     expect(input.content).toContain("| Area | Signal | Expected impact |");
     expect(input.content.split("\n")).toHaveLength(20);
     expect(output._meta.edit).toContain("```json");
+  });
+
+  it("creates task history with varied assistant parts", () => {
+    const messages = makeTaskHistoryMessages({
+      messageCount: 4,
+      assistantPartsPerMessage: 30,
+      partTextLength: 40,
+    });
+
+    expect(messages.map((message) => [message.role, message.parts.length]))
+      .toEqual([
+        ["user", 1],
+        ["assistant", 30],
+        ["user", 1],
+        ["assistant", 30],
+      ]);
+    const assistantParts = messages[1].parts;
+    expect(assistantParts.filter((part) => part.type === "reasoning"))
+      .toHaveLength(6);
+    expect(
+      new Set(
+        assistantParts
+          .filter((part) => part.type.startsWith("tool-"))
+          .map((part) => part.type),
+      ),
+    ).toEqual(
+      new Set([
+        "tool-readFile",
+        "tool-executeCommand",
+        "tool-searchFiles",
+        "tool-listFiles",
+        "tool-globFiles",
+        "tool-writeToFile",
+      ]),
+    );
+    expect(assistantParts.at(-1)?.type).toBe("text");
+  });
+
+  it("appends one deterministic user and assistant turn", () => {
+    const original = makeTaskHistoryMessages({
+      messageCount: 2,
+      assistantPartsPerMessage: 30,
+      partTextLength: 32,
+    });
+
+    const next = appendTaskHistoryTurn(original, {
+      assistantPartsPerMessage: 30,
+      partTextLength: 32,
+      turnIndex: 7,
+    });
+
+    expect(next.slice(0, 2)).toEqual(original);
+    expect(next.slice(2).map(({ id, role }) => ({ id, role }))).toEqual([
+      { id: "task-history-turn-7-user", role: "user" },
+      { id: "task-history-turn-7-assistant", role: "assistant" },
+    ]);
+  });
+
+  it("replaces only the streaming assistant message through one snapshot", () => {
+    const original = makeTaskHistoryMessages({
+      messageCount: 2,
+      assistantPartsPerMessage: 30,
+      partTextLength: 32,
+    });
+    const originalLastTextPart = original[1].parts.findLast(
+      (part) => part.type === "text",
+    );
+    if (!originalLastTextPart) {
+      throw new Error("Expected assistant text parts");
+    }
+    let snapshots = 0;
+
+    const next = updateTaskHistoryStream(original, {
+      updateIndex: 3,
+      chunkSize: 12,
+      snapshot: (message) => {
+        snapshots += 1;
+        return structuredClone(message);
+      },
+    });
+
+    const nextLastTextPart = next[1].parts.findLast(
+      (part) => part.type === "text",
+    );
+    if (!nextLastTextPart) {
+      throw new Error("Expected updated assistant text parts");
+    }
+    expect(snapshots).toBe(1);
+    expect(next[0]).toBe(original[0]);
+    expect(nextLastTextPart.state).toBe("streaming");
+    expect(nextLastTextPart.text).toHaveLength(
+      originalLastTextPart.text.length + 12,
+    );
+  });
+
+  it("summarizes full and mounted message data", () => {
+    const messages = makeTaskHistoryMessages({
+      messageCount: 4,
+      assistantPartsPerMessage: 30,
+      partTextLength: 40,
+    });
+
+    const summary = summarizeTaskHistory(messages);
+
+    expect(summary.messageCount).toBe(4);
+    expect(summary.partCount).toBe(62);
+    expect(summary.serializedBytes).toBeGreaterThan(0);
+    expect(summarizeMessageRange(messages, 2)).toEqual({
+      inputMessageCount: 4,
+      inputPartCount: 62,
+      mountedMessageCount: 2,
+      mountedPartCount: 31,
+    });
   });
 });

--- a/packages/vscode-webui/src/__stories__/perf/__tests__/perf-harness.test.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/__tests__/perf-harness.test.tsx
@@ -1,10 +1,11 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useEffect, useRef, useState } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   ComparisonPanel,
   MeasuredProfiler,
   PerfPanel,
+  readUsedJsHeapBytes,
   useAutoMeasureOnMount,
   usePerfHarness,
   waitForPerfElementCount,
@@ -265,7 +266,37 @@ function AsyncMeasureActionProbe() {
   );
 }
 
+function PipelineMetricsProbe() {
+  const perf = usePerfHarness();
+
+  return (
+    <div>
+      <PerfPanel recordsRef={perf.recordsRef} onClear={perf.clear} />
+      <button
+        type="button"
+        onClick={() => {
+          void perf.measureAction("stream tick", () => {}, {
+            metrics: () => ({
+              structuredCloneMs: 12.3,
+              formatterMs: 45.6,
+            }),
+          });
+        }}
+      >
+        Run pipeline metrics
+      </button>
+    </div>
+  );
+}
+
 describe("perf harness", () => {
+  it("reads Chromium heap usage when available and otherwise returns undefined", () => {
+    expect(readUsedJsHeapBytes({ memory: { usedJSHeapSize: 12_345 } })).toBe(
+      12_345,
+    );
+    expect(readUsedJsHeapBytes({})).toBeUndefined();
+  });
+
   it("does not update the profiled story from profiler records", async () => {
     render(<HarnessProbe />);
 
@@ -274,6 +305,15 @@ describe("perf harness", () => {
     });
 
     expect(document.body.textContent).toContain("profiled content");
+  });
+
+  it("keeps metric columns readable in a compact scroll viewport", () => {
+    render(<HarnessProbe />);
+
+    const table = screen.getByRole("table");
+    expect(table.className).toContain("min-w-[1200px]");
+    expect(table.parentElement?.className).toContain("max-h-32");
+    expect(table.parentElement?.className).toContain("overflow-auto");
   });
 
   it("does not show comparison rows from profiler mount records", async () => {
@@ -367,6 +407,7 @@ describe("perf harness", () => {
 
   it("waits for element counts to stabilize before resolving", async () => {
     const root = document.createElement("div");
+    const querySelectorAll = vi.spyOn(root, "querySelectorAll");
     const waiting = waitForStablePerfElementCount(
       { current: root },
       {
@@ -384,7 +425,8 @@ describe("perf harness", () => {
     }, 40);
 
     await expect(waiting).resolves.toBe(true);
-    expect(root.querySelectorAll("*").length).toBe(3);
+    expect(root.children.length).toBe(3);
+    expect(querySelectorAll).not.toHaveBeenCalled();
   });
 
   it("waits for async action settling before recording final node counts", async () => {
@@ -397,5 +439,16 @@ describe("perf harness", () => {
     });
 
     expect(screen.getByText("0->2")).toBeTruthy();
+  });
+
+  it("shows structured clone and formatter timings", async () => {
+    render(<PipelineMetricsProbe />);
+
+    fireEvent.click(screen.getByText("Run pipeline metrics"));
+
+    expect(screen.getByText("clone")).toBeTruthy();
+    expect(screen.getByText("format")).toBeTruthy();
+    expect(await screen.findByText("12.3")).toBeTruthy();
+    expect(screen.getByText("45.6")).toBeTruthy();
   });
 });

--- a/packages/vscode-webui/src/__stories__/perf/__tests__/task-history.perf.stories.test.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/__tests__/task-history.perf.stories.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import taskHistoryMeta, {
+  Full,
+  Paged,
+  TaskHistoryPerfStory,
+} from "../task-history.perf.stories";
+
+const mocks = vi.hoisted(() => ({
+  useScrollToBottom: vi.fn(),
+}));
+
+vi.mock("@getpochi/common", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@getpochi/common")>();
+  return {
+    ...original,
+    formatters: { ui: <T,>(messages: T) => messages },
+  };
+});
+
+vi.mock("../../../features/chat/components/chat-area", () => ({
+  ChatArea: (props: {
+    messages: Array<{ id: string }>;
+    messagesContainerRef?: React.RefObject<HTMLDivElement | null>;
+  }) => (
+    <div ref={props.messagesContainerRef} data-testid="chat-area">
+      {props.messages.map((message) => (
+        <div key={message.id}>{message.id}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../../../features/chat/hooks/use-scroll-to-bottom", () => ({
+  useScrollToBottom: mocks.useScrollToBottom,
+}));
+
+describe("TaskHistory performance story", () => {
+  beforeEach(() => {
+    mocks.useScrollToBottom.mockReset();
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("uses the sustained long-history pressure defaults", () => {
+    expect(taskHistoryMeta.args).toMatchObject({
+      initialMessageCount: 300,
+      assistantPartsPerMessage: 30,
+      streamChunkSize: 32,
+      streamIntervalMs: 50,
+    });
+    expect(Full.args?.renderAllMessages).toBe(true);
+    expect(Paged.args?.renderAllMessages).toBe(false);
+  });
+
+  it("makes append and stream updates visible and wires task auto-scroll", async () => {
+    renderStory();
+
+    fireEvent.click(screen.getByRole("button", { name: "Append turn" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-history-message-count").textContent).toBe(
+        "6",
+      );
+    });
+    expect(
+      mocks.useScrollToBottom.mock.calls.some(
+        ([options]) => options.lastUserMessageId === "task-history-turn-2-user",
+      ),
+    ).toBe(true);
+    expect(
+      await screen.findByText("append user + assistant turn", undefined, {
+        timeout: 2_000,
+      }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Stream tick" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-history-update-count").textContent).toBe(
+        "1",
+      );
+    });
+    expect(
+      await screen.findByText("assistant stream tick", undefined, {
+        timeout: 2_000,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("settles an in-flight stream measurement when the story unmounts", async () => {
+    let animationFrameCallCount = 0;
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      animationFrameCallCount += 1;
+      return window.setTimeout(() => callback(performance.now()), 16);
+    });
+    const view = renderStory();
+
+    fireEvent.click(screen.getByRole("button", { name: "Stream tick" }));
+    view.unmount();
+
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
+    const settledCallCount = animationFrameCallCount;
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
+
+    expect(animationFrameCallCount).toBe(settledCallCount);
+  });
+});
+
+function renderStory() {
+  return render(
+    <TaskHistoryPerfStory
+      initialMessageCount={4}
+      assistantPartsPerMessage={10}
+      partTextLength={20}
+      streamChunkSize={8}
+      streamIntervalMs={250}
+    />,
+  );
+}

--- a/packages/vscode-webui/src/__stories__/perf/__tests__/task-history.perf.stories.test.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/__tests__/task-history.perf.stories.test.tsx
@@ -56,6 +56,12 @@ describe("TaskHistory performance story", () => {
   it("makes append and stream updates visible and wires task auto-scroll", async () => {
     renderStory();
 
+    expect(
+      mocks.useScrollToBottom.mock.calls.some(
+        ([options]) => options.lastUserMessageId === "task-history-message-2",
+      ),
+    ).toBe(true);
+
     fireEvent.click(screen.getByRole("button", { name: "Append turn" }));
 
     await waitFor(() => {

--- a/packages/vscode-webui/src/__stories__/perf/message-list.perf.stories.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/message-list.perf.stories.tsx
@@ -1,63 +1,113 @@
 import { MessageList } from "@/components/message/message-list";
+import {
+  MessageListPaginationConfig,
+  computePageStart,
+} from "@/components/message/use-message-list-pagination";
 import type { Meta, StoryObj } from "@storybook/react";
-import { useMemo, useRef, useState } from "react";
-import { makePerfMessages } from "./perf-data";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { makeTaskHistoryMessages, summarizeMessageRange } from "./perf-data";
 import {
   ComparisonPanel,
   MeasuredProfiler,
-  useAutoMeasureOnMount,
   usePerfHarness,
+  waitForNextFrame,
 } from "./perf-harness";
+
+type Variant = "Full" | "Paged";
 
 function MessageListPerfStory({
   messageCount,
-  diffEvery,
-  diffLineCount,
+  assistantPartsPerMessage,
+  partTextLength,
 }: {
   messageCount: number;
-  diffEvery: number;
-  diffLineCount: number;
+  assistantPartsPerMessage: number;
+  partTextLength: number;
 }) {
   const perf = usePerfHarness();
-  const [offMounted, setOffMounted] = useState(false);
-  const [onMounted, setOnMounted] = useState(false);
-  const [offRenderKey, setOffRenderKey] = useState(0);
-  const [onRenderKey, setOnRenderKey] = useState(0);
-  const offRef = useRef<HTMLDivElement | null>(null);
-  const onRef = useRef<HTMLDivElement | null>(null);
-  const variants: [string, string] = [
-    "ContentVisibilityOff",
-    "ContentVisibilityOn",
-  ];
+  const [activeVariant, setActiveVariant] = useState<Variant | null>(null);
+  const [renderKey, setRenderKey] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const variants: [Variant, Variant] = ["Full", "Paged"];
   const messages = useMemo(
-    () => makePerfMessages({ count: messageCount, diffEvery, diffLineCount }),
-    [messageCount, diffEvery, diffLineCount],
+    () =>
+      makeTaskHistoryMessages({
+        messageCount,
+        assistantPartsPerMessage,
+        partTextLength,
+      }),
+    [assistantPartsPerMessage, messageCount, partTextLength],
+  );
+  const pagedStart = useMemo(
+    () =>
+      computePageStart(
+        messages.map((message) => message.parts.length),
+        messages.length,
+        MessageListPaginationConfig.partBudget,
+        MessageListPaginationConfig.minInitialMessages,
+      ),
+    [messages],
+  );
+  const summaries = useMemo(
+    () => ({
+      Full: summarizeMessageRange(messages, 0),
+      Paged: summarizeMessageRange(messages, pagedStart),
+    }),
+    [messages, pagedStart],
   );
 
-  const measureBoth = async (
-    comparisonKey: string,
-    offAction: () => void,
-    onAction: () => void,
-  ) => {
-    await perf.measureAction(`${variants[0]} ${comparisonKey}`, offAction, {
-      comparisonKey,
-      variant: variants[0],
-      target: offRef.current,
-    });
-    await perf.measureAction(`${variants[1]} ${comparisonKey}`, onAction, {
-      comparisonKey,
-      variant: variants[1],
-      target: onRef.current,
-    });
+  // ChatArea normally scrolls to bottom. Do it before observing the top trigger.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: renderKey remounts the viewport
+  useLayoutEffect(() => {
+    if (activeVariant !== "Paged" || !viewportRef.current) return;
+    viewportRef.current.scrollTop = viewportRef.current.scrollHeight;
+  }, [activeVariant, renderKey]);
+
+  const waitForMessageCount = (expected: number) =>
+    waitForStableMessageCount(listRef, expected);
+
+  const unmountCurrent = async () => {
+    setActiveVariant(null);
+    await waitForMessageCount(0);
   };
 
-  useAutoMeasureOnMount(() =>
-    measureBoth(
-      "mount message list",
-      () => setOffMounted(true),
-      () => setOnMounted(true),
-    ),
-  );
+  const measureVariant = async (variant: Variant) => {
+    await unmountCurrent();
+    const expected = summaries[variant].mountedMessageCount;
+    await perf.measureAction(
+      `${variant} mount ${messageCount} messages`,
+      () => {
+        setRenderKey((current) => current + 1);
+        setActiveVariant(variant);
+      },
+      {
+        kind: "mount",
+        comparisonKey: `mount ${messageCount} messages`,
+        variant,
+        target: listRef.current,
+        afterAction: () => waitForMessageCount(expected),
+      },
+    );
+  };
+
+  const run = async (action: () => Promise<void>) => {
+    if (isRunning) return;
+    setIsRunning(true);
+    try {
+      await action();
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const runComparison = () =>
+    run(async () => {
+      perf.clear();
+      await measureVariant("Full");
+      await measureVariant("Paged");
+    });
 
   return (
     <div ref={perf.rootRef} className="flex h-[760px] flex-col p-3">
@@ -67,93 +117,123 @@ function MessageListPerfStory({
         onClear={perf.clear}
       />
       <div className="mb-2 flex flex-wrap gap-2">
-        <button
-          type="button"
-          className="rounded border px-2 py-1 text-xs disabled:opacity-50"
-          disabled={offMounted && onMounted}
-          onClick={() =>
-            measureBoth(
-              "mount message list",
-              () => setOffMounted(true),
-              () => setOnMounted(true),
-            )
-          }
+        <ActionButton disabled={isRunning} onClick={() => void runComparison()}>
+          Run Full → Paged
+        </ActionButton>
+        <ActionButton
+          disabled={isRunning}
+          onClick={() => void run(() => measureVariant("Full"))}
         >
-          Mount Both
-        </button>
-        <button
-          type="button"
-          className="rounded border px-2 py-1 text-xs disabled:opacity-50"
-          disabled={!offMounted && !onMounted}
-          onClick={() =>
-            measureBoth(
-              "unmount message list",
-              () => setOffMounted(false),
-              () => setOnMounted(false),
-            )
-          }
+          Mount Full
+        </ActionButton>
+        <ActionButton
+          disabled={isRunning}
+          onClick={() => void run(() => measureVariant("Paged"))}
         >
-          Unmount Both
-        </button>
-        <button
-          type="button"
-          className="rounded border px-2 py-1 text-xs disabled:opacity-50"
-          disabled={!offMounted || !onMounted}
-          onClick={() =>
-            measureBoth(
-              "remount message list",
-              () => setOffRenderKey((prev) => prev + 1),
-              () => setOnRenderKey((prev) => prev + 1),
-            )
-          }
+          Mount Paged
+        </ActionButton>
+        <ActionButton
+          disabled={isRunning || activeVariant === null}
+          onClick={() => void run(unmountCurrent)}
         >
-          Remount Both
-        </button>
+          Unmount
+        </ActionButton>
       </div>
-      <div className="grid min-h-0 flex-1 grid-cols-2 gap-3">
-        <section ref={offRef} className="perf-content-visibility-off min-w-0">
-          <div className="mb-1 font-medium text-muted-foreground text-xs">
-            ContentVisibilityOff
-          </div>
-          {offMounted && (
-            <MeasuredProfiler
-              id="ContentVisibilityOffMessageListPerf"
-              record={perf.record}
-            >
-              <MessageList
-                key={offRenderKey}
-                messages={messages}
-                isLoading={false}
-                className="min-h-0"
-                user={{ name: "User" }}
-                assistant={{ name: "Pochi" }}
-              />
-            </MeasuredProfiler>
-          )}
-        </section>
-        <section ref={onRef} className="min-w-0">
-          <div className="mb-1 font-medium text-muted-foreground text-xs">
-            ContentVisibilityOn
-          </div>
-          {onMounted && (
-            <MeasuredProfiler
-              id="ContentVisibilityOnMessageListPerf"
-              record={perf.record}
-            >
-              <MessageList
-                key={onRenderKey}
-                messages={messages}
-                isLoading={false}
-                className="min-h-0"
-                user={{ name: "User" }}
-                assistant={{ name: "Pochi" }}
-              />
-            </MeasuredProfiler>
-          )}
-        </section>
+      <div className="mb-2 overflow-x-auto rounded border text-xs">
+        <table className="w-full min-w-[520px] text-left">
+          <thead className="bg-muted/40">
+            <tr>
+              <th className="px-2 py-1">variant</th>
+              <th className="px-2 py-1">input messages</th>
+              <th className="px-2 py-1">input parts</th>
+              <th className="px-2 py-1">mounted messages</th>
+              <th className="px-2 py-1">mounted parts</th>
+            </tr>
+          </thead>
+          <tbody>
+            {variants.map((variant) => {
+              const summary = summaries[variant];
+              return (
+                <tr key={variant} className="border-t">
+                  <td className="px-2 py-1 font-medium">{variant}</td>
+                  <td className="px-2 py-1">{summary.inputMessageCount}</td>
+                  <td className="px-2 py-1">{summary.inputPartCount}</td>
+                  <td className="px-2 py-1">{summary.mountedMessageCount}</td>
+                  <td className="px-2 py-1">{summary.mountedPartCount}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
+      <div className="mb-2 text-muted-foreground text-xs">
+        Both variants use the same preformatted data. Run sequentially so the
+        Full and Paged trees never coexist. Message and part counts come from
+        the fixture; DOM nodes in Comparison are secondary diagnostics.
+      </div>
+      <section ref={listRef} className="min-h-0 flex-1 overflow-hidden">
+        {activeVariant && (
+          <MeasuredProfiler
+            id={`${activeVariant}MessageListPerf`}
+            record={perf.record}
+          >
+            <MessageList
+              key={`${activeVariant}-${renderKey}`}
+              messages={messages}
+              isLoading={false}
+              className="h-full min-h-0"
+              user={{ name: "User" }}
+              assistant={{ name: "Pochi" }}
+              containerRef={viewportRef}
+              renderAllMessages={activeVariant === "Full"}
+            />
+          </MeasuredProfiler>
+        )}
+      </section>
     </div>
   );
+}
+
+function ActionButton({
+  disabled,
+  onClick,
+  children,
+}: {
+  disabled: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+async function waitForStableMessageCount(
+  rootRef: React.RefObject<ParentNode | null>,
+  expected: number,
+  timeoutMs = 15_000,
+) {
+  const startedAt = performance.now();
+
+  while (performance.now() - startedAt < timeoutMs) {
+    await waitForNextFrame();
+    if (countMountedMessages(rootRef.current) !== expected) continue;
+    await waitForNextFrame();
+    if (countMountedMessages(rootRef.current) === expected) return;
+  }
+
+  throw new Error(`Timed out waiting for ${expected} mounted messages`);
+}
+
+function countMountedMessages(root: ParentNode | null) {
+  return root?.querySelectorAll('[aria-label^="chat-message-"]').length ?? 0;
 }
 
 const meta: Meta<typeof MessageListPerfStory> = {
@@ -161,21 +241,21 @@ const meta: Meta<typeof MessageListPerfStory> = {
   component: MessageListPerfStory,
   args: {
     messageCount: 300,
-    diffEvery: 25,
-    diffLineCount: 500,
+    assistantPartsPerMessage: 30,
+    partTextLength: 240,
   },
   argTypes: {
     messageCount: {
       control: "select",
       options: [100, 300, 1000],
     },
-    diffEvery: {
+    assistantPartsPerMessage: {
       control: "select",
-      options: [0, 25, 50],
+      options: [10, 30, 60],
     },
-    diffLineCount: {
+    partTextLength: {
       control: "select",
-      options: [100, 500, 1000],
+      options: [80, 240, 1000],
     },
   },
 };
@@ -184,4 +264,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const ContentVisibilityOffVsOn: Story = {};
+export const StaticMount: Story = {};

--- a/packages/vscode-webui/src/__stories__/perf/perf-data.ts
+++ b/packages/vscode-webui/src/__stories__/perf/perf-data.ts
@@ -191,3 +191,307 @@ export function makePerfMessages({
     } satisfies Message;
   });
 }
+
+interface TaskHistoryShape {
+  assistantPartsPerMessage: number;
+  partTextLength: number;
+}
+
+export function makeTaskHistoryMessages({
+  messageCount,
+  assistantPartsPerMessage,
+  partTextLength,
+}: TaskHistoryShape & { messageCount: number }): Message[] {
+  return Array.from({ length: messageCount }, (_, index) =>
+    makeTaskHistoryMessage({
+      id: `task-history-message-${index}`,
+      role: index % 2 === 0 ? "user" : "assistant",
+      sequence: index,
+      assistantPartsPerMessage,
+      partTextLength,
+    }),
+  );
+}
+
+export function appendTaskHistoryTurn(
+  messages: Message[],
+  {
+    turnIndex,
+    assistantPartsPerMessage,
+    partTextLength,
+  }: TaskHistoryShape & { turnIndex: number },
+): Message[] {
+  return [
+    ...messages,
+    makeTaskHistoryMessage({
+      id: `task-history-turn-${turnIndex}-user`,
+      role: "user",
+      sequence: turnIndex * 2,
+      assistantPartsPerMessage,
+      partTextLength,
+    }),
+    makeTaskHistoryMessage({
+      id: `task-history-turn-${turnIndex}-assistant`,
+      role: "assistant",
+      sequence: turnIndex * 2 + 1,
+      assistantPartsPerMessage,
+      partTextLength,
+    }),
+  ];
+}
+
+export function updateTaskHistoryStream(
+  messages: Message[],
+  {
+    updateIndex,
+    chunkSize,
+    snapshot = structuredClone,
+  }: {
+    updateIndex: number;
+    chunkSize: number;
+    snapshot?: (message: Message) => Message;
+  },
+): Message[] {
+  const messageIndex = messages.length - 1;
+  const message = messages[messageIndex];
+  if (message?.role !== "assistant") return messages;
+
+  const textPartIndex = message.parts.findLastIndex(
+    (part) => part.type === "text",
+  );
+  if (textPartIndex === -1) return messages;
+
+  const parts = message.parts.map((part, partIndex) => {
+    if (partIndex !== textPartIndex || part.type !== "text") return part;
+    return {
+      ...part,
+      text:
+        part.text + makeSizedText(` stream update ${updateIndex}`, chunkSize),
+      state: "streaming" as const,
+    };
+  });
+
+  const nextMessage = snapshot({ ...message, parts });
+  return [
+    ...messages.slice(0, messageIndex),
+    nextMessage,
+    ...messages.slice(messageIndex + 1),
+  ];
+}
+
+export function summarizeTaskHistory(messages: Message[]) {
+  return {
+    messageCount: messages.length,
+    partCount: messages.reduce(
+      (partCount, message) => partCount + message.parts.length,
+      0,
+    ),
+    serializedBytes: new TextEncoder().encode(JSON.stringify(messages))
+      .byteLength,
+  };
+}
+
+export function summarizeMessageRange(messages: Message[], startIndex: number) {
+  const start = Math.min(Math.max(startIndex, 0), messages.length);
+  return {
+    inputMessageCount: messages.length,
+    inputPartCount: messages.reduce(
+      (partCount, message) => partCount + message.parts.length,
+      0,
+    ),
+    mountedMessageCount: messages.length - start,
+    mountedPartCount: messages
+      .slice(start)
+      .reduce((partCount, message) => partCount + message.parts.length, 0),
+  };
+}
+
+function makeTaskHistoryMessage({
+  id,
+  role,
+  sequence,
+  assistantPartsPerMessage,
+  partTextLength,
+}: TaskHistoryShape & {
+  id: string;
+  role: "user" | "assistant";
+  sequence: number;
+}): Message {
+  const parts =
+    role === "user"
+      ? [makeTaskHistoryTextPart(role, sequence, 0, partTextLength)]
+      : Array.from({ length: assistantPartsPerMessage }, (_, partIndex) =>
+          makeTaskHistoryAssistantPart({
+            sequence,
+            partIndex,
+            partCount: assistantPartsPerMessage,
+            partTextLength,
+          }),
+        );
+
+  if (role === "user") {
+    return {
+      id,
+      role,
+      metadata: { kind: "user" },
+      parts,
+    } satisfies Message;
+  }
+
+  return {
+    id,
+    role,
+    metadata: {
+      kind: "assistant",
+      totalTokens: 0,
+      finishReason: "stop",
+    },
+    parts,
+  } satisfies Message;
+}
+
+function makeTaskHistoryAssistantPart({
+  sequence,
+  partIndex,
+  partCount,
+  partTextLength,
+}: {
+  sequence: number;
+  partIndex: number;
+  partCount: number;
+  partTextLength: number;
+}): Message["parts"][number] {
+  if (
+    partIndex === partCount - 1 ||
+    partIndex % 10 === 2 ||
+    partIndex % 10 === 9
+  ) {
+    return makeTaskHistoryTextPart(
+      "assistant",
+      sequence,
+      partIndex,
+      partTextLength,
+    );
+  }
+
+  const toolCallId = `task-history-tool-${sequence}-${partIndex}`;
+  const filePath = `packages/example/src/task-history-${sequence}-${partIndex}.ts`;
+
+  switch (partIndex % 10) {
+    case 0:
+    case 4:
+      return {
+        type: "reasoning",
+        text: makeSizedText(
+          `Reasoning for message ${sequence}, part ${partIndex}.`,
+          partTextLength,
+        ),
+      };
+    case 1:
+      return {
+        type: "tool-readFile",
+        toolCallId,
+        state: "output-available",
+        input: { path: filePath },
+        output: {
+          content: makeSizedText(`Read ${filePath}.`, partTextLength),
+          isTruncated: false,
+          filePath,
+        },
+      } as Message["parts"][number];
+    case 3:
+      return {
+        type: "tool-executeCommand",
+        toolCallId,
+        state: "output-available",
+        input: {
+          command: `printf 'task history ${sequence}-${partIndex}'`,
+        },
+        output: {
+          output: makeSizedText(
+            `Completed command ${sequence}-${partIndex}.`,
+            partTextLength,
+          ),
+          isTruncated: false,
+        },
+      } as Message["parts"][number];
+    case 5:
+      return {
+        type: "tool-searchFiles",
+        toolCallId,
+        state: "output-available",
+        input: { path: "packages", regex: `task-history-${sequence}` },
+        output: {
+          matches: [
+            {
+              file: filePath,
+              line: partIndex + 1,
+              context: makeSizedText(
+                `Search match ${sequence}-${partIndex}.`,
+                partTextLength,
+              ),
+            },
+          ],
+          isTruncated: false,
+        },
+      } as Message["parts"][number];
+    case 6:
+      return {
+        type: "tool-listFiles",
+        toolCallId,
+        state: "output-available",
+        input: { path: "packages/example/src", recursive: false },
+        output: { files: [filePath], isTruncated: false },
+      } as Message["parts"][number];
+    case 7:
+      return {
+        type: "tool-globFiles",
+        toolCallId,
+        state: "output-available",
+        input: { path: "packages/example/src", globPattern: "**/*.ts" },
+        output: { files: [filePath], isTruncated: false },
+      } as Message["parts"][number];
+    case 8:
+      return {
+        type: "tool-writeToFile",
+        toolCallId,
+        state: "output-available",
+        input: {
+          path: filePath,
+          content: makeSizedText(
+            `export const taskHistory${sequence} = ${partIndex};`,
+            partTextLength,
+          ),
+        },
+        output: { success: true },
+      } as Message["parts"][number];
+    default:
+      return makeTaskHistoryTextPart(
+        "assistant",
+        sequence,
+        partIndex,
+        partTextLength,
+      );
+  }
+}
+
+function makeTaskHistoryTextPart(
+  role: "user" | "assistant",
+  sequence: number,
+  partIndex: number,
+  partTextLength: number,
+): Message["parts"][number] {
+  return {
+    type: "text",
+    text: makeSizedText(
+      `${role} message ${sequence}, part ${partIndex}.`,
+      partTextLength,
+    ),
+    state: "done",
+  };
+}
+
+function makeSizedText(prefix: string, length: number) {
+  if (prefix.length >= length) return prefix.slice(0, length);
+  return prefix + "x".repeat(length - prefix.length);
+}

--- a/packages/vscode-webui/src/__stories__/perf/perf-harness.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/perf-harness.tsx
@@ -16,6 +16,14 @@ export interface PerfRecord {
   updateActualDuration?: number;
   baseDuration?: number;
   actionMs?: number;
+  structuredCloneMs?: number;
+  formatterMs?: number;
+  jsHeapBeforeBytes?: number;
+  jsHeapAfterCloneBytes?: number;
+  jsHeapAfterFormatBytes?: number;
+  jsHeapAfterCommitBytes?: number;
+  jsHeapPeakBytes?: number;
+  jsHeapDeltaBytes?: number;
   expandMs?: number;
   collapseMs?: number;
   nodeCountBefore?: number;
@@ -51,7 +59,15 @@ interface PerfHarnessValue {
       variant?: string;
       comparisonKey?: string;
       target?: HTMLElement | null;
+      measureNodes?: boolean;
       afterAction?: () => unknown | Promise<unknown>;
+      metrics?: () => Pick<
+        PerfRecord,
+        | "structuredCloneMs"
+        | "formatterMs"
+        | "jsHeapAfterCloneBytes"
+        | "jsHeapAfterFormatBytes"
+      >;
     },
   ) => Promise<void>;
   sampleFrames: (label: string, durationMs?: number) => Promise<void>;
@@ -99,9 +115,12 @@ export function usePerfHarness(): PerfHarnessValue {
     options,
   ) => {
     const root = options?.target ?? rootRef.current ?? document.body;
+    const measureNodes = options?.measureNodes ?? true;
+    const nodeCountBefore = measureNodes ? countElements(root) : undefined;
+    const longTaskWindowStart = performance.now();
+    await waitForNextTask();
     const startedAt = performance.now();
-    const nodeCountBefore = countElements(root);
-    const longTaskStartIndex = longTasks.current.length;
+    const jsHeapBeforeBytes = readUsedJsHeapBytes();
 
     action();
     const settlePromise = Promise.resolve(
@@ -111,10 +130,24 @@ export function usePerfHarness(): PerfHarnessValue {
       settlePromise,
       startedAt,
     );
+    const jsHeapAfterCommitBytes = readUsedJsHeapBytes();
+    const pipelineMetrics = options?.metrics?.();
+    const jsHeapPeakBytes = maxDefined([
+      jsHeapBeforeBytes,
+      pipelineMetrics?.jsHeapAfterCloneBytes,
+      pipelineMetrics?.jsHeapAfterFormatBytes,
+      jsHeapAfterCommitBytes,
+    ]);
 
     const elapsed = performance.now() - startedAt;
-    const nodeCountAfter = countElements(root);
-    const actionLongTasks = longTasks.current.slice(longTaskStartIndex);
+    const longTaskWindowEnd = performance.now();
+    await waitForNextTask();
+    const nodeCountAfter = measureNodes ? countElements(root) : undefined;
+    const actionLongTasks = longTasks.current.filter(
+      (entry) =>
+        entry.startTime >= longTaskWindowStart &&
+        entry.startTime < longTaskWindowEnd,
+    );
     const longTaskTotalMs = actionLongTasks.reduce(
       (sum, entry) => sum + entry.duration,
       0,
@@ -129,6 +162,13 @@ export function usePerfHarness(): PerfHarnessValue {
       variant: options?.variant,
       comparisonKey: options?.comparisonKey,
       actionMs: elapsed,
+      jsHeapBeforeBytes,
+      jsHeapAfterCommitBytes,
+      jsHeapPeakBytes,
+      jsHeapDeltaBytes:
+        jsHeapBeforeBytes === undefined || jsHeapPeakBytes === undefined
+          ? undefined
+          : jsHeapPeakBytes - jsHeapBeforeBytes,
       nodeCountBefore,
       nodeCountAfter,
       longTaskCount: actionLongTasks.length,
@@ -138,6 +178,7 @@ export function usePerfHarness(): PerfHarnessValue {
       expandMs: options?.kind === "expand" ? elapsed : undefined,
       collapseMs: options?.kind === "collapse" ? elapsed : undefined,
       updateActualDuration: options?.kind === "update" ? elapsed : undefined,
+      ...pipelineMetrics,
     });
   };
 
@@ -209,39 +250,90 @@ export async function waitForStablePerfElementCount(
   },
 ) {
   const startedAt = performance.now();
-  let lastCount = -1;
+  let observedRoot = rootRef.current;
+  let hasMinimumCount = observedRoot
+    ? hasAtLeastElements(observedRoot, minCount)
+    : false;
   let lastChangedAt = startedAt;
   let stableFrameCount = 0;
+  const observer = new MutationObserver(() => {
+    hasMinimumCount = observedRoot
+      ? hasAtLeastElements(observedRoot, minCount)
+      : false;
+    lastChangedAt = performance.now();
+    stableFrameCount = 0;
+  });
 
-  while (performance.now() - startedAt < timeoutMs) {
-    const now = performance.now();
-    const root = rootRef.current;
-    const count = root ? countElements(root) : 0;
-
-    if (count !== lastCount) {
-      lastCount = count;
-      lastChangedAt = now;
-      stableFrameCount = 0;
-    } else {
-      stableFrameCount += 1;
-    }
-
-    if (
-      count >= minCount &&
-      stableFrameCount >= stableFrames &&
-      now - lastChangedAt >= stableMs
-    ) {
-      return true;
-    }
-
-    await waitForNextFrame();
+  if (observedRoot) {
+    observeStableRoot(observedRoot, observer);
   }
 
-  return false;
+  try {
+    while (performance.now() - startedAt < timeoutMs) {
+      const now = performance.now();
+      const root = rootRef.current;
+      if (root !== observedRoot) {
+        observer.disconnect();
+        observedRoot = root;
+        hasMinimumCount = root ? hasAtLeastElements(root, minCount) : false;
+        lastChangedAt = now;
+        stableFrameCount = 0;
+        if (root) {
+          observeStableRoot(root, observer);
+        }
+      } else {
+        stableFrameCount += 1;
+      }
+
+      if (
+        hasMinimumCount &&
+        stableFrameCount >= stableFrames &&
+        now - lastChangedAt >= stableMs
+      ) {
+        return true;
+      }
+
+      await waitForNextFrame();
+    }
+
+    return false;
+  } finally {
+    observer.disconnect();
+  }
+}
+
+function observeStableRoot(root: ParentNode, observer: MutationObserver) {
+  observer.observe(root as Node, {
+    childList: true,
+    characterData: true,
+    subtree: true,
+  });
 }
 
 export async function waitForNextFrame() {
   await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+interface PerformanceMemorySource {
+  memory?: {
+    usedJSHeapSize?: unknown;
+  };
+}
+
+export function readUsedJsHeapBytes(
+  source: PerformanceMemorySource | undefined = typeof performance ===
+  "undefined"
+    ? undefined
+    : (performance as PerformanceMemorySource),
+) {
+  const value = source?.memory?.usedJSHeapSize;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+async function waitForNextTask() {
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
 }
 
 export function ComparisonPanel({
@@ -370,14 +462,17 @@ export function PerfPanel({
           </button>
         </div>
       </div>
-      <div className="max-h-64 overflow-auto">
-        <table className="w-full table-fixed text-left">
+      <div className="max-h-32 overflow-auto">
+        <table className="w-full min-w-[1200px] table-fixed text-left">
           <thead className="sticky top-0 bg-[var(--vscode-editor-background)]">
             <tr>
               <th className="w-40 px-1">label</th>
               <th className="px-1">mount</th>
               <th className="px-1">update</th>
               <th className="px-1">action</th>
+              <th className="px-1">clone</th>
+              <th className="px-1">format</th>
+              <th className="w-80 px-1">heap stages MiB</th>
               <th className="px-1">expand</th>
               <th className="px-1">collapse</th>
               <th className="px-1">nodes</th>
@@ -394,6 +489,11 @@ export function PerfPanel({
                   {formatMs(record.updateActualDuration)}
                 </td>
                 <td className="px-1">{formatMs(record.actionMs)}</td>
+                <td className="px-1">{formatMs(record.structuredCloneMs)}</td>
+                <td className="px-1">{formatMs(record.formatterMs)}</td>
+                <td className="truncate px-1" title={formatHeapStages(record)}>
+                  {formatHeapStages(record)}
+                </td>
                 <td className="px-1">{formatMs(record.expandMs)}</td>
                 <td className="px-1">{formatMs(record.collapseMs)}</td>
                 <td className="px-1">
@@ -510,8 +610,59 @@ function countElements(root: ParentNode): number {
   return count;
 }
 
+function hasAtLeastElements(root: ParentNode, minCount: number): boolean {
+  if (minCount <= 0) return true;
+
+  let count = 0;
+  const roots: ParentNode[] = [root];
+
+  while (roots.length > 0) {
+    const currentRoot = roots.pop();
+    if (!currentRoot) continue;
+    const walker = document.createTreeWalker(
+      currentRoot as Node,
+      NodeFilter.SHOW_ELEMENT,
+    );
+    let current = walker.nextNode();
+
+    while (current) {
+      count += 1;
+      if (count >= minCount) return true;
+      if (current instanceof Element && current.shadowRoot) {
+        roots.push(current.shadowRoot);
+      }
+      current = walker.nextNode();
+    }
+  }
+
+  return false;
+}
+
 function formatMs(value: number | undefined) {
   return value === undefined ? "-" : value.toFixed(1);
+}
+
+function formatHeapStages(record: PerfRecord) {
+  if (record.jsHeapBeforeBytes === undefined) return "-";
+
+  return [
+    `b ${formatMiB(record.jsHeapBeforeBytes)}`,
+    `c ${formatMiB(record.jsHeapAfterCloneBytes)}`,
+    `f ${formatMiB(record.jsHeapAfterFormatBytes)}`,
+    `end ${formatMiB(record.jsHeapAfterCommitBytes)}`,
+    `peak +${formatMiB(record.jsHeapDeltaBytes)}`,
+  ].join(" / ");
+}
+
+function formatMiB(value: number | undefined) {
+  return value === undefined ? "-" : (value / (1024 * 1024)).toFixed(1);
+}
+
+function maxDefined(values: Array<number | undefined>) {
+  const definedValues = values.filter(
+    (value): value is number => value !== undefined,
+  );
+  return definedValues.length > 0 ? Math.max(...definedValues) : undefined;
 }
 
 interface ComparisonRowData {

--- a/packages/vscode-webui/src/__stories__/perf/task-history.perf.stories.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/task-history.perf.stories.tsx
@@ -518,9 +518,9 @@ function TaskHistoryMessageView({
   onMessagesCommitted: (revision: number) => void;
   renderAllMessages: boolean;
 }) {
-  const lastMessage = messages.at(-1);
-  const lastUserMessageId =
-    lastMessage?.role === "user" ? lastMessage.id : undefined;
+  const lastUserMessageId = messages.findLast(
+    (message) => message.role === "user",
+  )?.id;
   useScrollToBottom({ messagesContainerRef, lastUserMessageId });
   useLayoutEffect(() => {
     onMessagesCommitted(revision);

--- a/packages/vscode-webui/src/__stories__/perf/task-history.perf.stories.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/task-history.perf.stories.tsx
@@ -1,0 +1,644 @@
+import { formatters } from "@getpochi/common";
+import type { Message } from "@getpochi/livekit";
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { flushSync } from "react-dom";
+import { ChatArea } from "../../features/chat/components/chat-area";
+import { useScrollToBottom } from "../../features/chat/hooks/use-scroll-to-bottom";
+import {
+  appendTaskHistoryTurn,
+  makeTaskHistoryMessages,
+  summarizeTaskHistory,
+  updateTaskHistoryStream,
+} from "./perf-data";
+import {
+  MeasuredProfiler,
+  PerfPanel,
+  type PerfRecord,
+  readUsedJsHeapBytes,
+  usePerfHarness,
+  waitForStablePerfElementCount,
+} from "./perf-harness";
+
+interface TaskHistoryPerfStoryProps {
+  initialMessageCount: number;
+  assistantPartsPerMessage: number;
+  partTextLength: number;
+  streamChunkSize: number;
+  streamIntervalMs: number;
+  renderAllMessages?: boolean;
+}
+
+export function TaskHistoryPerfStory({
+  initialMessageCount,
+  assistantPartsPerMessage,
+  partTextLength,
+  streamChunkSize,
+  streamIntervalMs,
+  renderAllMessages = false,
+}: TaskHistoryPerfStoryProps) {
+  const perf = usePerfHarness();
+  const historyRef = useRef<HTMLDivElement | null>(null);
+  const messagesContainerRef = useRef<HTMLDivElement | null>(null);
+  const formatterMsByMessagesRef = useRef(new WeakMap<Message[], number>());
+  const heapAfterFormatByMessagesRef = useRef(
+    new WeakMap<Message[], number | undefined>(),
+  );
+  const revisionByMessagesRef = useRef(new WeakMap<Message[], number>());
+  const nextRevisionRef = useRef(0);
+  const committedRevisionRef = useRef(-1);
+  const commitWaitersRef = useRef(new Map<number, Set<() => void>>());
+  const timerRef = useRef<number | null>(null);
+  const streamingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const streamChunkSizeRef = useRef(streamChunkSize);
+  const streamIntervalMsRef = useRef(streamIntervalMs);
+  const updateCountRef = useRef(0);
+  const turnIndexRef = useRef(Math.ceil(initialMessageCount / 2));
+  const initialArgsRef = useRef(
+    `${initialMessageCount}:${assistantPartsPerMessage}:${partTextLength}`,
+  );
+  const [rawMessages, setRawMessages] = useState<Message[]>(() => {
+    const messages = makeTaskHistoryMessages({
+      messageCount: initialMessageCount,
+      assistantPartsPerMessage,
+      partTextLength,
+    });
+    revisionByMessagesRef.current.set(messages, 0);
+    return messages;
+  });
+  const rawMessagesRef = useRef(rawMessages);
+  const [summary, setSummary] = useState(() =>
+    summarizeTaskHistory(rawMessages),
+  );
+  const [updateCount, setUpdateCount] = useState(0);
+  const [mounted, setMounted] = useState(true);
+  const [renderKey, setRenderKey] = useState(0);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [runtimeAction, setRuntimeAction] = useState<string | null>(null);
+  streamChunkSizeRef.current = streamChunkSize;
+  streamIntervalMsRef.current = streamIntervalMs;
+
+  const assignRevision = useCallback((messages: Message[]) => {
+    const revision = nextRevisionRef.current + 1;
+    nextRevisionRef.current = revision;
+    revisionByMessagesRef.current.set(messages, revision);
+    return revision;
+  }, []);
+
+  const acknowledgeCommittedRevision = useCallback((revision: number) => {
+    committedRevisionRef.current = Math.max(
+      committedRevisionRef.current,
+      revision,
+    );
+    for (const [waitingRevision, resolvers] of commitWaitersRef.current) {
+      if (waitingRevision > committedRevisionRef.current) continue;
+      commitWaitersRef.current.delete(waitingRevision);
+      for (const resolve of resolvers) resolve();
+    }
+  }, []);
+
+  const resolveCommitWaiters = useCallback(() => {
+    for (const resolvers of commitWaitersRef.current.values()) {
+      for (const resolve of resolvers) resolve();
+    }
+    commitWaitersRef.current.clear();
+  }, []);
+
+  const waitForCommittedRevision = (revision: number) => {
+    if (!mountedRef.current || committedRevisionRef.current >= revision) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      const resolvers = commitWaitersRef.current.get(revision) ?? new Set();
+      resolvers.add(resolve);
+      commitWaitersRef.current.set(revision, resolvers);
+    });
+  };
+
+  const renderMessages = useMemo(() => {
+    const startedAt = performance.now();
+    const formatted = formatters.ui(rawMessages);
+    formatterMsByMessagesRef.current.set(
+      rawMessages,
+      performance.now() - startedAt,
+    );
+    heapAfterFormatByMessagesRef.current.set(
+      rawMessages,
+      readUsedJsHeapBytes(),
+    );
+    return formatted;
+  }, [rawMessages]);
+
+  useEffect(() => {
+    const nextArgs = `${initialMessageCount}:${assistantPartsPerMessage}:${partTextLength}`;
+    if (nextArgs === initialArgsRef.current) return;
+    initialArgsRef.current = nextArgs;
+
+    streamingRef.current = false;
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    const nextMessages = makeTaskHistoryMessages({
+      messageCount: initialMessageCount,
+      assistantPartsPerMessage,
+      partTextLength,
+    });
+    assignRevision(nextMessages);
+    rawMessagesRef.current = nextMessages;
+    updateCountRef.current = 0;
+    turnIndexRef.current = Math.ceil(initialMessageCount / 2);
+    setRawMessages(nextMessages);
+    setSummary(summarizeTaskHistory(nextMessages));
+    setUpdateCount(0);
+    setIsStreaming(false);
+    setRuntimeAction(null);
+  }, [
+    assignRevision,
+    assistantPartsPerMessage,
+    initialMessageCount,
+    partTextLength,
+  ]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      streamingRef.current = false;
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+      resolveCommitWaiters();
+    };
+  }, [resolveCommitWaiters]);
+
+  const waitForHistory = (minCount: number) =>
+    waitForStablePerfElementCount(historyRef, {
+      minCount,
+      timeoutMs: 15_000,
+    });
+
+  const pipelineMetrics = (
+    messages: Message[][],
+    structuredCloneMs = 0,
+    jsHeapAfterCloneBytes?: number,
+  ) => {
+    const heapAfterFormatSamples = messages
+      .map((item) => heapAfterFormatByMessagesRef.current.get(item))
+      .filter((value): value is number => value !== undefined);
+
+    return {
+      structuredCloneMs,
+      formatterMs: messages.reduce(
+        (total, item) =>
+          total + (formatterMsByMessagesRef.current.get(item) ?? 0),
+        0,
+      ),
+      jsHeapAfterCloneBytes,
+      jsHeapAfterFormatBytes:
+        heapAfterFormatSamples.length > 0
+          ? Math.max(...heapAfterFormatSamples)
+          : undefined,
+    };
+  };
+
+  const stopStreaming = () => {
+    streamingRef.current = false;
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setIsStreaming(false);
+    setRuntimeAction(`Streaming stopped · ${updateCountRef.current} updates`);
+  };
+
+  const resetHistory = () => {
+    stopStreaming();
+    const nextMessages = makeTaskHistoryMessages({
+      messageCount: initialMessageCount,
+      assistantPartsPerMessage,
+      partTextLength,
+    });
+    const nextRevision = assignRevision(nextMessages);
+    const nextSummary = summarizeTaskHistory(nextMessages);
+    updateCountRef.current = 0;
+    turnIndexRef.current = Math.ceil(initialMessageCount / 2);
+    const action = `Reset history applied · messages ${rawMessagesRef.current.length} → ${nextMessages.length}`;
+
+    void perf.measureAction(
+      "reset task history",
+      () => {
+        rawMessagesRef.current = nextMessages;
+        setRawMessages(nextMessages);
+        setSummary(nextSummary);
+        setUpdateCount(0);
+        setRuntimeAction(action);
+      },
+      {
+        target: historyRef.current,
+        afterAction: () => waitForCommittedRevision(nextRevision),
+        metrics: () => pipelineMetrics([nextMessages]),
+      },
+    );
+  };
+
+  const appendTurn = () => {
+    const currentMessages = rawMessagesRef.current;
+    const addedMessages = appendTaskHistoryTurn([], {
+      turnIndex: turnIndexRef.current,
+      assistantPartsPerMessage,
+      partTextLength,
+    });
+    const [userMessage, assistantMessage] = addedMessages;
+    if (!userMessage || !assistantMessage) return;
+    const messagesWithUser = [...currentMessages, userMessage];
+    const nextMessages = [...currentMessages, ...addedMessages];
+    assignRevision(messagesWithUser);
+    const nextRevision = assignRevision(nextMessages);
+    const userSummary = summarizeTaskHistory([userMessage]);
+    const assistantSummary = summarizeTaskHistory([assistantMessage]);
+    const action = `Append turn applied · messages ${currentMessages.length} → ${nextMessages.length}`;
+
+    void perf.measureAction(
+      "append user + assistant turn",
+      () => {
+        turnIndexRef.current += 1;
+        flushSync(() => {
+          rawMessagesRef.current = messagesWithUser;
+          setRawMessages(messagesWithUser);
+          setSummary((current) => ({
+            messageCount: messagesWithUser.length,
+            partCount: current.partCount + userSummary.partCount,
+            serializedBytes:
+              current.serializedBytes + userSummary.serializedBytes - 1,
+          }));
+        });
+
+        rawMessagesRef.current = nextMessages;
+        setRawMessages(nextMessages);
+        setSummary((current) => ({
+          messageCount: nextMessages.length,
+          partCount: current.partCount + assistantSummary.partCount,
+          serializedBytes:
+            current.serializedBytes + assistantSummary.serializedBytes - 1,
+        }));
+        setRuntimeAction(action);
+      },
+      {
+        target: historyRef.current,
+        afterAction: () => waitForCommittedRevision(nextRevision),
+        metrics: () => pipelineMetrics([messagesWithUser, nextMessages]),
+      },
+    );
+  };
+
+  const streamTick = (measureNodes = true) => {
+    const nextUpdateCount = updateCountRef.current + 1;
+    const chunkSize = streamChunkSizeRef.current;
+    let structuredCloneMs = 0;
+    let jsHeapAfterCloneBytes: number | undefined;
+    let nextMessagesForMetrics = rawMessagesRef.current;
+    let nextRevisionForMetrics = nextRevisionRef.current;
+    const action = `Stream tick applied · update ${nextUpdateCount} · +${chunkSize} chars`;
+
+    return perf.measureAction(
+      "assistant stream tick",
+      () => {
+        const nextMessages = updateTaskHistoryStream(rawMessagesRef.current, {
+          updateIndex: nextUpdateCount,
+          chunkSize,
+          snapshot: (message) => {
+            const startedAt = performance.now();
+            const snapshot = structuredClone(message);
+            structuredCloneMs = performance.now() - startedAt;
+            jsHeapAfterCloneBytes = readUsedJsHeapBytes();
+            return snapshot;
+          },
+        });
+        nextRevisionForMetrics = assignRevision(nextMessages);
+        nextMessagesForMetrics = nextMessages;
+        rawMessagesRef.current = nextMessages;
+        updateCountRef.current = nextUpdateCount;
+        setRawMessages(nextMessages);
+        setUpdateCount(nextUpdateCount);
+        setSummary((current) => ({
+          ...current,
+          serializedBytes: current.serializedBytes + chunkSize,
+        }));
+        setRuntimeAction(action);
+      },
+      {
+        target: historyRef.current,
+        measureNodes,
+        afterAction: () => waitForCommittedRevision(nextRevisionForMetrics),
+        metrics: () =>
+          pipelineMetrics(
+            [nextMessagesForMetrics],
+            structuredCloneMs,
+            jsHeapAfterCloneBytes,
+          ),
+      },
+    );
+  };
+
+  const scheduleStreamTick = () => {
+    if (!streamingRef.current) return;
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      if (!streamingRef.current) return;
+      scheduleStreamTick();
+      void streamTick(false);
+    }, streamIntervalMsRef.current);
+  };
+
+  const startStreaming = () => {
+    if (streamingRef.current) return;
+    streamingRef.current = true;
+    setIsStreaming(true);
+    scheduleStreamTick();
+    void streamTick(false);
+  };
+
+  const measureUiAction = (
+    label: string,
+    action: () => void,
+    minCount: number,
+  ) =>
+    perf.measureAction(label, action, {
+      target: historyRef.current,
+      afterAction: () => waitForHistory(minCount),
+    });
+
+  return (
+    <div ref={perf.rootRef} className="flex h-[760px] flex-col p-3">
+      <PerfPanel
+        recordsRef={perf.recordsRef}
+        onClear={perf.clear}
+        onSampleFrames={() => void perf.sampleFrames("manual frame sample")}
+      />
+
+      <div className="mb-2 grid grid-cols-2 gap-2 rounded border p-2 text-xs md:grid-cols-5">
+        <Stat
+          label="messages"
+          value={summary.messageCount}
+          valueTestId="task-history-message-count"
+        />
+        <Stat label="parts" value={summary.partCount} />
+        <Stat
+          label="stream updates"
+          value={updateCount}
+          valueTestId="task-history-update-count"
+        />
+        <Stat
+          label="approx size"
+          value={formatBytes(summary.serializedBytes)}
+        />
+        <Stat label="UI" value={mounted ? "mounted" : "unmounted"} />
+      </div>
+
+      <div className="mb-2 flex flex-wrap gap-2">
+        <ActionButton onClick={resetHistory}>Reset history</ActionButton>
+        <ActionButton onClick={appendTurn}>Append turn</ActionButton>
+        <ActionButton disabled={isStreaming} onClick={() => void streamTick()}>
+          Stream tick
+        </ActionButton>
+        <ActionButton disabled={isStreaming} onClick={startStreaming}>
+          Start streaming
+        </ActionButton>
+        <ActionButton disabled={!isStreaming} onClick={stopStreaming}>
+          Stop streaming
+        </ActionButton>
+      </div>
+
+      <output
+        aria-live="polite"
+        className="mb-2 rounded border bg-[var(--vscode-editor-background)] px-2 py-1 text-xs"
+      >
+        {runtimeAction
+          ? runtimeAction
+          : "Ready · use Append turn or Stream tick to update the live task history"}
+      </output>
+
+      <details className="mb-2 text-xs">
+        <summary className="cursor-pointer text-muted-foreground">
+          UI isolation controls
+        </summary>
+        <div className="mt-2 flex flex-wrap gap-2">
+          <ActionButton
+            disabled={!mounted}
+            onClick={() =>
+              void measureUiAction(
+                "unmount task UI",
+                () => {
+                  mountedRef.current = false;
+                  resolveCommitWaiters();
+                  setMounted(false);
+                },
+                0,
+              )
+            }
+          >
+            Unmount UI
+          </ActionButton>
+          <ActionButton
+            disabled={mounted}
+            onClick={() =>
+              void measureUiAction(
+                "mount task UI",
+                () => {
+                  mountedRef.current = true;
+                  setMounted(true);
+                },
+                1,
+              )
+            }
+          >
+            Mount UI
+          </ActionButton>
+          <ActionButton
+            disabled={!mounted}
+            onClick={() =>
+              void measureUiAction(
+                "remount task UI",
+                () => setRenderKey((current) => current + 1),
+                1,
+              )
+            }
+          >
+            Remount UI
+          </ActionButton>
+          <span className="self-center text-muted-foreground">
+            Unmount keeps raw-message updates and formatting active.
+          </span>
+        </div>
+      </details>
+
+      <section ref={historyRef} className="min-h-0 flex-1 overflow-hidden">
+        {mounted && (
+          <TaskHistoryMessageView
+            key={renderKey}
+            messages={renderMessages}
+            revision={revisionByMessagesRef.current.get(rawMessages) ?? 0}
+            isStreaming={isStreaming}
+            messagesContainerRef={messagesContainerRef}
+            record={perf.record}
+            onMessagesCommitted={acknowledgeCommittedRevision}
+            renderAllMessages={renderAllMessages}
+          />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function TaskHistoryMessageView({
+  messages,
+  revision,
+  isStreaming,
+  messagesContainerRef,
+  record,
+  onMessagesCommitted,
+  renderAllMessages,
+}: {
+  messages: Message[];
+  revision: number;
+  isStreaming: boolean;
+  messagesContainerRef: React.RefObject<HTMLDivElement | null>;
+  record: (record: PerfRecord) => void;
+  onMessagesCommitted: (revision: number) => void;
+  renderAllMessages: boolean;
+}) {
+  const lastMessage = messages.at(-1);
+  const lastUserMessageId =
+    lastMessage?.role === "user" ? lastMessage.id : undefined;
+  useScrollToBottom({ messagesContainerRef, lastUserMessageId });
+  useLayoutEffect(() => {
+    onMessagesCommitted(revision);
+  }, [onMessagesCommitted, revision]);
+
+  return (
+    <MeasuredProfiler id="TaskHistoryPerf" record={record}>
+      <div className="flex h-full min-h-0 flex-col">
+        <ChatArea
+          messages={messages}
+          isLoading={isStreaming}
+          user={{ name: "User" }}
+          messagesContainerRef={messagesContainerRef}
+          hideEmptyPlaceholder
+          className="min-h-0"
+          renderAllMessages={renderAllMessages}
+        />
+      </div>
+    </MeasuredProfiler>
+  );
+}
+
+function ActionButton({
+  children,
+  disabled,
+  onClick,
+}: {
+  children: React.ReactNode;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  valueTestId,
+}: {
+  label: string;
+  value: string | number;
+  valueTestId?: string;
+}) {
+  return (
+    <div>
+      <div className="text-muted-foreground">{label}</div>
+      <div data-testid={valueTestId} className="font-medium tabular-nums">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+const meta: Meta<typeof TaskHistoryPerfStory> = {
+  title: "Perf/TaskHistory",
+  component: TaskHistoryPerfStory,
+  excludeStories: ["TaskHistoryPerfStory"],
+  args: {
+    initialMessageCount: 300,
+    assistantPartsPerMessage: 30,
+    partTextLength: 120,
+    streamChunkSize: 32,
+    streamIntervalMs: 50,
+    renderAllMessages: false,
+  },
+  argTypes: {
+    initialMessageCount: {
+      control: "select",
+      options: [20, 100, 300, 1000],
+    },
+    assistantPartsPerMessage: {
+      control: "select",
+      options: [10, 30, 50, 100],
+    },
+    partTextLength: {
+      control: "select",
+      options: [40, 120, 500, 2000],
+    },
+    streamChunkSize: {
+      control: "select",
+      options: [16, 32, 128, 512],
+    },
+    streamIntervalMs: {
+      control: "select",
+      options: [50, 100, 250, 500],
+    },
+    renderAllMessages: {
+      control: false,
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Full: Story = {
+  args: {
+    renderAllMessages: true,
+  },
+};
+
+export const Paged: Story = {
+  args: {
+    renderAllMessages: false,
+  },
+};

--- a/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
@@ -1,0 +1,380 @@
+import type { Message } from "@getpochi/livekit";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Profiler, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageListPaginationConfig } from "../use-message-list-pagination";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options?.count === undefined ? key : `${key}:${options.count}`,
+  }),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  isVSCodeEnvironment: () => false,
+  vscodeHost: {
+    getGlobalState: vi.fn(async () => undefined),
+    setGlobalState: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock("@/lib/hooks/use-latest-checkpoint", () => ({
+  useLatestCheckpoint: () => null,
+}));
+
+vi.mock("@/features/chat", () => ({
+  BackgroundJobContextProvider: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <>{children}</>,
+  useAutoApproveGuard: () => ({ current: "manual" }),
+  useToolCallLifeCycle: () => ({
+    executingToolCalls: [],
+    completeToolCalls: [],
+    isExecuting: false,
+  }),
+}));
+
+vi.mock("@/features/tools", () => ({
+  ToolInvocationPart: ({
+    tool,
+    changes,
+    isLastPart,
+  }: {
+    tool: { toolCallId: string };
+    changes?: { origin?: string; modified?: string };
+    isLastPart?: boolean;
+  }) => (
+    <div
+      data-testid="tool-part"
+      data-tool-call-id={tool.toolCallId}
+      data-changes-origin={changes?.origin ?? ""}
+      data-changes-modified={changes?.modified ?? ""}
+      data-is-last-part={String(!!isLastPart)}
+    />
+  ),
+  BackgroundJobPanel: () => null,
+}));
+
+vi.mock("../markdown", () => ({
+  MessageMarkdown: ({ children }: { children: string }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
+
+// Import after installing mocks.
+const { MessageList } = await import("../message-list");
+
+class IntersectionObserverProbe implements IntersectionObserver {
+  static instances: IntersectionObserverProbe[] = [];
+
+  readonly root: Element | Document | null;
+  readonly rootMargin: string;
+  readonly thresholds = [0];
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.root = options?.root ?? null;
+    this.rootMargin = options?.rootMargin ?? "0px";
+    IntersectionObserverProbe.instances.push(this);
+  }
+
+  disconnect = vi.fn();
+  observe = vi.fn();
+  takeRecords = vi.fn(() => []);
+  unobserve = vi.fn();
+
+  intersect(isIntersecting = true) {
+    this.callback([{ isIntersecting } as IntersectionObserverEntry], this);
+  }
+}
+
+beforeEach(() => {
+  IntersectionObserverProbe.instances = [];
+  vi.stubGlobal("IntersectionObserver", IntersectionObserverProbe);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const PartsPerMessage = 5;
+const InitialMessages =
+  MessageListPaginationConfig.partBudget / PartsPerMessage; // 60 / 5 = 12
+
+function makeMessage(index: number): Message {
+  const role = index % 2 === 0 ? "user" : "assistant";
+  if (role === "user") {
+    return {
+      id: `m-${index}`,
+      role,
+      metadata: { kind: "user" },
+      parts: Array.from({ length: PartsPerMessage }, (_, i) => ({
+        type: "text" as const,
+        text: `user ${index} part ${i}`,
+      })),
+    } as Message;
+  }
+
+  return {
+    id: `m-${index}`,
+    role,
+    metadata: { kind: "assistant", totalTokens: 0, finishReason: "stop" },
+    parts: [
+      { type: "text", text: `assistant ${index} intro` },
+      {
+        type: "tool-readFile",
+        toolCallId: `call-${index}`,
+        state: "output-available",
+        input: { path: `file-${index}.ts` },
+        output: { content: "ok" },
+      },
+      { type: "data-checkpoint", data: { commit: `commit-${index}` } },
+      { type: "text", text: `assistant ${index} outro` },
+      { type: "text", text: `assistant ${index} tail` },
+    ],
+  } as unknown as Message;
+}
+
+function makeMessages(count: number) {
+  return Array.from({ length: count }, (_, index) => makeMessage(index));
+}
+
+function mountedMessageIds(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>('[aria-label^="chat-message-"]'),
+  ).map((node) => node.querySelector("[data-testid]")?.textContent ?? "");
+}
+
+function mountedCount(container: HTMLElement) {
+  return container.querySelectorAll('[aria-label^="chat-message-"]').length;
+}
+
+function MessageListProbe({
+  messages,
+  renderAllMessages = false,
+}: {
+  messages: Message[];
+  renderAllMessages?: boolean;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <MessageList
+      messages={messages}
+      isLoading={false}
+      showLoader={false}
+      renderAllMessages={renderAllMessages}
+      containerRef={containerRef}
+    />
+  );
+}
+
+function renderList(messages: Message[], renderAllMessages = false) {
+  return render(
+    <MessageListProbe
+      messages={messages}
+      renderAllMessages={renderAllMessages}
+    />,
+  );
+}
+
+describe("MessageList pagination", () => {
+  it("mounts only the tail page and always keeps the last message", () => {
+    const messages = makeMessages(200);
+    const { container } = renderList(messages);
+
+    expect(mountedCount(container)).toBe(InitialMessages);
+    // The tail must remain mounted.
+    expect(mountedMessageIds(container).at(-1)).toContain("assistant 199");
+    // The first message must remain unmounted.
+    expect(container.textContent).not.toContain("user 0 part 0");
+  });
+
+  it("mounts the whole history when renderAllMessages is set", () => {
+    const messages = makeMessages(40);
+    const { container } = renderList(messages, true);
+
+    expect(mountedCount(container)).toBe(40);
+  });
+
+  it("mounts the whole history when it fits in the budget", () => {
+    const messages = makeMessages(8);
+    const { container } = renderList(messages);
+
+    expect(mountedCount(container)).toBe(8);
+    expect(screen.queryByTestId("message-list-auto-load-earlier")).toBeNull();
+  });
+
+  it("automatically loads earlier messages from the top prefetch area", () => {
+    const messages = makeMessages(200);
+    const { container } = renderList(messages);
+
+    const autoLoadTrigger = screen.getByTestId(
+      "message-list-auto-load-earlier",
+    );
+    expect(autoLoadTrigger.textContent).toBe("");
+    expect(autoLoadTrigger.querySelector("button")).toBeNull();
+    expect(IntersectionObserverProbe.instances).toHaveLength(1);
+
+    act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
+
+    expect(mountedCount(container)).toBeGreaterThan(InitialMessages);
+    expect(mountedMessageIds(container).at(-1)).toContain("assistant 199");
+  });
+
+  it("mounts the whole history when no scroll container is available", () => {
+    const { container } = render(
+      <MessageList
+        messages={makeMessages(200)}
+        isLoading={false}
+        showLoader={false}
+      />,
+    );
+
+    expect(mountedCount(container)).toBe(200);
+    expect(IntersectionObserverProbe.instances).toHaveLength(0);
+  });
+
+  it("mounts the whole history when IntersectionObserver is unavailable", () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+
+    const { container } = renderList(makeMessages(200));
+
+    expect(mountedCount(container)).toBe(200);
+  });
+
+  it("keeps the range start frozen while the last message streams", () => {
+    const messages = makeMessages(200);
+    const { container, rerender } = renderList(messages);
+    const firstMountedBefore = mountedMessageIds(container)[0];
+
+    const last = messages[messages.length - 1];
+    const streamed: Message[] = [
+      ...messages.slice(0, -1),
+      {
+        ...last,
+        parts: [...last.parts, { type: "text", text: "streamed delta" }],
+      } as Message,
+    ];
+    rerender(<MessageListProbe messages={streamed} />);
+
+    expect(mountedMessageIds(container)[0]).toBe(firstMountedBefore);
+  });
+
+  it("shrinks loaded history back to the tail budget when the user returns to the bottom", () => {
+    const messages = makeMessages(200);
+    const { container } = renderList(messages);
+
+    act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
+    expect(mountedCount(container)).toBeGreaterThan(InitialMessages);
+    act(() => IntersectionObserverProbe.instances.at(-1)?.intersect(false));
+
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    );
+    if (!viewport) throw new Error("Expected MessageList viewport");
+    Object.defineProperties(viewport, {
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 400 },
+      scrollTop: { configurable: true, value: 600, writable: true },
+    });
+
+    fireEvent.scroll(viewport);
+
+    expect(mountedCount(container)).toBe(InitialMessages);
+  });
+
+  it("does not alternate between auto-loading and trimming while the top trigger remains visible", () => {
+    const messages = makeMessages(200);
+    const { container } = renderList(messages);
+
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    );
+    if (!viewport) throw new Error("Expected MessageList viewport");
+    Object.defineProperties(viewport, {
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 400 },
+      scrollTop: { configurable: true, value: 600, writable: true },
+    });
+
+    for (let i = 0; i < 3; i++) {
+      const beforeLoad = mountedCount(container);
+      act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
+      const afterLoad = mountedCount(container);
+      expect(afterLoad).toBeGreaterThan(beforeLoad);
+
+      fireEvent.scroll(viewport);
+
+      expect(mountedCount(container)).toBe(afterLoad);
+    }
+  });
+
+  it("resets the range to the tail budget when a new user message is appended", () => {
+    const messages = makeMessages(200);
+    const { container, rerender } = renderList(messages);
+
+    act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
+    expect(mountedCount(container)).toBeGreaterThan(InitialMessages);
+
+    const grown = [...messages, makeMessage(200)];
+    rerender(<MessageListProbe messages={grown} />);
+
+    expect(mountedCount(container)).toBe(InitialMessages);
+    expect(mountedMessageIds(container).at(-1)).toContain("user 200");
+  });
+
+  it("uses the tail budget in the first commit after a user message is appended", () => {
+    const messages = makeMessages(200);
+    let root: HTMLElement | null = null;
+    const committedCounts: number[] = [];
+    const onRender = () => {
+      if (root) committedCounts.push(mountedCount(root));
+    };
+    const view = render(
+      <Profiler id="render-range" onRender={onRender}>
+        <MessageListProbe messages={messages} />
+      </Profiler>,
+    );
+    root = view.container;
+
+    act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
+    expect(mountedCount(view.container)).toBeGreaterThan(InitialMessages);
+    committedCounts.length = 0;
+
+    view.rerender(
+      <Profiler id="render-range" onRender={onRender}>
+        <MessageListProbe messages={[...messages, makeMessage(200)]} />
+      </Profiler>,
+    );
+
+    expect(committedCounts).not.toHaveLength(0);
+    expect(Math.max(...committedCounts)).toBe(InitialMessages);
+  });
+
+  it("renders the tail identically to a full render (absolute index invariant)", () => {
+    const messages = makeMessages(200);
+
+    const full = renderList(messages, true);
+    const fullItems = Array.from(
+      full.container.querySelectorAll('[aria-label^="chat-message-"]'),
+    ).map((node) => node.outerHTML);
+    full.unmount();
+
+    const paged = renderList(messages);
+    const pagedItems = Array.from(
+      paged.container.querySelectorAll('[aria-label^="chat-message-"]'),
+    ).map((node) => node.outerHTML);
+
+    expect(pagedItems).toEqual(fullItems.slice(-pagedItems.length));
+    // Cross-message derivations still include checkpoints outside this page.
+    const firstTool = paged.container.querySelector<HTMLElement>(
+      '[data-testid="tool-part"]',
+    );
+    expect(firstTool?.dataset.changesOrigin).toBeTruthy();
+  });
+});

--- a/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
@@ -154,6 +154,19 @@ function mountedCount(container: HTMLElement) {
   return container.querySelectorAll('[aria-label^="chat-message-"]').length;
 }
 
+function setViewportScrollTop(container: HTMLElement, scrollTop: number) {
+  const viewport = container.querySelector<HTMLElement>(
+    '[data-slot="scroll-area-viewport"]',
+  );
+  if (!viewport) throw new Error("Expected MessageList viewport");
+  Object.defineProperties(viewport, {
+    scrollHeight: { configurable: true, value: 1000 },
+    clientHeight: { configurable: true, value: 400 },
+    scrollTop: { configurable: true, value: scrollTop, writable: true },
+  });
+  return viewport;
+}
+
 function MessageListProbe({
   messages,
   renderAllMessages = false,
@@ -209,7 +222,7 @@ describe("MessageList pagination", () => {
     expect(screen.queryByTestId("message-list-auto-load-earlier")).toBeNull();
   });
 
-  it("automatically loads earlier messages from the top prefetch area", () => {
+  it("loads earlier messages when the top trigger enters view", () => {
     const messages = makeMessages(200);
     const { container } = renderList(messages);
 
@@ -219,6 +232,7 @@ describe("MessageList pagination", () => {
     expect(autoLoadTrigger.textContent).toBe("");
     expect(autoLoadTrigger.querySelector("button")).toBeNull();
     expect(IntersectionObserverProbe.instances).toHaveLength(1);
+    expect(IntersectionObserverProbe.instances[0]?.rootMargin).toBe("0px");
 
     act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
 
@@ -265,53 +279,19 @@ describe("MessageList pagination", () => {
     expect(mountedMessageIds(container)[0]).toBe(firstMountedBefore);
   });
 
-  it("shrinks loaded history back to the tail budget when the user returns to the bottom", () => {
+  it("keeps loaded history mounted when the user returns to the bottom", () => {
     const messages = makeMessages(200);
     const { container } = renderList(messages);
 
     act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
-    expect(mountedCount(container)).toBeGreaterThan(InitialMessages);
+    const loadedCount = mountedCount(container);
+    expect(loadedCount).toBeGreaterThan(InitialMessages);
     act(() => IntersectionObserverProbe.instances.at(-1)?.intersect(false));
 
-    const viewport = container.querySelector<HTMLElement>(
-      '[data-slot="scroll-area-viewport"]',
-    );
-    if (!viewport) throw new Error("Expected MessageList viewport");
-    Object.defineProperties(viewport, {
-      scrollHeight: { configurable: true, value: 1000 },
-      clientHeight: { configurable: true, value: 400 },
-      scrollTop: { configurable: true, value: 600, writable: true },
-    });
-
+    const viewport = setViewportScrollTop(container, 600);
     fireEvent.scroll(viewport);
 
-    expect(mountedCount(container)).toBe(InitialMessages);
-  });
-
-  it("does not alternate between auto-loading and trimming while the top trigger remains visible", () => {
-    const messages = makeMessages(200);
-    const { container } = renderList(messages);
-
-    const viewport = container.querySelector<HTMLElement>(
-      '[data-slot="scroll-area-viewport"]',
-    );
-    if (!viewport) throw new Error("Expected MessageList viewport");
-    Object.defineProperties(viewport, {
-      scrollHeight: { configurable: true, value: 1000 },
-      clientHeight: { configurable: true, value: 400 },
-      scrollTop: { configurable: true, value: 600, writable: true },
-    });
-
-    for (let i = 0; i < 3; i++) {
-      const beforeLoad = mountedCount(container);
-      act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
-      const afterLoad = mountedCount(container);
-      expect(afterLoad).toBeGreaterThan(beforeLoad);
-
-      fireEvent.scroll(viewport);
-
-      expect(mountedCount(container)).toBe(afterLoad);
-    }
+    expect(mountedCount(container)).toBe(loadedCount);
   });
 
   it("resets the range to the tail budget when a new user message is appended", () => {
@@ -326,6 +306,23 @@ describe("MessageList pagination", () => {
 
     expect(mountedCount(container)).toBe(InitialMessages);
     expect(mountedMessageIds(container).at(-1)).toContain("user 200");
+  });
+
+  it("resets the range when a user and assistant are appended together", () => {
+    const messages = makeMessages(200);
+    const { container, rerender } = renderList(messages);
+
+    act(() => IntersectionObserverProbe.instances.at(-1)?.intersect());
+    expect(mountedCount(container)).toBeGreaterThan(InitialMessages);
+
+    rerender(
+      <MessageListProbe
+        messages={[...messages, makeMessage(200), makeMessage(201)]}
+      />,
+    );
+
+    expect(mountedCount(container)).toBe(InitialMessages);
+    expect(mountedMessageIds(container).at(-1)).toContain("assistant 201");
   });
 
   it("uses the tail budget in the first commit after a user message is appended", () => {

--- a/packages/vscode-webui/src/components/message/__tests__/use-message-list-pagination.test.ts
+++ b/packages/vscode-webui/src/components/message/__tests__/use-message-list-pagination.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  MessageListPaginationConfig,
+  computePageStart,
+  loadEarlier,
+  resetPaginationToTail,
+  resolvePageStart,
+} from "../use-message-list-pagination";
+
+const { partBudget, minInitialMessages } = MessageListPaginationConfig;
+
+function uniformPartCounts(messageCount: number, partsPerMessage: number) {
+  return Array.from({ length: messageCount }, () => partsPerMessage);
+}
+
+function sumRange(partCounts: number[], start: number) {
+  return partCounts.slice(start).reduce((total, count) => total + count, 0);
+}
+
+describe("computePageStart", () => {
+  it("uses one 60-part budget with a two-message initial floor", () => {
+    expect(MessageListPaginationConfig).toEqual({
+      partBudget: 60,
+      minInitialMessages: 2,
+    });
+  });
+
+  it("walks backward until the part budget would be exceeded", () => {
+    const partCounts = uniformPartCounts(200, 5);
+
+    const start = computePageStart(
+      partCounts,
+      partCounts.length,
+      partBudget,
+      minInitialMessages,
+    );
+
+    expect(sumRange(partCounts, start)).toBeLessThanOrEqual(partBudget);
+    expect(sumRange(partCounts, start - 1)).toBeGreaterThan(partBudget);
+    expect(start).toBe(200 - partBudget / 5);
+  });
+
+  it("keeps the initial message floor when a single message exceeds the budget", () => {
+    const partCounts = uniformPartCounts(50, partBudget * 2);
+
+    const start = computePageStart(
+      partCounts,
+      partCounts.length,
+      partBudget,
+      minInitialMessages,
+    );
+
+    expect(partCounts.length - start).toBe(minInitialMessages);
+  });
+
+  it("mounts the whole history when it fits in the budget", () => {
+    const partCounts = uniformPartCounts(4, 5);
+
+    expect(
+      computePageStart(
+        partCounts,
+        partCounts.length,
+        partBudget,
+        minInitialMessages,
+      ),
+    ).toBe(0);
+  });
+
+  it("returns 0 for an empty history", () => {
+    expect(computePageStart([], 0, partBudget, minInitialMessages)).toBe(0);
+  });
+});
+
+describe("loadEarlier", () => {
+  it("moves the start monotonically backward and stops at 0", () => {
+    const partCounts = uniformPartCounts(200, 5);
+    let state = { startIndex: null as number | null };
+    let previous = resolvePageStart(
+      state,
+      partCounts,
+      MessageListPaginationConfig,
+    );
+
+    for (let i = 0; i < 100; i++) {
+      state = loadEarlier(state, partCounts, MessageListPaginationConfig);
+      const current = resolvePageStart(
+        state,
+        partCounts,
+        MessageListPaginationConfig,
+      );
+      expect(current).toBeLessThan(previous);
+      previous = current;
+      if (current === 0) break;
+    }
+
+    expect(previous).toBe(0);
+    expect(
+      loadEarlier(state, partCounts, MessageListPaginationConfig).startIndex,
+    ).toBe(0);
+  });
+
+  it("adds roughly one page of parts per call", () => {
+    const partCounts = uniformPartCounts(200, 5);
+    const first = resolvePageStart(
+      { startIndex: null },
+      partCounts,
+      MessageListPaginationConfig,
+    );
+
+    const next = loadEarlier(
+      { startIndex: first },
+      partCounts,
+      MessageListPaginationConfig,
+    ).startIndex;
+
+    expect(next).not.toBeNull();
+    expect(sumRange(partCounts, next as number) - partBudget).toBeLessThanOrEqual(
+      partBudget,
+    );
+  });
+
+  it("always advances by at least one message, even past a huge one", () => {
+    // Loading must advance even when the previous message exceeds the budget.
+    const partCounts = [5, 5, partBudget * 10, 5];
+
+    const next = loadEarlier(
+      { startIndex: 3 },
+      partCounts,
+      MessageListPaginationConfig,
+    ).startIndex;
+
+    expect(next).toBe(2);
+  });
+});
+
+describe("resolvePageStart", () => {
+  it("evaluates the initial budget when startIndex is null", () => {
+    const partCounts = uniformPartCounts(200, 5);
+
+    expect(
+      resolvePageStart(
+        { startIndex: null },
+        partCounts,
+        MessageListPaginationConfig,
+      ),
+    ).toBe(
+      computePageStart(
+        partCounts,
+        partCounts.length,
+        partBudget,
+        minInitialMessages,
+      ),
+    );
+  });
+
+  it("keeps a frozen startIndex instead of re-evaluating the budget", () => {
+    const partCounts = uniformPartCounts(200, 5);
+
+    // Streaming must not move a frozen page start.
+    const grown = [...partCounts.slice(0, -1), 400];
+
+    expect(
+      resolvePageStart(
+        { startIndex: 120 },
+        grown,
+        MessageListPaginationConfig,
+      ),
+    ).toBe(120);
+  });
+
+  it("recomputes the tail range when a frozen startIndex is no longer valid", () => {
+    const partCounts = uniformPartCounts(40, 5);
+    const expectedTail = computePageStart(
+      partCounts,
+      partCounts.length,
+      partBudget,
+      minInitialMessages,
+    );
+
+    expect(
+      resolvePageStart(
+        { startIndex: 999 },
+        partCounts,
+        MessageListPaginationConfig,
+      ),
+    ).toBe(expectedTail);
+    expect(
+      resolvePageStart(
+        { startIndex: -3 },
+        partCounts,
+        MessageListPaginationConfig,
+      ),
+    ).toBe(expectedTail);
+    expect(
+      resolvePageStart({ startIndex: 5 }, [], MessageListPaginationConfig),
+    ).toBe(0);
+  });
+});
+
+describe("resetPaginationToTail", () => {
+  it("drops the frozen index so the next render re-evaluates the budget", () => {
+    expect(resetPaginationToTail()).toEqual({ startIndex: null });
+
+    const partCounts = uniformPartCounts(200, 5);
+    expect(
+      resolvePageStart(
+        resetPaginationToTail(),
+        partCounts,
+        MessageListPaginationConfig,
+      ),
+    ).toBe(
+      computePageStart(
+        partCounts,
+        partCounts.length,
+        partBudget,
+        minInitialMessages,
+      ),
+    );
+  });
+});

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -32,6 +32,7 @@ import { MessageMarkdown } from "./markdown";
 import type { MermaidContext } from "./mermaid-context";
 import { MermaidContextProvider } from "./mermaid-context";
 import { Reviews } from "./reviews";
+import { useMessageListPagination } from "./use-message-list-pagination";
 import { UserEditsPart } from "./user-edits";
 
 interface UserEditsCheckpoint {
@@ -63,6 +64,8 @@ export const MessageList: React.FC<{
   repairingChart?: string | null;
   showLastStepDuration?: boolean;
   taskStatus?: Task["status"];
+  /** Mounts the full history for shared output and performance baselines. */
+  renderAllMessages?: boolean;
 }> = ({
   messages: renderMessages,
   isLoading,
@@ -81,6 +84,7 @@ export const MessageList: React.FC<{
   repairingChart,
   showLastStepDuration,
   taskStatus,
+  renderAllMessages = false,
 }) => {
   const [debouncedIsLoading, setDebouncedIsLoading] = useDebounceState(
     isLoading,
@@ -130,6 +134,18 @@ export const MessageList: React.FC<{
     [repairMermaid, repairingChart, isLoading, isExecuting],
   );
 
+  // Paginate mounted messages; derive values from the full history.
+  const { start, hiddenAboveCount, loadEarlierTriggerRef } =
+    useMessageListPagination({
+      messages: renderMessages,
+      containerRef,
+      enabled: !renderAllMessages && containerRef !== undefined,
+    });
+  const visibleMessages = useMemo(
+    () => renderMessages.slice(start),
+    [renderMessages, start],
+  );
+
   return (
     <BackgroundJobContextProvider messages={renderMessages}>
       <MermaidContextProvider value={mermaidContextValue}>
@@ -138,95 +154,104 @@ export const MessageList: React.FC<{
           viewportClassname={viewportClassname}
           ref={containerRef}
         >
-          {renderMessages.map((m, messageIndex) => (
-            <div
-              key={m.id}
-              className="message-list-item flex flex-col"
-              aria-label={`chat-message-${m.role}`}
-            >
-              <div className={cn(showUserAvatar && "pt-4 pb-2")}>
-                {showUserAvatar && (
-                  <div className="flex items-center gap-2">
-                    {m.role === "user" ? (
-                      <Avatar className="size-7 select-none">
-                        <AvatarImage src={user?.image ?? undefined} />
-                        <AvatarFallback
-                          className={cn(
-                            "bg-[var(--vscode-chat-avatarBackground)] text-[var(--vscode-chat-avatarForeground)] text-xs uppercase",
-                          )}
-                        >
-                          {user?.name.slice(0, 2) || (
-                            <UserIcon className={cn("size-[50%]")} />
-                          )}
-                        </AvatarFallback>
-                      </Avatar>
-                    ) : (
-                      <Avatar className="size-7 select-none">
-                        <AvatarImage
-                          src={assistant?.image ?? undefined}
-                          className="scale-110"
-                        />
-                        <AvatarFallback className="bg-[var(--vscode-chat-avatarBackground)] text-[var(--vscode-chat-avatarForeground)]" />
-                      </Avatar>
+          {hiddenAboveCount > 0 && (
+            <EarlierMessagesEdge ref={loadEarlierTriggerRef} />
+          )}
+          {visibleMessages.map((m, indexInRange) => {
+            const messageIndex = start + indexInRange;
+            return (
+              <div
+                key={m.id}
+                className="message-list-item flex flex-col"
+                aria-label={`chat-message-${m.role}`}
+              >
+                <div className={cn(showUserAvatar && "pt-4 pb-2")}>
+                  {showUserAvatar && (
+                    <div className="flex items-center gap-2">
+                      {m.role === "user" ? (
+                        <Avatar className="size-7 select-none">
+                          <AvatarImage src={user?.image ?? undefined} />
+                          <AvatarFallback
+                            className={cn(
+                              "bg-[var(--vscode-chat-avatarBackground)] text-[var(--vscode-chat-avatarForeground)] text-xs uppercase",
+                            )}
+                          >
+                            {user?.name.slice(0, 2) || (
+                              <UserIcon className={cn("size-[50%]")} />
+                            )}
+                          </AvatarFallback>
+                        </Avatar>
+                      ) : (
+                        <Avatar className="size-7 select-none">
+                          <AvatarImage
+                            src={assistant?.image ?? undefined}
+                            className="scale-110"
+                          />
+                          <AvatarFallback className="bg-[var(--vscode-chat-avatarBackground)] text-[var(--vscode-chat-avatarForeground)]" />
+                        </Avatar>
+                      )}
+                      <strong>
+                        {m.role === "user" ? user?.name : assistantName}
+                      </strong>
+                    </div>
+                  )}
+                  <div
+                    className={cn(
+                      "ml-1 flex flex-col",
+                      showUserAvatar && "mt-3",
                     )}
-                    <strong>
-                      {m.role === "user" ? user?.name : assistantName}
-                    </strong>
+                  >
+                    {m.parts.map((part, index) => (
+                      <Part
+                        role={m.role}
+                        key={index}
+                        messageId={m.id}
+                        isLastPartInMessages={
+                          index === m.parts.length - 1 &&
+                          messageIndex === renderMessages.length - 1
+                        }
+                        partIndex={index}
+                        part={part}
+                        isLoading={isLoading}
+                        shouldCheckpointUseLoading={shouldCheckpointUseLoading}
+                        messages={renderMessages}
+                        forkTask={forkTask}
+                        isSubTask={isSubTask}
+                        hideUserEditsActions={hideUserEditsActions}
+                        latestCheckpoint={latestCheckpoint}
+                        lastCheckpointInMessage={lastCheckpointInMessage}
+                        userEditsCheckpoint={userEditsCheckpoints[messageIndex]}
+                        toolCallCheckpoints={toolCallCheckpoints}
+                      />
+                    ))}
                   </div>
-                )}
-                <div
-                  className={cn("ml-1 flex flex-col", showUserAvatar && "mt-3")}
-                >
-                  {m.parts.map((part, index) => (
-                    <Part
-                      role={m.role}
-                      key={index}
-                      messageId={m.id}
-                      isLastPartInMessages={
-                        index === m.parts.length - 1 &&
-                        messageIndex === renderMessages.length - 1
-                      }
-                      partIndex={index}
-                      part={part}
-                      isLoading={isLoading}
-                      shouldCheckpointUseLoading={shouldCheckpointUseLoading}
-                      messages={renderMessages}
-                      forkTask={forkTask}
-                      isSubTask={isSubTask}
-                      hideUserEditsActions={hideUserEditsActions}
-                      latestCheckpoint={latestCheckpoint}
-                      lastCheckpointInMessage={lastCheckpointInMessage}
-                      userEditsCheckpoint={userEditsCheckpoints[messageIndex]}
-                      toolCallCheckpoints={toolCallCheckpoints}
-                    />
-                  ))}
+                  {/* Display attachments at the bottom of the message */}
+                  <UserAttachments message={m} />
+                  <UserSelections message={m} />
+                  <MessageBackgroundJobNotifications message={m} />
                 </div>
-                {/* Display attachments at the bottom of the message */}
-                <UserAttachments message={m} />
-                <UserSelections message={m} />
-                <MessageBackgroundJobNotifications message={m} />
-              </div>
-              {messageIndex < renderMessages.length - 1 ? (
-                <SeparatorWithCheckpoint
-                  messageIndex={messageIndex}
-                  message={m}
-                  nextMessage={renderMessages[messageIndex + 1]}
-                  isLoading={shouldCheckpointUseLoading}
-                  forkTask={forkTask}
-                  isSubTask={isSubTask}
-                  latestCheckpoint={latestCheckpoint}
-                  lastCheckpointInMessage={lastCheckpointInMessage}
-                />
-              ) : (
-                showLastStepDuration &&
-                !shouldCheckpointUseLoading && (
-                  <OptionalSeparatorWithExecutionDuration
-                    duration={computeExecutionDuration(m)}
+                {messageIndex < renderMessages.length - 1 ? (
+                  <SeparatorWithCheckpoint
+                    messageIndex={messageIndex}
+                    message={m}
+                    nextMessage={renderMessages[messageIndex + 1]}
+                    isLoading={shouldCheckpointUseLoading}
+                    forkTask={forkTask}
+                    isSubTask={isSubTask}
+                    latestCheckpoint={latestCheckpoint}
+                    lastCheckpointInMessage={lastCheckpointInMessage}
                   />
-                )
-              )}
-            </div>
-          ))}
+                ) : (
+                  showLastStepDuration &&
+                  !shouldCheckpointUseLoading && (
+                    <OptionalSeparatorWithExecutionDuration
+                      duration={computeExecutionDuration(m)}
+                    />
+                  )
+                )}
+              </div>
+            );
+          })}
           {showLoader && (
             <div className="py-2">
               {debouncedIsLoading ? (
@@ -316,6 +341,21 @@ function MessageBackgroundJobNotifications({ message }: { message: Message }) {
     part.type === "data-background-job-notification" ? [part.data] : [],
   );
   return <BackgroundJobNotifications notifications={notifications} />;
+}
+
+function EarlierMessagesEdge({
+  ref,
+}: {
+  ref: React.Ref<HTMLDivElement>;
+}) {
+  return (
+    <div
+      ref={ref}
+      data-testid="message-list-auto-load-earlier"
+      aria-hidden="true"
+      className="pointer-events-none h-px w-full"
+    />
+  );
 }
 
 function Part({

--- a/packages/vscode-webui/src/components/message/use-message-list-pagination.ts
+++ b/packages/vscode-webui/src/components/message/use-message-list-pagination.ts
@@ -1,0 +1,251 @@
+import type { Message } from "@getpochi/livekit";
+import type React from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+/**
+ * Paginates MessageList with a tail-aligned slice.
+ * The newest messages remain mounted to preserve bottom anchoring.
+ */
+export const MessageListPaginationConfig = {
+  /** Part budget for initial mount, reset, and each earlier-page load. */
+  partBudget: 60,
+  /** Minimum messages kept when one message exceeds the budget. */
+  minInitialMessages: 2,
+} as const;
+
+export type MessageListPaginationConfigValue = {
+  partBudget: number;
+  minInitialMessages: number;
+};
+
+export interface MessageListPaginationState {
+  /** Absolute index of the first mounted message; null recalculates it. */
+  startIndex: number | null;
+}
+
+/** Matches use-is-at-bottom.ts. */
+const BottomThreshold = 150;
+/** Preloads 200px before the top trigger enters view. */
+const LoadEarlierRootMargin = "200px 0px";
+
+/** Walks backward within budget, except to satisfy minMessages. */
+export function computePageStart(
+  partCounts: number[],
+  fromIndex: number,
+  budget: number,
+  minMessages: number,
+): number {
+  const upper = Math.min(fromIndex, partCounts.length);
+  let start = Math.max(upper, 0);
+  let used = 0;
+
+  for (let i = upper - 1; i >= 0; i--) {
+    const count = Math.max(partCounts[i] ?? 0, 0);
+    const taken = upper - i - 1;
+    if (used + count > budget && taken >= minMessages) {
+      break;
+    }
+    used += count;
+    start = i;
+  }
+
+  return start;
+}
+
+/** Keeps a valid start during streaming; invalid indices reset to the tail. */
+export function resolvePageStart(
+  state: MessageListPaginationState,
+  partCounts: number[],
+  config: MessageListPaginationConfigValue,
+): number {
+  const total = partCounts.length;
+  if (total === 0) {
+    return 0;
+  }
+  if (
+    state.startIndex === null ||
+    state.startIndex < 0 ||
+    state.startIndex >= total
+  ) {
+    return computePageStart(
+      partCounts,
+      total,
+      config.partBudget,
+      config.minInitialMessages,
+    );
+  }
+  return state.startIndex;
+}
+
+/** Loads one more part budget before the current page. */
+export function loadEarlier(
+  state: MessageListPaginationState,
+  partCounts: number[],
+  config: MessageListPaginationConfigValue,
+): MessageListPaginationState {
+  const current = resolvePageStart(state, partCounts, config);
+  if (current === 0) {
+    return { startIndex: 0 };
+  }
+  // Require progress only; the initial floor could load multiple huge messages.
+  return {
+    startIndex: computePageStart(partCounts, current, config.partBudget, 1),
+  };
+}
+
+/** Recomputes the tail page on the next render. */
+export function resetPaginationToTail(): MessageListPaginationState {
+  return { startIndex: null };
+}
+
+export function useMessageListPagination({
+  messages,
+  containerRef,
+  enabled = true,
+  config = MessageListPaginationConfig,
+}: {
+  messages: Message[];
+  containerRef?: React.RefObject<HTMLDivElement | null>;
+  enabled?: boolean;
+  config?: MessageListPaginationConfigValue;
+}) {
+  const paginationEnabled =
+    enabled && typeof IntersectionObserver !== "undefined";
+  const [state, setState] = useState<MessageListPaginationState>(
+    resetPaginationToTail,
+  );
+
+  const partCounts = useMemo(
+    () => messages.map((m) => m.parts.length),
+    [messages],
+  );
+  const partCountsRef = useRef(partCounts);
+  const isLoadEarlierTriggerVisibleRef = useRef(false);
+  useEffect(() => {
+    partCountsRef.current = partCounts;
+  }, [partCounts]);
+
+  const lastMessage = messages.at(-1);
+  const lastMessageId = lastMessage?.id;
+  const lastMessageRole = lastMessage?.role;
+  const previousLastIdRef = useRef(lastMessageId);
+  const shouldResetForNewUser =
+    previousLastIdRef.current !== lastMessageId && lastMessageRole === "user";
+  const effectiveState = shouldResetForNewUser
+    ? resetPaginationToTail()
+    : state;
+  const start = paginationEnabled
+    ? resolvePageStart(effectiveState, partCounts, config)
+    : 0;
+
+  // Reset before commit to avoid mounting the expanded page first.
+  useLayoutEffect(() => {
+    previousLastIdRef.current = lastMessageId;
+    if (!paginationEnabled || messages.length === 0) return;
+    setState((prev) =>
+      shouldResetForNewUser || prev.startIndex === null
+        ? { startIndex: start }
+        : prev,
+    );
+  }, [
+    paginationEnabled,
+    lastMessageId,
+    messages.length,
+    shouldResetForNewUser,
+    start,
+  ]);
+
+  // Trim loaded pages after the user returns to the bottom.
+  useEffect(() => {
+    const container = containerRef?.current;
+    if (!paginationEnabled || !container) return;
+
+    const onScroll = () => {
+      if (isLoadEarlierTriggerVisibleRef.current) return;
+      const distanceToBottom =
+        container.scrollHeight - container.scrollTop - container.clientHeight;
+      if (distanceToBottom > BottomThreshold) return;
+      setState((prev) => {
+        if (prev.startIndex === null) return prev;
+        const counts = partCountsRef.current;
+        const next = computePageStart(
+          counts,
+          counts.length,
+          config.partBudget,
+          config.minInitialMessages,
+        );
+        return next === prev.startIndex ? prev : { startIndex: next };
+      });
+    };
+
+    container.addEventListener("scroll", onScroll, { passive: true });
+    return () => container.removeEventListener("scroll", onScroll);
+  }, [paginationEnabled, containerRef, config]);
+
+  // Preserve the bottom distance when prepending messages.
+  const pendingBottomDistanceRef = useRef<number | null>(null);
+  const loadPendingRef = useRef(false);
+
+  const handleLoadEarlier = useCallback(() => {
+    if (!paginationEnabled || loadPendingRef.current) return;
+    const next = loadEarlier(
+      { startIndex: start },
+      partCountsRef.current,
+      config,
+    );
+    if (next.startIndex === start) return;
+
+    const container = containerRef?.current;
+    if (container) {
+      pendingBottomDistanceRef.current =
+        container.scrollHeight - container.scrollTop;
+    }
+    loadPendingRef.current = true;
+    setState(next);
+  }, [paginationEnabled, start, config, containerRef]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: start triggers restoration after commit but is not read
+  useLayoutEffect(() => {
+    loadPendingRef.current = false;
+    const container = containerRef?.current;
+    const distance = pendingBottomDistanceRef.current;
+    if (!container || distance === null) return;
+    pendingBottomDistanceRef.current = null;
+    container.scrollTop = container.scrollHeight - distance;
+  }, [start, containerRef]);
+
+  const loadEarlierTriggerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const trigger = loadEarlierTriggerRef.current;
+    const root = containerRef?.current;
+    if (!paginationEnabled || start === 0 || !trigger || !root) {
+      isLoadEarlierTriggerVisibleRef.current = false;
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const isVisible = entries.some((entry) => entry.isIntersecting);
+        isLoadEarlierTriggerVisibleRef.current = isVisible;
+        if (isVisible) {
+          handleLoadEarlier();
+        }
+      },
+      { root, rootMargin: LoadEarlierRootMargin },
+    );
+    observer.observe(trigger);
+    return () => observer.disconnect();
+  }, [paginationEnabled, start, containerRef, handleLoadEarlier]);
+
+  return {
+    start,
+    hiddenAboveCount: start,
+    loadEarlierTriggerRef,
+  };
+}

--- a/packages/vscode-webui/src/components/message/use-message-list-pagination.ts
+++ b/packages/vscode-webui/src/components/message/use-message-list-pagination.ts
@@ -30,10 +30,8 @@ export interface MessageListPaginationState {
   startIndex: number | null;
 }
 
-/** Matches use-is-at-bottom.ts. */
-const BottomThreshold = 150;
-/** Preloads 200px before the top trigger enters view. */
-const LoadEarlierRootMargin = "200px 0px";
+/** Loads when the top trigger enters view. */
+const LoadEarlierRootMargin = "0px";
 
 /** Walks backward within budget, except to satisfy minMessages. */
 export function computePageStart(
@@ -127,17 +125,16 @@ export function useMessageListPagination({
     [messages],
   );
   const partCountsRef = useRef(partCounts);
-  const isLoadEarlierTriggerVisibleRef = useRef(false);
   useEffect(() => {
     partCountsRef.current = partCounts;
   }, [partCounts]);
 
-  const lastMessage = messages.at(-1);
-  const lastMessageId = lastMessage?.id;
-  const lastMessageRole = lastMessage?.role;
-  const previousLastIdRef = useRef(lastMessageId);
+  const lastUserMessageId = messages.findLast(
+    (message) => message.role === "user",
+  )?.id;
+  const previousLastUserMessageIdRef = useRef(lastUserMessageId);
   const shouldResetForNewUser =
-    previousLastIdRef.current !== lastMessageId && lastMessageRole === "user";
+    previousLastUserMessageIdRef.current !== lastUserMessageId;
   const effectiveState = shouldResetForNewUser
     ? resetPaginationToTail()
     : state;
@@ -145,9 +142,9 @@ export function useMessageListPagination({
     ? resolvePageStart(effectiveState, partCounts, config)
     : 0;
 
-  // Reset before commit to avoid mounting the expanded page first.
-  useLayoutEffect(() => {
-    previousLastIdRef.current = lastMessageId;
+  // Persist the render-time reset after the tail page commits.
+  useEffect(() => {
+    previousLastUserMessageIdRef.current = lastUserMessageId;
     if (!paginationEnabled || messages.length === 0) return;
     setState((prev) =>
       shouldResetForNewUser || prev.startIndex === null
@@ -156,38 +153,11 @@ export function useMessageListPagination({
     );
   }, [
     paginationEnabled,
-    lastMessageId,
+    lastUserMessageId,
     messages.length,
     shouldResetForNewUser,
     start,
   ]);
-
-  // Trim loaded pages after the user returns to the bottom.
-  useEffect(() => {
-    const container = containerRef?.current;
-    if (!paginationEnabled || !container) return;
-
-    const onScroll = () => {
-      if (isLoadEarlierTriggerVisibleRef.current) return;
-      const distanceToBottom =
-        container.scrollHeight - container.scrollTop - container.clientHeight;
-      if (distanceToBottom > BottomThreshold) return;
-      setState((prev) => {
-        if (prev.startIndex === null) return prev;
-        const counts = partCountsRef.current;
-        const next = computePageStart(
-          counts,
-          counts.length,
-          config.partBudget,
-          config.minInitialMessages,
-        );
-        return next === prev.startIndex ? prev : { startIndex: next };
-      });
-    };
-
-    container.addEventListener("scroll", onScroll, { passive: true });
-    return () => container.removeEventListener("scroll", onScroll);
-  }, [paginationEnabled, containerRef, config]);
 
   // Preserve the bottom distance when prepending messages.
   const pendingBottomDistanceRef = useRef<number | null>(null);
@@ -211,14 +181,15 @@ export function useMessageListPagination({
     setState(next);
   }, [paginationEnabled, start, config, containerRef]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: start triggers restoration after commit but is not read
+  // biome-ignore lint/correctness/useExhaustiveDependencies: start triggers anchor restoration after loading earlier messages.
   useLayoutEffect(() => {
     loadPendingRef.current = false;
     const container = containerRef?.current;
     const distance = pendingBottomDistanceRef.current;
     if (!container || distance === null) return;
     pendingBottomDistanceRef.current = null;
-    container.scrollTop = container.scrollHeight - distance;
+    const targetScrollTop = container.scrollHeight - distance;
+    container.scrollTop = targetScrollTop;
   }, [start, containerRef]);
 
   const loadEarlierTriggerRef = useRef<HTMLDivElement | null>(null);
@@ -226,13 +197,11 @@ export function useMessageListPagination({
     const trigger = loadEarlierTriggerRef.current;
     const root = containerRef?.current;
     if (!paginationEnabled || start === 0 || !trigger || !root) {
-      isLoadEarlierTriggerVisibleRef.current = false;
       return;
     }
     const observer = new IntersectionObserver(
       (entries) => {
-        const isVisible = entries.some((entry) => entry.isIntersecting);
-        isLoadEarlierTriggerVisibleRef.current = isVisible;
+        const isVisible = entries.some((item) => item.isIntersecting);
         if (isVisible) {
           handleLoadEarlier();
         }

--- a/packages/vscode-webui/src/features/chat/components/chat-area.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.test.tsx
@@ -1,0 +1,44 @@
+import type { Message } from "@getpochi/livekit";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatArea } from "./chat-area";
+
+const mocks = vi.hoisted(() => ({
+  messageListProps: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@/components/message/message-list", () => ({
+  MessageList: (props: Record<string, unknown>) => {
+    mocks.messageListProps.push(props);
+    return null;
+  },
+}));
+
+vi.mock("@/components/empty-chat-placeholder", () => ({
+  EmptyChatPlaceholder: () => null,
+}));
+
+vi.mock("@/lib/hooks/use-resource-uri", () => ({
+  useResourceURI: () => undefined,
+}));
+
+const message: Message = {
+  id: "message-1",
+  role: "user",
+  metadata: { kind: "user" },
+  parts: [{ type: "text", text: "hello" }],
+};
+
+describe("ChatArea", () => {
+  beforeEach(() => {
+    mocks.messageListProps.length = 0;
+  });
+
+  it("passes the diagnostic full-history mode to MessageList", () => {
+    render(
+      <ChatArea messages={[message]} isLoading={false} renderAllMessages />,
+    );
+
+    expect(mocks.messageListProps.at(-1)?.renderAllMessages).toBe(true);
+  });
+});

--- a/packages/vscode-webui/src/features/chat/components/chat-area.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.tsx
@@ -19,6 +19,7 @@ interface ChatAreaProps {
   repairingChart?: string | null;
   showLastStepDuration?: boolean;
   taskStatus?: Task["status"];
+  renderAllMessages?: boolean;
 }
 
 export function ChatArea({
@@ -35,6 +36,7 @@ export function ChatArea({
   repairingChart,
   showLastStepDuration,
   taskStatus,
+  renderAllMessages,
 }: ChatAreaProps) {
   const resourceUri = useResourceURI();
   return (
@@ -60,6 +62,7 @@ export function ChatArea({
         repairingChart={repairingChart}
         showLastStepDuration={showLastStepDuration}
         taskStatus={taskStatus}
+        renderAllMessages={renderAllMessages}
       />
     </>
   );

--- a/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.test.tsx
@@ -66,6 +66,48 @@ describe("useScrollToBottom", () => {
     });
   });
 
+  it("keeps following while a smooth scroll catches a growing bottom", () => {
+    const context = setup();
+
+    context.scrollTo.mockClear();
+    context.setScrollHeight(3000);
+    act(() => {
+      context.programmaticScrollTo(1800);
+      context.resizeObserver.trigger();
+    });
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 3000,
+      behavior: "smooth",
+    });
+
+    context.scrollTo.mockClear();
+    context.setScrollHeight(3500);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 3500,
+      behavior: "smooth",
+    });
+  });
+
+  it("keeps following when an upward correction lands at the bottom", () => {
+    const context = setup();
+
+    context.setScrollHeight(1200);
+    act(() => context.programmaticScrollTo(700));
+    context.setScrollHeight(1000);
+    act(() => context.programmaticScrollTo(500));
+
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1200,
+      behavior: "smooth",
+    });
+  });
+
   it("does not scroll on rerender after the user scrolls away from the bottom", () => {
     const context = setup();
 
@@ -106,6 +148,24 @@ describe("useScrollToBottom", () => {
     });
   });
 
+  it("resumes following content growth after a new user message", () => {
+    const context = setup();
+
+    act(() => context.userScrollTo(300));
+    context.rerender({
+      lastUserMessageId: "user-message-1",
+    });
+
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1200,
+      behavior: "smooth",
+    });
+  });
+
   it("does not scroll for the initially observed user message id", () => {
     const context = setup({
       lastUserMessageId: "existing-user-message",
@@ -139,8 +199,14 @@ function setup(
     lastUserMessageId?: string;
   } = {},
 ) {
-  const { container, scrollTo, setScrollTop, userScrollTo } =
-    createScrollContainer();
+  const {
+    container,
+    programmaticScrollTo,
+    scrollTo,
+    setScrollHeight,
+    setScrollTop,
+    userScrollTo,
+  } = createScrollContainer();
 
   type HookProps = {
     lastUserMessageId?: string;
@@ -169,9 +235,11 @@ function setup(
     container,
     onToolCallApprovalVisible:
       hook.result.current?.onToolCallApprovalVisible ?? missingApprovalCallback,
+    programmaticScrollTo,
     rerender: hook.rerender,
     resizeObserver: ResizeObserverMock.instances[0],
     scrollTo,
+    setScrollHeight,
     setScrollTop,
     userScrollTo,
   };
@@ -183,7 +251,7 @@ function missingApprovalCallback() {
 
 function createScrollContainer() {
   let scrollTop = 500;
-  const scrollHeight = 1000;
+  let scrollHeight = 1000;
   const container = document.createElement("div");
   container.appendChild(document.createElement("div"));
 
@@ -220,7 +288,14 @@ function createScrollContainer() {
 
   return {
     container,
+    programmaticScrollTo: (value: number) => {
+      scrollTop = value;
+      container.dispatchEvent(new Event("scroll"));
+    },
     scrollTo,
+    setScrollHeight: (value: number) => {
+      scrollHeight = value;
+    },
     setScrollTop: (value: number) => {
       scrollTop = value;
     },

--- a/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.ts
@@ -13,6 +13,7 @@ export function useScrollToBottom({
 }: UseScrollToBottomProps) {
   const { getIsAtBottom, scrollToBottom } = useIsAtBottom(messagesContainerRef);
   const lastObservedUserMessageIdRef = useRef(lastUserMessageId);
+  const shouldAutoFollowRef = useRef(true);
 
   // Scroll to bottom when the message list height changes
   useEffect(() => {
@@ -20,14 +21,33 @@ export function useScrollToBottom({
     if (!container?.children[0]) {
       return;
     }
-    const resizeObserver = new ResizeObserver(() => {
-      if (getIsAtBottom()) {
-        requestAnimationFrame(() => scrollToBottom());
+    let previousScrollTop = container.scrollTop;
+    const onScroll = () => {
+      const scrollTop = container.scrollTop;
+      const distanceToBottom =
+        container.scrollHeight - scrollTop - container.clientHeight;
+      if (distanceToBottom <= 1) {
+        shouldAutoFollowRef.current = true;
+      } else if (scrollTop < previousScrollTop - 1) {
+        shouldAutoFollowRef.current = false;
+      } else if (getIsAtBottom()) {
+        shouldAutoFollowRef.current = true;
       }
+      previousScrollTop = scrollTop;
+    };
+    const followResize = () => {
+      if (!shouldAutoFollowRef.current) return;
+      scrollToBottom();
+    };
+    const resizeObserver = new ResizeObserver(() => {
+      if (!shouldAutoFollowRef.current) return;
+      requestAnimationFrame(followResize);
     });
+    container.addEventListener("scroll", onScroll, { passive: true });
     resizeObserver.observe(container);
     resizeObserver.observe(container.children[0]);
     return () => {
+      container.removeEventListener("scroll", onScroll);
       resizeObserver.disconnect();
     }; // clean up
   }, [getIsAtBottom, scrollToBottom, messagesContainerRef]);
@@ -43,14 +63,14 @@ export function useScrollToBottom({
     }
 
     lastObservedUserMessageIdRef.current = lastUserMessageId;
+    shouldAutoFollowRef.current = true;
     scrollToBottom(false);
   }, [lastUserMessageId, scrollToBottom]);
 
   // Initial scroll to bottom once when component mounts (without smooth behavior)
   useLayoutEffect(() => {
-    if (messagesContainerRef.current) {
-      scrollToBottom(false); // false = not smooth
-    }
+    if (!messagesContainerRef.current) return;
+    scrollToBottom(false); // false = not smooth
   }, [scrollToBottom, messagesContainerRef]);
 
   const onToolCallApprovalVisible = useCallback(() => {

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -401,9 +401,9 @@ function Chat({ user, uid, info }: ChatProps) {
     messages,
   });
 
-  const lastMessage = messages.at(-1);
-  const lastUserMessageId =
-    lastMessage?.role === "user" ? lastMessage.id : undefined;
+  const lastUserMessageId = messages.findLast(
+    (message) => message.role === "user",
+  )?.id;
 
   const { onToolCallApprovalVisible } = useScrollToBottom({
     messagesContainerRef,

--- a/packages/vscode-webui/src/features/share/page.tsx
+++ b/packages/vscode-webui/src/features/share/page.tsx
@@ -195,6 +195,7 @@ export function SharePage() {
                     assistant={assistant}
                     messages={renderMessages}
                     isLoading={isLoading}
+                    renderAllMessages
                     hideUserEditsActions
                     showLastStepDuration={showLastStepDuration}
                   />


### PR DESCRIPTION
## Summary
- Introduces `useMessageListPagination` to slice the message list with a tail-aligned window.
- Restricts the rendered message parts based on a budget (`partBudget: 60`), preventing renderer OOM on long chat histories.
- Retains bottom-anchoring and allows users to load earlier messages smoothly.

## Perf
### Before
<img width="1614" height="490" alt="image" src="https://github.com/user-attachments/assets/83de3516-0813-4200-92d0-062b1f8a1fcd" />


### After
<img width="1616" height="468" alt="image" src="https://github.com/user-attachments/assets/a977cd12-243e-4286-b6cf-8bbe59fb7f5f" />


## Test plan
- Verified with unit tests in `use-message-list-pagination.test.ts` and `message-list-pagination.test.tsx`.
- Verified with performance story tests in `task-history.perf.stories.test.tsx`.
- Ran full test suite to ensure no regression.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-6fc1dbb9a6fe446997168cc6c70a4a2f)