### PR TITLE
chore(vscode-webui): stop passing full message array to tool parts

### DIFF
--- a/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
@@ -38,21 +38,24 @@ vi.mock("@/features/chat", () => ({
 }));
 
 vi.mock("@/features/tools", () => ({
-  ToolInvocationPart: ({
-    tool,
-    changes,
-    isLastPart,
-  }: {
+  ToolInvocationPart: (props: {
     tool: { toolCallId: string };
     changes?: { origin?: string; modified?: string };
+    messages?: Message[];
     isLastPart?: boolean;
+    isInLatestAssistantMessage?: boolean;
   }) => (
     <div
       data-testid="tool-part"
-      data-tool-call-id={tool.toolCallId}
-      data-changes-origin={changes?.origin ?? ""}
-      data-changes-modified={changes?.modified ?? ""}
-      data-is-last-part={String(!!isLastPart)}
+      data-tool-call-id={props.tool.toolCallId}
+      data-has-changes={String("changes" in props)}
+      data-has-messages={String("messages" in props)}
+      data-changes-origin={props.changes?.origin ?? ""}
+      data-changes-modified={props.changes?.modified ?? ""}
+      data-is-last-part={String(!!props.isLastPart)}
+      data-is-in-latest-assistant-message={String(
+        !!props.isInLatestAssistantMessage,
+      )}
     />
   ),
   BackgroundJobPanel: () => null,
@@ -368,10 +371,26 @@ describe("MessageList pagination", () => {
     ).map((node) => node.outerHTML);
 
     expect(pagedItems).toEqual(fullItems.slice(-pagedItems.length));
-    // Cross-message derivations still include checkpoints outside this page.
-    const firstTool = paged.container.querySelector<HTMLElement>(
-      '[data-testid="tool-part"]',
+  });
+
+  it("passes targeted context instead of the full message list to tools", () => {
+    const messages = makeMessages(4);
+    const { container } = renderList(messages, true);
+    const tools = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-testid="tool-part"]'),
     );
-    expect(firstTool?.dataset.changesOrigin).toBeTruthy();
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0]?.dataset.isInLatestAssistantMessage).toBe("false");
+    expect(tools[1]?.dataset.isInLatestAssistantMessage).toBe("true");
+    expect(tools[1]?.dataset.changesOrigin).toBe("commit-1");
+    expect(tools[1]?.dataset.changesModified).toBe("commit-3");
+    expect(
+      tools.every(
+        (tool) =>
+          tool.dataset.hasMessages === "false" &&
+          tool.dataset.hasChanges === "true",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -210,18 +210,25 @@ export const MessageList: React.FC<{
                           index === m.parts.length - 1 &&
                           messageIndex === renderMessages.length - 1
                         }
+                        isInLatestAssistantMessage={
+                          m.role === "assistant" &&
+                          messageIndex === renderMessages.length - 1
+                        }
                         partIndex={index}
                         part={part}
                         isLoading={isLoading}
                         shouldCheckpointUseLoading={shouldCheckpointUseLoading}
-                        messages={renderMessages}
                         forkTask={forkTask}
                         isSubTask={isSubTask}
                         hideUserEditsActions={hideUserEditsActions}
                         latestCheckpoint={latestCheckpoint}
                         lastCheckpointInMessage={lastCheckpointInMessage}
                         userEditsCheckpoint={userEditsCheckpoints[messageIndex]}
-                        toolCallCheckpoints={toolCallCheckpoints}
+                        toolCallCheckpoint={
+                          isStaticToolUIPart(part)
+                            ? toolCallCheckpoints.get(part.toolCallId)
+                            : undefined
+                        }
                       />
                     ))}
                   </div>
@@ -364,25 +371,25 @@ function Part({
   partIndex,
   messageId,
   isLastPartInMessages,
+  isInLatestAssistantMessage,
   isLoading,
   shouldCheckpointUseLoading,
-  messages,
   forkTask,
   isSubTask,
   latestCheckpoint,
   lastCheckpointInMessage,
   hideUserEditsActions,
   userEditsCheckpoint,
-  toolCallCheckpoints,
+  toolCallCheckpoint,
 }: {
   role: Message["role"];
   partIndex: number;
   messageId: string;
   part: NonNullable<Message["parts"]>[number];
   isLastPartInMessages: boolean;
+  isInLatestAssistantMessage: boolean;
   isLoading: boolean;
   shouldCheckpointUseLoading: boolean;
-  messages: Message[];
   forkTask?: (commitId: string) => Promise<void>;
   isSubTask?: boolean;
   hideUserEditsActions?: boolean;
@@ -392,7 +399,7 @@ function Part({
     origin: string | undefined;
     modified: string | undefined;
   };
-  toolCallCheckpoints: Map<string, ToolCallCheckpoint>;
+  toolCallCheckpoint?: ToolCallCheckpoint;
 }) {
   const paddingClass = partIndex === 0 ? "" : "mt-2";
   if (part.type === "text") {
@@ -469,10 +476,10 @@ function Part({
         className={paddingClass}
         tool={part}
         isLoading={isLoading}
-        changes={toolCallCheckpoints.get(part.toolCallId)}
-        messages={messages}
+        changes={toolCallCheckpoint}
         isSubTask={isSubTask}
         isLastPart={isLastPartInMessages}
+        isInLatestAssistantMessage={isInLatestAssistantMessage}
       />
     );
   }

--- a/packages/vscode-webui/src/features/tools/__stories__/attempt-completion.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/attempt-completion.stories.tsx
@@ -1,4 +1,3 @@
-import type { Message } from "@getpochi/livekit";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AttemptCompletionTool } from "../components/attempt-completion";
 import type { ToolProps } from "../components/types";
@@ -25,25 +24,13 @@ const toolCall: ToolProps<"attemptCompletion">["tool"] = {
   },
 };
 
-const messageWithTool: Message = {
-  id: "msg-1",
-  role: "assistant",
-  parts: [toolCall],
-};
-
 export const ShowButton: Story = {
   args: {
     tool: toolCall,
     isExecuting: false,
     isLoading: false,
-    messages: [messageWithTool],
+    isLastPart: true,
   },
-};
-
-const messageWithToolNotLast: Message = {
-  id: "msg-1",
-  role: "assistant",
-  parts: [toolCall, { type: "text", text: "Some text after tool call" }],
 };
 
 export const HideButtonNotLastPart: Story = {
@@ -51,20 +38,8 @@ export const HideButtonNotLastPart: Story = {
     tool: toolCall,
     isExecuting: false,
     isLoading: false,
-    messages: [messageWithToolNotLast],
+    isLastPart: false,
   },
-};
-
-const messageWithToolNotLastMessage: Message = {
-  id: "msg-1",
-  role: "assistant",
-  parts: [toolCall],
-};
-
-const nextMessage: Message = {
-  id: "msg-2",
-  role: "user",
-  parts: [{ type: "text", text: "Thanks" }],
 };
 
 export const HideButtonNotLastMessage: Story = {
@@ -72,7 +47,7 @@ export const HideButtonNotLastMessage: Story = {
     tool: toolCall,
     isExecuting: false,
     isLoading: false,
-    messages: [messageWithToolNotLastMessage, nextMessage],
+    isLastPart: false,
   },
 };
 
@@ -91,6 +66,6 @@ Please review the changes.`,
     },
     isExecuting: false,
     isLoading: false,
-    messages: [messageWithTool],
+    isLastPart: true,
   },
 };

--- a/packages/vscode-webui/src/features/tools/__stories__/attempt-todo-completion-view.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/attempt-todo-completion-view.stories.tsx
@@ -117,7 +117,6 @@ function makeProps(
     tool,
     isExecuting: options.isExecuting ?? false,
     isLoading: options.isLoading ?? false,
-    messages: [],
     taskSource: options.taskSource ?? taskSource,
     isLastPart: true,
   };

--- a/packages/vscode-webui/src/features/tools/__stories__/browser-view.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/browser-view.stories.tsx
@@ -90,7 +90,6 @@ const baseProps: NewTaskToolViewProps = {
   tool: baseTool,
   isExecuting: true,
   isLoading: false,
-  messages: [],
   uid: "task-123",
   taskSource: {
     isLoading: false,

--- a/packages/vscode-webui/src/features/tools/__stories__/new-task-tool-gallery.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/new-task-tool-gallery.stories.tsx
@@ -24,7 +24,6 @@ const ToolsGallery: React.FC<{
           key={tool.toolCallId + index}
           isExecuting={isExecuting ?? false}
           isLoading={false}
-          messages={[]}
           taskThreadSource={taskThreadSource}
         />
       ))}

--- a/packages/vscode-webui/src/features/tools/__stories__/tool-gallery.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/tool-gallery.stories.tsx
@@ -15,7 +15,6 @@ const ToolsGallery: React.FC<{
           // @ts-expect-error
           tool={tool}
           isLoading={false}
-          messages={[]}
         />
       ))}
     </div>

--- a/packages/vscode-webui/src/features/tools/__stories__/use-skill.stories.tsx
+++ b/packages/vscode-webui/src/features/tools/__stories__/use-skill.stories.tsx
@@ -1,4 +1,3 @@
-import type { Message } from "@getpochi/livekit";
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ToolProps } from "../components/types";
 import { UseSkillTool } from "../components/use-skill";
@@ -36,18 +35,11 @@ const executingToolCall: ToolProps<"useSkill">["tool"] = {
   state: "input-available",
 };
 
-const messageWithTool: Message = {
-  id: "msg-1",
-  role: "assistant",
-  parts: [toolCall],
-};
-
 export const Executing: Story = {
   args: {
     tool: executingToolCall,
     isExecuting: true,
     isLoading: false,
-    messages: [messageWithTool],
   },
 };
 
@@ -56,7 +48,6 @@ export const Completed: Story = {
     tool: toolCall,
     isExecuting: false,
     isLoading: false,
-    messages: [messageWithTool],
   },
 };
 
@@ -73,7 +64,6 @@ export const WithoutFilePath: Story = {
     },
     isExecuting: false,
     isLoading: false,
-    messages: [messageWithTool],
   },
 };
 
@@ -98,6 +88,5 @@ console.log(x);
     },
     isExecuting: false,
     isLoading: false,
-    messages: [messageWithTool],
   },
 };

--- a/packages/vscode-webui/src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/attempt-todo-completion-view.test.tsx
@@ -149,7 +149,6 @@ describe("AttemptTodoCompletionView", () => {
         tool={makeAttemptTodoCompletionTool()}
         isExecuting={true}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -168,7 +167,6 @@ describe("AttemptTodoCompletionView", () => {
         tool={makeAttemptTodoCompletionTool()}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -196,7 +194,6 @@ describe("AttemptTodoCompletionView", () => {
         })}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -224,7 +221,6 @@ describe("AttemptTodoCompletionView", () => {
         })}
         isExecuting={false}
         isLoading={true}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -253,7 +249,6 @@ describe("AttemptTodoCompletionView", () => {
         )}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -273,7 +268,6 @@ describe("AttemptTodoCompletionView", () => {
         )}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -294,7 +288,6 @@ describe("AttemptTodoCompletionView", () => {
         )}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -317,7 +310,6 @@ describe("AttemptTodoCompletionView", () => {
         )}
         isExecuting={true}
         isLoading={true}
-        messages={[]}
         taskSource={emptyTaskSource}
       />,
     );
@@ -351,7 +343,6 @@ describe("AttemptTodoCompletionView", () => {
         )}
         isExecuting={true}
         isLoading={true}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -376,7 +367,6 @@ describe("AttemptTodoCompletionView", () => {
         )}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -391,7 +381,6 @@ describe("AttemptTodoCompletionView", () => {
         tool={makeErroredAttemptTodoCompletionTool("Todo audit failed")}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -413,7 +402,6 @@ describe("AttemptTodoCompletionView", () => {
         tool={makeErroredAttemptTodoCompletionTool("Todo audit failed")}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={emptyTaskSource}
       />,
     );
@@ -447,7 +435,6 @@ describe("AttemptTodoCompletionView", () => {
         })}
         isExecuting={true}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );

--- a/packages/vscode-webui/src/features/tools/components/__tests__/browser-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/browser-view.test.tsx
@@ -113,7 +113,6 @@ describe("BrowserView", () => {
         tool={browserTool}
         isExecuting={true}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -134,7 +133,6 @@ describe("BrowserView", () => {
         tool={browserTool}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -162,7 +160,6 @@ describe("BrowserView", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -183,7 +180,6 @@ describe("BrowserView", () => {
         tool={browserTool}
         isExecuting={true}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -206,7 +202,6 @@ describe("BrowserView", () => {
         tool={browserTool}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -240,7 +235,6 @@ describe("BrowserView", () => {
         }
         isExecuting={true}
         isLoading={true}
-        messages={[]}
         taskSource={taskSource}
       />,
     );

--- a/packages/vscode-webui/src/features/tools/components/__tests__/execute-command.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/execute-command.test.tsx
@@ -81,7 +81,6 @@ describe("executeCommandTool", () => {
         }}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 

--- a/packages/vscode-webui/src/features/tools/components/__tests__/legacy-background-tools.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/legacy-background-tools.test.tsx
@@ -40,7 +40,6 @@ vi.mock("../command-execution-panel", () => ({
 const commonProps = {
   isExecuting: false,
   isLoading: false,
-  messages: [],
 };
 
 describe("legacy background tool renderers", () => {

--- a/packages/vscode-webui/src/features/tools/components/__tests__/list-files.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/list-files.test.tsx
@@ -74,7 +74,6 @@ describe("listFilesTool", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 

--- a/packages/vscode-webui/src/features/tools/components/__tests__/path-display.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/path-display.test.tsx
@@ -61,7 +61,6 @@ describe("tool path display", () => {
         }}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -83,7 +82,6 @@ describe("tool path display", () => {
         }}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 

--- a/packages/vscode-webui/src/features/tools/components/__tests__/planner-view.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/planner-view.test.tsx
@@ -119,7 +119,6 @@ describe("PlannerView", () => {
         tool={plannerTool}
         isExecuting={true}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );
@@ -139,7 +138,6 @@ describe("PlannerView", () => {
         tool={plannerTool}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -167,7 +165,6 @@ describe("PlannerView", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -195,7 +192,6 @@ describe("PlannerView", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -212,7 +208,6 @@ describe("PlannerView", () => {
         tool={plannerTool}
         isExecuting={false}
         isLoading={false}
-        messages={[]}
         taskSource={taskSource}
       />,
     );

--- a/packages/vscode-webui/src/features/tools/components/__tests__/read-file.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/read-file.test.tsx
@@ -117,7 +117,6 @@ const renderReadFileTool = (
       }
       isExecuting={false}
       isLoading={false}
-      messages={[]}
     />,
   );
 

--- a/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
+++ b/packages/vscode-webui/src/features/tools/components/attempt-completion.tsx
@@ -6,9 +6,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
-import { isStaticToolUIPart } from "ai";
 import { Check, CheckIcon, CopyIcon } from "lucide-react";
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { CreatePrAction } from "./create-pr-action";
 import {
@@ -19,25 +17,10 @@ import type { ToolProps } from "./types";
 
 export const AttemptCompletionTool: React.FC<
   ToolProps<"attemptCompletion">
-> = ({ tool: toolCall, messages, isSubTask }) => {
+> = ({ tool: toolCall, isLastPart, isSubTask }) => {
   const { t } = useTranslation();
   const { result = "" } = toolCall.input || {};
   const resultContent = getAttemptCompletionResultDisplay(result);
-
-  const isLastPart = useMemo(() => {
-    if (!messages || messages.length === 0) return false;
-    const lastMessage = messages[messages.length - 1];
-
-    // Check if tool is in last message
-    const partIndex = lastMessage.parts.findIndex(
-      (p) => isStaticToolUIPart(p) && p.toolCallId === toolCall.toolCallId,
-    );
-
-    if (partIndex === -1) return false;
-
-    // Check if it is the last part
-    return partIndex === lastMessage.parts.length - 1;
-  }, [messages, toolCall.toolCallId]);
 
   // Return null if there's nothing to display
   if (!resultContent.content) {

--- a/packages/vscode-webui/src/features/tools/components/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/index.tsx
@@ -1,7 +1,6 @@
 import type { ToolCallCheckpoint } from "@/components/message/message-list";
 import { useToolCallLifeCycle } from "@/features/chat";
 import { cn } from "@/lib/utils";
-import type { Message } from "@getpochi/livekit";
 import { getStaticToolName } from "ai";
 import { applyDiffTool } from "./apply-diff";
 import { AskFollowupQuestionTool } from "./ask-followup-question";
@@ -27,10 +26,10 @@ import { writeToFileTool } from "./write-to-file";
 type ToolInvocationPartBaseProps = {
   tool: UIToolPart;
   isLoading: boolean;
-  messages: Message[];
   changes?: ToolCallCheckpoint;
   isSubTask?: boolean;
   isLastPart?: boolean;
+  isInLatestAssistantMessage?: boolean;
 };
 
 type ToolRendererProps = ToolInvocationPartBaseProps & {
@@ -47,10 +46,10 @@ function ToolInvocationRenderer({
   tool,
   isExecuting,
   isLoading,
-  messages,
   changes,
   isSubTask,
   isLastPart,
+  isInLatestAssistantMessage,
 }: ToolRendererProps) {
   return C ? (
     <C
@@ -58,17 +57,12 @@ function ToolInvocationRenderer({
       isExecuting={isExecuting}
       isLoading={isLoading}
       changes={changes}
-      messages={messages}
       isSubTask={isSubTask}
       isLastPart={isLastPart}
+      isInLatestAssistantMessage={isInLatestAssistantMessage}
     />
   ) : (
-    <McpToolCall
-      tool={tool}
-      isLoading={isLoading}
-      isExecuting={isExecuting}
-      messages={messages}
-    />
+    <McpToolCall tool={tool} isLoading={isLoading} isExecuting={isExecuting} />
   );
 }
 
@@ -76,10 +70,10 @@ export function ToolInvocationPart({
   tool,
   isLoading,
   className,
-  messages,
   changes,
   isSubTask,
   isLastPart,
+  isInLatestAssistantMessage,
 }: ToolInvocationPartProps) {
   const toolName = getStaticToolName(tool);
   const lifecycle = useToolCallLifeCycle().getToolCallLifeCycle({
@@ -97,9 +91,9 @@ export function ToolInvocationPart({
         isExecuting={isExecuting}
         isLoading={isLoading}
         changes={changes}
-        messages={messages}
         isSubTask={isSubTask}
         isLastPart={isLastPart}
+        isInLatestAssistantMessage={isInLatestAssistantMessage}
       />
     </div>
   );

--- a/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/__tests__/render-widget.test.tsx
@@ -177,7 +177,7 @@ describe("RenderWidgetTool", () => {
         tool={tool}
         isExecuting={false}
         isLoading={false}
-        messages={createMessagesWithTool(tool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -214,7 +214,7 @@ describe("RenderWidgetTool", () => {
         tool={tool}
         isExecuting={true}
         isLoading={true}
-        messages={createMessagesWithTool(tool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -244,7 +244,7 @@ describe("RenderWidgetTool", () => {
         tool={tool}
         isExecuting={false}
         isLoading={false}
-        messages={createMessagesWithTool(tool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -255,7 +255,7 @@ describe("RenderWidgetTool", () => {
         tool={tool}
         isExecuting={false}
         isLoading={false}
-        messages={createMessagesWithTool(tool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -278,7 +278,6 @@ describe("RenderWidgetTool", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -303,7 +302,7 @@ describe("RenderWidgetTool", () => {
         tool={tool}
         isExecuting={false}
         isLoading={false}
-        messages={createMessagesWithTool(tool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -336,7 +335,6 @@ describe("RenderWidgetTool", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -370,7 +368,6 @@ describe("RenderWidgetTool", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -428,7 +425,6 @@ describe("RenderWidgetTool", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -453,7 +449,6 @@ describe("RenderWidgetTool", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -481,7 +476,6 @@ describe("RenderWidgetTool", () => {
         }
         isExecuting={false}
         isLoading={false}
-        messages={[]}
       />,
     );
 
@@ -568,7 +562,6 @@ describe("RenderWidgetTool", () => {
         isExecuting={true}
         isLoading={true}
         isLastPart={true}
-        messages={[]}
       />,
     );
 
@@ -601,7 +594,6 @@ describe("RenderWidgetTool", () => {
         isExecuting={false}
         isLoading={false}
         isLastPart={true}
-        messages={[]}
       />,
     );
 
@@ -656,7 +648,6 @@ describe("RenderWidgetTool", () => {
         isExecuting={false}
         isLoading={false}
         isLastPart={true}
-        messages={[]}
       />,
     );
 
@@ -702,7 +693,7 @@ describe("RenderWidgetTool", () => {
         tool={tool}
         isExecuting={false}
         isLoading={false}
-        messages={createMessagesWithTool(tool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -752,7 +743,7 @@ describe("RenderWidgetTool", () => {
         tool={tool}
         isExecuting={false}
         isLoading={false}
-        messages={createMessagesWithTool(tool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -801,7 +792,7 @@ describe("RenderWidgetTool", () => {
         tool={tool}
         isExecuting={false}
         isLoading={false}
-        messages={createMessagesWithTool(tool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -859,7 +850,7 @@ describe("RenderWidgetTool", () => {
         tool={inputTool}
         isExecuting={false}
         isLoading={false}
-        messages={createMessagesWithTool(inputTool)}
+        isInLatestAssistantMessage
       />,
     );
 
@@ -893,7 +884,7 @@ describe("RenderWidgetTool", () => {
           tool={outputTool}
           isExecuting={false}
           isLoading={false}
-          messages={createMessagesWithTool(outputTool)}
+          isInLatestAssistantMessage
         />,
       );
     });
@@ -930,12 +921,7 @@ describe("RenderWidgetTool", () => {
     } as never;
 
     render(
-      <RenderWidgetTool
-        tool={tool}
-        isExecuting={false}
-        isLoading={false}
-        messages={[]}
-      />,
+      <RenderWidgetTool tool={tool} isExecuting={false} isLoading={false} />,
     );
 
     expect(screen.queryByText("Widget failed")).toBeNull();
@@ -959,23 +945,7 @@ describe("RenderWidgetTool", () => {
       },
     } as never;
     const { container } = render(
-      <RenderWidgetTool
-        tool={tool}
-        isExecuting={false}
-        isLoading={false}
-        messages={[
-          {
-            id: "assistant-old",
-            role: "assistant",
-            parts: [tool],
-          } as never,
-          {
-            id: "user-latest",
-            role: "user",
-            parts: [{ type: "text", text: "next" }],
-          } as never,
-        ]}
-      />,
+      <RenderWidgetTool tool={tool} isExecuting={false} isLoading={false} />,
     );
 
     const frozenText =
@@ -1003,15 +973,3 @@ describe("RenderWidgetTool", () => {
     ).toBeUndefined();
   });
 });
-
-function createMessagesWithTool(
-  tool: Parameters<typeof RenderWidgetTool>[0]["tool"],
-) {
-  return [
-    {
-      id: "assistant-active",
-      role: "assistant",
-      parts: [tool],
-    },
-  ] as Parameters<typeof RenderWidgetTool>[0]["messages"];
-}

--- a/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
+++ b/packages/vscode-webui/src/features/tools/components/render-widget/index.tsx
@@ -86,7 +86,7 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
   isExecuting,
   isLoading,
   isLastPart,
-  messages,
+  isInLatestAssistantMessage = false,
 }) => {
   const { theme } = useTheme();
   const { t } = useTranslation();
@@ -152,10 +152,7 @@ export const RenderWidgetTool: React.FC<ToolProps<"renderWidget">> = ({
     tool.state === "input-available" ||
     tool.state === "output-available" ||
     tool.state === "output-error";
-  const isActive = isRenderWidgetPartInLatestAssistantMessage(
-    messages,
-    tool.toolCallId,
-  );
+  const isActive = isInLatestAssistantMessage;
   const isInteractive = isActive;
   const isFrozen = !isActive;
   const shouldBlockPointerEvents = isFrozen;
@@ -518,18 +515,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function clampHeight(height: number | undefined) {
   if (height === undefined || !Number.isFinite(height)) return 0;
   return Math.min(Math.max(Math.ceil(height), 0), 1200);
-}
-
-function isRenderWidgetPartInLatestAssistantMessage(
-  messages: ToolProps<"renderWidget">["messages"],
-  toolCallId: string,
-) {
-  const message = messages.at(-1);
-  if (message?.role !== "assistant") return false;
-  return message.parts.some(
-    (part) =>
-      part.type === "tool-renderWidget" && part.toolCallId === toolCallId,
-  );
 }
 
 function getWebviewScriptNonce() {

--- a/packages/vscode-webui/src/features/tools/components/types.ts
+++ b/packages/vscode-webui/src/features/tools/components/types.ts
@@ -1,5 +1,5 @@
 import type { ToolCallCheckpoint } from "@/components/message/message-list";
-import type { Message, UITools } from "@getpochi/livekit";
+import type { UITools } from "@getpochi/livekit";
 import type { ToolUIPart } from "ai";
 
 export type UIToolName = keyof UITools;
@@ -11,8 +11,9 @@ export interface ToolProps<T extends UIToolName> {
   tool: UIToolPart<T>;
   isExecuting: boolean;
   isLoading: boolean;
-  messages: Message[];
+  // TODO: No tool renderer consumes this; remove after confirming checkpoint diff compatibility.
   changes?: ToolCallCheckpoint;
   isSubTask?: boolean;
   isLastPart?: boolean;
+  isInLatestAssistantMessage?: boolean;
 }


### PR DESCRIPTION
## Summary
Every tool part received the whole formatted renderMessages array, whose identity changes on each streaming tick, defeating memoization for all tool parts. Only attemptCompletion and renderWidget consumed it, and both only needed to know their position, so replace it with two booleans derived once per part: the existing isLastPart and a new isInLastAssistantMessage.

🤖 Generated with [Pochi](https://getpochi.com)