### PR TITLE
perf(common): implement copy-on-write behavior in formatters

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -62,6 +62,7 @@
     "simple-git": "^3.28.0",
     "silver-fleece": "^1.2.1",
     "tslog": "catalog:",
+    "type-fest": "^4.41.0",
     "unist-util-remove": "^4.0.0",
     "vfile-matter": "^5.0.1",
     "ws": "^8.19.0",

--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -73,6 +73,232 @@ const baseMessages: UIMessage[] = [
 
 describe('formatters', () => {
   describe('formatters.ui', () => {
+    describe('copy-on-write behavior', () => {
+      it('returns a new array while reusing messages and parts when formatting makes no changes', () => {
+        const messages: UIMessage[] = [
+          {
+            id: 'user-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Hi' }],
+          },
+        ];
+        const original = clone(messages);
+
+        const formatted = formatters.ui(messages);
+
+        expect(formatted).not.toBe(messages);
+        expect(formatted[0]).toBe(messages[0]);
+        expect(formatted[0].parts).toBe(messages[0].parts);
+        expect(formatted[0].parts[0]).toBe(messages[0].parts[0]);
+        expect(messages).toEqual(original);
+      });
+
+      it('copies only the message that loses an empty part', () => {
+        const keptTool = createToolPart(
+          'webSearch',
+          'output-available',
+          {},
+          { result: 'ok' },
+        );
+        const messages: UIMessage[] = [
+          {
+            id: 'user-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [
+              { type: 'reasoning', text: '' },
+              keptTool,
+            ],
+          },
+        ];
+        const original = clone(messages);
+
+        const formatted = formatters.ui(messages);
+
+        expect(formatted).not.toBe(messages);
+        expect(formatted[0]).toBe(messages[0]);
+        expect(formatted[1]).not.toBe(messages[1]);
+        expect(formatted[1].parts).toEqual([keptTool]);
+        expect(formatted[1].parts[0]).toBe(keptTool);
+        expect(messages).toEqual(original);
+      });
+
+      it('keeps historical references when only the latest message changes', () => {
+        const history: UIMessage[] = [
+          {
+            id: 'user-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Earlier response' }],
+          },
+          {
+            id: 'user-2',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Continue' }],
+          },
+        ];
+        const firstLatest: UIMessage = {
+          id: 'assistant-2',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Streaming' }],
+        };
+        const firstInput = [...history, firstLatest];
+        const firstFormatted = formatters.ui(firstInput);
+        const secondLatest: UIMessage = {
+          ...firstLatest,
+          parts: [{ type: 'text', text: 'Streaming update' }],
+        };
+
+        const secondFormatted = formatters.ui([...history, secondLatest]);
+
+        expect(secondFormatted[0]).toBe(firstFormatted[0]);
+        expect(secondFormatted[0].parts[0]).toBe(firstFormatted[0].parts[0]);
+        expect(secondFormatted[1]).toBe(firstFormatted[1]);
+        expect(secondFormatted[2]).toBe(firstFormatted[2]);
+        expect(secondFormatted[3]).toBe(secondLatest);
+      });
+
+      it('isolates the latest user message from later request mutations', () => {
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Earlier response' }],
+          },
+          {
+            id: 'user-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Continue' }],
+          },
+        ];
+
+        const formatted = formatters.ui(messages);
+        messages[1].parts.push({
+          type: 'text',
+          text: '<system-reminder>Environment</system-reminder>',
+        });
+
+        expect(formatted[0]).toBe(messages[0]);
+        expect(formatted[1]).not.toBe(messages[1]);
+        expect(formatted[1].parts).not.toBe(messages[1].parts);
+        expect(formatted[1].parts).toEqual([
+          { type: 'text', text: 'Continue' },
+        ]);
+      });
+
+      it('resolves a pending tool without copying historical messages', () => {
+        const pendingTool = createToolPart('readFile', 'input-available');
+        const messages: UIMessage[] = [
+          {
+            id: 'user-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Earlier request' }],
+          },
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [pendingTool],
+          },
+          {
+            id: 'user-2',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Continue' }],
+          },
+        ];
+        const original = clone(messages);
+
+        const formatted = formatters.ui(messages);
+
+        expect(formatted[0]).toBe(messages[0]);
+        expect(formatted[1]).not.toBe(messages[1]);
+        expect(formatted[1].parts[0]).not.toBe(pendingTool);
+        expect((formatted[1].parts[0] as any).state).toBe('output-available');
+        expect(formatted[2]).not.toBe(messages[2]);
+        expect(messages).toEqual(original);
+      });
+
+      it('merges assistants without mutating or copying their source parts', () => {
+        const firstPart = { type: 'text' as const, text: 'First' };
+        const secondPart = { type: 'text' as const, text: 'Second' };
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [firstPart],
+          },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            parts: [secondPart],
+          },
+        ];
+        const original = clone(messages);
+
+        const formatted = formatters.ui(messages);
+
+        expect(formatted).toHaveLength(1);
+        expect(formatted[0]).not.toBe(messages[0]);
+        expect(formatted[0]).not.toBe(messages[1]);
+        expect(formatted[0].parts[0]).toBe(firstPart);
+        expect(formatted[0].parts[1]).toBe(secondPart);
+        expect(messages).toEqual(original);
+      });
+
+      it('copies only the tool output changed by problem refinement', () => {
+        const previousTool = createToolPart(
+          'applyDiff',
+          'output-available',
+          {},
+          { newProblems: 'first\nsecond' },
+        );
+        const resolvingTool = createToolPart(
+          'applyDiff',
+          'output-available',
+          {},
+          { _transient: { resolvedProblems: 'first' } },
+        );
+        const messages: UIMessage[] = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              previousTool,
+              resolvingTool,
+            ],
+          },
+        ];
+        const original = clone(messages);
+
+        const formatted = formatters.ui(messages);
+
+        expect(formatted[0]).not.toBe(messages[0]);
+        expect(formatted[0].parts[0]).toBe(messages[0].parts[0]);
+        expect(formatted[0].parts[1]).not.toBe(previousTool);
+        expect((formatted[0].parts[1] as any).output).not.toBe(
+          (previousTool as any).output,
+        );
+        expect((formatted[0].parts[1] as any).output.newProblems).toBe(
+          'second',
+        );
+        expect(formatted[0].parts[2]).toBe(resolvingTool);
+        expect(messages).toEqual(original);
+      });
+    });
+
     it('should combine consecutive assistant messages', () => {
       const formatted = formatters.ui(clone(baseMessages));
       const assistantMessages = formatted.filter((m) => m.role === 'assistant');
@@ -108,8 +334,9 @@ describe('formatters', () => {
           ],
         },
       ];
+      const original = clone(messages);
 
-      const formatted = formatters.ui(clone(messages));
+      const formatted = formatters.ui(messages);
 
       expect(formatted[0].parts).toHaveLength(3);
       expect(formatted[0].parts[0]).toEqual({
@@ -122,6 +349,8 @@ describe('formatters', () => {
         type: 'reasoning',
         text: 'Third reasoning paragraph.\nFourth reasoning paragraph.',
       });
+      expect(formatted[0].parts[1]).toBe(messages[0].parts[2]);
+      expect(messages).toEqual(original);
     });
 
     it('should use the latest reasoning state when combining consecutive reasoning parts', () => {
@@ -195,16 +424,24 @@ describe('formatters', () => {
           ],
         },
       ];
+      const original = clone(messages);
 
-      const formatted = formatters.ui(clone(messages));
+      const formatted = formatters.ui(messages);
 
       expect(formatted[0].parts).toHaveLength(1);
       expect(formatted[0].parts[0].type).toBe('tool-webSearch');
+      expect(formatted[0].parts[0]).toBe(messages[0].parts[1]);
+      expect(messages).toEqual(original);
     });
 
     it('should remove system reminder messages', () => {
-      const formatted = formatters.ui(clone(baseMessages));
+      const messages = clone(baseMessages);
+      const original = clone(messages);
+
+      const formatted = formatters.ui(messages);
+
       expect(formatted.find((m) => m.id === 'user-2')).toBeUndefined();
+      expect(messages).toEqual(original);
     });
 
     it('should merge compact-only user messages into adjacent assistant messages with compact between the two responses', () => {
@@ -228,7 +465,10 @@ describe('formatters', () => {
           parts: [{ type: 'text', text: 'Second assistant response' }],
         },
       ];
-      const formatted = formatters.ui(clone(messages));
+      const original = clone(messages);
+
+      const formatted = formatters.ui(messages);
+
       expect(formatted.find((m) => m.id === 'user-compact')).toBeUndefined();
       expect(formatted.filter((m) => m.role === 'assistant')).toHaveLength(1);
       const textParts = formatted[0].parts.filter((p) => p.type === 'text');
@@ -236,6 +476,10 @@ describe('formatters', () => {
       expect((textParts[0] as any).text).toBe('First assistant response');
       expect((textParts[1] as any).text).toContain('<compact>');
       expect((textParts[2] as any).text).toBe('Second assistant response');
+      expect(textParts[0]).toBe(messages[0].parts[0]);
+      expect(textParts[1]).toBe(messages[1].parts[0]);
+      expect(textParts[2]).toBe(messages[2].parts[0]);
+      expect(messages).toEqual(original);
     });
 
     it('should resolve pending tool calls and combine messages', () => {
@@ -271,6 +515,7 @@ describe('formatters', () => {
           ],
         },
       ];
+      const original = clone(messages);
 
       const formatted = formatters.ui(messages, {
         hidePendingTodoAttemptCompletion: true,
@@ -279,6 +524,8 @@ describe('formatters', () => {
       expect(formatted[0].parts).toEqual([
         { type: 'text', text: 'Checking the todo...' },
       ]);
+      expect(formatted[0].parts[0]).toBe(messages[0].parts[0]);
+      expect(messages).toEqual(original);
     });
 
     describe('message metadata merging', () => {
@@ -514,6 +761,7 @@ describe('formatters', () => {
           ],
         },
       ];
+      const original = clone(messages);
 
       const formatted = formatters.ui(messages);
 
@@ -521,6 +769,8 @@ describe('formatters', () => {
       expect(formatted[0].parts).toEqual([
         { type: 'text', text: 'Working on todos.' },
       ]);
+      expect(formatted[0].parts[0]).toBe(messages[0].parts[0]);
+      expect(messages).toEqual(original);
     });
   });
 

--- a/packages/common/src/base/__tests__/message.test.ts
+++ b/packages/common/src/base/__tests__/message.test.ts
@@ -1,8 +1,44 @@
 import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
 import {
   MessageMetadata,
   createBackgroundJobNotification,
+  updateMessage,
 } from "../message";
+
+describe("updateMessage", () => {
+  it("replaces a message without mutating existing snapshots", () => {
+    const message: UIMessage = {
+      id: "user-1",
+      role: "user",
+      parts: [{ type: "text", text: "hello" }],
+    };
+    const messages = [message];
+    const snapshot = [...messages];
+
+    const updated = updateMessage(messages, 0, (current) => ({
+      parts: [...current.parts, { type: "text", text: "world" }],
+    }));
+
+    expect(messages[0]).toBe(updated);
+    expect(messages[0]).not.toBe(message);
+    expect(snapshot[0]).toBe(message);
+    expect(snapshot[0].parts).toEqual([{ type: "text", text: "hello" }]);
+
+    if (false) {
+      updateMessage(messages, 0, (current) => {
+        // @ts-expect-error update callbacks receive deeply readonly messages.
+        current.parts.push({ type: "text", text: "mutated" });
+        const textPart = current.parts[0];
+        if (textPart?.type === "text") {
+          // @ts-expect-error nested part fields are readonly too.
+          textPart.text = "mutated";
+        }
+        return undefined;
+      });
+    }
+  });
+});
 
 describe("MessageMetadata", () => {
   it("preserves assistant input and cache-read token usage", () => {

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -16,16 +16,75 @@ import { AttemptTodoCompletionAgentName, KnownTags } from "./constants";
 import type { MessageMetadata } from "./message";
 import { prompts } from "./prompts";
 
+function mapOrOriginal<T>(items: T[], map: (item: T, index: number) => T): T[] {
+  let result: T[] | undefined;
+
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index];
+    const mapped = map(item, index);
+
+    if (result) {
+      result.push(mapped);
+    } else if (mapped !== item) {
+      result = items.slice(0, index);
+      result.push(mapped);
+    }
+  }
+
+  return result ?? items;
+}
+
+function filterOrOriginal<T>(
+  items: T[],
+  predicate: (item: T, index: number) => boolean,
+): T[] {
+  let result: T[] | undefined;
+
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index];
+    if (predicate(item, index)) {
+      result?.push(item);
+    } else if (!result) {
+      result = items.slice(0, index);
+    }
+  }
+
+  return result ?? items;
+}
+
+function mapMessagePartsOrOriginal(
+  messages: UIMessage[],
+  map: (parts: UIMessage["parts"], message: UIMessage) => UIMessage["parts"],
+): UIMessage[] {
+  return mapOrOriginal(messages, (message) => {
+    const parts = map(message.parts, message);
+    return parts === message.parts ? message : { ...message, parts };
+  });
+}
+
+function createUIMessageSnapshot(messages: UIMessage[]): UIMessage[] {
+  const snapshot = [...messages];
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role !== "user") return snapshot;
+
+  // Request preparation mutates the latest raw user message; keep the UI snapshot isolated.
+  snapshot[snapshot.length - 1] = {
+    ...lastMessage,
+    parts: [...lastMessage.parts],
+  };
+  return snapshot;
+}
+
 function resolvePendingToolCalls(
   messages: UIMessage[],
   resolveLastMessage = false,
 ): UIMessage[] {
-  return messages.map((message, index) => {
+  return mapOrOriginal(messages, (message, index) => {
     if (
       (resolveLastMessage ? true : index < messages.length - 1) &&
       message.role === "assistant"
     ) {
-      const parts = message.parts.map((part) => {
+      const parts = mapOrOriginal(message.parts, (part) => {
         if (
           isStaticToolUIPart(part) &&
           part.state !== "output-available" &&
@@ -44,10 +103,7 @@ function resolvePendingToolCalls(
         }
         return part;
       });
-      return {
-        ...message,
-        parts,
-      };
+      return parts === message.parts ? message : { ...message, parts };
     }
 
     return message;
@@ -89,15 +145,20 @@ function stripKnownXMLTags(messages: UIMessage[]): UIMessage[] {
 }
 
 function removeSystemReminder(messages: UIMessage[]): UIMessage[] {
-  return messages.filter((message) => {
+  const withoutReminders = mapMessagePartsOrOriginal(
+    messages,
+    (parts, message) => {
+      if (message.role !== "user") return parts;
+      return filterOrOriginal(parts, (part) => {
+        return part.type !== "text" || !prompts.isSystemReminder(part.text);
+      });
+    },
+  );
+
+  return filterOrOriginal(withoutReminders, (message) => {
     if (message.role !== "user") return true;
-    const parts = message.parts.filter((part) => {
-      if (part.type !== "text") return true;
-      return !prompts.isSystemReminder(part.text);
-    });
-    message.parts = parts;
     if (
-      parts.some(
+      message.parts.some(
         (x) =>
           (x.type === "text" && !prompts.isCompact(x.text)) ||
           x.type === "data-reviews" ||
@@ -110,10 +171,9 @@ function removeSystemReminder(messages: UIMessage[]): UIMessage[] {
     }
     // Keep messages that carry a compact checkpoint — the checkpoint
     // is meaningful UI content even when all other parts were system reminders.
-    if (parts.some((x) => x.type === "text" && prompts.isCompact(x.text))) {
-      return true;
-    }
-    return false;
+    return message.parts.some(
+      (x) => x.type === "text" && prompts.isCompact(x.text),
+    );
   });
 }
 
@@ -163,11 +223,12 @@ function mergeAssistantMetadata(
 function combineConsecutiveAssistantMessages(
   messages: UIMessage[],
 ): UIMessage[] {
-  const result: UIMessage[] = [];
+  let result: UIMessage[] | undefined;
+  let pendingCompactParts: UIMessage["parts"] | undefined;
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
-    const prev = result[result.length - 1];
+    const prev = result?.at(-1) ?? messages[i - 1];
 
     // Fold a compact-only user message's checkpoint parts into an adjacent
     // assistant message so the surrounding assistant messages combine and the
@@ -178,52 +239,82 @@ function combineConsecutiveAssistantMessages(
       );
       const next = messages[i + 1];
       if (prev?.role === "assistant") {
-        prev.parts.push(...compactParts);
+        if (!result) {
+          result = messages.slice(0, i);
+        }
+        if (compactParts.length > 0) {
+          result[result.length - 1] = {
+            ...prev,
+            parts: [...prev.parts, ...compactParts],
+          };
+        }
         continue;
       }
       if (next?.role === "assistant") {
-        next.parts.unshift(...compactParts);
+        if (!result) {
+          result = messages.slice(0, i);
+        }
+        pendingCompactParts =
+          compactParts.length > 0 ? compactParts : undefined;
         continue;
       }
-      result.push(message);
+      result?.push(message);
       continue;
     }
 
+    const current =
+      pendingCompactParts && message.role === "assistant"
+        ? {
+            ...message,
+            parts: [...pendingCompactParts, ...message.parts],
+          }
+        : message;
+    pendingCompactParts = undefined;
+
     // Merge into the previous assistant message, keeping the later message's id
     // and prepending the earlier message's parts.
-    if (message.role === "assistant" && prev?.role === "assistant") {
-      message.parts.unshift(...prev.parts);
-
+    if (current.role === "assistant" && prev?.role === "assistant") {
+      if (!result) {
+        result = messages.slice(0, i);
+      }
       const prevMessageMetadata = isAssistantMetadata(prev.metadata)
         ? prev.metadata
         : undefined;
-      const messageMetadata = isAssistantMetadata(message.metadata)
-        ? message.metadata
+      const messageMetadata = isAssistantMetadata(current.metadata)
+        ? current.metadata
         : undefined;
+      const merged = {
+        ...current,
+        parts: [...prev.parts, ...current.parts],
+      };
       if (prevMessageMetadata || messageMetadata) {
-        message.metadata = mergeAssistantMetadata(
+        merged.metadata = mergeAssistantMetadata(
           prevMessageMetadata,
           messageMetadata,
         );
       }
 
-      result[result.length - 1] = message;
+      result[result.length - 1] = merged;
       continue;
     }
 
-    result.push(message);
+    result?.push(current);
   }
 
-  return result;
+  return result ?? messages;
 }
 
 function combineConsecutiveReasoningParts(messages: UIMessage[]): UIMessage[] {
-  return messages.map((message) => {
-    const parts: UIMessage["parts"] = [];
+  return mapOrOriginal(messages, (message) => {
+    let parts: UIMessage["parts"] | undefined;
 
-    for (const part of message.parts) {
-      const prev = parts.at(-1);
+    for (let index = 0; index < message.parts.length; index++) {
+      const part = message.parts[index];
+      const prev = parts?.at(-1) ?? message.parts[index - 1];
       if (part.type === "reasoning" && prev?.type === "reasoning") {
+        if (!parts) {
+          parts = message.parts.slice(0, index);
+        }
         // This merge is only for UI rendering. A shallow merge may overwrite
         // nested providerMetadata from earlier reasoning parts, but losing that
         // metadata here is acceptable because LLM/storage formatting does not
@@ -250,18 +341,15 @@ function combineConsecutiveReasoningParts(messages: UIMessage[]): UIMessage[] {
         continue;
       }
 
-      parts.push(part);
+      parts?.push(part);
     }
 
-    return {
-      ...message,
-      parts,
-    };
+    return parts ? { ...message, parts } : message;
   });
 }
 
 function removeEmptyMessages(messages: UIMessage[]): UIMessage[] {
-  return messages.filter((message) => message.parts.length > 0);
+  return filterOrOriginal(messages, (message) => message.parts.length > 0);
 }
 
 function removeMessagesWithoutTextOrToolCall(
@@ -582,8 +670,8 @@ function removeUnstableOpenAIItemReferences(
 }
 
 function removeEmptyTextParts(messages: UIMessage[]) {
-  return messages.map((message) => {
-    message.parts = message.parts.filter((part) => {
+  return mapMessagePartsOrOriginal(messages, (parts) => {
+    return filterOrOriginal(parts, (part) => {
       if (part.type === "text") {
         return part.text.trim().length > 0;
       }
@@ -601,19 +689,17 @@ function removeEmptyTextParts(messages: UIMessage[]) {
       }
       return true;
     });
-    return message;
   });
 }
 
 function removeEmptyReasoningPartsForUI(messages: UIMessage[]) {
-  return messages.map((message) => {
-    message.parts = message.parts.filter((part) => {
+  return mapMessagePartsOrOriginal(messages, (parts) => {
+    return filterOrOriginal(parts, (part) => {
       if (part.type === "reasoning") {
         return part.text.trim().length > 0;
       }
       return true;
     });
-    return message;
   });
 }
 
@@ -663,9 +749,12 @@ function refineDetectedNewPromblems(messages: UIMessage[]) {
       .findLastIndex((p) => p.type === "step-start");
   };
 
-  for (const message of messages) {
+  return mapOrOriginal(messages, (message) => {
+    let parts: UIMessage["parts"] | undefined;
+
     for (let i = 0; i < message.parts.length; i++) {
-      const part = message.parts[i];
+      const currentParts = parts ?? message.parts;
+      const part = currentParts[i];
       if (!isWriteFileResultToolPart(part)) {
         continue;
       }
@@ -677,11 +766,11 @@ function refineDetectedNewPromblems(messages: UIMessage[]) {
         continue;
       }
 
-      const lastStepStartIndex = findLastStepStartIndex(message.parts, i);
+      const lastStepStartIndex = findLastStepStartIndex(currentParts, i);
 
       for (const resolvedProblem of resolvedProblems) {
         for (let j = i - 1; j > lastStepStartIndex; j--) {
-          const prevPart = message.parts[j];
+          const prevPart = (parts ?? message.parts)[j];
           if (!isWriteFileResultToolPart(prevPart)) {
             continue;
           }
@@ -692,20 +781,25 @@ function refineDetectedNewPromblems(messages: UIMessage[]) {
               .filter((p) => p !== resolvedProblem)
               .join("\n")
               .trim();
+            const output = { ...prevPart.output };
             if (!newProblems) {
               // biome-ignore lint/performance/noDelete: remove newProblems
-              delete prevPart.output.newProblems;
+              delete output.newProblems;
             } else {
-              prevPart.output.newProblems = newProblems;
+              output.newProblems = newProblems;
             }
+            if (!parts) {
+              parts = message.parts.slice();
+            }
+            parts[j] = { ...prevPart, output };
             break;
           }
         }
       }
     }
-  }
 
-  return messages;
+    return parts ? { ...message, parts } : message;
+  });
 }
 
 function resolvePendingToolCallsForShareUI(messages: UIMessage[]) {
@@ -750,15 +844,15 @@ function removeDeprecatedTodoWriteToolCalls(
   messages: UIMessage[],
 ): UIMessage[] {
   return removeEmptyMessages(
-    messages.map((message) => ({
-      ...message,
-      parts: message.parts.filter(
+    mapMessagePartsOrOriginal(messages, (parts) =>
+      filterOrOriginal(
+        parts,
         (part) =>
           !(
             isStaticToolUIPart(part) && getStaticToolName(part) === "todoWrite"
           ),
       ),
-    })),
+    ),
   );
 }
 
@@ -797,9 +891,13 @@ const StorageFormatOps = [
   removeToolCallResultTransientData,
 ];
 
+function applyFormatOps(messages: UIMessage[], ops: FormatOp[]): UIMessage[] {
+  return ops.reduce((acc, op) => op(acc), messages);
+}
+
 function formatMessages(messages: UIMessage[], ops: FormatOp[]): UIMessage[] {
   // Clone the messages to avoid mutating the original array.
-  return ops.reduce((acc, op) => op(acc), clone(messages));
+  return applyFormatOps(clone(messages), ops);
 }
 
 export interface UIFormatterOptions {
@@ -820,7 +918,10 @@ export const formatters = {
         ? [removePendingTodoAttemptCompletion, removeEmptyMessages]
         : []),
     ];
-    return formatMessages(messages, uiFormatOps) as T[];
+    return applyFormatOps(
+      createUIMessageSnapshot(messages),
+      uiFormatOps,
+    ) as T[];
   },
 
   shareUI: <T extends UIMessage>(messages: T[]) =>

--- a/packages/common/src/base/message.ts
+++ b/packages/common/src/base/message.ts
@@ -1,5 +1,23 @@
-import type { FinishReason } from "ai";
+import type { FinishReason, UIMessage } from "ai";
+import type { ReadonlyDeep } from "type-fest";
 import { z } from "zod";
+
+/** Replaces one message while exposing the existing value as deeply readonly. */
+export function updateMessage<T extends UIMessage>(
+  messages: T[],
+  index: number,
+  update: (message: ReadonlyDeep<T>) => Partial<ReadonlyDeep<T>> | undefined,
+): T | undefined {
+  const message = messages[index];
+  if (!message) return;
+
+  const patch = update(message as ReadonlyDeep<T>);
+  if (!patch) return message;
+
+  const updatedMessage = { ...message, ...patch } as T;
+  messages[index] = updatedMessage;
+  return updatedMessage;
+}
 
 export const MessageMetadata = z.discriminatedUnion("kind", [
   z.object({

--- a/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
+++ b/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
@@ -181,6 +181,19 @@ describe("long-term memory prompt helpers", () => {
     expect(userPart.text).toBe("hello");
   });
 
+  it("injectAutoMemory replaces the user message without mutating its snapshot", () => {
+    const message = makeUserMessage("hello");
+    const originalParts = message.parts;
+    const messages = [message];
+
+    injectAutoMemory(messages, sampleContext);
+
+    expect(messages[0]).not.toBe(message);
+    expect(message.parts).toBe(originalParts);
+    expect(message.parts).toEqual([{ type: "text", text: "hello" }]);
+    expect(messages[0].parts).toHaveLength(2);
+  });
+
   it("injectAutoMemory is a no-op without context or memory block", () => {
     const messages = [makeUserMessage("hello")];
     expect(injectAutoMemory(messages, undefined)).toBe(messages);
@@ -215,6 +228,27 @@ describe("long-term memory prompt helpers", () => {
     const userPart = messages[0].parts[0];
     if (userPart.type !== "text") throw new Error("expected text part");
     expect(userPart.text).toBe("first");
+  });
+
+  it("strips a persisted reminder without mutating its snapshot", () => {
+    const reminder = {
+      type: "text" as const,
+      text: `<system-reminder>${buildAutoMemoryDynamicPrompt(sampleContext)}</system-reminder>`,
+    };
+    const message: UIMessage = {
+      id: "user-1",
+      role: "user",
+      parts: [reminder, { type: "text", text: "hello" }],
+    };
+    const originalParts = message.parts;
+    const messages = [message];
+
+    injectAutoMemory(messages, undefined);
+
+    expect(messages[0]).not.toBe(message);
+    expect(message.parts).toBe(originalParts);
+    expect(message.parts).toHaveLength(2);
+    expect(messages[0].parts).toEqual([{ type: "text", text: "hello" }]);
   });
 
   it("injectAutoMemory only fires on the first user turn", () => {

--- a/packages/common/src/base/prompts/__tests__/prompt.test.ts
+++ b/packages/common/src/base/prompts/__tests__/prompt.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "vitest";
 import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
 import type { Environment } from "../../environment";
 import {
   createEnvironmentPrompt,
+  injectEnvironment,
   parseEnvironmentInfo,
 } from "../environment";
 import { createSystemPrompt } from "../system";
@@ -234,6 +236,23 @@ test("parseEnvironmentInfo ignores missing or incomplete environment prompt", ()
       },
     ]),
   ).toBeUndefined();
+});
+
+test("injectEnvironment replaces the user message without mutating its snapshot", () => {
+  const message: UIMessage = {
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "hello" }],
+  };
+  const originalParts = message.parts;
+  const messages = [message];
+
+  injectEnvironment(messages, createTestEnvironment());
+
+  expect(messages[0]).not.toBe(message);
+  expect(message.parts).toBe(originalParts);
+  expect(message.parts).toEqual([{ type: "text", text: "hello" }]);
+  expect(messages[0].parts).toHaveLength(2);
 });
 
 function createTestEnvironment(): Environment {

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -1,4 +1,5 @@
 import type { TextUIPart, UIMessage } from "ai";
+import { updateMessage } from "../message";
 
 export const AutoMemoryIndexName = "MEMORY.md";
 
@@ -163,16 +164,17 @@ ${indexContent}`;
  * persisted into the first user message on an earlier turn) stops being sent.
  */
 function stripAutoMemoryReminders(messages: UIMessage[]): UIMessage[] {
-  for (const message of messages) {
-    if (message.role !== "user") continue;
-    const parts = message.parts ?? [];
-    const filtered = parts.filter(
-      (part) =>
-        part.type !== "text" || !isAutoMemorySystemReminder(part.text ?? ""),
-    );
-    if (filtered.length !== parts.length) {
-      message.parts = filtered;
-    }
+  for (let index = 0; index < messages.length; index++) {
+    if (messages[index]?.role !== "user") continue;
+
+    updateMessage(messages, index, (message) => {
+      const parts = message.parts ?? [];
+      const filtered = parts.filter(
+        (part) =>
+          part.type !== "text" || !isAutoMemorySystemReminder(part.text ?? ""),
+      );
+      return filtered.length === parts.length ? undefined : { parts: filtered };
+    });
   }
   return messages;
 }
@@ -192,29 +194,32 @@ export function injectAutoMemory(
   if (!memoryBlock) return stripAutoMemoryReminders(messages);
   if (messages.length !== 1) return messages;
 
-  const messageToInject = messages.at(-1);
-  if (!messageToInject || messageToInject.role !== "user") return messages;
+  const messageIndex = messages.length - 1;
+  if (messages[messageIndex]?.role !== "user") return messages;
 
   const reminderPart: TextUIPart = {
     type: "text",
     text: `<system-reminder>${memoryBlock}</system-reminder>`,
   };
 
-  const filteredParts = (messageToInject.parts ?? []).filter(
-    (part) =>
-      part.type !== "text" || !isAutoMemorySystemReminder(part.text ?? ""),
-  );
-  // Place reminder before the user's text so the prompt remains the tail.
-  const lastTextPartIndex = filteredParts.findLastIndex(
-    (part) => part.type === "text",
-  );
-  const insertIndex = lastTextPartIndex >= 0 ? lastTextPartIndex : 0;
+  updateMessage(messages, messageIndex, (message) => {
+    const filteredParts = (message.parts ?? []).filter(
+      (part) =>
+        part.type !== "text" || !isAutoMemorySystemReminder(part.text ?? ""),
+    );
+    const lastTextPartIndex = filteredParts.findLastIndex(
+      (part) => part.type === "text",
+    );
+    const insertIndex = lastTextPartIndex >= 0 ? lastTextPartIndex : 0;
 
-  messageToInject.parts = [
-    ...filteredParts.slice(0, insertIndex),
-    reminderPart,
-    ...filteredParts.slice(insertIndex),
-  ];
+    return {
+      parts: [
+        ...filteredParts.slice(0, insertIndex),
+        reminderPart,
+        ...filteredParts.slice(insertIndex),
+      ],
+    };
+  });
   return messages;
 }
 

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -1,6 +1,7 @@
 import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
 import type { TextUIPart, UIMessage } from "ai";
 import type { Environment, GitStatus } from "../environment";
+import { updateMessage } from "../message";
 import { prompts } from "./index";
 
 type User = { name: string; email: string };
@@ -195,9 +196,8 @@ export function injectEnvironment(
   options?: { forceFull?: boolean },
 ): UIMessage[] {
   if (environment === undefined) return messages;
-  const messageToInject = messages.at(-1);
-  if (!messageToInject) return messages;
-  if (messageToInject.role !== "user") return messages;
+  const messageIndex = messages.length - 1;
+  if (messages[messageIndex]?.role !== "user") return messages;
 
   const { gitStatus } = environment.workspace;
   const user =
@@ -218,20 +218,23 @@ export function injectEnvironment(
     text: prompts.createSystemReminder(environmentDetails),
   } satisfies TextUIPart;
 
-  const parts =
-    // Remove existing environment system reminders.
-    messageToInject.parts.filter(
-      (x) => x.type !== "text" || !prompts.isEnvironmentSystemReminder(x.text),
-    ) || [];
-  const lastTextPartIndex = parts.findLastIndex(
-    (parts) => parts.type === "text",
-  );
-  // Insert remainderPart before lastTextPartIndex
-  messageToInject.parts = [
-    ...parts.slice(0, lastTextPartIndex),
-    reminderPart,
-    ...parts.slice(lastTextPartIndex),
-  ];
+  updateMessage(messages, messageIndex, (message) => {
+    const parts = message.parts.filter(
+      (part) =>
+        part.type !== "text" || !prompts.isEnvironmentSystemReminder(part.text),
+    );
+    const lastTextPartIndex = parts.findLastIndex(
+      (part) => part.type === "text",
+    );
+
+    return {
+      parts: [
+        ...parts.slice(0, lastTextPartIndex),
+        reminderPart,
+        ...parts.slice(lastTextPartIndex),
+      ],
+    };
+  });
 
   return messages;
 }

--- a/packages/livekit/src/chat/__tests__/compact-task.test.ts
+++ b/packages/livekit/src/chat/__tests__/compact-task.test.ts
@@ -1,3 +1,4 @@
+import { formatters } from "@getpochi/common";
 import { describe, expect, it } from "vitest";
 import type { Message } from "../../types";
 import {
@@ -201,5 +202,36 @@ describe("compactTask", () => {
         text: expect.stringContaining("<compact>"),
       },
     });
+  });
+
+  it("does not change a UI snapshot when attaching compact history", async () => {
+    const messages = [
+      userMsg("u0"),
+      assistantMsg("a0"),
+      userMsg("u1"),
+      assistantMsg("a1"),
+      userMsg("u2"),
+    ];
+    const snapshot = formatters.ui(messages);
+
+    await compactTask({
+      blobStore: {} as never,
+      taskId: "task-1",
+      storeId: "store-1",
+      model: {} as never,
+      messages,
+      taskMemoryBoundaryMessageId: "u1",
+      inline: true,
+      store: {
+        query: () => ({ content: "memory summary" }),
+        commit: () => {},
+      } as never,
+    });
+
+    expect(messages[2].parts[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("<compact>"),
+    });
+    expect(snapshot[2].parts).toEqual([{ type: "text", text: "hi" }]);
   });
 });

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -105,7 +105,10 @@ export async function compactTask({
           recentFileContext,
           { verbatimTail: true },
         );
-        memoryAttachMessage.parts.unshift({ type: "text", text });
+        messages[memoryAttachIndex] = {
+          ...memoryAttachMessage,
+          parts: [{ type: "text", text }, ...memoryAttachMessage.parts],
+        };
         persistInlineCompactMessage(store, memoryAttachMessage.id, text);
         logger.debug(
           `Inline compact attached at index ${memoryAttachIndex}; preserving ${
@@ -125,7 +128,10 @@ export async function compactTask({
         recentFileContext,
         attachIndex < messages.length - 1 ? { verbatimTail: true } : undefined,
       );
-      attachMessage.parts.unshift({ type: "text", text });
+      messages[attachIndex] = {
+        ...attachMessage,
+        parts: [{ type: "text", text }, ...attachMessage.parts],
+      };
       persistInlineCompactMessage(store, attachMessage.id, text);
       return;
     }

--- a/packages/livekit/src/chat/llm/compact-task.ts
+++ b/packages/livekit/src/chat/llm/compact-task.ts
@@ -6,6 +6,7 @@ import {
   formatters,
   getLogger,
   prompts,
+  updateMessage,
 } from "@getpochi/common";
 import type { RecentFileState } from "@getpochi/common/tool-utils";
 import { convertToModelMessages, generateText } from "ai";
@@ -105,10 +106,9 @@ export async function compactTask({
           recentFileContext,
           { verbatimTail: true },
         );
-        messages[memoryAttachIndex] = {
-          ...memoryAttachMessage,
-          parts: [{ type: "text", text }, ...memoryAttachMessage.parts],
-        };
+        updateMessage(messages, memoryAttachIndex, (message) => ({
+          parts: [{ type: "text", text }, ...message.parts],
+        }));
         persistInlineCompactMessage(store, memoryAttachMessage.id, text);
         logger.debug(
           `Inline compact attached at index ${memoryAttachIndex}; preserving ${
@@ -128,10 +128,9 @@ export async function compactTask({
         recentFileContext,
         attachIndex < messages.length - 1 ? { verbatimTail: true } : undefined,
       );
-      messages[attachIndex] = {
-        ...attachMessage,
-        parts: [{ type: "text", text }, ...attachMessage.parts],
-      };
+      updateMessage(messages, attachIndex, (message) => ({
+        parts: [{ type: "text", text }, ...message.parts],
+      }));
       persistInlineCompactMessage(store, attachMessage.id, text);
       return;
     }

--- a/packages/vscode-webui/src/features/chat/lib/__tests__/on-override-messages.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/__tests__/on-override-messages.test.ts
@@ -1,10 +1,11 @@
+import { formatters } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRenderWidgetStore } from "../../hooks/use-render-widget-store";
 import { onOverrideMessages } from "../on-override-messages";
 
 const vscodeHostMock = vi.hoisted(() => ({
-  saveCheckpoint: vi.fn(async () => undefined),
+  saveCheckpoint: vi.fn(async (): Promise<string | undefined> => undefined),
   diffWithCheckpoint: vi.fn(),
   readTaskChangedFiles: vi.fn(),
 }));
@@ -259,6 +260,55 @@ describe("onOverrideMessages", () => {
     expect(messages[0].parts[0]).toMatchObject({
       state: "output-error",
       output: existingOutput,
+    });
+  });
+
+  it("does not change a formatted snapshot when appending a checkpoint", async () => {
+    const messages = [
+      createAssistantMessage([{ type: "text", text: "Finished" }]),
+    ];
+    const snapshot = formatters.ui(messages);
+    vscodeHostMock.saveCheckpoint.mockResolvedValueOnce("checkpoint-1");
+
+    await onOverrideMessages({
+      store: {} as never,
+      taskId: "task-1",
+      messages,
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(messages[0].parts).toHaveLength(2);
+    expect(snapshot[0].parts).toEqual([{ type: "text", text: "Finished" }]);
+  });
+
+  it("does not change a formatted snapshot when committing renderWidget output", async () => {
+    const messages = [
+      createAssistantMessage([
+        createRenderWidgetPart({
+          toolCallId: "widget-1",
+          state: "output-available",
+          output: { state: { hex: "#000000" } },
+        }),
+      ]),
+      createUserMessage("continue"),
+    ];
+    const snapshot = formatters.ui(messages);
+    useRenderWidgetStore
+      .getState()
+      .setWidgetState("widget-1", { hex: "#ffffff" });
+
+    await onOverrideMessages({
+      store: {} as never,
+      taskId: "task-1",
+      messages,
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(messages[0].parts[0]).toMatchObject({
+      output: { state: { hex: "#ffffff" } },
+    });
+    expect(snapshot[0].parts[0]).toMatchObject({
+      output: { state: { hex: "#000000" } },
     });
   });
 });

--- a/packages/vscode-webui/src/features/chat/lib/on-override-messages.ts
+++ b/packages/vscode-webui/src/features/chat/lib/on-override-messages.ts
@@ -24,7 +24,8 @@ export async function onOverrideMessages({
     .map((p) => p.data.commit);
   const lastMessage = messages.at(-1);
   if (lastMessage) {
-    const ckpt = await appendCheckpoint(lastMessage);
+    const lastMessageIndex = messages.length - 1;
+    const ckpt = await appendCheckpoint(messages, lastMessageIndex);
 
     const firstCheckpoint = checkpoints.at(0);
     if (firstCheckpoint) {
@@ -33,9 +34,10 @@ export async function onOverrideMessages({
     }
 
     const lastCheckpoint = checkpoints.at(-1);
-    if (ckpt && lastMessage.role === "assistant" && lastCheckpoint) {
+    const updatedLastMessage = messages[lastMessageIndex];
+    if (ckpt && updatedLastMessage.role === "assistant" && lastCheckpoint) {
       // diff summary in chat view
-      await updateChangedFiles(taskId, lastCheckpoint, lastMessage);
+      await updateChangedFiles(taskId, lastCheckpoint, updatedLastMessage);
     }
   }
 }
@@ -45,12 +47,14 @@ export function writeRenderWidgetOutput(messages: Message[]) {
   const message = getRenderWidgetOutputMessage(messages);
   if (!message) return;
 
-  message.parts = message.parts.map((part) => {
+  let changed = false;
+  const parts = message.parts.map((part): Message["parts"][number] => {
     if (part.type !== "tool-renderWidget") return part;
     if (part.state !== "input-available" && part.state !== "output-available") {
       return part;
     }
 
+    changed = true;
     const state =
       store.getWidgetState(part.toolCallId) ??
       getExistingRenderWidgetState(part.output) ??
@@ -68,6 +72,9 @@ export function writeRenderWidgetOutput(messages: Message[]) {
       output,
     };
   });
+  if (changed) {
+    messages[messages.length - 2] = { ...message, parts };
+  }
 }
 
 function getRenderWidgetOutputMessage(messages: Message[]) {
@@ -86,7 +93,8 @@ function getExistingRenderWidgetState(output: unknown) {
  * Appends a checkpoint to a message if one doesn't already exist in the current step.
  * A checkpoint is created to save the current state before making changes.
  */
-async function appendCheckpoint(message: Message) {
+async function appendCheckpoint(messages: Message[], messageIndex: number) {
+  const message = messages[messageIndex];
   const lastStepStartIndex =
     message.parts.reduce((lastIndex, part, index) => {
       return part.type === "step-start" ? index : lastIndex;
@@ -106,12 +114,18 @@ async function appendCheckpoint(message: Message) {
   });
   if (!ckpt) return;
 
-  message.parts.push({
-    type: "data-checkpoint",
-    data: {
-      commit: ckpt,
-    },
-  });
+  messages[messageIndex] = {
+    ...message,
+    parts: [
+      ...message.parts,
+      {
+        type: "data-checkpoint",
+        data: {
+          commit: ckpt,
+        },
+      },
+    ],
+  };
   return ckpt;
 }
 

--- a/packages/vscode-webui/src/features/chat/lib/on-override-messages.ts
+++ b/packages/vscode-webui/src/features/chat/lib/on-override-messages.ts
@@ -1,4 +1,5 @@
 import { vscodeHost } from "@/lib/vscode";
+import { updateMessage } from "@getpochi/common";
 import { type LiveKitStore, type Message, catalog } from "@getpochi/livekit";
 import { unique } from "remeda";
 import { useRenderWidgetStore } from "../hooks/use-render-widget-store";
@@ -44,43 +45,42 @@ export async function onOverrideMessages({
 
 export function writeRenderWidgetOutput(messages: Message[]) {
   const store = useRenderWidgetStore.getState();
-  const message = getRenderWidgetOutputMessage(messages);
-  if (!message) return;
-
-  let changed = false;
-  const parts = message.parts.map((part): Message["parts"][number] => {
-    if (part.type !== "tool-renderWidget") return part;
-    if (part.state !== "input-available" && part.state !== "output-available") {
-      return part;
-    }
-
-    changed = true;
-    const state =
-      store.getWidgetState(part.toolCallId) ??
-      getExistingRenderWidgetState(part.output) ??
-      {};
-    const output = { state };
-    const error = store.getWidgetError(part.toolCallId);
-    if (error !== undefined) {
-      // @ts-expect-error renderWidget output schema intentionally omits runtime errors.
-      output.error = error.message;
-    }
-    store.clearWidgetState(part.toolCallId);
-    return {
-      ...part,
-      state: "output-available",
-      output,
-    };
-  });
-  if (changed) {
-    messages[messages.length - 2] = { ...message, parts };
-  }
-}
-
-function getRenderWidgetOutputMessage(messages: Message[]) {
   if (messages.at(-1)?.role !== "user") return;
-  const message = messages.at(-2);
-  return message?.role === "assistant" ? message : undefined;
+  const messageIndex = messages.length - 2;
+  if (messages[messageIndex]?.role !== "assistant") return;
+
+  updateMessage(messages, messageIndex, (message) => {
+    let changed = false;
+    const parts = message.parts.map((part) => {
+      if (part.type !== "tool-renderWidget") return part;
+      if (
+        part.state !== "input-available" &&
+        part.state !== "output-available"
+      ) {
+        return part;
+      }
+
+      changed = true;
+      const state =
+        store.getWidgetState(part.toolCallId) ??
+        getExistingRenderWidgetState(part.output) ??
+        {};
+      const output = { state };
+      const error = store.getWidgetError(part.toolCallId);
+      if (error !== undefined) {
+        // @ts-expect-error renderWidget output schema intentionally omits runtime errors.
+        output.error = error.message;
+      }
+      store.clearWidgetState(part.toolCallId);
+      return {
+        ...part,
+        state: "output-available" as const,
+        output,
+      };
+    });
+
+    return changed ? { parts } : undefined;
+  });
 }
 
 function getExistingRenderWidgetState(output: unknown) {
@@ -114,10 +114,9 @@ async function appendCheckpoint(messages: Message[], messageIndex: number) {
   });
   if (!ckpt) return;
 
-  messages[messageIndex] = {
-    ...message,
+  updateMessage(messages, messageIndex, (current) => ({
     parts: [
-      ...message.parts,
+      ...current.parts,
       {
         type: "data-checkpoint",
         data: {
@@ -125,7 +124,7 @@ async function appendCheckpoint(messages: Message[], messageIndex: number) {
         },
       },
     ],
-  };
+  }));
   return ckpt;
 }
 

--- a/rule-tests/no-mutate-shared-message-parts-test.yml
+++ b/rule-tests/no-mutate-shared-message-parts-test.yml
@@ -1,0 +1,37 @@
+id: no-mutate-shared-message-parts
+valid:
+  - |
+    const result = [];
+    result.push(part);
+  - |
+    const output = { ...part.output };
+    output.result = value;
+  - |
+    const parts = message.parts.slice();
+    parts[index] = nextPart;
+  - |
+    updateMessage(messages, index, (message) => ({
+      parts: [...message.parts, nextPart],
+    }));
+  - |
+    function removeToolCallArgumentMetadata(messages) {
+      return messages.map((message) => {
+        message.parts = message.parts.map((part) => {
+          delete part.input._meta;
+          return part;
+        });
+        return message;
+      });
+    }
+invalid:
+  - messages[index] = nextMessage;
+  - part.state = "output-available";
+  - message.parts.push(part);
+  - messageToInject.parts = nextParts;
+  - messages[index].parts = nextParts;
+  - messages[index].parts.push(part);
+  - messages[index].parts[0].output.result = value;
+  - prevPart.output.newProblems = value;
+  - part.output.items.splice(index, 1);
+  - delete part.metadata.foo;
+  - Object.assign(part.output, patch);

--- a/rules/no-mutate-shared-message-parts.yml
+++ b/rules/no-mutate-shared-message-parts.yml
@@ -1,0 +1,64 @@
+id: no-mutate-shared-message-parts
+language: tsx
+rule:
+  all:
+    - any:
+        - all:
+            - any:
+                - kind: assignment_expression
+                - kind: augmented_assignment_expression
+            - has:
+                field: left
+                any:
+                  - regex: ^(message([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Message[A-Za-z0-9_$]*|part([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Part[A-Za-z0-9_$]*|prev|next|current)([.]|\[).*
+                  - regex: ^messages\[.*\]$
+                  - regex: ^messages\[.*\][.].*
+                  - regex: .*[.](parts|input|output|metadata|providerMetadata|callProviderMetadata)([.]|\[).*
+        - all:
+            - kind: update_expression
+            - has:
+                field: argument
+                any:
+                  - regex: ^(message([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Message[A-Za-z0-9_$]*|part([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Part[A-Za-z0-9_$]*|prev|next|current)([.]|\[).*
+                  - regex: ^messages\[.*\][.].*
+                  - regex: .*[.](parts|input|output|metadata|providerMetadata|callProviderMetadata)([.]|\[).*
+        - all:
+            - kind: unary_expression
+            - regex: ^delete\s+.*
+            - has:
+                field: argument
+                any:
+                  - regex: ^(message([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Message[A-Za-z0-9_$]*|part([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Part[A-Za-z0-9_$]*|prev|next|current)([.]|\[).*
+                  - regex: ^messages\[.*\][.].*
+                  - regex: .*[.](parts|input|output|metadata|providerMetadata|callProviderMetadata)([.]|\[).*
+        - all:
+            - kind: call_expression
+            - has:
+                field: function
+                any:
+                  - regex: ^(message([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Message[A-Za-z0-9_$]*|part([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Part[A-Za-z0-9_$]*|prev|next|current)([.]|\[).*?[.](push|pop|shift|unshift|splice|sort|reverse|fill|copyWithin|set|add|delete|clear)$
+                  - regex: .*[.](parts|input|output|metadata|providerMetadata|callProviderMetadata)([.]|\[).*?(push|pop|shift|unshift|splice|sort|reverse|fill|copyWithin|set|add|delete|clear)$
+        - all:
+            - pattern: Object.assign($$$ARGS)
+            - has:
+                field: arguments
+                any:
+                  - regex: ^\((message([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Message[A-Za-z0-9_$]*|part([A-Z0-9_$][A-Za-z0-9_$]*)?|[A-Za-z0-9_$]*Part[A-Za-z0-9_$]*|prev|next|current)([.]|\[).*
+                  - regex: ^\(messages\[.*\]([.]|,).*
+                  - regex: ^\([^,]*[.](parts|input|output|metadata|providerMetadata|callProviderMetadata)([.]|\[|,).*
+    - not:
+        inside:
+          all:
+            - kind: function_declaration
+            - has:
+                field: name
+                regex: ^(removeInvalidCharForStorage|removeToolCallArgumentMetadata|removeToolCallArgumentTransientData|removeToolCallResultMetadata|removeToolCallResultTransientData)$
+          stopBy: end
+files:
+  - packages/common/src/base/formatters.ts
+  - packages/common/src/base/prompts/auto-memory.ts
+  - packages/common/src/base/prompts/environment.ts
+  - packages/livekit/src/chat/llm/compact-task.ts
+  - packages/vscode-webui/src/features/chat/lib/on-override-messages.ts
+message: Do not mutate shared message parts. Return new values instead.
+severity: error


### PR DESCRIPTION
## Summary
- **Implements Copy-on-Write:** Introduces helper functions `mapOrOriginal`, `filterOrOriginal`, and `mapMessagePartsOrOriginal` to replace in-place array/object mutations inside `formatters.ui`.
- **Immutable State Updates:** Refactors `compactTask`, `writeRenderWidgetOutput`, and `appendCheckpoint` to perform immutable updates on `messages` and `parts` arrays instead of using in-place methods like `unshift` or `push`.
- **Preserves Reference Equality:** Ensures that unmodified parts and messages conserve reference equality across formatters, avoiding unnecessary re-renders in the React-based UI of vscode-webui.

## Perf

### Before
<img width="1676" height="700" alt="image" src="https://github.com/user-attachments/assets/915c6bdd-70c9-4352-8cff-efdbc5a3a174" />


### After
<img width="1632" height="352" alt="image" src="https://github.com/user-attachments/assets/4fc83053-4a2f-4cb0-a8ba-0c58f9a9cfef" />


## Test plan
- Run unit tests to verify copy-on-write behaviors and that UI snapshots are not mutated:
  - `bun turbo test --filter=@getpochi/common`
  - `bun turbo test --filter=@getpochi/livekit`
  - `bun turbo test --filter=@getpochi/vscode-webui`
- Verify that types check successfully:
  - `bun tsc`
- Format and lint checks:
  - `bun check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-31f6de164c5d468584ff9b1236c9d519)