### PR TITLE
feat(common): add parseEnvironmentInfoResult helper

### DIFF
--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -11,6 +11,7 @@ export {
   assertBackgroundJobReadInterval,
   prompts,
   parseEnvironmentInfo,
+  parseEnvironmentInfoResult,
 } from "./prompts";
 
 export { SocialLinks } from "./social";

--- a/packages/common/src/base/prompts/__tests__/prompt.test.ts
+++ b/packages/common/src/base/prompts/__tests__/prompt.test.ts
@@ -4,6 +4,7 @@ import type { Environment } from "../../environment";
 import {
   createEnvironmentPrompt,
   parseEnvironmentInfo,
+  parseEnvironmentInfoResult,
 } from "../environment";
 import { createSystemPrompt } from "../system";
 
@@ -211,6 +212,53 @@ test("parseEnvironmentInfo from user text parts", () => {
     shell: "zsh",
     homedir: "/Users/pochi",
     cwd: "/Users/pochi/project",
+  });
+});
+
+test("parseEnvironmentInfo does not require a default shell", () => {
+  const prompt = [
+    {
+      role: "system",
+      content: `# System Information
+
+Operating System: win32
+Default Shell:
+Home Directory: C:\\Users\\exile
+Current Working Directory: d:\\Icy\\project`,
+    },
+  ] satisfies LanguageModelV3CallOptions["prompt"];
+
+  expect(parseEnvironmentInfo(prompt)).toEqual({
+    os: "win32",
+    shell: "",
+    homedir: "C:\\Users\\exile",
+    cwd: "d:\\Icy\\project",
+  });
+});
+
+test("parseEnvironmentInfoResult returns a value on success", () => {
+  const prompt = [
+    {
+      role: "system",
+      content: createEnvironmentPrompt(createTestEnvironment(), undefined),
+    },
+  ] satisfies LanguageModelV3CallOptions["prompt"];
+
+  expect(parseEnvironmentInfoResult(prompt)).toEqual({
+    success: true,
+    value: {
+      os: "darwin",
+      shell: "zsh",
+      homedir: "/Users/pochi",
+      cwd: "/Users/pochi/project",
+    },
+  });
+});
+
+test("parseEnvironmentInfoResult returns missing fields on failure", () => {
+  expect(parseEnvironmentInfoResult(undefined)).toEqual({
+    success: false,
+    missingFields: ["os", "homedir", "cwd"],
   });
 });
 

--- a/packages/common/src/base/prompts/environment.ts
+++ b/packages/common/src/base/prompts/environment.ts
@@ -8,6 +8,16 @@ export type EnvironmentInfo = Pick<
   Environment["info"],
   "os" | "shell" | "homedir" | "cwd"
 >;
+type RequiredEnvironmentInfo = Omit<EnvironmentInfo, "shell">;
+
+type EnvironmentInfoField = keyof RequiredEnvironmentInfo;
+export type EnvironmentInfoParseResult =
+  | { success: true; value: EnvironmentInfo; missingFields?: never }
+  | {
+      success: false;
+      value?: never;
+      missingFields: EnvironmentInfoField[];
+    };
 
 export function createEnvironmentPrompt(
   environment: Environment,
@@ -41,7 +51,18 @@ export function createLiteEnvironmentPrompt(environment: Environment) {
 export function parseEnvironmentInfo(
   prompt: LanguageModelV3CallOptions["prompt"] | undefined,
 ): EnvironmentInfo | undefined {
-  if (!prompt) return;
+  const result = parseEnvironmentInfoResult(prompt);
+  return result?.value;
+}
+
+export function parseEnvironmentInfoResult(
+  prompt: LanguageModelV3CallOptions["prompt"] | undefined,
+): EnvironmentInfoParseResult {
+  let closestMissingFields: EnvironmentInfoField[] = ["os", "homedir", "cwd"];
+
+  if (!prompt) {
+    return { success: false, missingFields: closestMissingFields };
+  }
 
   for (const message of prompt) {
     const content = message.content;
@@ -61,16 +82,30 @@ export function parseEnvironmentInfo(
       const homedir = systemInfo["Home Directory"];
       const cwd = systemInfo["Current Working Directory"];
 
-      if (os && shell && homedir && cwd) {
+      if (os && homedir && cwd) {
         return {
-          os,
-          shell,
-          homedir,
-          cwd,
+          success: true,
+          value: {
+            os,
+            shell: shell ?? "",
+            homedir,
+            cwd,
+          },
         };
+      }
+
+      const missingFields: EnvironmentInfoField[] = [];
+      if (!os) missingFields.push("os");
+      if (!homedir) missingFields.push("homedir");
+      if (!cwd) missingFields.push("cwd");
+
+      if (missingFields.length < closestMissingFields.length) {
+        closestMissingFields = missingFields;
       }
     }
   }
+
+  return { success: false, missingFields: closestMissingFields };
 }
 
 function parseSystemInfoLines(text: string) {

--- a/packages/common/src/base/prompts/index.ts
+++ b/packages/common/src/base/prompts/index.ts
@@ -33,7 +33,10 @@ import {
 import { renderTerminalContext } from "./terminal-context";
 import { renderUserEdits } from "./user-edits";
 
-export { parseEnvironmentInfo } from "./environment";
+export {
+  parseEnvironmentInfo,
+  parseEnvironmentInfoResult,
+} from "./environment";
 
 export const prompts = {
   system: createSystemPrompt,


### PR DESCRIPTION
## Summary
- Added `parseEnvironmentInfoResult` to parse the `# System Information` block and return a structured `{ success, value, missingFields }` shape.
- Allowed parsing to succeed without being blocked by a missing `Default Shell` field.
- Fully tested the new behavior and verified both types and formatting.

## Test plan
- Run `bun run test -- -t "parseEnvironmentInfo"` to verify all tests in `packages/common` pass successfully.

🤖 Generated with [Pochi](https://getpochi.com)