### PR TITLE
docs: add weekly update #38

### DIFF
--- a/packages/docs/content/docs/developer-updates/2026-08-22-weekly-update-38.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-08-22-weekly-update-38.mdx
@@ -21,4 +21,4 @@ More below!
 
 ### 👀 Coming Up
 
-- **Rendered widgets that remain available:** A P1 item planned for 0.68 will preserve generated widget content so interactive visuals remain available in the task after Pochi creates them.
+- **Save rendered widgets to a file:** A P1 item planned for 0.68 will let you save generated widget content to a file instead of leaving it only in the chat.

--- a/packages/docs/content/docs/developer-updates/2026-08-22-weekly-update-38.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-08-22-weekly-update-38.mdx
@@ -21,4 +21,4 @@ More below!
 
 ### 👀 Coming Up
 
-- **Save rendered widgets to a file:** A P1 item planned for 0.68 will let you save generated widget content to a file instead of leaving it only in the chat.
+- **Save rendered widgets to a file:** Planned work for 0.68 will let you save generated widget content to a file instead of leaving it only in the chat.

--- a/packages/docs/content/docs/developer-updates/2026-08-22-weekly-update-38.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-08-22-weekly-update-38.mdx
@@ -1,0 +1,24 @@
+---
+title: 'Weekly Update #38'
+---
+# Weekly Update #38
+
+### TL;DR
+
+Pochi 0.66 shipped on August 20 with the automatic background-job completion notifications and cleaner changed-files summary previewed in last week's update. With that release out, Pochi 0.68 is expected on August 31 and is shaping up to make agents better at exercising and verifying the software they build, while keeping very long task histories responsive and available instead of letting them overwhelm the chat view.
+
+More below!
+
+### 🚀 Features
+
+- **Run and verify software through its real interface:** Pochi is expected to gain built-in workflows for exercising CLI tools, servers, browser apps, desktop apps, terminal interfaces, libraries, and agent workflows. It will be able to run a project through the interface its users actually see, formally verify the result when asked, and create reusable project-specific run instructions for later tasks.
+
+  This will be most useful when tests alone cannot show whether an interactive workflow behaves correctly from end to end. [**#1904**](https://github.com/TabbyML/pochi/pull/1904)
+
+### 🐛 Bug Fixes
+
+- **Long task histories will stay responsive:** Pochi will render long conversations in manageable sections, keeping the newest work anchored in view while still letting you load earlier messages. This is expected to prevent large histories with many sub-agent steps from exhausting the chat view's memory or causing the page to collapse. [**#1900**](https://github.com/TabbyML/pochi/pull/1900)
+
+### 👀 Coming Up
+
+- **Rendered widgets that remain available:** A P1 item planned for 0.68 will preserve generated widget content so interactive visuals remain available in the task after Pochi creates them.

--- a/packages/docs/content/docs/developer-updates/index.mdx
+++ b/packages/docs/content/docs/developer-updates/index.mdx
@@ -16,6 +16,14 @@ Here you will find highlights on features, enhancements, and bug fixes, plus ins
 
 --- */}
 
+## [Weekly Update #38](./2026-08-22-weekly-update-38)
+
+#### August 22, 2026
+
+<include>./2026-08-22-weekly-update-38.mdx</include>
+
+---
+
 ## [Weekly Update #37](./2026-08-16-weekly-update-37)
 
 #### August 16, 2026


### PR DESCRIPTION
## Summary
- publish Weekly Update #38 with the Pochi 0.66 release status and an early look at 0.68
- preview built-in run and verification workflows and saving rendered widgets to files
- cover the long-task-history reliability fix

## Test plan
- [ ] Preview the Developer Updates index locally
- [ ] Verify the Weekly Update #38 page renders correctly
- [ ] Confirm links to #1900 and #1904

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-01e98f4171e941629542dae84f02d75c)