### PR TITLE
fix(tools): restore best-effort file staleness guard

### DIFF
--- a/packages/common/src/tool-utils/__tests__/file-state-cache.test.ts
+++ b/packages/common/src/tool-utils/__tests__/file-state-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   checkStaleness,
   FileStateCache,
@@ -75,28 +75,25 @@ describe("FileStateCache", () => {
     ).resolves.toBeUndefined();
   });
 
-  // The "read before edit/write" guard requires the file to have been read
-  // first when it exists on disk.
-  it("throws when editing a file that was never read but exists on disk", async () => {
+  it("allows editing an existing file when no cached baseline is available", async () => {
     const cache = new FileStateCache();
 
     await expect(
       checkStaleness(cache, "/tmp/file.txt", async () => 1234, "editing"),
-    ).rejects.toThrow("File has not been read yet");
+    ).resolves.toBeUndefined();
   });
 
-  it("throws when writing a file that was never read but exists on disk", async () => {
+  it("allows writing an existing file when no cached baseline is available", async () => {
     const cache = new FileStateCache();
 
     await expect(
       checkStaleness(cache, "/tmp/file.txt", async () => 1234, "writing"),
-    ).rejects.toThrow("File has not been read yet");
+    ).resolves.toBeUndefined();
   });
 
-  it("allows writing a new file that does not exist on disk and was never read", async () => {
+  it("allows writing a new file when no cached baseline is available", async () => {
     const cache = new FileStateCache();
 
-    // getMtime returns undefined => file does not exist
     await expect(
       checkStaleness(cache, "/tmp/new-file.txt", async () => undefined, "writing"),
     ).resolves.toBeUndefined();
@@ -135,7 +132,7 @@ describe("FileStateCache", () => {
 
   // markAllAsWritten is used when the read tool_results that populated the
   // cache leave the conversation (compaction / retry-strip). It must retain
-  // the entries (so edits are not falsely rejected) while disabling dedup.
+  // their staleness baselines while disabling dedup.
   it("keeps entries editable but stops read dedup after markAllAsWritten", async () => {
     const cache = new FileStateCache();
     cache.set("/tmp/file.txt", {
@@ -205,7 +202,7 @@ describe("FileStateCache", () => {
 });
 
 describe("withFileStateCacheGuard", () => {
-  it("allows editing a stale file while the staleness guard is disabled", async () => {
+  it("rejects editing a file that changed from its cached baseline", async () => {
     const cache = new FileStateCache();
     cache.set("/tmp/existing.txt", {
       content: "old content",
@@ -213,14 +210,71 @@ describe("withFileStateCacheGuard", () => {
       startLine: 1,
       endLine: 1,
     });
-    const getMtime = async (_path: string) => 1000;
+    const doWork = vi.fn(async () => ({
+      result: { success: true as const },
+      fileCacheContent: "new content",
+    }));
 
     await expect(
       withFileStateCacheGuard({
         cache,
         path: "/tmp/existing.txt",
         cwd: "/tmp",
-        getMtime,
+        getMtime: async () => 1000,
+        operation: "editing",
+        doWork,
+      }),
+    ).rejects.toThrow("File has been modified since it was last read");
+    expect(doWork).not.toHaveBeenCalled();
+  });
+
+  it("allows editing an existing file without a cached baseline", async () => {
+    const cache = new FileStateCache();
+
+    await expect(
+      withFileStateCacheGuard({
+        cache,
+        path: "/tmp/existing.txt",
+        cwd: "/tmp",
+        getMtime: async () => 1000,
+        operation: "editing",
+        doWork: async () => ({
+          result: { success: true as const },
+          fileCacheContent: "new content",
+        }),
+      }),
+    ).resolves.toEqual({ success: true });
+    expect(cache.get("/tmp/existing.txt")).toMatchObject({
+      content: "new content",
+      timestamp: 1000,
+      fromWrite: true,
+    });
+  });
+
+  it("allows editing after the cached baseline is evicted", async () => {
+    const cache = new FileStateCache();
+    cache.set("/tmp/evicted.txt", {
+      content: "old content",
+      timestamp: 1,
+      startLine: 1,
+      endLine: 1,
+    });
+    for (let index = 0; index < 100; index++) {
+      cache.set(`/tmp/file-${index}.txt`, {
+        content: String(index),
+        timestamp: index,
+        startLine: 1,
+        endLine: 1,
+      });
+    }
+    expect(cache.has("/tmp/evicted.txt")).toBe(false);
+
+    await expect(
+      withFileStateCacheGuard({
+        cache,
+        path: "/tmp/evicted.txt",
+        cwd: "/tmp",
+        getMtime: async () => 1000,
         operation: "editing",
         doWork: async () => ({
           result: { success: true as const },

--- a/packages/common/src/tool-utils/file-state-cache.ts
+++ b/packages/common/src/tool-utils/file-state-cache.ts
@@ -120,11 +120,10 @@ export class FileStateCache {
    *
    * Used when the read tool_results that populated the cache are about to
    * leave the conversation — a compaction summary, or a retry that strips a
-   * completed read. Keeping the entries preserves the edit/write staleness
-   * guard (so a later edit of an already-read file is not falsely rejected
-   * with "File has not been read yet"), while `fromWrite: true` stops them
-   * from producing a "File unchanged" dedup stub that would dangle onto a
-   * tool_result no longer present in the conversation.
+   * completed read. Keeping the entries preserves their staleness baselines,
+   * while `fromWrite: true` stops them from producing a "File unchanged"
+   * dedup stub that would dangle onto a tool_result no longer present in the
+   * conversation.
    */
   markAllAsWritten(): void {
     for (const entry of this.entries.values()) {
@@ -219,17 +218,10 @@ export async function checkStaleness(
   operation: "editing" | "writing" = "editing",
 ): Promise<void> {
   const cachedState = cache.get(resolvedPath);
-  if (!cachedState) {
-    const currentMtime = await getMtime(resolvedPath);
-    // If the file exists on disk but was never read, require a read first.
-    // A missing mtime means the file doesn't exist yet, so creating it is fine.
-    if (currentMtime !== undefined) {
-      throw new Error(
-        `File has not been read yet. Please read the file before ${operation} it.`,
-      );
-    }
-    return;
-  }
+  // A cache miss is not proof that the file was never read. Entries can be
+  // evicted or skipped because of cache limits, so only validate files for
+  // which a trustworthy baseline is still available.
+  if (!cachedState) return;
 
   const currentMtime = await getMtime(resolvedPath);
   if (currentMtime === cachedState.timestamp) return;
@@ -270,8 +262,9 @@ async function updateCacheAfterWrite(
 }
 
 /**
- * Wraps a file-editing callback with a cache update after the write. The
- * staleness guard is temporarily disabled.
+ * Wraps a file-editing callback with a best-effort staleness guard before the
+ * write and a cache update afterward. Cache misses are allowed because entries
+ * may have been evicted or skipped due to cache limits.
  *
  * Path resolution and virtual-path detection are handled automatically:
  * `pochi://` URIs are passed through as-is and skip all cache operations,
@@ -281,7 +274,7 @@ async function updateCacheAfterWrite(
  * @param opts.path         - Raw path from the tool input (may be relative or a `pochi://` URI)
  * @param opts.cwd          - Working directory used to resolve relative paths
  * @param opts.getMtime     - Platform-specific function to get current file mtime
- * @param opts.operation    - Reserved for the temporarily disabled staleness guard
+ * @param opts.operation    - "editing" or "writing" — used in the staleness error message
  * @param opts.doWork       - Callback that performs the actual edit/write. Receives the resolved
  *                            absolute path and returns `{ result, fileCacheContent }`.
  * @returns The `result` value produced by `doWork`
@@ -294,10 +287,14 @@ export async function withFileStateCacheGuard<T>(opts: {
   operation: "editing" | "writing";
   doWork: (resolvedPath: string) => Promise<FileCacheCallbackResult<T>>;
 }): Promise<T> {
-  const { cache, path: inputPath, cwd, getMtime, doWork } = opts;
+  const { cache, path: inputPath, cwd, getMtime, operation, doWork } = opts;
 
   const isVirtual = isVirtualPath(inputPath);
   const resolvedPath = isVirtual ? inputPath : resolvePath(inputPath, cwd);
+
+  if (!isVirtual && cache) {
+    await checkStaleness(cache, resolvedPath, getMtime, operation);
+  }
 
   const { result, fileCacheContent } = await doWork(resolvedPath);
 


### PR DESCRIPTION
## Summary
- restore the pre-write staleness guard when a cached file baseline is available
- allow writes when the baseline is missing or was evicted, avoiding false read-first failures
- cover stale, missing, evicted, and post-write cache behavior

## Test plan
- [x] `bun run test src/tool-utils/__tests__/file-state-cache.test.ts` (from `packages/common`)
- [x] `bun check`
- [x] `bun tsc`
- [x] `git diff --check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8ce72aa17be14b829cca58fbd60356cf)