### PR TITLE
fix: avoid broken UTF-8 when stopping background jobs

### DIFF
--- a/packages/cli/src/lib/__tests__/background-job-manager.test.ts
+++ b/packages/cli/src/lib/__tests__/background-job-manager.test.ts
@@ -129,4 +129,35 @@ describe("BackgroundJobManager", () => {
       await rm(outputDir, { recursive: true, force: true });
     }
   });
+
+  it("discards an incomplete UTF-8 character when manually stopped", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "pochi-bgjob-stop-utf8-test-"));
+    try {
+      const manager = new BackgroundJobManager({
+        taskId: "task-test",
+        outputDir,
+      });
+      const eventPromise = new Promise<
+        Parameters<Parameters<typeof manager.onDidFinish>[0]>[0]
+      >((resolve) => manager.onDidFinish(resolve));
+      const script = [
+        "const bytes = Buffer.from('中');",
+        "process.stdout.write(Buffer.concat([Buffer.from('ready'), bytes.subarray(0, 1)]));",
+        "setInterval(() => {}, 1000);",
+      ].join("");
+      const { backgroundJobId, outputFile } = manager.start(
+        `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
+        ".",
+      );
+
+      await expect.poll(() => readFile(outputFile, "utf8")).toBe("ready");
+      expect(manager.kill(backgroundJobId)).toBe(true);
+
+      const event = await eventPromise;
+      expect(event.status).toBe("stopped");
+      expect(await readFile(outputFile, "utf8")).toBe("ready");
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/src/lib/background-job-manager.ts
+++ b/packages/cli/src/lib/background-job-manager.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import type { BackgroundJobTerminalEvent } from "@getpochi/common";
 import { assertBackgroundJobReadInterval } from "@getpochi/common";
 import { getTerminalEnv } from "@getpochi/common/env-utils";
@@ -99,12 +100,19 @@ export class BackgroundJobManager {
       [child.stdout, child.stderr]
         .filter((stream) => stream !== null)
         .map(async (stream) => {
+          const decoder = new StringDecoder("utf8");
           const sanitizer = new PlainOutputSanitizer();
-          // setEncoding uses Node's streaming decoder, so a multi-byte UTF-8
-          // character split between Buffer chunks is not replaced with U+FFFD.
-          stream.setEncoding("utf8");
           for await (const chunk of stream) {
-            await appendOutput(sanitizer.write(chunk));
+            await appendOutput(sanitizer.write(decoder.write(chunk)));
+          }
+
+          // StringDecoder buffers an incomplete trailing UTF-8 sequence. A
+          // manually stopped process may end in the middle of a character, so
+          // discard that partial sequence instead of flushing it as U+FFFD.
+          // For a naturally completed process, preserve Node's usual behavior
+          // for genuinely malformed output by flushing the decoder.
+          if (!job.stopRequested) {
+            await appendOutput(sanitizer.write(decoder.end()));
           }
           await appendOutput(sanitizer.end());
         }),

--- a/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
@@ -226,6 +226,62 @@ describe("TerminalJob", () => {
     );
   });
 
+  it("discards a trailing replacement character when manually stopped", async () => {
+    let finishOutput: (() => void) | undefined;
+    const outputStopped = new Promise<void>((resolve) => {
+      finishOutput = resolve;
+    });
+    const harness = createHarness({
+      read: async function* () {
+        yield "ready\uFFFD";
+        await outputStopped;
+      },
+    });
+
+    await flushPromises();
+    assert.deepStrictEqual(harness.lifecycle, [
+      "output:$ sleep 10\n",
+      "output:ready",
+    ]);
+
+    harness.job.kill();
+    finishOutput?.();
+    await flushPromises();
+    await flushPromises();
+
+    assert.deepStrictEqual(harness.lifecycle, [
+      "output:$ sleep 10\n",
+      "output:ready",
+      "file-closed",
+      "event-fired",
+    ]);
+    assert.strictEqual(harness.finishEvents[0]?.status, "stopped");
+  });
+
+  it("preserves a trailing replacement character after normal completion", async () => {
+    const harness = createHarness({
+      read: async function* () {
+        yield "valid replacement: \uFFFD";
+      },
+    });
+
+    await flushPromises();
+    harness.executionEndEmitter.fire({
+      execution: harness.execution,
+      exitCode: 0,
+    });
+    await flushPromises();
+
+    assert.deepStrictEqual(harness.lifecycle, [
+      "output:$ sleep 10\n",
+      "output:valid replacement: ",
+      "output:\uFFFD",
+      "file-closed",
+      "event-fired",
+    ]);
+    assert.strictEqual(harness.finishEvents[0]?.status, "completed");
+  });
+
   it("waits for trailing output before notifying about a failed job", async () => {
     let releaseOutput: (() => void) | undefined;
     const outputReady = new Promise<void>((resolve) => {

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -226,16 +226,36 @@ export class TerminalJob implements vscode.Disposable {
     outputStream: AsyncIterable<string>,
   ): Promise<void> {
     const sanitizer = new PlainOutputSanitizer();
+    let pendingReplacementCharacters = "";
+    const appendPlainText = async (plainText: string) => {
+      if (plainText.length === 0) return;
+
+      const text = pendingReplacementCharacters + plainText;
+      const trailingReplacements = text.match(/\uFFFD+$/u)?.[0] ?? "";
+      const completeText = text.slice(
+        0,
+        text.length - trailingReplacements.length,
+      );
+      pendingReplacementCharacters = trailingReplacements;
+      if (completeText.length === 0) return;
+
+      await this.outputWriter.append(completeText);
+      this.outputManager.addChunk(completeText);
+    };
+
     for await (const chunk of outputStream) {
-      const plainText = sanitizer.write(chunk);
-      if (plainText.length === 0) continue;
-      await this.outputWriter.append(plainText);
-      this.outputManager.addChunk(plainText);
+      await appendPlainText(sanitizer.write(chunk));
     }
-    const remainder = sanitizer.end();
-    if (remainder.length > 0) {
-      await this.outputWriter.append(remainder);
-      this.outputManager.addChunk(remainder);
+    await appendPlainText(sanitizer.end());
+
+    // VS Code exposes terminal output as decoded strings, so the original
+    // bytes are unavailable here. If terminal disposal interrupted a UTF-8
+    // sequence, its decoder can leave U+FFFD at the very end of the stream.
+    // Hold that trailing marker until completion and discard it only when the
+    // job was stopped. A naturally completed job still preserves U+FFFD.
+    if (!this.stopRequested && pendingReplacementCharacters.length > 0) {
+      await this.outputWriter.append(pendingReplacementCharacters);
+      this.outputManager.addChunk(pendingReplacementCharacters);
     }
   }
 


### PR DESCRIPTION
## Summary
- decode CLI background process output with an explicit streaming UTF-8 decoder
- discard incomplete trailing UTF-8 bytes when CLI jobs are manually stopped
- guard the VS Code terminal path against a trailing replacement marker produced when terminal disposal interrupts decoding
- preserve legitimate replacement characters after normal completion
- add regression coverage for both CLI and VS Code background jobs

## Test plan
- [x] Run CLI unit tests (`bun run test src/lib/__tests__/background-job-manager.test.ts`)
- [x] Run VS Code extension tests (`bun run test` from `packages/vscode` — 201 passing)
- [x] Run type checks (`bun tsc`)
- [x] Run formatting and lint checks (`bun check`)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-f416fe9bc93349e0b3ce570f9b678336)