### PR TITLE
fix(vscode): notify when open file target is missing

### DIFF
--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -1,4 +1,3 @@
-import * as os from "node:os";
 import path from "node:path";
 import { executeCommandWithPty } from "@/integrations/terminal/execute-command-with-pty";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -21,6 +20,7 @@ import { asRelativePath, isFileExists } from "@/lib/fs";
 import { getLogger } from "@/lib/logger";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { ModelList } from "@/lib/model-list";
+import { openFile as openFileInEditor } from "@/lib/open-file";
 // biome-ignore lint/style/useImportType: needed for dependency injection
 import { PochiLanguage } from "@/lib/pochi-language";
 // biome-ignore lint/style/useImportType: needed for dependency injection
@@ -82,7 +82,6 @@ import { McpHub } from "@getpochi/common/mcp-utils";
 import {
   GitStatusReader,
   ignoreWalk,
-  isPlainTextFile,
   maybePersistToolResult,
 } from "@getpochi/common/tool-utils";
 import { getVendor } from "@getpochi/common/vendor";
@@ -689,116 +688,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
       cellId?: string;
     },
   ) => {
-    let fileUri = vscode.Uri.parse(filePath);
-    let resolvedPath = filePath;
-
-    // Open file directly if it's a pochi scheme
-    if (fileUri.scheme === "pochi") {
-      vscode.commands.executeCommand(
-        "vscode.open",
-        vscode.Uri.parse(resolvedPath),
-      );
-      return;
-    }
-
-    // Expand ~ to home directory if present
-    if (resolvedPath.startsWith("~/")) {
-      const homedir = os.homedir();
-      resolvedPath = resolvedPath.replace(/^~/, homedir);
-    }
-
-    fileUri = path.isAbsolute(resolvedPath)
-      ? vscode.Uri.file(resolvedPath)
-      : this.cwd
-        ? vscode.Uri.joinPath(vscode.Uri.file(this.cwd), resolvedPath)
-        : vscode.Uri.file(resolvedPath);
-
-    try {
-      const stat = await vscode.workspace.fs.stat(fileUri);
-      if (stat.type === vscode.FileType.Directory) {
-        // reveal and expand it
-        await vscode.commands.executeCommand("revealInExplorer", fileUri);
-        await vscode.commands.executeCommand("list.expand");
-      } else if (stat.type === vscode.FileType.File) {
-        if (fileUri.fsPath.endsWith(".ipynb")) {
-          // Open notebook with the notebook editor
-          await vscode.commands.executeCommand(
-            "vscode.openWith",
-            fileUri,
-            "jupyter-notebook",
-          );
-
-          if (options?.cellId) {
-            const notebook = vscode.workspace.notebookDocuments.find(
-              (nb) => nb.uri.toString() === fileUri.toString(),
-            );
-            if (!notebook) return;
-            const cellIndex = notebook
-              .getCells()
-              .findIndex((cell) => cell.metadata?.id === options.cellId);
-            if (cellIndex < 0) return;
-            const editor = vscode.window.visibleNotebookEditors.find(
-              (e) => e.notebook.uri.toString() === fileUri.toString(),
-            );
-            if (!editor) return;
-            editor.selection = new vscode.NotebookRange(
-              cellIndex,
-              cellIndex + 1,
-            );
-            await vscode.commands.executeCommand("notebook.cell.edit");
-          }
-          return;
-        }
-
-        const isPlainText = await isPlainTextFile(fileUri.fsPath);
-        if (!isPlainText) {
-          await vscode.commands.executeCommand("vscode.open", fileUri);
-        } else {
-          const start = options?.start ?? 1;
-          const end = options?.end ?? start;
-          vscode.window.showTextDocument(fileUri, {
-            selection: new vscode.Range(start - 1, 0, end - 1, 0),
-            preserveFocus: options?.preserveFocus,
-          });
-        }
-      }
-    } catch (error) {
-      logger.info("File not found, trying to open from base64 data", error);
-      // file may not exist, check if has base64Data
-      if (options?.base64Data) {
-        try {
-          // If base64 data is present, open it as a temp file
-          const tempFile = vscode.Uri.file(
-            path.join(os.tmpdir(), fileUri.path),
-          );
-          await vscode.workspace.fs.writeFile(
-            tempFile,
-            Buffer.from(options?.base64Data ?? "", "base64"),
-          );
-          await vscode.commands.executeCommand("vscode.open", tempFile);
-          return;
-        } catch (error) {
-          logger.error(`Failed to open file from base64 data: ${error}`);
-        }
-      }
-
-      if (options?.fallbackGlobPattern) {
-        const result = await vscode.workspace.findFiles(
-          options.fallbackGlobPattern,
-          null,
-          1,
-        );
-
-        logger.info("found file by glob pattern", result[0]);
-
-        if (result.length > 0) {
-          await vscode.commands.executeCommand("vscode.open", result[0]);
-          return;
-        }
-      }
-
-      await vscode.window.showErrorMessage(`File not found: ${filePath}`);
-    }
+    await openFileInEditor(filePath, this.cwd, options);
   };
 
   capture = async ({ event, properties }: CaptureEvent) => {

--- a/packages/vscode/src/integrations/webview/vscode-host-impl.ts
+++ b/packages/vscode/src/integrations/webview/vscode-host-impl.ts
@@ -776,6 +776,7 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
             Buffer.from(options?.base64Data ?? "", "base64"),
           );
           await vscode.commands.executeCommand("vscode.open", tempFile);
+          return;
         } catch (error) {
           logger.error(`Failed to open file from base64 data: ${error}`);
         }
@@ -792,8 +793,11 @@ export class VSCodeHostImpl implements VSCodeHostApi, vscode.Disposable {
 
         if (result.length > 0) {
           await vscode.commands.executeCommand("vscode.open", result[0]);
+          return;
         }
       }
+
+      await vscode.window.showErrorMessage(`File not found: ${filePath}`);
     }
   };
 

--- a/packages/vscode/src/lib/__test__/open-file.test.ts
+++ b/packages/vscode/src/lib/__test__/open-file.test.ts
@@ -1,0 +1,92 @@
+import * as assert from "node:assert";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, describe, it } from "mocha";
+import proxyquire from "proxyquire";
+import sinon from "sinon";
+import * as vscode from "vscode";
+import type { openFile as openFileType } from "../open-file";
+
+const overrideObject = <T extends object>(
+  target: T,
+  overrides: Record<PropertyKey, unknown>,
+): T =>
+  new Proxy(target, {
+    get: (object, property) =>
+      property in overrides ? overrides[property] : Reflect.get(object, property),
+  });
+
+const loadOpenFile = (
+  vscodeOverrides: Record<PropertyKey, unknown>,
+): typeof openFileType => {
+  const vscodeMock = overrideObject(vscode, vscodeOverrides);
+  return proxyquire("../open-file", {
+    "@/lib/logger": {
+      getLogger: () => ({
+        info: sinon.stub(),
+        error: sinon.stub(),
+      }),
+    },
+    "@getpochi/common/tool-utils": {
+      isPlainTextFile: sinon.stub().resolves(true),
+    },
+    vscode: vscodeMock,
+  }).openFile;
+};
+
+describe("openFile", () => {
+  let testDirectory: vscode.Uri;
+
+  before(async () => {
+    testDirectory = vscode.Uri.file(
+      path.join(os.tmpdir(), `pochi-open-file-${Date.now()}`),
+    );
+    await vscode.workspace.fs.createDirectory(testDirectory);
+  });
+
+  after(async () => {
+    await vscode.workspace.fs.delete(testDirectory, {
+      recursive: true,
+      useTrash: false,
+    });
+  });
+
+  it("does not classify an error opening an existing directory as missing", async () => {
+    const openError = new Error("Failed to reveal directory");
+    const showErrorMessage = sinon.stub();
+    const executeCommand = sinon.stub().rejects(openError);
+    const openFile = loadOpenFile({
+      commands: overrideObject(vscode.commands, { executeCommand }),
+      window: overrideObject(vscode.window, { showErrorMessage }),
+    });
+
+    await assert.rejects(
+      openFile(testDirectory.fsPath, undefined),
+      openError,
+    );
+    assert.strictEqual(showErrorMessage.called, false);
+  });
+
+  it("shows a non-blocking error when the file and glob fallback are missing", async () => {
+    const missingName = `missing-${Date.now()}`;
+    const missingPath = vscode.Uri.joinPath(testDirectory, missingName).fsPath;
+    const showErrorMessage = sinon.stub().returns(new Promise(() => {}));
+    const openFile = loadOpenFile({
+      window: overrideObject(vscode.window, { showErrorMessage }),
+    });
+
+    await Promise.race([
+      openFile(missingPath, undefined, {
+        fallbackGlobPattern: `**/${missingName}`,
+      }),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("openFile did not complete")), 3_000),
+      ),
+    ]);
+
+    assert.strictEqual(
+      showErrorMessage.calledOnceWithExactly(`File not found: ${missingPath}`),
+      true,
+    );
+  });
+});

--- a/packages/vscode/src/lib/__test__/open-file.test.ts
+++ b/packages/vscode/src/lib/__test__/open-file.test.ts
@@ -10,28 +10,40 @@ import type { openFile as openFileType } from "../open-file";
 const overrideObject = <T extends object>(
   target: T,
   overrides: Record<PropertyKey, unknown>,
-): T =>
-  new Proxy(target, {
-    get: (object, property) =>
-      property in overrides ? overrides[property] : Reflect.get(object, property),
-  });
+): T => {
+  const descriptors = Object.fromEntries(
+    Reflect.ownKeys(overrides).map((property) => [
+      property,
+      {
+        configurable: true,
+        enumerable: true,
+        value: overrides[property],
+        writable: true,
+      },
+    ]),
+  );
+  return Object.create(target, descriptors);
+};
 
 const loadOpenFile = (
   vscodeOverrides: Record<PropertyKey, unknown>,
 ): typeof openFileType => {
   const vscodeMock = overrideObject(vscode, vscodeOverrides);
-  return proxyquire("../open-file", {
-    "@/lib/logger": {
-      getLogger: () => ({
-        info: sinon.stub(),
-        error: sinon.stub(),
-      }),
-    },
-    "@getpochi/common/tool-utils": {
-      isPlainTextFile: sinon.stub().resolves(true),
-    },
-    vscode: vscodeMock,
-  }).openFile;
+  return proxyquire
+    .noCallThru()
+    .noPreserveCache()
+    .load("../open-file", {
+      "@/lib/logger": {
+        getLogger: () => ({
+          info: sinon.stub(),
+          error: sinon.stub(),
+        }),
+      },
+      "@getpochi/common/tool-utils": {
+        isPlainTextFile: sinon.stub().resolves(true),
+      },
+      vscode: vscodeMock,
+    }).openFile;
 };
 
 describe("openFile", () => {
@@ -88,5 +100,58 @@ describe("openFile", () => {
       showErrorMessage.calledOnceWithExactly(`File not found: ${missingPath}`),
       true,
     );
+  });
+
+  it("does not run missing-file fallbacks for other file system errors", async () => {
+    const filePath = vscode.Uri.joinPath(testDirectory, "restricted").fsPath;
+    const stat = sinon
+      .stub()
+      .rejects(vscode.FileSystemError.NoPermissions(filePath));
+    const findFiles = sinon.stub();
+    const showErrorMessage = sinon.stub();
+    const openFile = loadOpenFile({
+      workspace: overrideObject(vscode.workspace, {
+        fs: overrideObject(vscode.workspace.fs, { stat }),
+        findFiles,
+      }),
+      window: overrideObject(vscode.window, { showErrorMessage }),
+    });
+
+    await openFile(filePath, undefined, { fallbackGlobPattern: "**/*" });
+
+    assert.strictEqual(stat.calledOnce, true);
+    assert.strictEqual(findFiles.called, false);
+    assert.deepStrictEqual(showErrorMessage.args, [
+      [`No permissions to access file: ${filePath}`],
+    ]);
+  });
+
+  it("opens empty base64 content without showing a missing-file error", async () => {
+    const filePath = vscode.Uri.joinPath(testDirectory, "empty.txt").fsPath;
+    const stat = sinon.stub().rejects(vscode.FileSystemError.FileNotFound());
+    const writeFile = sinon.stub().resolves();
+    const executeCommand = sinon.stub().resolves();
+    const showErrorMessage = sinon.stub();
+    const openFile = loadOpenFile({
+      commands: overrideObject(vscode.commands, { executeCommand }),
+      workspace: overrideObject(vscode.workspace, {
+        fs: overrideObject(vscode.workspace.fs, { stat, writeFile }),
+      }),
+      window: overrideObject(vscode.window, { showErrorMessage }),
+    });
+
+    await openFile(filePath, undefined, { base64Data: "" });
+
+    assert.strictEqual(stat.calledOnce, true);
+    assert.strictEqual(writeFile.calledOnce, true);
+    assert.strictEqual(writeFile.firstCall.args[1].byteLength, 0);
+    assert.strictEqual(
+      executeCommand.calledOnceWithExactly(
+        "vscode.open",
+        writeFile.firstCall.args[0],
+      ),
+      true,
+    );
+    assert.strictEqual(showErrorMessage.called, false);
   });
 });

--- a/packages/vscode/src/lib/open-file.ts
+++ b/packages/vscode/src/lib/open-file.ts
@@ -6,6 +6,49 @@ import * as vscode from "vscode";
 
 const logger = getLogger("openFile");
 
+const fileSystemErrorCode = {
+  fileNotFound: vscode.FileSystemError.FileNotFound().code,
+  fileExists: vscode.FileSystemError.FileExists().code,
+  fileNotADirectory: vscode.FileSystemError.FileNotADirectory().code,
+  fileIsADirectory: vscode.FileSystemError.FileIsADirectory().code,
+  noPermissions: vscode.FileSystemError.NoPermissions().code,
+  unavailable: vscode.FileSystemError.Unavailable().code,
+} as const;
+
+const fileSystemErrorMessages: Record<string, string> = {
+  [fileSystemErrorCode.fileNotFound]: "File not found",
+  [fileSystemErrorCode.fileExists]: "File already exists",
+  [fileSystemErrorCode.fileNotADirectory]: "Not a directory",
+  [fileSystemErrorCode.fileIsADirectory]: "Is a directory",
+  [fileSystemErrorCode.noPermissions]: "No permissions to access file",
+  [fileSystemErrorCode.unavailable]: "File system unavailable",
+};
+
+const getFileSystemErrorCode = (error: unknown): string | undefined => {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+  return undefined;
+};
+
+const isFileNotFoundError = (error: unknown): boolean =>
+  getFileSystemErrorCode(error) === fileSystemErrorCode.fileNotFound;
+
+const showFileSystemError = (filePath: string, error: unknown): void => {
+  const errorCode = getFileSystemErrorCode(error);
+  const message = errorCode
+    ? (fileSystemErrorMessages[errorCode] ?? "Failed to access file")
+    : "Failed to access file";
+
+  logger.error(`${message}: ${filePath}`, error);
+  void vscode.window.showErrorMessage(`${message}: ${filePath}`);
+};
+
 export type OpenFileOptions = {
   start?: number;
   end?: number;
@@ -47,42 +90,56 @@ export const openFile = async (
   try {
     stat = await vscode.workspace.fs.stat(fileUri);
   } catch (error) {
-    logger.info("File not found, trying to open from base64 data", error);
+    if (!isFileNotFoundError(error)) {
+      showFileSystemError(filePath, error);
+      return;
+    }
 
-    if (options?.base64Data) {
+    logger.info("File not found, trying to open from base64 data", error);
+    let fallbackError: unknown = error;
+
+    if (options?.base64Data !== undefined) {
+      const tempFile = vscode.Uri.file(path.join(os.tmpdir(), fileUri.path));
+      let didWriteTempFile = false;
       try {
-        const tempFile = vscode.Uri.file(path.join(os.tmpdir(), fileUri.path));
         await vscode.workspace.fs.writeFile(
           tempFile,
           Buffer.from(options.base64Data, "base64"),
         );
+        didWriteTempFile = true;
+      } catch (error) {
+        fallbackError = error;
+        logger.error(`Failed to write file from base64 data: ${error}`);
+      }
+
+      if (didWriteTempFile) {
         await vscode.commands.executeCommand("vscode.open", tempFile);
         return;
-      } catch (error) {
-        logger.error(`Failed to open file from base64 data: ${error}`);
       }
     }
 
     if (options?.fallbackGlobPattern) {
+      let result: readonly vscode.Uri[] | undefined;
       try {
-        const result = await vscode.workspace.findFiles(
+        result = await vscode.workspace.findFiles(
           options.fallbackGlobPattern,
           null,
           1,
         );
-
-        logger.info("found file by glob pattern", result[0]);
-
-        if (result.length > 0) {
-          await vscode.commands.executeCommand("vscode.open", result[0]);
-          return;
-        }
       } catch (error) {
-        logger.error(`Failed to open file by glob pattern: ${error}`);
+        fallbackError = error;
+        logger.error(`Failed to find file by glob pattern: ${error}`);
+      }
+
+      logger.info("found file by glob pattern", result?.[0]);
+
+      if (result && result.length > 0) {
+        await vscode.commands.executeCommand("vscode.open", result[0]);
+        return;
       }
     }
 
-    void vscode.window.showErrorMessage(`File not found: ${filePath}`);
+    showFileSystemError(filePath, fallbackError);
     return;
   }
 

--- a/packages/vscode/src/lib/open-file.ts
+++ b/packages/vscode/src/lib/open-file.ts
@@ -1,0 +1,131 @@
+import * as os from "node:os";
+import path from "node:path";
+import { getLogger } from "@/lib/logger";
+import { isPlainTextFile } from "@getpochi/common/tool-utils";
+import * as vscode from "vscode";
+
+const logger = getLogger("openFile");
+
+export type OpenFileOptions = {
+  start?: number;
+  end?: number;
+  preserveFocus?: boolean;
+  base64Data?: string;
+  fallbackGlobPattern?: string;
+  cellId?: string;
+};
+
+export const openFile = async (
+  filePath: string,
+  cwd: string | null | undefined,
+  options?: OpenFileOptions,
+): Promise<void> => {
+  let fileUri = vscode.Uri.parse(filePath);
+  let resolvedPath = filePath;
+
+  // Open file directly if it's a pochi scheme
+  if (fileUri.scheme === "pochi") {
+    vscode.commands.executeCommand(
+      "vscode.open",
+      vscode.Uri.parse(resolvedPath),
+    );
+    return;
+  }
+
+  // Expand ~ to home directory if present
+  if (resolvedPath.startsWith("~/")) {
+    resolvedPath = resolvedPath.replace(/^~/, os.homedir());
+  }
+
+  fileUri = path.isAbsolute(resolvedPath)
+    ? vscode.Uri.file(resolvedPath)
+    : cwd
+      ? vscode.Uri.joinPath(vscode.Uri.file(cwd), resolvedPath)
+      : vscode.Uri.file(resolvedPath);
+
+  let stat: vscode.FileStat;
+  try {
+    stat = await vscode.workspace.fs.stat(fileUri);
+  } catch (error) {
+    logger.info("File not found, trying to open from base64 data", error);
+
+    if (options?.base64Data) {
+      try {
+        const tempFile = vscode.Uri.file(path.join(os.tmpdir(), fileUri.path));
+        await vscode.workspace.fs.writeFile(
+          tempFile,
+          Buffer.from(options.base64Data, "base64"),
+        );
+        await vscode.commands.executeCommand("vscode.open", tempFile);
+        return;
+      } catch (error) {
+        logger.error(`Failed to open file from base64 data: ${error}`);
+      }
+    }
+
+    if (options?.fallbackGlobPattern) {
+      try {
+        const result = await vscode.workspace.findFiles(
+          options.fallbackGlobPattern,
+          null,
+          1,
+        );
+
+        logger.info("found file by glob pattern", result[0]);
+
+        if (result.length > 0) {
+          await vscode.commands.executeCommand("vscode.open", result[0]);
+          return;
+        }
+      } catch (error) {
+        logger.error(`Failed to open file by glob pattern: ${error}`);
+      }
+    }
+
+    void vscode.window.showErrorMessage(`File not found: ${filePath}`);
+    return;
+  }
+
+  if (stat.type === vscode.FileType.Directory) {
+    await vscode.commands.executeCommand("revealInExplorer", fileUri);
+    await vscode.commands.executeCommand("list.expand");
+  } else if (stat.type === vscode.FileType.File) {
+    if (fileUri.fsPath.endsWith(".ipynb")) {
+      await vscode.commands.executeCommand(
+        "vscode.openWith",
+        fileUri,
+        "jupyter-notebook",
+      );
+
+      if (options?.cellId) {
+        const notebook = vscode.workspace.notebookDocuments.find(
+          (item) => item.uri.toString() === fileUri.toString(),
+        );
+        if (!notebook) return;
+        const cellIndex = notebook
+          .getCells()
+          .findIndex((cell) => cell.metadata?.id === options.cellId);
+        if (cellIndex < 0) return;
+        const editor = vscode.window.visibleNotebookEditors.find(
+          (item) => item.notebook.uri.toString() === fileUri.toString(),
+        );
+        if (!editor) return;
+        editor.selection = new vscode.NotebookRange(cellIndex, cellIndex + 1);
+        await vscode.commands.executeCommand("notebook.cell.edit");
+      }
+      return;
+    }
+
+    const isPlainText = await isPlainTextFile(fileUri.fsPath);
+    if (!isPlainText) {
+      await vscode.commands.executeCommand("vscode.open", fileUri);
+    } else {
+      const start = options?.start ?? 1;
+      const end = options?.end ?? start;
+      vscode.window.showTextDocument(fileUri, {
+        selection: new vscode.Range(start - 1, 0, end - 1, 0),
+        preserveFocus: options?.preserveFocus,
+      });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- show an error notification when `vscodeHost.openFile` cannot find the requested file
- stop fallback handling after base64 or glob content opens successfully to avoid false missing-file notifications

## Test plan
- [x] Run `bun check`
- [x] Run `bun tsc`
- [x] Run `git diff --check`
- [x] Run the pre-push validation suite (17 tasks successful; 199 VS Code tests passing)
- [ ] Run integration tests (blocked by `ECONNRESET` while downloading VS Code)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-821b2d11355f499ea86656c6f994a017)