### PR TITLE
fix(vscode-webui): resolve completed parallel subtasks

### DIFF
--- a/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.test.tsx
@@ -2,7 +2,7 @@ import type { Message } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
 // @vitest-environment jsdom
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAddSubtaskResult } from "./use-subtask-completed";
 
 const addResultMock = vi.hoisted(() => vi.fn());
@@ -69,6 +69,11 @@ function makeParentMessage(): Message {
 }
 
 describe("useAddSubtaskResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    autoApproveGuardMock.current = "stop";
+  });
+
   it("resolves attemptTodoCompletion subtask output before completing the parent tool call", async () => {
     extractTaskResultMock.mockReturnValue({
       summary: "Done.",
@@ -84,6 +89,46 @@ describe("useAddSubtaskResult", () => {
         todos: [{ ...auditTodo, status: "completed" }],
       },
     });
+    expect(autoApproveGuardMock.current).toBe("auto");
+  });
+
+  it("resolves a completed parallel subtask that is not the last message part", async () => {
+    const message = makeParentMessage();
+    message.parts.push({
+      type: "tool-newTask",
+      toolCallId: "tool-call-2",
+      state: "input-available",
+      input: {
+        description: "Second parallel subtask",
+        prompt: "Explore the second area",
+        agentType: "explore",
+        _meta: { uid: "subtask-2" },
+      },
+    });
+    extractTaskResultMock.mockImplementation(
+      (_store: unknown, subtaskUid: string) =>
+        subtaskUid === "subtask-1"
+          ? {
+              summary: "First parallel subtask completed.",
+              todoUpdates: [{ id: "todo-1", status: "completed" }],
+            }
+          : undefined,
+    );
+
+    renderHook(() => useAddSubtaskResult({ messages: [message] }));
+
+    await waitFor(() =>
+      expect(addResultMock).toHaveBeenCalledWith({
+        result: {
+          summary: "First parallel subtask completed.",
+          todos: [{ ...auditTodo, status: "completed" }],
+        },
+      }),
+    );
+    expect(extractTaskResultMock).toHaveBeenCalledWith(
+      { storeId: "store-1" },
+      "subtask-1",
+    );
     expect(autoApproveGuardMock.current).toBe("auto");
   });
 });

--- a/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-subtask-completed.ts
@@ -60,21 +60,26 @@ export const useAddSubtaskResult = ({
   const { getToolCallLifeCycle } = useToolCallLifeCycle();
 
   useEffect(() => {
-    const toolPart = messages.at(-1)?.parts.at(-1);
-    if (
-      !toolPart ||
-      toolPart.type !== "tool-newTask" ||
-      toolPart.state !== "input-available"
-    ) {
-      return;
-    }
-    const subtaskUid = toolPart.input?._meta?.uid;
-    if (!subtaskUid) return;
-    const lifecycle = getToolCallLifeCycle({
-      toolName: getStaticToolName(toolPart),
-      toolCallId: toolPart.toolCallId,
-    });
-    if (lifecycle.status === "init") {
+    const lastMessage = messages.at(-1);
+    if (!lastMessage) return;
+
+    for (const toolPart of lastMessage.parts) {
+      if (
+        toolPart.type !== "tool-newTask" ||
+        toolPart.state !== "input-available"
+      ) {
+        continue;
+      }
+
+      const subtaskUid = toolPart.input?._meta?.uid;
+      if (!subtaskUid) continue;
+
+      const lifecycle = getToolCallLifeCycle({
+        toolName: getStaticToolName(toolPart),
+        toolCallId: toolPart.toolCallId,
+      });
+      if (lifecycle.status !== "init") continue;
+
       const result = extractTaskResult(store, subtaskUid);
       if (result) {
         autoApproveGuard.current = "auto";


### PR DESCRIPTION
## Summary
- reconcile results for every pending `newTask` in the latest assistant message
- prevent manual parallel subtask approval from reopening an already completed first subtask
- add regression coverage for a completed subtask that is not the final message part

## Test plan
- [x] `bun run test -- src/features/chat/hooks/use-subtask-completed.test.tsx`
- [x] `bun check`
- [x] `bun tsc`
- [x] `git diff --check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3e05142f56b743299d3b3744340fad48)