### PR TITLE
fix(vscode-webui): format only visible messages in paginated range

### DIFF
--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -1,7 +1,7 @@
 import type { UIMessage } from 'ai';
 import { clone } from 'remeda';
 import { describe, expect, it, vi } from 'vitest';
-import { formatters } from '../formatters';
+import { formatters, getUIUserMessageKind } from '../formatters';
 
 // Mock dependencies
 vi.mock('@getpochi/tools', async (importOriginal) => {
@@ -73,6 +73,28 @@ const baseMessages: UIMessage[] = [
 
 describe('formatters', () => {
   describe('formatters.ui', () => {
+    it.each([
+      ['content', [{ type: 'text', text: 'Visible prompt' }]],
+      ['compact', [{ type: 'text', text: '<compact>Summary</compact>' }]],
+      [
+        'hidden',
+        [
+          {
+            type: 'data-active-selection',
+            data: { activeSelection: undefined },
+          },
+        ],
+      ],
+    ] as const)('classifies a user message as %s', (kind, parts) => {
+      expect(
+        getUIUserMessageKind({
+          id: 'user-message',
+          role: 'user',
+          parts: [...parts],
+        } as UIMessage),
+      ).toBe(kind);
+    });
+
     it('does not increase the part count', () => {
       const rawPartCount = baseMessages.reduce(
         (total, message) => total + message.parts.length,

--- a/packages/common/src/base/__tests__/formatters.test.ts
+++ b/packages/common/src/base/__tests__/formatters.test.ts
@@ -73,6 +73,20 @@ const baseMessages: UIMessage[] = [
 
 describe('formatters', () => {
   describe('formatters.ui', () => {
+    it('does not increase the part count', () => {
+      const rawPartCount = baseMessages.reduce(
+        (total, message) => total + message.parts.length,
+        0,
+      );
+      const formatted = formatters.ui(clone(baseMessages));
+      const formattedPartCount = formatted.reduce(
+        (total, message) => total + message.parts.length,
+        0,
+      );
+
+      expect(formattedPartCount).toBeLessThanOrEqual(rawPartCount);
+    });
+
     it('should combine consecutive assistant messages', () => {
       const formatted = formatters.ui(clone(baseMessages));
       const assistantMessages = formatted.filter((m) => m.role === 'assistant');

--- a/packages/common/src/base/formatters.ts
+++ b/packages/common/src/base/formatters.ts
@@ -88,6 +88,54 @@ function stripKnownXMLTags(messages: UIMessage[]): UIMessage[] {
   });
 }
 
+export type UIUserMessageKind = "content" | "compact" | "hidden";
+
+/** Classifies how a raw user message participates in the UI message list. */
+export function getUIUserMessageKind(message: UIMessage): UIUserMessageKind {
+  if (message.role !== "user") return "content";
+
+  let hasCompact = false;
+  let hasOtherPart = false;
+
+  for (const part of message.parts) {
+    if (part.type === "text") {
+      if (
+        part.text.trim().length === 0 ||
+        prompts.isSystemReminder(part.text)
+      ) {
+        continue;
+      }
+      if (prompts.isCompact(part.text)) {
+        hasCompact = true;
+        continue;
+      }
+      return "content";
+    }
+
+    if (part.type === "reasoning" && part.text.trim().length === 0) {
+      continue;
+    }
+
+    if (
+      part.type === "data-reviews" ||
+      part.type === "data-bash-outputs" ||
+      part.type === "data-background-job-notification" ||
+      isStaticToolUIPart(part)
+    ) {
+      return "content";
+    }
+
+    if (part.type !== "data-checkpoint") {
+      hasOtherPart = true;
+    }
+  }
+
+  if (hasCompact) {
+    return hasOtherPart ? "content" : "compact";
+  }
+  return "hidden";
+}
+
 function removeSystemReminder(messages: UIMessage[]): UIMessage[] {
   return messages.filter((message) => {
     if (message.role !== "user") return true;
@@ -96,35 +144,12 @@ function removeSystemReminder(messages: UIMessage[]): UIMessage[] {
       return !prompts.isSystemReminder(part.text);
     });
     message.parts = parts;
-    if (
-      parts.some(
-        (x) =>
-          (x.type === "text" && !prompts.isCompact(x.text)) ||
-          x.type === "data-reviews" ||
-          x.type === "data-bash-outputs" ||
-          x.type === "data-background-job-notification" ||
-          isStaticToolUIPart(x),
-      )
-    ) {
-      return true;
-    }
-    // Keep messages that carry a compact checkpoint — the checkpoint
-    // is meaningful UI content even when all other parts were system reminders.
-    if (parts.some((x) => x.type === "text" && prompts.isCompact(x.text))) {
-      return true;
-    }
-    return false;
+    return getUIUserMessageKind(message) !== "hidden";
   });
 }
 
 function isCompactOnlyUserMessage(message: UIMessage): boolean {
-  if (message.role !== "user") return false;
-  return message.parts.every(
-    (part) =>
-      (part.type === "text" && prompts.isCompact(part.text)) ||
-      (part.type === "text" && part.text.trim().length === 0) ||
-      part.type === "data-checkpoint",
-  );
+  return getUIUserMessageKind(message) === "compact";
 }
 
 type AssistantMessageMetadata = Extract<MessageMetadata, { kind: "assistant" }>;

--- a/packages/common/src/base/index.ts
+++ b/packages/common/src/base/index.ts
@@ -5,7 +5,9 @@ export { attachTransport, getLogger } from "./logger";
 
 export {
   formatters,
+  getUIUserMessageKind,
   type LLMFormatterOptions,
+  type UIUserMessageKind,
 } from "./formatters";
 export {
   assertBackgroundJobReadInterval,

--- a/packages/vscode-webui/src/__stories__/perf/__tests__/message-list.perf.stories.test.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/__tests__/message-list.perf.stories.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import messageListMeta from "../message-list.perf.stories";
+
+const mocks = vi.hoisted(() => ({
+  messageListProps: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("../../../components/message/message-list", () => ({
+  MessageList: (props: Record<string, unknown>) => {
+    mocks.messageListProps.push(props);
+    return null;
+  },
+}));
+
+vi.mock("../perf-harness", () => ({
+  ComparisonPanel: () => null,
+  MeasuredProfiler: ({ children }: { children: React.ReactNode }) => children,
+  usePerfHarness: () => ({
+    recordsRef: { current: [] },
+    rootRef: { current: null },
+    clear: vi.fn(),
+    record: vi.fn(),
+    measureAction: async (_label: string, action: () => void) => action(),
+  }),
+  waitForNextFrame: async () => {},
+}));
+
+describe("MessageList performance story", () => {
+  beforeEach(() => {
+    mocks.messageListProps = [];
+  });
+
+  it("passes raw messages with a formatter to MessageList", async () => {
+    const Story = messageListMeta.component as ComponentType<{
+      messageCount: number;
+      assistantPartsPerMessage: number;
+      partTextLength: number;
+    }>;
+    render(
+      <Story
+        messageCount={4}
+        assistantPartsPerMessage={10}
+        partTextLength={20}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Mount Paged" }));
+
+    await waitFor(() =>
+      expect(mocks.messageListProps.length).toBeGreaterThan(0),
+    );
+    expect(mocks.messageListProps.at(-1)?.formatMessages).toBeTypeOf(
+      "function",
+    );
+  });
+});

--- a/packages/vscode-webui/src/__stories__/perf/__tests__/task-history.perf.stories.test.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/__tests__/task-history.perf.stories.test.tsx
@@ -8,6 +8,10 @@ import taskHistoryMeta, {
 
 const mocks = vi.hoisted(() => ({
   useScrollToBottom: vi.fn(),
+  chatAreaProps: [] as Array<{
+    messages: Array<{ id: string }>;
+    formatMessages?: (messages: Array<{ id: string }>) => Array<{ id: string }>;
+  }>,
 }));
 
 vi.mock("@getpochi/common", async (importOriginal) => {
@@ -22,13 +26,17 @@ vi.mock("../../../features/chat/components/chat-area", () => ({
   ChatArea: (props: {
     messages: Array<{ id: string }>;
     messagesContainerRef?: React.RefObject<HTMLDivElement | null>;
-  }) => (
-    <div ref={props.messagesContainerRef} data-testid="chat-area">
-      {props.messages.map((message) => (
-        <div key={message.id}>{message.id}</div>
-      ))}
-    </div>
-  ),
+    formatMessages?: (messages: Array<{ id: string }>) => Array<{ id: string }>;
+  }) => {
+    mocks.chatAreaProps.push(props);
+    return (
+      <div ref={props.messagesContainerRef} data-testid="chat-area">
+        {props.messages.map((message) => (
+          <div key={message.id}>{message.id}</div>
+        ))}
+      </div>
+    );
+  },
 }));
 
 vi.mock("../../../features/chat/hooks/use-scroll-to-bottom", () => ({
@@ -38,6 +46,15 @@ vi.mock("../../../features/chat/hooks/use-scroll-to-bottom", () => ({
 describe("TaskHistory performance story", () => {
   beforeEach(() => {
     mocks.useScrollToBottom.mockReset();
+    mocks.chatAreaProps = [];
+  });
+
+  it("passes raw history with a window formatter to ChatArea", () => {
+    renderStory();
+
+    const props = mocks.chatAreaProps.at(-1);
+    expect(props?.messages).toHaveLength(4);
+    expect(props?.formatMessages).toBeTypeOf("function");
   });
 
   afterEach(() => vi.unstubAllGlobals());

--- a/packages/vscode-webui/src/__stories__/perf/message-list.perf.stories.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/message-list.perf.stories.tsx
@@ -3,6 +3,8 @@ import {
   MessageListPaginationConfig,
   computePageStart,
 } from "@/components/message/use-message-list-pagination";
+import { formatters } from "@getpochi/common";
+import type { Message } from "@getpochi/livekit";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { makeTaskHistoryMessages, summarizeMessageRange } from "./perf-data";
@@ -14,6 +16,8 @@ import {
 } from "./perf-harness";
 
 type Variant = "Full" | "Paged";
+
+const formatVisibleMessages = (messages: Message[]) => formatters.ui(messages);
 
 function MessageListPerfStory({
   messageCount,
@@ -167,9 +171,9 @@ function MessageListPerfStory({
         </table>
       </div>
       <div className="mb-2 text-muted-foreground text-xs">
-        Both variants use the same preformatted data. Run sequentially so the
-        Full and Paged trees never coexist. Message and part counts come from
-        the fixture; DOM nodes in Comparison are secondary diagnostics.
+        Both variants use the same raw data and UI formatter. Run sequentially
+        so the Full and Paged trees never coexist. Message and part counts come
+        from the fixture; DOM nodes in Comparison are secondary diagnostics.
       </div>
       <section ref={listRef} className="min-h-0 flex-1 overflow-hidden">
         {activeVariant && (
@@ -186,6 +190,7 @@ function MessageListPerfStory({
               assistant={{ name: "Pochi" }}
               containerRef={viewportRef}
               renderAllMessages={activeVariant === "Full"}
+              formatMessages={formatVisibleMessages}
             />
           </MeasuredProfiler>
         )}

--- a/packages/vscode-webui/src/__stories__/perf/task-history.perf.stories.tsx
+++ b/packages/vscode-webui/src/__stories__/perf/task-history.perf.stories.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -124,19 +123,22 @@ export function TaskHistoryPerfStory({
     });
   };
 
-  const renderMessages = useMemo(() => {
-    const startedAt = performance.now();
-    const formatted = formatters.ui(rawMessages);
-    formatterMsByMessagesRef.current.set(
-      rawMessages,
-      performance.now() - startedAt,
-    );
-    heapAfterFormatByMessagesRef.current.set(
-      rawMessages,
-      readUsedJsHeapBytes(),
-    );
-    return formatted;
-  }, [rawMessages]);
+  const formatVisibleMessages = useCallback(
+    (visibleMessages: Message[]) => {
+      const startedAt = performance.now();
+      const formatted = formatters.ui(visibleMessages);
+      formatterMsByMessagesRef.current.set(
+        rawMessages,
+        performance.now() - startedAt,
+      );
+      heapAfterFormatByMessagesRef.current.set(
+        rawMessages,
+        readUsedJsHeapBytes(),
+      );
+      return formatted;
+    },
+    [rawMessages],
+  );
 
   useEffect(() => {
     const nextArgs = `${initialMessageCount}:${assistantPartsPerMessage}:${partTextLength}`;
@@ -478,7 +480,7 @@ export function TaskHistoryPerfStory({
             Remount UI
           </ActionButton>
           <span className="self-center text-muted-foreground">
-            Unmount keeps raw-message updates and formatting active.
+            Unmount keeps raw-message updates active.
           </span>
         </div>
       </details>
@@ -487,7 +489,8 @@ export function TaskHistoryPerfStory({
         {mounted && (
           <TaskHistoryMessageView
             key={renderKey}
-            messages={renderMessages}
+            messages={rawMessages}
+            formatMessages={formatVisibleMessages}
             revision={revisionByMessagesRef.current.get(rawMessages) ?? 0}
             isStreaming={isStreaming}
             messagesContainerRef={messagesContainerRef}
@@ -503,6 +506,7 @@ export function TaskHistoryPerfStory({
 
 function TaskHistoryMessageView({
   messages,
+  formatMessages,
   revision,
   isStreaming,
   messagesContainerRef,
@@ -511,6 +515,7 @@ function TaskHistoryMessageView({
   renderAllMessages,
 }: {
   messages: Message[];
+  formatMessages: (messages: Message[]) => Message[];
   revision: number;
   isStreaming: boolean;
   messagesContainerRef: React.RefObject<HTMLDivElement | null>;
@@ -531,6 +536,7 @@ function TaskHistoryMessageView({
       <div className="flex h-full min-h-0 flex-col">
         <ChatArea
           messages={messages}
+          formatMessages={formatMessages}
           isLoading={isStreaming}
           user={{ name: "User" }}
           messagesContainerRef={messagesContainerRef}

--- a/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
@@ -1,8 +1,10 @@
 import type { Message } from "@getpochi/livekit";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { Profiler, useRef } from "react";
+import { Profiler, type ReactNode, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MessageListPaginationConfig } from "../use-message-list-pagination";
+
+const vscodeMock = vi.hoisted(() => ({ isVSCodeEnvironment: false }));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -12,11 +14,16 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/lib/vscode", () => ({
-  isVSCodeEnvironment: () => false,
+  isVSCodeEnvironment: () => vscodeMock.isVSCodeEnvironment,
   vscodeHost: {
     getGlobalState: vi.fn(async () => undefined),
     setGlobalState: vi.fn(async () => undefined),
   },
+}));
+
+vi.mock("../../checkpoint-ui", () => ({
+  CheckpointUI: () => <div data-testid="checkpoint" />,
+  CompactCheckpointUI: () => <div data-testid="compact-checkpoint" />,
 }));
 
 vi.mock("@/lib/hooks/use-latest-checkpoint", () => ({
@@ -67,6 +74,20 @@ vi.mock("../markdown", () => ({
   ),
 }));
 
+vi.mock("../user-edits", () => ({
+  UserEditsPart: ({
+    checkpoints,
+  }: {
+    checkpoints?: { origin?: string; modified?: string };
+  }) => (
+    <div
+      data-testid="user-edits"
+      data-origin={checkpoints?.origin ?? ""}
+      data-modified={checkpoints?.modified ?? ""}
+    />
+  ),
+}));
+
 // Import after installing mocks.
 const { MessageList } = await import("../message-list");
 
@@ -98,6 +119,7 @@ class IntersectionObserverProbe implements IntersectionObserver {
 
 beforeEach(() => {
   IntersectionObserverProbe.instances = [];
+  vscodeMock.isVSCodeEnvironment = false;
   vi.stubGlobal("IntersectionObserver", IntersectionObserverProbe);
 });
 
@@ -173,9 +195,13 @@ function setViewportScrollTop(container: HTMLElement, scrollTop: number) {
 function MessageListProbe({
   messages,
   renderAllMessages = false,
+  formatMessages,
+  emptyPlaceholder,
 }: {
   messages: Message[];
   renderAllMessages?: boolean;
+  formatMessages?: (messages: Message[]) => Message[];
+  emptyPlaceholder?: ReactNode;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   return (
@@ -185,6 +211,8 @@ function MessageListProbe({
       showLoader={false}
       renderAllMessages={renderAllMessages}
       containerRef={containerRef}
+      formatMessages={formatMessages}
+      emptyPlaceholder={emptyPlaceholder}
     />
   );
 }
@@ -199,6 +227,97 @@ function renderList(messages: Message[], renderAllMessages = false) {
 }
 
 describe("MessageList pagination", () => {
+  it("formats only the raw tail page", () => {
+    const messages = makeMessages(200);
+    const formatMessages = vi.fn((visible: Message[]) => visible);
+
+    render(
+      <MessageListProbe messages={messages} formatMessages={formatMessages} />,
+    );
+
+    expect(formatMessages).toHaveBeenCalledTimes(1);
+    expect(formatMessages).toHaveBeenCalledWith(
+      messages.slice(-InitialMessages),
+    );
+  });
+
+  it("shows the empty placeholder when the full raw history is filtered out", () => {
+    const messages = [
+      {
+        id: "system-reminder",
+        role: "user",
+        parts: [
+          {
+            type: "text",
+            text: "<system-reminder>Reminder</system-reminder>",
+          },
+        ],
+      } as Message,
+    ];
+
+    render(
+      <MessageListProbe
+        messages={messages}
+        formatMessages={() => []}
+        emptyPlaceholder={<div data-testid="empty-placeholder" />}
+      />,
+    );
+
+    expect(screen.getByTestId("empty-placeholder")).toBeTruthy();
+  });
+
+  it("looks up user-edit checkpoints by message id after formatting", () => {
+    const messages: Message[] = [
+      {
+        id: "checkpoint-1",
+        role: "assistant",
+        parts: [{ type: "data-checkpoint", data: { commit: "commit-1" } }],
+      } as Message,
+      {
+        id: "checkpoint-2",
+        role: "assistant",
+        parts: [{ type: "data-checkpoint", data: { commit: "commit-2" } }],
+      } as Message,
+      {
+        id: "user-edits",
+        role: "user",
+        parts: [{ type: "data-user-edits", data: { userEdits: [] } }],
+      } as unknown as Message,
+    ];
+
+    render(
+      <MessageListProbe
+        messages={messages}
+        renderAllMessages
+        formatMessages={(visible) => visible.slice(1)}
+      />,
+    );
+
+    const userEdits = screen.getByTestId("user-edits");
+    expect(userEdits.dataset.origin).toBe("commit-1");
+    expect(userEdits.dataset.modified).toBe("commit-2");
+  });
+
+  it("does not treat the first formatted user message as the start of history", () => {
+    vscodeMock.isVSCodeEnvironment = true;
+    const messages = makeMessages(14);
+    messages[2] = {
+      ...messages[2],
+      role: "user",
+      parts: [
+        ...messages[2].parts.slice(0, -1),
+        { type: "data-checkpoint", data: { commit: "commit-1" } },
+      ],
+    } as Message;
+
+    const { container } = render(<MessageListProbe messages={messages} />);
+
+    const firstMessage = container.querySelector(".message-list-item");
+    expect(
+      firstMessage?.querySelector('[data-testid="checkpoint"]'),
+    ).toBeNull();
+  });
+
   it("mounts only the tail page and always keeps the last message", () => {
     const messages = makeMessages(200);
     const { container } = renderList(messages);

--- a/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/message-list-pagination.test.tsx
@@ -1,3 +1,4 @@
+import { formatters } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Profiler, type ReactNode, useRef } from "react";
@@ -9,7 +10,11 @@ const vscodeMock = vi.hoisted(() => ({ isVSCodeEnvironment: false }));
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, options?: Record<string, unknown>) =>
-      options?.count === undefined ? key : `${key}:${options.count}`,
+      options?.count !== undefined
+        ? `${key}:${options.count}`
+        : options?.duration !== undefined
+          ? `${key}:${options.duration}`
+          : key,
   }),
 }));
 
@@ -169,6 +174,17 @@ function makeMessages(count: number) {
   return Array.from({ length: count }, (_, index) => makeMessage(index));
 }
 
+function makeAssistantMessage(id: string, label: string, partCount = 30) {
+  return {
+    id,
+    role: "assistant",
+    parts: Array.from({ length: partCount }, (_, partIndex) => ({
+      type: "text" as const,
+      text: `${label} part ${partIndex}`,
+    })),
+  } as Message;
+}
+
 function mountedMessageIds(container: HTMLElement) {
   return Array.from(
     container.querySelectorAll<HTMLElement>('[aria-label^="chat-message-"]'),
@@ -197,11 +213,13 @@ function MessageListProbe({
   renderAllMessages = false,
   formatMessages,
   emptyPlaceholder,
+  showLastStepDuration = false,
 }: {
   messages: Message[];
   renderAllMessages?: boolean;
   formatMessages?: (messages: Message[]) => Message[];
   emptyPlaceholder?: ReactNode;
+  showLastStepDuration?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   return (
@@ -213,6 +231,7 @@ function MessageListProbe({
       containerRef={containerRef}
       formatMessages={formatMessages}
       emptyPlaceholder={emptyPlaceholder}
+      showLastStepDuration={showLastStepDuration}
     />
   );
 }
@@ -239,6 +258,203 @@ describe("MessageList pagination", () => {
     expect(formatMessages).toHaveBeenCalledWith(
       messages.slice(-InitialMessages),
     );
+  });
+
+  it("keeps consecutive assistant messages on the same page", () => {
+    const messages = [
+      ["assistant-1", 100, 10],
+      ["assistant-2", 200, 20],
+      ["assistant-3", 300, 30],
+    ].map(
+      ([id, totalStreamingDuration, totalToolsExecutionDuration], index) =>
+        ({
+          id,
+          role: "assistant",
+          metadata: {
+            kind: "assistant",
+            totalTokens: 0,
+            finishReason: "stop",
+            totalStreamingDuration,
+            totalToolsExecutionDuration,
+          },
+          parts: Array.from({ length: 30 }, (_, partIndex) => ({
+            type: "text",
+            text: `assistant ${index + 1} part ${partIndex}`,
+          })),
+        }) as Message,
+    );
+
+    render(
+      <MessageListProbe
+        messages={messages}
+        formatMessages={formatters.ui}
+        showLastStepDuration
+      />,
+    );
+
+    expect(screen.getByText("assistant 1 part 0")).toBeTruthy();
+    expect(screen.getByText("messageList.completedIn:660ms")).toBeTruthy();
+  });
+
+  it.each([
+    ["compact", ["<compact>Previous conversation summary</compact>"]],
+    [
+      "filtered system reminder",
+      ["<system-reminder>Reminder</system-reminder>"],
+    ],
+    [
+      "filtered message run",
+      ["<system-reminder>Reminder</system-reminder>", null],
+    ],
+  ])("keeps a %s with its surrounding assistant messages", (_, texts) => {
+    const messages = [
+      makeAssistantMessage("assistant-1", "first assistant"),
+      ...texts.map(
+        (text, index) =>
+          ({
+            id: `continuation-${index}`,
+            role: "user",
+            parts: text === null ? [] : [{ type: "text" as const, text }],
+          }) as Message,
+      ),
+      makeAssistantMessage("assistant-2", "second assistant"),
+    ];
+
+    render(
+      <MessageListProbe messages={messages} formatMessages={formatters.ui} />,
+    );
+
+    expect(screen.getByText("first assistant part 0")).toBeTruthy();
+    expect(screen.getByText("second assistant part 0")).toBeTruthy();
+  });
+
+  it("keeps assistants together across a filtered data message", () => {
+    const messages = [
+      makeAssistantMessage("assistant-1", "first assistant"),
+      {
+        id: "active-selection",
+        role: "user",
+        parts: [
+          {
+            type: "data-active-selection",
+            data: { activeSelection: undefined },
+          },
+        ],
+      } as Message,
+      makeAssistantMessage("assistant-2", "second assistant"),
+    ];
+
+    render(
+      <MessageListProbe messages={messages} formatMessages={formatters.ui} />,
+    );
+
+    expect(screen.getByText("first assistant part 0")).toBeTruthy();
+    expect(screen.getByText("second assistant part 0")).toBeTruthy();
+  });
+
+  it("keeps a compact message before the visible assistant page", () => {
+    const messages = [
+      {
+        id: "user",
+        role: "user",
+        parts: [{ type: "text", text: "Visible user prompt" }],
+      } as Message,
+      {
+        id: "compact",
+        role: "user",
+        parts: [{ type: "text", text: "<compact>Summary</compact>" }],
+      } as Message,
+      makeAssistantMessage("assistant", "assistant", 60),
+      {
+        id: "latest-user",
+        role: "user",
+        parts: [{ type: "text", text: "Latest user prompt" }],
+      } as Message,
+    ];
+
+    render(
+      <MessageListProbe messages={messages} formatMessages={formatters.ui} />,
+    );
+
+    expect(screen.getByTestId("compact-checkpoint")).toBeTruthy();
+  });
+
+  it("keeps a compact message with the preceding assistant page", () => {
+    const messages = [
+      makeAssistantMessage("assistant", "assistant", 60),
+      {
+        id: "compact",
+        role: "user",
+        parts: [{ type: "text", text: "<compact>Summary</compact>" }],
+      } as Message,
+      {
+        id: "user",
+        role: "user",
+        parts: Array.from({ length: 60 }, (_, index) => ({
+          type: "text" as const,
+          text: `user part ${index}`,
+        })),
+      } as Message,
+    ];
+
+    render(
+      <MessageListProbe messages={messages} formatMessages={formatters.ui} />,
+    );
+
+    expect(screen.getByText("assistant part 0")).toBeTruthy();
+    expect(screen.getByTestId("compact-checkpoint")).toBeTruthy();
+  });
+
+  it("backs up across the full assistant formatter group", () => {
+    const messages = [
+      {
+        id: "older-user",
+        role: "user",
+        parts: [{ type: "text", text: "Older user prompt" }],
+      } as Message,
+      makeAssistantMessage("assistant", "assistant", 60),
+      {
+        id: "system-reminder",
+        role: "user",
+        parts: [
+          {
+            type: "text",
+            text: "<system-reminder>Reminder</system-reminder>",
+          },
+        ],
+      } as Message,
+      {
+        id: "compact",
+        role: "user",
+        parts: [{ type: "text", text: "<compact>Summary</compact>" }],
+      } as Message,
+      {
+        id: "active-selection",
+        role: "user",
+        parts: [
+          {
+            type: "data-active-selection",
+            data: { activeSelection: undefined },
+          },
+        ],
+      } as Message,
+      {
+        id: "user",
+        role: "user",
+        parts: Array.from({ length: 60 }, (_, index) => ({
+          type: "text" as const,
+          text: `user part ${index}`,
+        })),
+      } as Message,
+    ];
+
+    render(
+      <MessageListProbe messages={messages} formatMessages={formatters.ui} />,
+    );
+
+    expect(screen.getByText("assistant part 0")).toBeTruthy();
+    expect(screen.getByTestId("compact-checkpoint")).toBeTruthy();
+    expect(screen.queryByText("Older user prompt")).toBeNull();
   });
 
   it("shows the empty placeholder when the full raw history is filtered out", () => {

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -66,8 +66,11 @@ export const MessageList: React.FC<{
   taskStatus?: Task["status"];
   /** Mounts the full history for shared output and performance baselines. */
   renderAllMessages?: boolean;
+  /** Formats only the mounted raw-message range. */
+  formatMessages?: (messages: Message[]) => Message[];
+  emptyPlaceholder?: React.ReactNode;
 }> = ({
-  messages: renderMessages,
+  messages,
   isLoading,
   loadingLabel,
   user = { name: "User" },
@@ -85,6 +88,8 @@ export const MessageList: React.FC<{
   showLastStepDuration,
   taskStatus,
   renderAllMessages = false,
+  formatMessages,
+  emptyPlaceholder,
 }) => {
   const [debouncedIsLoading, setDebouncedIsLoading] = useDebounceState(
     isLoading,
@@ -109,18 +114,18 @@ export const MessageList: React.FC<{
   const assistantName = assistant?.name ?? "Pochi";
   const latestCheckpoint = useLatestCheckpoint();
   const toolCallCheckpoints = useMemo(
-    () => buildToolCallCheckpoints(renderMessages),
-    [renderMessages],
+    () => buildToolCallCheckpoints(messages),
+    [messages],
   );
   const userEditsCheckpoints = useMemo(
-    () => buildUserEditsCheckpoints(renderMessages),
-    [renderMessages],
+    () => buildUserEditsCheckpoints(messages),
+    [messages],
   );
   const lastCheckpointInMessage = useMemo(() => {
-    return renderMessages
+    return messages
       .flatMap((msg) => msg.parts)
       .findLast((part) => part.type === "data-checkpoint")?.data.commit;
-  }, [renderMessages]);
+  }, [messages]);
 
   const mermaidContextValue = useMemo(
     () =>
@@ -134,31 +139,36 @@ export const MessageList: React.FC<{
     [repairMermaid, repairingChart, isLoading, isExecuting],
   );
 
-  // Paginate mounted messages; derive values from the full history.
+  // Paginate raw messages before formatting the mounted range.
   const { start, hiddenAboveCount, loadEarlierTriggerRef } =
     useMessageListPagination({
-      messages: renderMessages,
+      messages,
       containerRef,
       enabled: !renderAllMessages && containerRef !== undefined,
     });
-  const visibleMessages = useMemo(
-    () => renderMessages.slice(start),
-    [renderMessages, start],
+  const visibleRawMessages = useMemo(
+    () => messages.slice(start),
+    [messages, start],
+  );
+  const renderMessages = useMemo(
+    () =>
+      formatMessages ? formatMessages(visibleRawMessages) : visibleRawMessages,
+    [formatMessages, visibleRawMessages],
   );
 
   return (
-    <BackgroundJobContextProvider messages={renderMessages}>
+    <BackgroundJobContextProvider messages={messages}>
       <MermaidContextProvider value={mermaidContextValue}>
         <ScrollArea
           className={cn("mb-2 flex-1 overflow-y-auto px-4", className)}
           viewportClassname={viewportClassname}
           ref={containerRef}
         >
+          {start === 0 && renderMessages.length === 0 && emptyPlaceholder}
           {hiddenAboveCount > 0 && (
             <EarlierMessagesEdge ref={loadEarlierTriggerRef} />
           )}
-          {visibleMessages.map((m, indexInRange) => {
-            const messageIndex = start + indexInRange;
+          {renderMessages.map((m, messageIndex) => {
             return (
               <div
                 key={m.id}
@@ -223,7 +233,7 @@ export const MessageList: React.FC<{
                         hideUserEditsActions={hideUserEditsActions}
                         latestCheckpoint={latestCheckpoint}
                         lastCheckpointInMessage={lastCheckpointInMessage}
-                        userEditsCheckpoint={userEditsCheckpoints[messageIndex]}
+                        userEditsCheckpoint={userEditsCheckpoints.get(m.id)}
                         toolCallCheckpoint={
                           isStaticToolUIPart(part)
                             ? toolCallCheckpoints.get(part.toolCallId)
@@ -239,7 +249,7 @@ export const MessageList: React.FC<{
                 </div>
                 {messageIndex < renderMessages.length - 1 ? (
                   <SeparatorWithCheckpoint
-                    messageIndex={messageIndex}
+                    isFirstMessageInHistory={start === 0 && messageIndex === 0}
                     message={m}
                     nextMessage={renderMessages[messageIndex + 1]}
                     isLoading={shouldCheckpointUseLoading}
@@ -535,7 +545,7 @@ const MemoReasoningPartUI = memo(ReasoningPartRenderer, (prev, next) => {
 MemoReasoningPartUI.displayName = "MemoReasoningPartUI";
 
 const SeparatorWithCheckpoint: React.FC<{
-  messageIndex: number;
+  isFirstMessageInHistory: boolean;
   message: Message;
   nextMessage: Message;
   isLoading: boolean;
@@ -544,7 +554,7 @@ const SeparatorWithCheckpoint: React.FC<{
   latestCheckpoint: string | null;
   lastCheckpointInMessage: string | undefined;
 }> = ({
-  messageIndex,
+  isFirstMessageInHistory,
   message,
   nextMessage,
   isLoading,
@@ -558,7 +568,7 @@ const SeparatorWithCheckpoint: React.FC<{
 
   let checkpointMessage: Message | null = null;
   let restoreMessageId: string | undefined = undefined;
-  if (messageIndex === 0 && message.role === "user") {
+  if (isFirstMessageInHistory && message.role === "user") {
     checkpointMessage = message;
   }
 
@@ -701,10 +711,10 @@ function findCompactPart(message: Message): TextUIPart | undefined {
 }
 
 function buildUserEditsCheckpoints(messages: Message[]) {
-  const userEditsCheckpoints: Array<UserEditsCheckpoint | undefined> = [];
+  const userEditsCheckpoints = new Map<string, UserEditsCheckpoint>();
   const checkpointHistory: string[] = [];
 
-  for (const [index, message] of messages.entries()) {
+  for (const message of messages) {
     let hasUserEdits = false;
 
     for (const part of message.parts) {
@@ -723,14 +733,13 @@ function buildUserEditsCheckpoints(messages: Message[]) {
       !hasUserEdits ||
       checkpointHistory.length < 2
     ) {
-      userEditsCheckpoints[index] = undefined;
       continue;
     }
 
-    userEditsCheckpoints[index] = {
+    userEditsCheckpoints.set(message.id, {
       origin: checkpointHistory.at(-2),
       modified: checkpointHistory.at(-1),
-    };
+    });
   }
 
   return userEditsCheckpoints;

--- a/packages/vscode-webui/src/components/message/use-message-list-pagination.ts
+++ b/packages/vscode-webui/src/components/message/use-message-list-pagination.ts
@@ -1,3 +1,4 @@
+import { getUIUserMessageKind } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
 import type React from "react";
 import {
@@ -103,6 +104,26 @@ export function resetPaginationToTail(): MessageListPaginationState {
   return { startIndex: null };
 }
 
+function isMessageInAssistantGroup(message: Message | undefined) {
+  if (message?.role === "assistant") return true;
+  return (
+    message?.role === "user" && getUIUserMessageKind(message) !== "content"
+  );
+}
+
+function alignPageStartToAssistantGroup(messages: Message[], start: number) {
+  if (!isMessageInAssistantGroup(messages[start])) return start;
+
+  let groupStart = start;
+  while (
+    groupStart > 0 &&
+    isMessageInAssistantGroup(messages[groupStart - 1])
+  ) {
+    groupStart--;
+  }
+  return groupStart;
+}
+
 export function useMessageListPagination({
   messages,
   containerRef,
@@ -139,7 +160,10 @@ export function useMessageListPagination({
     ? resetPaginationToTail()
     : state;
   const start = paginationEnabled
-    ? resolvePageStart(effectiveState, partCounts, config)
+    ? alignPageStartToAssistantGroup(
+        messages,
+        resolvePageStart(effectiveState, partCounts, config),
+      )
     : 0;
 
   // Persist the render-time reset after the tail page commits.

--- a/packages/vscode-webui/src/components/task-thread.test.tsx
+++ b/packages/vscode-webui/src/components/task-thread.test.tsx
@@ -7,18 +7,21 @@ import { TaskThread, type TaskThreadSource } from "./task-thread";
 const mocks = vi.hoisted(() => ({
   scrollToBottom: vi.fn(),
   resizeCallback: undefined as ResizeObserverCallback | undefined,
+  formatMessages: vi.fn((messages: Message[]) => messages),
+  messageListProps: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock("@/components/message/message-list", () => ({
-  MessageList: ({
-    containerRef,
-  }: {
+  MessageList: (props: {
     containerRef: React.RefObject<HTMLDivElement | null>;
-  }) => (
-    <div ref={containerRef}>
-      <div />
-    </div>
-  ),
+  }) => {
+    mocks.messageListProps.push(props);
+    return (
+      <div ref={props.containerRef}>
+        <div />
+      </div>
+    );
+  },
 }));
 
 vi.mock("@/lib/hooks/use-is-at-bottom", () => ({
@@ -29,7 +32,7 @@ vi.mock("@/lib/hooks/use-is-at-bottom", () => ({
 }));
 
 vi.mock("@getpochi/common", () => ({
-  formatters: { ui: (messages: Message[]) => messages },
+  formatters: { ui: mocks.formatMessages },
 }));
 
 const message = {
@@ -45,6 +48,8 @@ function makeSource(messages: Message[]): TaskThreadSource {
 describe("TaskThread scrolling", () => {
   beforeEach(() => {
     mocks.scrollToBottom.mockReset();
+    mocks.formatMessages.mockClear();
+    mocks.messageListProps = [];
     mocks.resizeCallback = undefined;
     vi.stubGlobal(
       "ResizeObserver",
@@ -60,6 +65,15 @@ describe("TaskThread scrolling", () => {
       callback(0);
       return 0;
     });
+  });
+
+  it("does not format a collapsed message list", async () => {
+    render(
+      <TaskThread source={makeSource([message])} showMessageList={false} />,
+    );
+
+    await waitFor(() => expect(mocks.messageListProps).toHaveLength(0));
+    expect(mocks.formatMessages).not.toHaveBeenCalled();
   });
 
   it("scrolls after the first messages are rendered in instant mode", async () => {

--- a/packages/vscode-webui/src/components/task-thread.tsx
+++ b/packages/vscode-webui/src/components/task-thread.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { formatters } from "@getpochi/common";
 import type { Message } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 export type TaskThreadSource = {
   messages: Message[];
@@ -49,7 +49,6 @@ export const TaskThread: React.FC<{
     setMessages(source.messages);
   }, [source]);
 
-  const renderMessages = useMemo(() => prepareForRender(messages), [messages]);
   const newTaskContainer = useRef<HTMLDivElement>(null);
   const { isAtBottom, scrollToBottom } = useIsAtBottom(newTaskContainer);
   const isAtBottomRef = useRef(isAtBottom);
@@ -90,19 +89,14 @@ export const TaskThread: React.FC<{
     if (
       instantAutoScroll &&
       showMessageList &&
-      renderMessages.length > 0 &&
+      messages.length > 0 &&
       !hasInitiallyScrolledRef.current &&
       newTaskContainer.current
     ) {
       hasInitiallyScrolledRef.current = true;
       scrollToBottom(false);
     }
-  }, [
-    instantAutoScroll,
-    renderMessages.length,
-    scrollToBottom,
-    showMessageList,
-  ]);
+  }, [instantAutoScroll, messages.length, scrollToBottom, showMessageList]);
 
   return (
     <div className={cn("flex flex-col", className)}>
@@ -111,7 +105,7 @@ export const TaskThread: React.FC<{
           className={cn(
             "px-1 py-0.5",
             {
-              "mt-2": !renderMessages.length,
+              "mt-2": !messages.length,
             },
             messageListClassName,
           )}
@@ -120,7 +114,8 @@ export const TaskThread: React.FC<{
             scrollAreaClassName,
           )}
           showUserAvatar={false}
-          messages={renderMessages}
+          messages={messages}
+          formatMessages={prepareForRender}
           user={user}
           assistant={assistant}
           isLoading={isLoading}

--- a/packages/vscode-webui/src/features/chat/components/chat-area.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.test.tsx
@@ -41,4 +41,27 @@ describe("ChatArea", () => {
 
     expect(mocks.messageListProps.at(-1)?.renderAllMessages).toBe(true);
   });
+
+  it("passes raw messages with a UI formatter to MessageList", () => {
+    const messages = [message];
+    render(<ChatArea messages={messages} isLoading={false} />);
+
+    const props = mocks.messageListProps.at(-1);
+    expect(props?.messages).toBe(messages);
+    expect(props?.formatMessages).toBeTypeOf("function");
+  });
+
+  it("passes the empty placeholder for a non-empty raw history", () => {
+    render(
+      <ChatArea messages={[message]} isLoading={false} hideEmptyPlaceholder />,
+    );
+
+    expect(mocks.messageListProps.at(-1)?.emptyPlaceholder).toBeTruthy();
+  });
+
+  it("keeps the empty placeholder hidden for an empty raw history", () => {
+    render(<ChatArea messages={[]} isLoading={false} hideEmptyPlaceholder />);
+
+    expect(mocks.messageListProps.at(-1)?.emptyPlaceholder).toBeUndefined();
+  });
 });

--- a/packages/vscode-webui/src/features/chat/components/chat-area.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.test.tsx
@@ -51,12 +51,18 @@ describe("ChatArea", () => {
     expect(props?.formatMessages).toBeTypeOf("function");
   });
 
-  it("passes the empty placeholder for a non-empty raw history", () => {
+  it("passes the empty placeholder for formatting to decide", () => {
+    render(<ChatArea messages={[message]} isLoading={false} />);
+
+    expect(mocks.messageListProps.at(-1)?.emptyPlaceholder).toBeTruthy();
+  });
+
+  it("respects hideEmptyPlaceholder for a non-empty raw history", () => {
     render(
       <ChatArea messages={[message]} isLoading={false} hideEmptyPlaceholder />,
     );
 
-    expect(mocks.messageListProps.at(-1)?.emptyPlaceholder).toBeTruthy();
+    expect(mocks.messageListProps.at(-1)?.emptyPlaceholder).toBeUndefined();
   });
 
   it("keeps the empty placeholder hidden for an empty raw history", () => {

--- a/packages/vscode-webui/src/features/chat/components/chat-area.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.tsx
@@ -67,9 +67,7 @@ export function ChatArea({
         renderAllMessages={renderAllMessages}
         formatMessages={formatMessages}
         emptyPlaceholder={
-          !hideEmptyPlaceholder || messages.length > 0 ? (
-            <EmptyChatPlaceholder />
-          ) : undefined
+          !hideEmptyPlaceholder ? <EmptyChatPlaceholder /> : undefined
         }
       />
     </>

--- a/packages/vscode-webui/src/features/chat/components/chat-area.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-area.tsx
@@ -2,8 +2,11 @@ import { EmptyChatPlaceholder } from "@/components/empty-chat-placeholder";
 import type { MermaidContext } from "@/components/message/mermaid-context";
 import { MessageList } from "@/components/message/message-list";
 import { useResourceURI } from "@/lib/hooks/use-resource-uri";
+import { formatters } from "@getpochi/common";
 import type { Message, Task } from "@getpochi/livekit";
 import type React from "react";
+
+const defaultFormatMessages = (messages: Message[]) => formatters.ui(messages);
 
 interface ChatAreaProps {
   messages: Message[];
@@ -20,6 +23,7 @@ interface ChatAreaProps {
   showLastStepDuration?: boolean;
   taskStatus?: Task["status"];
   renderAllMessages?: boolean;
+  formatMessages?: (messages: Message[]) => Message[];
 }
 
 export function ChatArea({
@@ -37,13 +41,11 @@ export function ChatArea({
   showLastStepDuration,
   taskStatus,
   renderAllMessages,
+  formatMessages = defaultFormatMessages,
 }: ChatAreaProps) {
   const resourceUri = useResourceURI();
   return (
     <>
-      {!hideEmptyPlaceholder && messages.length === 0 && (
-        <EmptyChatPlaceholder />
-      )}
       {messages.length > 0 && <div className="h-4" />}
       <MessageList
         messages={messages}
@@ -63,6 +65,12 @@ export function ChatArea({
         showLastStepDuration={showLastStepDuration}
         taskStatus={taskStatus}
         renderAllMessages={renderAllMessages}
+        formatMessages={formatMessages}
+        emptyPlaceholder={
+          !hideEmptyPlaceholder || messages.length > 0 ? (
+            <EmptyChatPlaceholder />
+          ) : undefined
+        }
       />
     </>
   );

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-initialization.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-initialization.test.tsx
@@ -14,6 +14,29 @@ vi.mock("@/lib/vscode", () => ({
 }));
 
 describe("useChatInitialization", () => {
+  it("keeps a compact task in the loading state until initialization can run", () => {
+    const init = vi.fn();
+    const { result } = renderHook(() =>
+      useChatInitialization({
+        chatKit: { inited: false, init } as never,
+        info: {
+          type: "compact-task",
+          uid: "task-1",
+          cwd: "/workspace",
+          messages: "[]",
+        },
+        storeRegistry: {} as never,
+        jwt: null,
+        t: ((key: string) => key) as TFunction,
+        setMcpConfigOverride: vi.fn() as never,
+        isMcpConfigLoading: true,
+      }),
+    );
+
+    expect(result.current.isInitializing).toBe(true);
+    expect(init).not.toHaveBeenCalled();
+  });
+
   it("assembles invoked skills as reminder parts for a new task", () => {
     const skill: ValidSkillFile = {
       name: "deploy",

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-initialization.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-initialization.ts
@@ -29,7 +29,7 @@ export function useChatInitialization({
   isMcpConfigLoading,
 }: UseChatInitializationProps) {
   const [isInitializing, setIsInitializing] = useState(
-    info.type === "fork-task",
+    info.type === "fork-task" || info.type === "compact-task",
   );
 
   useEffect(() => {

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -306,9 +306,10 @@ function Chat({ user, uid, info }: ChatProps) {
       formatters.ui(visibleMessages, { hidePendingTodoAttemptCompletion }),
     [hidePendingTodoAttemptCompletion],
   );
-  const isTaskWithoutContent =
-    (info.type === "new-task" && !info.prompt && !info.files?.length) ||
-    (info.type === "open-task" && messages.length === 0);
+  const shouldHideEmptyPlaceholder =
+    info.type === "new-task" &&
+    (!!info.prompt || !!info.files?.length) &&
+    messages.length === 0;
 
   const approvalAndRetry = useApprovalAndRetry({
     ...chat,
@@ -467,7 +468,7 @@ function Chat({ user, uid, info }: ChatProps) {
           // Leave more space for errors as errors / approval button are absolutely positioned
           "pb-14": !!displayError,
         })}
-        hideEmptyPlaceholder={!isTaskWithoutContent}
+        hideEmptyPlaceholder={shouldHideEmptyPlaceholder}
         forkTask={task?.cwd ? forkTask : undefined}
         isSubTask={isSubTask}
         repairMermaid={repairMermaid}

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -307,9 +307,7 @@ function Chat({ user, uid, info }: ChatProps) {
     [hidePendingTodoAttemptCompletion],
   );
   const shouldHideEmptyPlaceholder =
-    info.type === "new-task" &&
-    (!!info.prompt || !!info.files?.length) &&
-    messages.length === 0;
+    info.type === "new-task" && (!!info.prompt || !!info.files?.length);
 
   const approvalAndRetry = useApprovalAndRetry({
     ...chat,

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -301,9 +301,10 @@ function Chat({ user, uid, info }: ChatProps) {
     !isSubTask && !todoPaused && hasActiveTodos(todosRef.current);
   const hidePendingTodoAttemptCompletion = isLoading && todoModeActive;
   todoModeActiveRef.current = todoModeActive;
-  const renderMessages = useMemo(
-    () => formatters.ui(messages, { hidePendingTodoAttemptCompletion }),
-    [messages, hidePendingTodoAttemptCompletion],
+  const formatRenderMessages = useCallback(
+    (visibleMessages: Message[]) =>
+      formatters.ui(visibleMessages, { hidePendingTodoAttemptCompletion }),
+    [hidePendingTodoAttemptCompletion],
   );
   const isTaskWithoutContent =
     (info.type === "new-task" && !info.prompt && !info.files?.length) ||
@@ -456,7 +457,8 @@ function Chat({ user, uid, info }: ChatProps) {
         />
       )}
       <ChatArea
-        messages={renderMessages}
+        messages={messages}
+        formatMessages={formatRenderMessages}
         isLoading={isLoading || isCompacting}
         loadingLabel={isCompacting ? t("tokenUsage.compacting") : undefined}
         user={user || defaultUser}


### PR DESCRIPTION
## Summary
* Pass raw messages to `MessageList` and delay formatting until after the pagination window has been sliced.
* Only format the visible subset of messages inside the pagination hook, which dramatically reduces React rendering overhead and formatting costs.
* Update related unit tests and Storybook performance stories to align with the new raw-message and formatter prop contracts.

## Perf

### Before
<img width="1718" height="420" alt="image" src="https://github.com/user-attachments/assets/6436ab0b-8fc4-48cf-bf1b-ed1b71bc4e4b" />


### After
<img width="1608" height="460" alt="image" src="https://github.com/user-attachments/assets/2efc7ed2-d1dd-4627-9a34-1898b94feed2" />


## Test plan
- [x] Run `bun check` to ensure code style, formatting, and lint rules are fully satisfied.
- [x] Run `bun tsc` to verify TypeScript types compile without errors.
- [x] Run `bun run test` to confirm all unit tests in `vscode-webui` and `common` pass successfully (including the updated/added test cases).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-aef5b9e7c04c44e980c8497aead2ab35)