### PR TITLE
fix(vscode-webui): keep chat pinned to bottom while streaming

### DIFF
--- a/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { useRef } from "react";
+import { createRef, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useScrollToBottom } from "./use-scroll-to-bottom";
 
@@ -34,6 +34,7 @@ describe("useScrollToBottom", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -50,7 +51,83 @@ describe("useScrollToBottom", () => {
     expect(context.scrollTo).not.toHaveBeenCalled();
   });
 
-  it("continues following streaming resizes while near the bottom", () => {
+  it("pauses following after keyboard scrolling up", () => {
+    const context = setup();
+
+    act(() => context.keyboardScrollTo("ArrowUp", 300));
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("pauses following after touch scrolling up", () => {
+    const context = setup();
+
+    act(() => context.touchScrollTo(300));
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("pauses following after dragging the scrollbar up", () => {
+    const context = setup();
+
+    act(() => context.dragScrollbarTo(300));
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("keeps following when the user scrolls up by less than 40 pixels", () => {
+    const context = setup();
+
+    context.scrollTo.mockClear();
+    act(() => context.userScrollTo(461));
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1200,
+      behavior: "auto",
+    });
+  });
+
+  it("pauses following after 40 pixels of cumulative user scrolling", () => {
+    const context = setup();
+
+    act(() => {
+      context.userScrollTo(480);
+      context.userScrollTo(460);
+    });
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("accumulates explicit user scrolling across pauses", () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const context = setup();
+
+    act(() => context.userScrollTo(480));
+    act(() => vi.advanceTimersByTime(151));
+    act(() => context.userScrollTo(460));
+
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("follows streaming resizes without smooth scrolling", () => {
     const context = setup();
 
     context.scrollTo.mockClear();
@@ -62,11 +139,38 @@ describe("useScrollToBottom", () => {
 
     expect(context.scrollTo).toHaveBeenCalledWith({
       top: 1000,
-      behavior: "smooth",
+      behavior: "auto",
     });
   });
 
-  it("keeps following while a smooth scroll catches a growing bottom", () => {
+  it("coalesces streaming resizes within the same animation frame", () => {
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    const context = setup();
+
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => {
+      context.resizeObserver.trigger();
+      context.resizeObserver.trigger();
+    });
+
+    expect(animationFrames).toHaveLength(1);
+    expect(context.scrollTo).not.toHaveBeenCalled();
+
+    act(() => animationFrames[0](0));
+    expect(context.scrollTo).toHaveBeenCalledOnce();
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1200,
+      behavior: "auto",
+    });
+  });
+
+  it("keeps following across repeated content growth", () => {
     const context = setup();
 
     context.scrollTo.mockClear();
@@ -77,7 +181,7 @@ describe("useScrollToBottom", () => {
     });
     expect(context.scrollTo).toHaveBeenCalledWith({
       top: 3000,
-      behavior: "smooth",
+      behavior: "auto",
     });
 
     context.scrollTo.mockClear();
@@ -86,7 +190,7 @@ describe("useScrollToBottom", () => {
 
     expect(context.scrollTo).toHaveBeenCalledWith({
       top: 3500,
-      behavior: "smooth",
+      behavior: "auto",
     });
   });
 
@@ -104,8 +208,67 @@ describe("useScrollToBottom", () => {
 
     expect(context.scrollTo).toHaveBeenCalledWith({
       top: 1200,
-      behavior: "smooth",
+      behavior: "auto",
     });
+  });
+
+  it("keeps following after a non-user upward scroll correction", () => {
+    const context = setup();
+
+    context.setScrollHeight(1500);
+    act(() => context.programmaticScrollTo(300));
+
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1600);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1600,
+      behavior: "auto",
+    });
+  });
+
+  it("resumes following when the user scrolls down into the near-bottom range", () => {
+    const context = setup();
+
+    act(() => {
+      context.userScrollTo(300);
+      context.userScrollTo(350);
+    });
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).toHaveBeenCalledWith({
+      top: 1200,
+      behavior: "auto",
+    });
+  });
+
+  it("does not resume following outside the 150-pixel near-bottom range", () => {
+    const context = setup();
+
+    act(() => {
+      context.userScrollTo(300);
+      context.userScrollTo(349);
+    });
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("does not resume following after a non-user near-bottom correction", () => {
+    const context = setup();
+
+    act(() => context.userScrollTo(300));
+    act(() => context.programmaticScrollTo(360));
+    context.scrollTo.mockClear();
+    context.setScrollHeight(1200);
+    act(() => context.resizeObserver.trigger());
+
+    expect(context.scrollTo).not.toHaveBeenCalled();
   });
 
   it("does not scroll on rerender after the user scrolls away from the bottom", () => {
@@ -162,7 +325,7 @@ describe("useScrollToBottom", () => {
 
     expect(context.scrollTo).toHaveBeenCalledWith({
       top: 1200,
-      behavior: "smooth",
+      behavior: "auto",
     });
   });
 
@@ -192,6 +355,31 @@ describe("useScrollToBottom", () => {
       behavior: "smooth",
     });
   });
+
+  it("starts observing after the chat scroll container mounts", () => {
+    const { container, scrollTo } = createScrollContainer();
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    const hook = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useScrollToBottom({
+          enabled,
+          messagesContainerRef,
+        }),
+      { initialProps: { enabled: false } },
+    );
+
+    expect(ResizeObserverMock.instances).toHaveLength(0);
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    messagesContainerRef.current = container;
+    hook.rerender({ enabled: true });
+
+    expect(ResizeObserverMock.instances).toHaveLength(1);
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 1000,
+      behavior: "auto",
+    });
+  });
 });
 
 function setup(
@@ -201,10 +389,13 @@ function setup(
 ) {
   const {
     container,
+    dragScrollbarTo,
+    keyboardScrollTo,
     programmaticScrollTo,
     scrollTo,
     setScrollHeight,
     setScrollTop,
+    touchScrollTo,
     userScrollTo,
   } = createScrollContainer();
 
@@ -233,6 +424,8 @@ function setup(
 
   return {
     container,
+    dragScrollbarTo,
+    keyboardScrollTo,
     onToolCallApprovalVisible:
       hook.result.current?.onToolCallApprovalVisible ?? missingApprovalCallback,
     programmaticScrollTo,
@@ -241,6 +434,7 @@ function setup(
     scrollTo,
     setScrollHeight,
     setScrollTop,
+    touchScrollTo,
     userScrollTo,
   };
 }
@@ -252,8 +446,14 @@ function missingApprovalCallback() {
 function createScrollContainer() {
   let scrollTop = 500;
   let scrollHeight = 1000;
+  const scrollArea = document.createElement("div");
+  scrollArea.dataset.slot = "scroll-area";
   const container = document.createElement("div");
   container.appendChild(document.createElement("div"));
+  scrollArea.appendChild(container);
+  const scrollbar = document.createElement("div");
+  scrollbar.dataset.slot = "scroll-area-scrollbar";
+  scrollArea.appendChild(scrollbar);
 
   Object.defineProperties(container, {
     scrollHeight: {
@@ -288,6 +488,17 @@ function createScrollContainer() {
 
   return {
     container,
+    dragScrollbarTo: (value: number) => {
+      scrollbar.dispatchEvent(createPointerEvent("pointerdown", "mouse"));
+      scrollTop = value;
+      container.dispatchEvent(new Event("scroll"));
+      scrollbar.dispatchEvent(createPointerEvent("pointerup", "mouse"));
+    },
+    keyboardScrollTo: (key: string, value: number) => {
+      container.dispatchEvent(new KeyboardEvent("keydown", { key }));
+      scrollTop = value;
+      container.dispatchEvent(new Event("scroll"));
+    },
     programmaticScrollTo: (value: number) => {
       scrollTop = value;
       container.dispatchEvent(new Event("scroll"));
@@ -299,9 +510,34 @@ function createScrollContainer() {
     setScrollTop: (value: number) => {
       scrollTop = value;
     },
+    touchScrollTo: (value: number) => {
+      container.dispatchEvent(createPointerEvent("pointerdown", "touch", 100));
+      container.dispatchEvent(
+        createPointerEvent(
+          "pointermove",
+          "touch",
+          value < scrollTop ? 120 : 80,
+        ),
+      );
+      container.dispatchEvent(createPointerEvent("pointercancel", "touch"));
+      scrollTop = value;
+      container.dispatchEvent(new Event("scroll"));
+    },
     userScrollTo: (value: number) => {
+      container.dispatchEvent(
+        new WheelEvent("wheel", { deltaY: value < scrollTop ? -1 : 1 }),
+      );
       scrollTop = value;
       container.dispatchEvent(new Event("scroll"));
     },
   };
+}
+
+function createPointerEvent(type: string, pointerType: string, clientY = 0) {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperties(event, {
+    clientY: { value: clientY },
+    pointerType: { value: pointerType },
+  });
+  return event;
 }

--- a/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-scroll-to-bottom.ts
@@ -3,54 +3,159 @@ import type React from "react";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 interface UseScrollToBottomProps {
+  enabled?: boolean;
   messagesContainerRef: React.RefObject<HTMLDivElement | null>;
   lastUserMessageId?: string;
 }
 
+const AutoFollowPauseThresholdPx = 40;
+const NearBottomThresholdPx = 150;
+
 export function useScrollToBottom({
+  enabled = true,
   messagesContainerRef,
   lastUserMessageId,
 }: UseScrollToBottomProps) {
-  const { getIsAtBottom, scrollToBottom } = useIsAtBottom(messagesContainerRef);
+  const { scrollToBottom } = useIsAtBottom(messagesContainerRef);
   const lastObservedUserMessageIdRef = useRef(lastUserMessageId);
   const shouldAutoFollowRef = useRef(true);
+  const userScrollUpDistanceRef = useRef(0);
 
   // Scroll to bottom when the message list height changes
   useEffect(() => {
+    if (!enabled) return;
     const container = messagesContainerRef.current;
     if (!container?.children[0]) {
       return;
     }
+    const scrollArea =
+      container.closest<HTMLElement>('[data-slot="scroll-area"]') ?? container;
+    let isDraggingScrollbar = false;
+    let resizeAnimationFrame: number | undefined;
+    let resizeAnimationFramePending = false;
     let previousScrollTop = container.scrollTop;
+    let previousTouchY: number | undefined;
+    let userScrollDirection: "up" | "down" | undefined;
+    const isFromCurrentScrollArea = (target: EventTarget | null) =>
+      target instanceof Element &&
+      (target.closest('[data-slot="scroll-area"]') ?? container) === scrollArea;
+    const markUserScroll = (direction: "up" | "down") => {
+      userScrollDirection = direction;
+      if (direction === "down") {
+        userScrollUpDistanceRef.current = 0;
+      }
+    };
+    const onWheel = (event: WheelEvent) => {
+      if (!isFromCurrentScrollArea(event.target)) return;
+      markUserScroll(event.deltaY < 0 ? "up" : "down");
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (!isFromCurrentScrollArea(target)) return;
+      if (
+        target instanceof HTMLElement &&
+        (target.isContentEditable ||
+          target.matches("input, textarea, select, button"))
+      ) {
+        return;
+      }
+      if (["ArrowUp", "PageUp", "Home"].includes(event.key)) {
+        markUserScroll("up");
+      } else if (["ArrowDown", "PageDown", "End"].includes(event.key)) {
+        markUserScroll("down");
+      } else if (event.key === " ") {
+        markUserScroll(event.shiftKey ? "up" : "down");
+      }
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!isFromCurrentScrollArea(target)) return;
+      if (event.pointerType === "touch") {
+        previousTouchY = event.clientY;
+        return;
+      }
+      const scrollbar =
+        target instanceof Element
+          ? target.closest('[data-slot="scroll-area-scrollbar"]')
+          : null;
+      isDraggingScrollbar =
+        scrollbar?.closest('[data-slot="scroll-area"]') === scrollArea;
+    };
+    const onPointerMove = (event: PointerEvent) => {
+      if (
+        event.pointerType !== "touch" ||
+        previousTouchY === undefined ||
+        !isFromCurrentScrollArea(event.target)
+      ) {
+        return;
+      }
+      if (event.clientY !== previousTouchY) {
+        markUserScroll(event.clientY > previousTouchY ? "up" : "down");
+        previousTouchY = event.clientY;
+      }
+    };
+    const onPointerEnd = () => {
+      isDraggingScrollbar = false;
+      previousTouchY = undefined;
+    };
     const onScroll = () => {
       const scrollTop = container.scrollTop;
+      const delta = scrollTop - previousScrollTop;
+      if (isDraggingScrollbar && delta !== 0) {
+        markUserScroll(delta < 0 ? "up" : "down");
+      }
       const distanceToBottom =
         container.scrollHeight - scrollTop - container.clientHeight;
-      if (distanceToBottom <= 1) {
+      if (userScrollDirection === "up" && delta < 0) {
+        userScrollUpDistanceRef.current -= delta;
+        if (userScrollUpDistanceRef.current >= AutoFollowPauseThresholdPx) {
+          shouldAutoFollowRef.current = false;
+        }
+      } else if (
+        userScrollDirection === "down" &&
+        delta > 0 &&
+        distanceToBottom <= NearBottomThresholdPx
+      ) {
         shouldAutoFollowRef.current = true;
-      } else if (scrollTop < previousScrollTop - 1) {
-        shouldAutoFollowRef.current = false;
-      } else if (getIsAtBottom()) {
-        shouldAutoFollowRef.current = true;
+        userScrollUpDistanceRef.current = 0;
       }
       previousScrollTop = scrollTop;
-    };
-    const followResize = () => {
-      if (!shouldAutoFollowRef.current) return;
-      scrollToBottom();
+      userScrollDirection = undefined;
     };
     const resizeObserver = new ResizeObserver(() => {
-      if (!shouldAutoFollowRef.current) return;
-      requestAnimationFrame(followResize);
+      if (!shouldAutoFollowRef.current || resizeAnimationFramePending) return;
+      resizeAnimationFramePending = true;
+      resizeAnimationFrame = requestAnimationFrame(() => {
+        resizeAnimationFramePending = false;
+        resizeAnimationFrame = undefined;
+        if (shouldAutoFollowRef.current) {
+          scrollToBottom(false);
+        }
+      });
     });
+    container.addEventListener("wheel", onWheel, { passive: true });
+    container.addEventListener("keydown", onKeyDown);
     container.addEventListener("scroll", onScroll, { passive: true });
+    scrollArea.addEventListener("pointerdown", onPointerDown, true);
+    scrollArea.addEventListener("pointermove", onPointerMove, true);
+    scrollArea.addEventListener("pointerup", onPointerEnd, true);
+    scrollArea.addEventListener("pointercancel", onPointerEnd, true);
     resizeObserver.observe(container);
     resizeObserver.observe(container.children[0]);
     return () => {
+      if (resizeAnimationFramePending && resizeAnimationFrame !== undefined) {
+        cancelAnimationFrame(resizeAnimationFrame);
+      }
+      container.removeEventListener("wheel", onWheel);
+      container.removeEventListener("keydown", onKeyDown);
       container.removeEventListener("scroll", onScroll);
+      scrollArea.removeEventListener("pointerdown", onPointerDown, true);
+      scrollArea.removeEventListener("pointermove", onPointerMove, true);
+      scrollArea.removeEventListener("pointerup", onPointerEnd, true);
+      scrollArea.removeEventListener("pointercancel", onPointerEnd, true);
       resizeObserver.disconnect();
     }; // clean up
-  }, [getIsAtBottom, scrollToBottom, messagesContainerRef]);
+  }, [enabled, scrollToBottom, messagesContainerRef]);
 
   // Scroll to bottom immediately when a user message is sent.
   useLayoutEffect(() => {
@@ -64,14 +169,16 @@ export function useScrollToBottom({
 
     lastObservedUserMessageIdRef.current = lastUserMessageId;
     shouldAutoFollowRef.current = true;
+    userScrollUpDistanceRef.current = 0;
     scrollToBottom(false);
   }, [lastUserMessageId, scrollToBottom]);
 
   // Initial scroll to bottom once when component mounts (without smooth behavior)
   useLayoutEffect(() => {
+    if (!enabled) return;
     if (!messagesContainerRef.current) return;
     scrollToBottom(false); // false = not smooth
-  }, [scrollToBottom, messagesContainerRef]);
+  }, [enabled, scrollToBottom, messagesContainerRef]);
 
   const onToolCallApprovalVisible = useCallback(() => {
     scrollToBottom();

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -406,6 +406,7 @@ function Chat({ user, uid, info }: ChatProps) {
   )?.id;
 
   const { onToolCallApprovalVisible } = useScrollToBottom({
+    enabled: !isInitializing,
     messagesContainerRef,
     lastUserMessageId,
   });


### PR DESCRIPTION
## Summary
- Chat auto-follow could latch off for the rest of a run. The old rule paused on *any* upward `scrollTop` delta, and the follow itself was `smooth` — a scroll animation that restarts on every streamed chunk and emits scroll events for hundreds of ms, so its own jitter tripped the pause. Nothing re-armed it except sending a new message.
- Follow is now instant (`scrollToBottom(false)`) and pausing requires a real user gesture: wheel / arrow-PageUp-Home keys / scrollbar drag / touch drag mark the direction, and only a cumulative **40px** of user-driven upward scrolling pauses it. Scrolling back down within **150px** of the bottom resumes and re-pins.
- `useScrollToBottom` gains `enabled`, wired to `!isInitializing` in `page.tsx`, so the effects re-run once the container actually mounts (forked tasks render `<ChatSkeleton/>` first, which previously left auto-follow permanently dead).

## Test plan
- [x] `bun run test -- src/features/chat/hooks/use-scroll-to-bottom.test.tsx` in `packages/vscode-webui` → 22/22 passing (fixture overrides layout metrics since jsdom has none)
- [x] `bun check` (biome / ast-grep / eslint-i18n) clean
- [x] `bun tsc` clean
- [ ] Manual: start a long streaming task, confirm the view stays pinned; scroll up mid-stream and confirm it stays put; scroll back near the bottom and confirm it re-pins; send a new message and confirm it snaps down

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-fcb6a36701234edfa386afcf47050e40)