### PR TITLE
chore(vscode): bump development version to 0.67.0

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.65.0-dev",
+  "version": "0.67.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- bump the VS Code extension package version from `0.65.0-dev` to `0.67.0-dev`
- prepare the package metadata for the next development cycle

## Test plan
- [x] Run automated pre-push dependency checks and test suite

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7ed41eed798944e980ce26b9f9d59f67)