### PR TITLE
fix(vscode-webui): support CJK file names in @ mention search

### DIFF
--- a/packages/vscode-webui/src/lib/fuzzy-search.test.ts
+++ b/packages/vscode-webui/src/lib/fuzzy-search.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { fuzzySearchFiles } from "./fuzzy-search";
+
+// Non-ASCII fixtures are written as escape sequences to keep this file ASCII-only.
+const ChineseFile = "docs/\u4ea7\u54c1\u9700\u6c42\u6587\u6863.md";
+const ChineseQuery = "\u9700\u6c42";
+// Characters outside the BMP (CJK extension B) are surrogate pairs in UTF-16.
+const ExtensionFile = "docs/\u{20BB7}\u{2A6B2}.md";
+const ExtensionQuery = "\u{20BB7}";
+// U+20800 (D842 DC00) and U+213B7 (D844 DFB7) contain the same surrogates as
+// U+20BB7 (D842 DFB7), but neither is that character.
+const SurrogateLookalikeFile = "docs/\u{20800}\u{213B7}.md";
+
+const files = [
+  { filepath: ChineseFile, isDir: false },
+  { filepath: ExtensionFile, isDir: false },
+  { filepath: SurrogateLookalikeFile, isDir: false },
+  { filepath: "packages/vscode-webui/src/lib/fuzzy-search.ts", isDir: false },
+  { filepath: "packages/vscode/src/tools/list-files.ts", isDir: false },
+];
+
+const search = (needle: string) =>
+  fuzzySearchFiles(needle, { files, activeTabs: [] }).map((x) => x.filepath);
+
+describe("fuzzySearchFiles", () => {
+  it("matches a file name by a non-Latin substring", () => {
+    expect(search(ChineseQuery)).toEqual([ChineseFile]);
+  });
+
+  it("never matches a character outside the BMP against another one", () => {
+    // Matching per code unit would let the surrogate halves drift apart and
+    // report the lookalike file, which contains neither queried character.
+    expect(search(ExtensionQuery)).not.toContain(SurrogateLookalikeFile);
+  });
+
+  it("keeps matching ascii paths fuzzily", () => {
+    expect(search("fuzzy-search")).toEqual([
+      "packages/vscode-webui/src/lib/fuzzy-search.ts",
+    ]);
+    expect(search("vscode/tools")).toEqual([
+      "packages/vscode/src/tools/list-files.ts",
+    ]);
+  });
+});

--- a/packages/vscode-webui/src/lib/fuzzy-search.ts
+++ b/packages/vscode-webui/src/lib/fuzzy-search.ts
@@ -2,12 +2,18 @@ import uFuzzy from "@leeoniya/ufuzzy";
 
 const MaxResult = 500;
 
-// Create a single uFuzzy instance to reuse
+// Create a single uFuzzy instance to reuse.
+// uFuzzy defaults to Latin-only regexps, which treat CJK/accented characters as
+// term separators, so those file names can never be matched. Treat every
+// non-ascii code unit as a regular term character instead, except surrogates:
+// uFuzzy matches per code unit, so the halves of a character outside the BMP
+// could drift apart and match unrelated characters. Such characters stay
+// separators and are ignored by the search.
 const uf = new uFuzzy({
-  // Allow @ symbols and basic path characters
-  intraChars: "[a-z\\d'@\\-_./]",
+  // Allow @ symbols, basic path characters and any non-ascii BMP character
+  intraChars: "[a-z\\d'@\\-_./\\u0080-\\ud7ff\\ue000-\\uffff]",
   // Don't split on forward slashes - treat them as regular characters
-  interSplit: "[^a-zA-Z\\d'@\\-_./]+",
+  interSplit: "[^a-zA-Z\\d'@\\-_./\\u0080-\\ud7ff\\ue000-\\uffff]+",
   // Allow more insertions for path matching (like amp -> amp-07-08-2025)
   intraIns: 5,
 });


### PR DESCRIPTION
## Summary
The @ mention matcher used uFuzzy's Latin-only defaults, so CJK or accented characters counted as term separators and those file names could never be found. Non-ascii BMP characters are now regular term characters.

Characters outside the BMP stay separators and are ignored by the search: uFuzzy matches per UTF-16 code unit, so including surrogates would let the halves of such a character drift apart and match unrelated characters.

## Screenshot
<img width="1042" height="404" alt="image" src="https://github.com/user-attachments/assets/af060039-0d2b-407c-b0f8-24cc7fda36d5" />


🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-ec518446ed38498fa869aacfe2323071)