### PR TITLE
fix(vscode-webui): remove the duplicate scrollbar in the chat view

### DIFF
--- a/packages/vscode-webui/src/components/message/__stories__/scroll-area-katex-scrollbar.stories.tsx
+++ b/packages/vscode-webui/src/components/message/__stories__/scroll-area-katex-scrollbar.stories.tsx
@@ -1,0 +1,148 @@
+import type { Message } from "@getpochi/livekit";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useState } from "react";
+import { MessageList } from "../message-list";
+
+/**
+ * Regression story for the "two scrollbars in the chat" bug.
+ *
+ * KaTeX renders a screen-reader-only `<span class="katex-mathml">` with
+ * `position: absolute` for every formula. When the Radix `ScrollArea`
+ * viewport is not positioned, those spans resolve their containing block to
+ * the `ScrollArea` root (`position: relative`). An absolutely positioned
+ * element whose containing block is an ancestor of a clipping box is not
+ * clipped by that box, so every formula of the whole conversation leaks into
+ * the root's scrollable area. Combined with `overflow-y-auto` on the root,
+ * the root grows its own native scrollbar next to the Radix one.
+ *
+ * The diagnostics banner reports which state we are in, so this story can be
+ * checked before and after the fix.
+ */
+const mathMarkdown = `
+### Setup
+
+Let Patrick's speed be $v$ mph, then Tanya's speed is $v+3$ mph.
+
+$$
+vT = (v + 3)(T - 1) = vT - v + 3T - 3
+$$
+
+$$
+0 = -v + 3T - 3 \\implies v = 3(T - 1)
+$$
+
+$$
+3(T - 1) = 5(T - 2) \\implies 2T = 7 \\implies T = \\frac{7}{2}
+$$
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+`;
+
+const messages: Message[] = Array.from({ length: 6 }, (_, i) => ({
+  id: `math-message-${i}`,
+  role: i % 2 === 0 ? "user" : "assistant",
+  metadata: { kind: i % 2 === 0 ? "user" : "assistant" } as Message["metadata"],
+  parts: [
+    { type: "step-start" },
+    { type: "text", text: `${mathMarkdown}\n\nMessage ${i}`, state: "done" },
+  ],
+})) as Message[];
+
+/**
+ * Reports whether the `ScrollArea` root became a second scroll container.
+ */
+function ScrollbarDiagnostics() {
+  const [state, setState] = useState<{
+    rootOverflow: number;
+    rootClientHeight: number;
+    rootScrollHeight: number;
+    viewportScrollHeight: number;
+    escapingAbsoluteElements: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const measure = () => {
+      const root = document.querySelector<HTMLElement>(
+        '[data-slot="scroll-area"]',
+      );
+      const viewport = document.querySelector<HTMLElement>(
+        '[data-slot="scroll-area-viewport"]',
+      );
+      if (!root || !viewport) return;
+      const escaping = Array.from(
+        viewport.querySelectorAll<HTMLElement>(".katex-mathml"),
+      ).filter((el) => el.offsetParent === root).length;
+      setState({
+        rootOverflow: root.scrollHeight - root.clientHeight,
+        rootClientHeight: root.clientHeight,
+        rootScrollHeight: root.scrollHeight,
+        viewportScrollHeight: viewport.scrollHeight,
+        escapingAbsoluteElements: escaping,
+      });
+    };
+    measure();
+    const interval = setInterval(measure, 500);
+    return () => clearInterval(interval);
+  }, []);
+
+  const isBuggy = !!state && state.rootOverflow > 0;
+  return (
+    <pre
+      data-testid="scrollbar-diagnostics"
+      className={`shrink-0 whitespace-pre-wrap px-4 py-1 font-mono text-[10px] ${
+        isBuggy ? "bg-red-950 text-red-300" : "bg-emerald-950 text-emerald-300"
+      }`}
+    >
+      {state
+        ? [
+            isBuggy
+              ? `BUG: the ScrollArea root scrolls too (${state.rootOverflow}px of overflow) -> two scrollbars`
+              : "OK: only the Radix viewport scrolls -> one scrollbar",
+            `root: clientHeight=${state.rootClientHeight} scrollHeight=${state.rootScrollHeight}`,
+            `viewport: scrollHeight=${state.viewportScrollHeight}`,
+            `.katex-mathml escaping the viewport: ${state.escapingAbsoluteElements}`,
+          ].join("\n")
+        : "measuring…"}
+    </pre>
+  );
+}
+
+const meta: Meta<typeof MessageList> = {
+  title: "Message/ScrollAreaKatexScrollbar",
+  component: MessageList,
+  parameters: {
+    backgrounds: { disable: true },
+    layout: "fullscreen",
+    viewport: { defaultViewport: "vscodeLarge" },
+  },
+};
+
+export default meta;
+
+/**
+ * A chat-like layout (the same one `features/chat/page.tsx` builds) filled
+ * with math-heavy messages.
+ *
+ * Before the fix: a red banner and two vertical scrollbars on the message
+ * area. After the fix: a green banner and a single scrollbar.
+ */
+export const DuplicateScrollbar: StoryObj<typeof MessageList> = {
+  render: () => (
+    <div className="mx-auto flex h-screen max-w-6xl flex-col">
+      <ScrollbarDiagnostics />
+      <MessageList
+        messages={messages}
+        isLoading={false}
+        className="pb-14"
+        renderAllMessages
+      />
+      <div className="relative flex shrink-0 flex-col px-4 pb-2">
+        <div className="h-16 rounded border border-border p-2 text-muted-foreground text-xs">
+          prompt form placeholder
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/vscode-webui/src/components/message/message-list.tsx
+++ b/packages/vscode-webui/src/components/message/message-list.tsx
@@ -160,7 +160,7 @@ export const MessageList: React.FC<{
     <BackgroundJobContextProvider messages={messages}>
       <MermaidContextProvider value={mermaidContextValue}>
         <ScrollArea
-          className={cn("mb-2 flex-1 overflow-y-auto px-4", className)}
+          className={cn("mb-2 min-h-0 flex-1 px-4", className)}
           viewportClassname={viewportClassname}
           ref={containerRef}
         >

--- a/packages/vscode-webui/src/components/ui/scroll-area.tsx
+++ b/packages/vscode-webui/src/components/ui/scroll-area.tsx
@@ -17,8 +17,10 @@ const ScrollArea = React.forwardRef<
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
+        // `relative` makes the viewport the containing block for absolutely
+        // positioned content, so it scrolls and clips with the content.
         className={cn(
-          "[&>div]:!block h-full w-full rounded-[inherit]",
+          "[&>div]:!block relative h-full w-full rounded-[inherit]",
           viewportClassname,
         )}
         ref={ref}


### PR DESCRIPTION
## Summary

- The chat message area had **two** scroll containers: `MessageList` put `overflow-y-auto` on the Radix `ScrollArea` **root** while Radix already scrolls the **viewport**, so the root painted a second, unstyled native scrollbar next to the VSCode-themed one.
- The root only overflows because the viewport was not positioned: KaTeX renders a screen-reader `span.katex-mathml` with `position: absolute` for every formula, whose containing block then resolves to the root (`position: relative`). Absolutely positioned boxes are not clipped by an intermediate `overflow` box, so every formula of the conversation leaked into the root's scrollable area (measured: root `scrollHeight` 1810 vs `clientHeight` 446, 18 escaping spans).
- Fix: make the viewport the containing block (`relative`) and keep scrolling on it alone (`overflow-y-auto` → `min-h-0` on the message-list root). The shared `ScrollArea` root is intentionally left without `overflow-hidden`, since several consumers pass `max-h-*`/`overflow-*` in the root `className` and would silently clip instead of scroll.

## Test plan

- [x] `packages/vscode-webui`: `bun vitest --run src/components/message src/features/chat/hooks/use-scroll-to-bottom.test.tsx src/features/chat/components/chat-area.test.tsx` — 9 files / 80 tests pass.
- [x] `bunx biome check` on the touched files and `bun tsc --noEmit` in `packages/vscode-webui` are clean.
- [x] Manual, via the Storybook regression story added in the first commit (`Message/ScrollAreaKatexScrollbar → DuplicateScrollbar`, `cd packages/vscode-webui && bun run storybook`). It renders `MessageList` in the chat layout with math-heavy messages and a live diagnostics banner:
  - at `0cc7b16a9` (story only, before the patch): `BUG: the ScrollArea root scrolls too (1364px of overflow) -> two scrollbars`, `.katex-mathml escaping the viewport: 18` — two scrollbars visible;
  - at `562ebec61` (patch applied): `OK: only the Radix viewport scrolls -> one scrollbar`, `root: clientHeight=446 scrollHeight=446`, `escaping: 0`, viewport still scrolls (`scrollHeight=1977`).
- [ ] Reviewer: open a chat containing LaTeX in the extension and confirm a single scrollbar, and that auto-scroll / "scroll to bottom" still work.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5cae52f3438b4684b00dd3ce15b9549d)