### PR TITLE
fix(vscode-webui): refine background job notifications

### DIFF
--- a/packages/vscode-webui/src/components/message/__tests__/background-job-notifications.test.tsx
+++ b/packages/vscode-webui/src/components/message/__tests__/background-job-notifications.test.tsx
@@ -5,12 +5,9 @@ import { BackgroundJobNotifications } from "../background-job-notifications";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, options?: { count?: number }) => {
+    t: (key: string) => {
       if (key === "backgroundJobNotifications.title") {
-        return "Background job notifications";
-      }
-      if (key === "backgroundJobNotifications.notificationCount") {
-        return `${options?.count} notifications`;
+        return "Notifications";
       }
       return key;
     },
@@ -41,12 +38,14 @@ vi.mock("@/features/tools", () => ({
   BackgroundJobPanel: ({
     backgroundJobId,
     command,
+    summary,
     status,
     outputFile,
     appearance,
   }: {
     backgroundJobId: string;
     command?: string;
+    summary?: string;
     status?: string;
     outputFile?: string;
     appearance?: string;
@@ -58,7 +57,8 @@ vi.mock("@/features/tools", () => ({
       data-output-file={outputFile}
       data-appearance={appearance}
     >
-      {command}
+      <span>{command}</span>
+      <span>{summary}</span>
     </div>
   ),
 }));
@@ -75,8 +75,8 @@ describe("BackgroundJobNotifications", () => {
     );
 
     expect(container.querySelectorAll("section")).toHaveLength(1);
-    expect(getByText("Background job notifications")).toBeDefined();
-    expect(getByText("2 notifications")).toBeDefined();
+    expect(getByText("Notifications")).toBeDefined();
+    expect(getByText("2").getAttribute("data-slot")).toBe("badge");
     expect(getAllByTestId("background-job-panel")).toHaveLength(2);
     expect(
       getAllByTestId("background-job-panel")[0]?.getAttribute(
@@ -85,6 +85,10 @@ describe("BackgroundJobNotifications", () => {
     ).toBe("notification");
     expect(getByText("run bgjob-cmd-1")).toBeDefined();
     expect(getByText("run bgjob-cmd-2")).toBeDefined();
+    expect(getByText("bgjob-cmd-1 completed")).toBeDefined();
+    expect(getByText("bgjob-cmd-2 failed")).toBeDefined();
+    expect(container.textContent).not.toContain("Job 1");
+    expect(container.textContent).not.toContain("Job 2");
   });
 });
 

--- a/packages/vscode-webui/src/components/message/background-job-notifications.tsx
+++ b/packages/vscode-webui/src/components/message/background-job-notifications.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { BackgroundJobPanel } from "@/features/tools";
 import type { BackgroundJobNotification } from "@getpochi/common";
@@ -8,6 +9,23 @@ interface BackgroundJobNotificationsProps {
   notifications: BackgroundJobNotification[];
 }
 
+export function BackgroundJobNotificationItems({
+  notifications,
+}: BackgroundJobNotificationsProps) {
+  return notifications.map((notification) => (
+    <BackgroundJobPanel
+      key={notification.notificationId}
+      backgroundJobId={notification.backgroundJobId}
+      appearance="notification"
+      command={notification.command}
+      summary={notification.summary}
+      status={notification.status}
+      exitCode={notification.exitCode}
+      outputFile={notification.outputFile}
+    />
+  ));
+}
+
 export function BackgroundJobNotifications({
   notifications,
 }: BackgroundJobNotificationsProps) {
@@ -16,32 +34,24 @@ export function BackgroundJobNotifications({
 
   return (
     <CollapsibleSection
+      className="overflow-hidden"
       title={
         <>
-          <Bell className="size-4 shrink-0" />
+          <Bell className="size-4 shrink-0 text-muted-foreground" />
           {t("backgroundJobNotifications.title")}
         </>
       }
       actions={
-        <span className="text-muted-foreground text-xs">
-          {t("backgroundJobNotifications.notificationCount", {
-            count: notifications.length,
-          })}
-        </span>
+        <Badge
+          variant="secondary"
+          className="h-5 min-w-5 rounded-full px-1.5 text-muted-foreground"
+        >
+          {notifications.length}
+        </Badge>
       }
-      contentClassName="gap-2 p-2"
+      contentClassName="gap-0.5 border-t p-2"
     >
-      {notifications.map((notification) => (
-        <BackgroundJobPanel
-          key={notification.notificationId}
-          backgroundJobId={notification.backgroundJobId}
-          appearance="notification"
-          command={notification.command}
-          status={notification.status}
-          exitCode={notification.exitCode}
-          outputFile={notification.outputFile}
-        />
-      ))}
+      <BackgroundJobNotificationItems notifications={notifications} />
     </CollapsibleSection>
   );
 }

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
@@ -23,23 +23,17 @@ vi.mock("@/features/tools", () => ({
   BackgroundJobPanel: ({
     command,
     summary,
+    status,
   }: {
     command?: string;
     summary?: string;
-  }) => {
-    const prefix = command ? `Background command "${command}" ` : "";
-    const conciseSummary =
-      summary && prefix && summary.startsWith(prefix)
-        ? summary.slice(prefix.length)
-        : summary;
-    return (
-      <div>
-        <span aria-hidden="true">status</span>
-        <span>{command}</span>
-        <span>{conciseSummary}</span>
-      </div>
-    );
-  },
+    status?: string;
+  }) => (
+    <div>
+      <span>{command}</span>
+      <span title={summary}>{status}</span>
+    </div>
+  ),
 }));
 
 describe("QueuedMessages", () => {
@@ -160,7 +154,7 @@ describe("QueuedMessages", () => {
     );
   });
 
-  it("shows queued notification commands and lifecycle summaries", () => {
+  it("shows queued notification commands and statuses", () => {
     const { container, getAllByText, getByText, queryByLabelText } = render(
       <QueuedMessages
         messages={[

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.test.tsx
@@ -19,6 +19,29 @@ vi.mock("@/lib/vscode", () => ({
   },
 }));
 
+vi.mock("@/features/tools", () => ({
+  BackgroundJobPanel: ({
+    command,
+    summary,
+  }: {
+    command?: string;
+    summary?: string;
+  }) => {
+    const prefix = command ? `Background command "${command}" ` : "";
+    const conciseSummary =
+      summary && prefix && summary.startsWith(prefix)
+        ? summary.slice(prefix.length)
+        : summary;
+    return (
+      <div>
+        <span aria-hidden="true">status</span>
+        <span>{command}</span>
+        <span>{conciseSummary}</span>
+      </div>
+    );
+  },
+}));
+
 describe("QueuedMessages", () => {
   it("uses the todo icon for queued todo-mode messages", () => {
     const { container } = render(
@@ -137,20 +160,65 @@ describe("QueuedMessages", () => {
     );
   });
 
-  it("does not offer removal for a system notification", () => {
-    const { queryByLabelText } = render(
+  it("shows queued notification commands and lifecycle summaries", () => {
+    const { container, getAllByText, getByText, queryByLabelText } = render(
       <QueuedMessages
         messages={[
-          queuedMessage({
-            text: "background job completed",
-            nonRemovable: true,
-          }),
+          {
+            parts: [
+              {
+                type: "data-background-job-notification",
+                data: {
+                  notificationId: "notification-1",
+                  backgroundJobId: "bgjob-cmd-1",
+                  outputFile: "/tmp/bgjob-cmd-1.log",
+                  command: "sleep 2 && echo secret",
+                  status: "completed",
+                  summary:
+                    'Background command "sleep 2 && echo secret" completed',
+                  exitCode: 0,
+                  finishedAt: 1,
+                },
+              },
+              {
+                type: "data-background-job-notification",
+                data: {
+                  notificationId: "notification-2",
+                  backgroundJobId: "bgjob-cmd-2",
+                  outputFile: "/tmp/bgjob-cmd-2.log",
+                  command: "sleep 4 && echo hidden",
+                  status: "completed",
+                  summary:
+                    'Background command "sleep 4 && echo hidden" completed',
+                  exitCode: 0,
+                  finishedAt: 2,
+                },
+              },
+            ],
+            raw: {
+              text: "raw command summaries",
+              nonRemovable: true,
+            },
+          },
         ]}
         onRemove={vi.fn()}
         onSteer={vi.fn()}
       />,
     );
 
+    expect(getByText("backgroundJobNotifications.title")).toBeTruthy();
+    expect(getByText("2").getAttribute("data-slot")).toBe("badge");
+    const firstCommand = getByText("sleep 2 && echo secret");
+    expect(firstCommand).toBeTruthy();
+    const notificationItems = firstCommand.parentElement?.parentElement;
+    expect(notificationItems?.classList.contains("ml-5")).toBe(false);
+    expect(notificationItems?.classList.contains("-ml-1")).toBe(true);
+    expect(getByText("sleep 4 && echo hidden")).toBeTruthy();
+    expect(queryByLabelText("completed")).toBeNull();
+    expect(getAllByText("completed")).toHaveLength(2);
+    expect(container.textContent).not.toContain("Job 1");
+    expect(container.textContent).not.toContain("raw command summaries");
+    expect(container.querySelector(".lucide-bell")).toBeTruthy();
     expect(queryByLabelText("Remove queued message")).toBeNull();
     expect(queryByLabelText("chat.steer")).toBeTruthy();
   });

--- a/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
+++ b/packages/vscode-webui/src/features/chat/components/queued-messages.tsx
@@ -1,4 +1,6 @@
 import { CodeBlock } from "@/components/message";
+import { BackgroundJobNotificationItems } from "@/components/message/background-job-notifications";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   HoverCard,
@@ -12,9 +14,11 @@ import {
   languageIdFromExtension,
 } from "@/lib/utils/languages";
 import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
+import type { BackgroundJobNotification } from "@getpochi/common";
 import { parseTitle } from "@getpochi/common/message-utils";
 import type { ActiveSelection } from "@getpochi/common/vscode-webui-bridge";
 import {
+  Bell,
   CornerDownRight,
   FileCode,
   ListEnd,
@@ -36,6 +40,7 @@ interface RenderMessage {
   title: string;
   details: string;
   isTodoMode?: boolean;
+  notifications?: BackgroundJobNotification[];
   activeSelection?: ActiveSelection;
   nonRemovable?: boolean;
 }
@@ -48,7 +53,7 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
 }) => {
   const { t } = useTranslation();
   const renderMessages = useMemo<RenderMessage[]>(() => {
-    return messages.map(({ raw }) => {
+    return messages.map(({ parts, raw }) => {
       const {
         text = "",
         filesCount = 0,
@@ -58,22 +63,35 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
         isTodoMode,
         activeSelection,
       } = raw;
-      const title = text.trim() ? parseTitle(text) : t("chat.noMessage");
-      const details = [
-        filesCount > 0 ? t("chat.fileCount", { count: filesCount }) : "",
-        reviewsCount > 0 ? t("chat.reviewCount", { count: reviewsCount }) : "",
-        userEditsCount > 0
-          ? t("chat.userEditCount", { count: userEditsCount })
-          : "",
-        terminalContextCount > 0
-          ? t("chat.terminalContextCount", { count: terminalContextCount })
-          : "",
-      ].filter(Boolean);
+      const notifications = parts.flatMap((part) =>
+        part.type === "data-background-job-notification" ? [part.data] : [],
+      );
+      const isNotification = notifications.length > 0;
+      const title = isNotification
+        ? t("backgroundJobNotifications.title")
+        : text.trim()
+          ? parseTitle(text)
+          : t("chat.noMessage");
+      const details = isNotification
+        ? [String(notifications.length)]
+        : [
+            filesCount > 0 ? t("chat.fileCount", { count: filesCount }) : "",
+            reviewsCount > 0
+              ? t("chat.reviewCount", { count: reviewsCount })
+              : "",
+            userEditsCount > 0
+              ? t("chat.userEditCount", { count: userEditsCount })
+              : "",
+            terminalContextCount > 0
+              ? t("chat.terminalContextCount", { count: terminalContextCount })
+              : "",
+          ].filter(Boolean);
 
       return {
         title,
         details: details.join(" · "),
         isTodoMode,
+        notifications: isNotification ? notifications : undefined,
         activeSelection,
         nonRemovable: raw.nonRemovable,
       };
@@ -81,68 +99,88 @@ export const QueuedMessages: React.FC<QueuedMessagesProps> = ({
   }, [messages, t]);
 
   return (
-    <div className="mx-1 mt-2 mb-1.5 flex max-h-28 flex-col gap-0.5 overflow-y-auto rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
+    <div className="mx-1 mt-2 mb-1.5 flex max-h-40 flex-col gap-0.5 overflow-y-auto rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
       {renderMessages.map((message, index) => (
         <div
           key={index}
-          className="group flex h-6 items-center gap-2 text-muted-foreground"
+          className="group flex flex-col gap-0.5 text-muted-foreground"
         >
-          {message.isTodoMode ? (
-            <Target className="size-3.5 shrink-0" />
-          ) : (
-            <ListEnd className="size-3.5 shrink-0 scale-x-[-1]" />
-          )}
-          <div className="flex min-w-0 flex-1 items-center gap-1.5">
-            <p
-              className="min-w-0 truncate text-sm"
-              title={
-                message.details
-                  ? `${message.title} (${message.details})`
-                  : message.title
-              }
-            >
-              {message.title}
-            </p>
-            {message.details ? (
-              <span className="shrink-0 text-muted-foreground/70 text-xs">
-                {message.details}
-              </span>
-            ) : null}
-          </div>
-          {message.activeSelection && (
-            <ActiveSelectionPreviewIcon
-              activeSelection={message.activeSelection}
-            />
-          )}
-          <div className="flex shrink-0 items-center gap-1">
-            <Button
-              variant="ghost"
-              size="xs"
-              type="button"
-              onClick={() => onSteer?.(index)}
-              aria-label={t("chat.steer")}
-              disabled={!onSteer || !allowSteer}
-              className={cn(
-                "h-7 gap-1 rounded-full px-1.5 text-muted-foreground text-sm",
-                "hover:bg-transparent hover:text-foreground",
-              )}
-            >
-              <CornerDownRight className="size-3.5" />
-              <span>{t("chat.steer")}</span>
-            </Button>
-            {!message.nonRemovable && (
+          <div className="flex h-6 w-full items-center gap-2">
+            {message.notifications ? (
+              <Bell className="size-3.5 shrink-0" />
+            ) : message.isTodoMode ? (
+              <Target className="size-3.5 shrink-0" />
+            ) : (
+              <ListEnd className="size-3.5 shrink-0 scale-x-[-1]" />
+            )}
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
+              <p
+                className="min-w-0 truncate text-sm"
+                title={
+                  message.details
+                    ? `${message.title} (${message.details})`
+                    : message.title
+                }
+              >
+                {message.title}
+              </p>
+              {message.details ? (
+                message.notifications ? (
+                  <Badge
+                    variant="secondary"
+                    className="h-5 min-w-5 rounded-full px-1.5 text-muted-foreground"
+                  >
+                    {message.details}
+                  </Badge>
+                ) : (
+                  <span className="shrink-0 text-muted-foreground/70 text-xs">
+                    {message.details}
+                  </span>
+                )
+              ) : null}
+            </div>
+            {message.activeSelection && (
+              <ActiveSelectionPreviewIcon
+                activeSelection={message.activeSelection}
+              />
+            )}
+            <div className="flex shrink-0 items-center gap-1">
               <Button
                 variant="ghost"
-                size="icon"
+                size="xs"
                 type="button"
-                aria-label="Remove queued message"
-                onClick={() => onRemove(index)}
-                className="h-7 w-7 rounded-full text-muted-foreground hover:bg-transparent hover:text-foreground"
+                onClick={() => onSteer?.(index)}
+                aria-label={t("chat.steer")}
+                disabled={!onSteer || !allowSteer}
+                className={cn(
+                  "h-7 gap-1 rounded-full px-1.5 text-muted-foreground text-sm",
+                  "hover:bg-transparent hover:text-foreground",
+                )}
               >
-                <Trash2 className="size-3.5" />
+                <CornerDownRight className="size-3.5" />
+                <span>{t("chat.steer")}</span>
               </Button>
-            )}
+              {!message.nonRemovable && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  type="button"
+                  aria-label="Remove queued message"
+                  onClick={() => onRemove(index)}
+                  className="h-7 w-7 rounded-full text-muted-foreground hover:bg-transparent hover:text-foreground"
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              )}
+            </div>
           </div>
+          {message.notifications && (
+            <div className="-ml-1 flex min-w-0 flex-col gap-0.5">
+              <BackgroundJobNotificationItems
+                notifications={message.notifications}
+              />
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BackgroundJobPanel } from "../command-execution-panel";
 
@@ -9,6 +9,15 @@ let terminals:
   | { backgroundJobId: string; name: string; isActive: boolean }[]
   | undefined = [];
 let jobInfo: { command: string | undefined; displayId: string } | undefined;
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -138,15 +147,17 @@ describe("BackgroundJobPanel job control", () => {
     ).toBeNull();
   });
 
-  it("shows a terminal command followed by its lifecycle summary", () => {
+  it("shows status text and exposes the full summary in a tooltip", async () => {
     jobInfo = undefined;
+    const fullSummary =
+      'Background command "echo 123" completed with exit code 0';
 
     const { container } = render(
       <BackgroundJobPanel
         backgroundJobId="bgjob-cmd-1"
         appearance="notification"
         command="echo 123"
-        summary={'Background command "echo 123" completed with exit code 0'}
+        summary={fullSummary}
         status="completed"
         exitCode={0}
         outputFile="/tmp/bgjob-cmd-1.log"
@@ -155,15 +166,18 @@ describe("BackgroundJobPanel job control", () => {
 
     expect(container.querySelector(".lucide-terminal")).toBeTruthy();
     expect(screen.getByText("echo 123")).toBeDefined();
-    const summary = screen.getByText("Completed with exit code 0");
-    const statusIcon = container.querySelector(".lucide-check");
-    expect(statusIcon?.getAttribute("aria-hidden")).toBe("true");
-    expect(statusIcon?.getAttribute("data-slot")).toBeNull();
-    expect(summary.parentElement?.lastElementChild).toBe(statusIcon);
-    expect(screen.queryByLabelText("Completed with exit code 0")).toBeNull();
+    const status = screen.getByText("backgroundJobNotifications.completed");
+    expect(status.getAttribute("data-slot")).toBe("tooltip-trigger");
+    expect(container.querySelector(".lucide-check")).toBeNull();
+    expect(screen.queryByText(fullSummary)).toBeNull();
     expect(
       screen.queryByLabelText("backgroundJobNotifications.openOutput"),
     ).toBeNull();
+
+    fireEvent.pointerMove(status, { pointerType: "mouse" });
+    await waitFor(() =>
+      expect(screen.getByRole("tooltip").textContent).toContain(fullSummary),
+    );
 
     fireEvent.click(
       screen.getByLabelText("commandExecutionPanel.terminalClosedOpenOutput"),
@@ -210,7 +224,9 @@ describe("BackgroundJobPanel job control", () => {
     expect(command?.classList.contains("truncate")).toBe(true);
     expect(command?.getAttribute("title")).toBe(longCommand);
     expect(command?.textContent).toBe(longCommand);
-    expect(screen.getByText("Completed with exit code 0")).toBeDefined();
+    expect(
+      screen.getByText("backgroundJobNotifications.completed"),
+    ).toBeDefined();
   });
 
   it("recovers the actual command when structured data contains a legacy ID", () => {
@@ -228,27 +244,38 @@ describe("BackgroundJobPanel job control", () => {
     );
 
     expect(screen.getByText(command)).toBeDefined();
-    expect(screen.getByText("Completed")).toBeDefined();
+    expect(
+      screen.getByText("backgroundJobNotifications.completed"),
+    ).toBeDefined();
     expect(screen.queryByText("bgjob-cmd-legacy")).toBeNull();
   });
 
-  it("preserves failure details from the notification summary", () => {
+  it("shows an error icon and puts failure details in the status tooltip", async () => {
     jobInfo = undefined;
+    const fullSummary =
+      'Background command "bun run build" failed: dependency unavailable';
 
-    render(
+    const { container } = render(
       <BackgroundJobPanel
         backgroundJobId="bgjob-cmd-1"
         appearance="notification"
         command="bun run build"
-        summary={
-          'Background command "bun run build" failed: dependency unavailable'
-        }
+        summary={fullSummary}
         status="failed"
         outputFile="/tmp/bgjob-cmd-1.log"
       />,
     );
 
     expect(screen.getByText("bun run build")).toBeDefined();
-    expect(screen.getByText("Failed: dependency unavailable")).toBeDefined();
+    const status = screen.getByText("backgroundJobNotifications.failedNoExit");
+    const statusIcon = container.querySelector(".lucide-x");
+    expect(statusIcon?.getAttribute("aria-hidden")).toBe("true");
+    expect(status.lastElementChild).toBe(statusIcon);
+    expect(screen.queryByText(fullSummary)).toBeNull();
+
+    fireEvent.pointerMove(status, { pointerType: "mouse" });
+    await waitFor(() =>
+      expect(screen.getByRole("tooltip").textContent).toContain(fullSummary),
+    );
   });
 });

--- a/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
@@ -166,7 +166,9 @@ describe("BackgroundJobPanel job control", () => {
 
     expect(container.querySelector(".lucide-terminal")).toBeTruthy();
     expect(screen.getByText("echo 123")).toBeDefined();
-    const status = screen.getByText("backgroundJobNotifications.completed");
+    const status = screen.getByText(
+      "backgroundJobNotifications.completedNoExit",
+    );
     expect(status.getAttribute("data-slot")).toBe("tooltip-trigger");
     expect(container.querySelector(".lucide-check")).toBeNull();
     expect(screen.queryByText(fullSummary)).toBeNull();
@@ -225,7 +227,7 @@ describe("BackgroundJobPanel job control", () => {
     expect(command?.getAttribute("title")).toBe(longCommand);
     expect(command?.textContent).toBe(longCommand);
     expect(
-      screen.getByText("backgroundJobNotifications.completed"),
+      screen.getByText("backgroundJobNotifications.completedNoExit"),
     ).toBeDefined();
   });
 
@@ -245,7 +247,7 @@ describe("BackgroundJobPanel job control", () => {
 
     expect(screen.getByText(command)).toBeDefined();
     expect(
-      screen.getByText("backgroundJobNotifications.completed"),
+      screen.getByText("backgroundJobNotifications.completedNoExit"),
     ).toBeDefined();
     expect(screen.queryByText("bgjob-cmd-legacy")).toBeNull();
   });

--- a/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BackgroundJobPanel } from "../command-execution-panel";
+
+const openBackgroundJobTerminal = vi.fn();
+const openFile = vi.fn();
+let terminals:
+  | { backgroundJobId: string; name: string; isActive: boolean }[]
+  | undefined = [];
+let jobInfo: { command: string | undefined; displayId: string } | undefined;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/features/chat", () => ({
+  useBackgroundJobInfo: () => jobInfo,
+}));
+
+vi.mock("@/lib/hooks/use-visible-terminals", () => ({
+  useVisibleTerminals: () => ({
+    terminals,
+    openBackgroundJobTerminal,
+  }),
+}));
+
+vi.mock("@/lib/vscode", () => ({
+  isVSCodeEnvironment: () => false,
+  vscodeHost: {
+    openFile: (path: string) => openFile(path),
+  },
+}));
+
+vi.mock("../xterm", () => ({
+  XTerm: () => null,
+}));
+
+const renderTerminalPanel = (outputFile?: string) =>
+  render(
+    <BackgroundJobPanel
+      backgroundJobId="term-1"
+      output="terminal output"
+      outputFile={outputFile}
+      terminalName="zsh"
+      lastCommand="ll"
+    />,
+  );
+
+const renderBackgroundJobPanel = (outputFile?: string) =>
+  render(
+    <BackgroundJobPanel
+      backgroundJobId="bgjob-cmd-1"
+      output="job output"
+      outputFile={outputFile}
+    />,
+  );
+
+describe("BackgroundJobPanel job control", () => {
+  beforeEach(() => {
+    openBackgroundJobTerminal.mockClear();
+    openFile.mockClear();
+    terminals = [];
+    jobInfo = { command: "bun run dev", displayId: "%1" };
+  });
+
+  it("opens the terminal while it is still visible", () => {
+    terminals = [{ backgroundJobId: "term-1", name: "zsh", isActive: true }];
+
+    renderTerminalPanel("/tmp/term-1.log");
+
+    fireEvent.click(
+      screen.getByLabelText("commandExecutionPanel.openTerminal"),
+    );
+    expect(openBackgroundJobTerminal).toHaveBeenCalledWith("term-1");
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it("opens the output file once the user terminal is gone", () => {
+    renderTerminalPanel("/tmp/term-1.log");
+
+    fireEvent.click(
+      screen.getByLabelText("commandExecutionPanel.terminalClosedOpenOutput"),
+    );
+    expect(openFile).toHaveBeenCalledWith("/tmp/term-1.log");
+    expect(openBackgroundJobTerminal).not.toHaveBeenCalled();
+  });
+
+  it("opens the output file once the background job terminal is gone", () => {
+    renderBackgroundJobPanel("/tmp/bgjob-cmd-1.log");
+
+    fireEvent.click(
+      screen.getByLabelText("commandExecutionPanel.terminalClosedOpenOutput"),
+    );
+    expect(openFile).toHaveBeenCalledWith("/tmp/bgjob-cmd-1.log");
+    expect(openBackgroundJobTerminal).not.toHaveBeenCalled();
+  });
+
+  it("top-aligns the display ID with a multi-line command", () => {
+    terminals = [
+      { backgroundJobId: "bgjob-cmd-1", name: "zsh", isActive: false },
+    ];
+    jobInfo = {
+      command: `bun run build ${"--filter package ".repeat(20)}`,
+      displayId: "%1",
+    };
+
+    renderBackgroundJobPanel();
+
+    const displayId = screen.getByLabelText("commandExecutionPanel.openJob");
+    expect(displayId.parentElement?.classList.contains("self-start")).toBe(
+      true,
+    );
+  });
+
+  it("keeps an inert badge when there is no output file to fall back to", () => {
+    renderTerminalPanel();
+
+    fireEvent.click(
+      screen.getByLabelText("commandExecutionPanel.terminalClosed"),
+    );
+    expect(openFile).not.toHaveBeenCalled();
+    expect(openBackgroundJobTerminal).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the terminal is closed before terminals are loaded", () => {
+    terminals = undefined;
+
+    renderTerminalPanel("/tmp/term-1.log");
+
+    expect(
+      screen.queryByLabelText("commandExecutionPanel.terminalClosed"),
+    ).toBeNull();
+    expect(
+      screen.queryByLabelText("commandExecutionPanel.openTerminal"),
+    ).toBeNull();
+  });
+
+  it("shows a terminal command followed by its lifecycle summary", () => {
+    jobInfo = undefined;
+
+    const { container } = render(
+      <BackgroundJobPanel
+        backgroundJobId="bgjob-cmd-1"
+        appearance="notification"
+        command="echo 123"
+        summary={'Background command "echo 123" completed with exit code 0'}
+        status="completed"
+        exitCode={0}
+        outputFile="/tmp/bgjob-cmd-1.log"
+      />,
+    );
+
+    expect(container.querySelector(".lucide-terminal")).toBeTruthy();
+    expect(screen.getByText("echo 123")).toBeDefined();
+    const summary = screen.getByText("Completed with exit code 0");
+    const statusIcon = container.querySelector(".lucide-check");
+    expect(statusIcon?.getAttribute("aria-hidden")).toBe("true");
+    expect(statusIcon?.getAttribute("data-slot")).toBeNull();
+    expect(summary.parentElement?.lastElementChild).toBe(statusIcon);
+    expect(screen.queryByLabelText("Completed with exit code 0")).toBeNull();
+    expect(
+      screen.queryByLabelText("backgroundJobNotifications.openOutput"),
+    ).toBeNull();
+
+    fireEvent.click(
+      screen.getByLabelText("commandExecutionPanel.terminalClosedOpenOutput"),
+    );
+    expect(openFile).toHaveBeenCalledWith("/tmp/bgjob-cmd-1.log");
+    expect(screen.queryByText("Job 1")).toBeNull();
+  });
+
+  it("opens a live background terminal from the notification terminal button", () => {
+    jobInfo = undefined;
+    terminals = [
+      { backgroundJobId: "bgjob-cmd-1", name: "zsh", isActive: false },
+    ];
+
+    render(
+      <BackgroundJobPanel
+        backgroundJobId="bgjob-cmd-1"
+        appearance="notification"
+        command="echo 123"
+        summary={'Background command "echo 123" completed with exit code 0'}
+        status="completed"
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("commandExecutionPanel.openJob"));
+    expect(openBackgroundJobTerminal).toHaveBeenCalledWith("bgjob-cmd-1");
+  });
+
+  it("truncates a long command without squeezing out its lifecycle summary", () => {
+    jobInfo = undefined;
+    const longCommand = `bun run build ${"--filter package ".repeat(20)}`;
+
+    const { container } = render(
+      <BackgroundJobPanel
+        backgroundJobId="bgjob-cmd-1"
+        appearance="notification"
+        command={longCommand}
+        summary={`Background command "${longCommand}" completed with exit code 0`}
+        status="completed"
+      />,
+    );
+
+    const command = container.querySelector("code");
+    expect(command?.classList.contains("truncate")).toBe(true);
+    expect(command?.getAttribute("title")).toBe(longCommand);
+    expect(command?.textContent).toBe(longCommand);
+    expect(screen.getByText("Completed with exit code 0")).toBeDefined();
+  });
+
+  it("recovers the actual command when structured data contains a legacy ID", () => {
+    jobInfo = undefined;
+    const command = 'sleep 5 && echo "notification completed"';
+
+    render(
+      <BackgroundJobPanel
+        backgroundJobId="bgjob-cmd-legacy"
+        appearance="notification"
+        command="bgjob-cmd-legacy"
+        summary={`Background command "${command}" completed`}
+        status="completed"
+      />,
+    );
+
+    expect(screen.getByText(command)).toBeDefined();
+    expect(screen.getByText("Completed")).toBeDefined();
+    expect(screen.queryByText("bgjob-cmd-legacy")).toBeNull();
+  });
+
+  it("preserves failure details from the notification summary", () => {
+    jobInfo = undefined;
+
+    render(
+      <BackgroundJobPanel
+        backgroundJobId="bgjob-cmd-1"
+        appearance="notification"
+        command="bun run build"
+        summary={
+          'Background command "bun run build" failed: dependency unavailable'
+        }
+        status="failed"
+        outputFile="/tmp/bgjob-cmd-1.log"
+      />,
+    );
+
+    expect(screen.getByText("bun run build")).toBeDefined();
+    expect(screen.getByText("Failed: dependency unavailable")).toBeDefined();
+  });
+});

--- a/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
@@ -147,7 +147,7 @@ describe("BackgroundJobPanel job control", () => {
     ).toBeNull();
   });
 
-  it("shows status text and exposes the full summary in a tooltip", async () => {
+  it("opens the output file from the notification row and shows its summary tooltip", async () => {
     jobInfo = undefined;
     const fullSummary =
       'Background command "echo 123" completed with exit code 0';
@@ -164,31 +164,31 @@ describe("BackgroundJobPanel job control", () => {
       />,
     );
 
-    expect(container.querySelector(".lucide-terminal")).toBeTruthy();
+    const terminalIcon = container.querySelector(".lucide-terminal");
+    const terminalControl = terminalIcon?.parentElement;
+    expect(terminalIcon?.classList.contains("size-3")).toBe(true);
+    expect(terminalControl?.classList.contains("bg-secondary")).toBe(true);
+    expect(terminalControl?.classList.contains("size-[16px]")).toBe(true);
+    expect(terminalControl?.classList.contains("h-8")).toBe(false);
+    expect(terminalControl?.classList.contains("px-3")).toBe(false);
     expect(screen.getByText("echo 123")).toBeDefined();
-    const status = screen.getByText(
-      "backgroundJobNotifications.completedNoExit",
-    );
-    expect(status.getAttribute("data-slot")).toBe("tooltip-trigger");
-    expect(container.querySelector(".lucide-check")).toBeNull();
+    expect(container.querySelector(".lucide-badge-check")).toBeNull();
+    const row = screen.getByLabelText("backgroundJobNotifications.openOutput");
+    expect(row.getAttribute("data-slot")).toBe("tooltip-trigger");
     expect(screen.queryByText(fullSummary)).toBeNull();
-    expect(
-      screen.queryByLabelText("backgroundJobNotifications.openOutput"),
-    ).toBeNull();
 
-    fireEvent.pointerMove(status, { pointerType: "mouse" });
+    fireEvent.pointerMove(row, { pointerType: "mouse" });
     await waitFor(() =>
       expect(screen.getByRole("tooltip").textContent).toContain(fullSummary),
     );
 
-    fireEvent.click(
-      screen.getByLabelText("commandExecutionPanel.terminalClosedOpenOutput"),
-    );
+    fireEvent.click(row);
     expect(openFile).toHaveBeenCalledWith("/tmp/bgjob-cmd-1.log");
+    expect(openBackgroundJobTerminal).not.toHaveBeenCalled();
     expect(screen.queryByText("Job 1")).toBeNull();
   });
 
-  it("opens a live background terminal from the notification terminal button", () => {
+  it("opens the output file from the notification row while its terminal is live", () => {
     jobInfo = undefined;
     terminals = [
       { backgroundJobId: "bgjob-cmd-1", name: "zsh", isActive: false },
@@ -201,14 +201,18 @@ describe("BackgroundJobPanel job control", () => {
         command="echo 123"
         summary={'Background command "echo 123" completed with exit code 0'}
         status="completed"
+        outputFile="/tmp/bgjob-cmd-1.log"
       />,
     );
 
-    fireEvent.click(screen.getByLabelText("commandExecutionPanel.openJob"));
-    expect(openBackgroundJobTerminal).toHaveBeenCalledWith("bgjob-cmd-1");
+    fireEvent.click(
+      screen.getByLabelText("backgroundJobNotifications.openOutput"),
+    );
+    expect(openFile).toHaveBeenCalledWith("/tmp/bgjob-cmd-1.log");
+    expect(openBackgroundJobTerminal).not.toHaveBeenCalled();
   });
 
-  it("truncates a long command without squeezing out its lifecycle summary", () => {
+  it("truncates a long notification command", () => {
     jobInfo = undefined;
     const longCommand = `bun run build ${"--filter package ".repeat(20)}`;
 
@@ -226,9 +230,6 @@ describe("BackgroundJobPanel job control", () => {
     expect(command?.classList.contains("truncate")).toBe(true);
     expect(command?.getAttribute("title")).toBe(longCommand);
     expect(command?.textContent).toBe(longCommand);
-    expect(
-      screen.getByText("backgroundJobNotifications.completedNoExit"),
-    ).toBeDefined();
   });
 
   it("recovers the actual command when structured data contains a legacy ID", () => {
@@ -246,13 +247,27 @@ describe("BackgroundJobPanel job control", () => {
     );
 
     expect(screen.getByText(command)).toBeDefined();
-    expect(
-      screen.getByText("backgroundJobNotifications.completedNoExit"),
-    ).toBeDefined();
     expect(screen.queryByText("bgjob-cmd-legacy")).toBeNull();
   });
 
-  it("shows an error icon and puts failure details in the status tooltip", async () => {
+  it("does not render a trailing status icon for a stopped notification", () => {
+    jobInfo = undefined;
+
+    const { container } = render(
+      <BackgroundJobPanel
+        backgroundJobId="bgjob-cmd-1"
+        appearance="notification"
+        command="sleep 60"
+        summary={'Background command "sleep 60" was stopped'}
+        status="stopped"
+      />,
+    );
+
+    expect(container.querySelector(".lucide-octagon")).toBeNull();
+    expect(container.querySelectorAll(".lucide-terminal")).toHaveLength(1);
+  });
+
+  it("puts failure details in the notification row tooltip without a trailing icon", async () => {
     jobInfo = undefined;
     const fullSummary =
       'Background command "bun run build" failed: dependency unavailable';
@@ -269,15 +284,11 @@ describe("BackgroundJobPanel job control", () => {
     );
 
     expect(screen.getByText("bun run build")).toBeDefined();
-    const status = screen.getByText("backgroundJobNotifications.failedNoExit");
-    const statusIcon = container.querySelector(".lucide-x");
-    expect(statusIcon?.getAttribute("aria-hidden")).toBe("true");
-    expect(status.classList.contains("text-destructive")).toBe(false);
-    expect(statusIcon?.classList.contains("text-destructive")).toBe(true);
-    expect(status.lastElementChild).toBe(statusIcon);
+    expect(container.querySelector(".lucide-triangle-alert")).toBeNull();
+    const row = screen.getByLabelText("backgroundJobNotifications.openOutput");
     expect(screen.queryByText(fullSummary)).toBeNull();
 
-    fireEvent.pointerMove(status, { pointerType: "mouse" });
+    fireEvent.pointerMove(row, { pointerType: "mouse" });
     await waitFor(() =>
       expect(screen.getByRole("tooltip").textContent).toContain(fullSummary),
     );

--- a/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
@@ -272,6 +272,8 @@ describe("BackgroundJobPanel job control", () => {
     const status = screen.getByText("backgroundJobNotifications.failedNoExit");
     const statusIcon = container.querySelector(".lucide-x");
     expect(statusIcon?.getAttribute("aria-hidden")).toBe("true");
+    expect(status.classList.contains("text-destructive")).toBe(false);
+    expect(statusIcon?.classList.contains("text-destructive")).toBe(true);
     expect(status.lastElementChild).toBe(statusIcon);
     expect(screen.queryByText(fullSummary)).toBeNull();
 

--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -22,7 +22,6 @@ import {
   CopyIcon,
   FileText,
   TerminalIcon,
-  X,
   XCircle,
 } from "lucide-react";
 import {
@@ -332,31 +331,48 @@ export const BackgroundJobPanel: FC<{
       );
 
   if (isNotification) {
+    const notificationRowClassName =
+      "group flex w-full min-w-0 items-center gap-2 rounded-sm px-1 py-1 text-left text-sm hover:bg-muted/30";
+    const notificationRowContent = (
+      <>
+        <span className="inline-flex size-[16px] shrink-0 items-center justify-center rounded-sm bg-secondary text-secondary-foreground shadow-xs ring-primary">
+          <TerminalIcon className="size-3" />
+        </span>
+        <code
+          className="min-w-0 flex-1 truncate bg-transparent p-0 font-mono text-foreground text-xs"
+          title={resolvedCommand ?? backgroundJobId}
+        >
+          {resolvedCommand ?? backgroundJobId}
+        </code>
+      </>
+    );
+    const notificationRow = outputFile ? (
+      <button
+        type="button"
+        aria-label={t("backgroundJobNotifications.openOutput")}
+        className={cn(
+          notificationRowClassName,
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        )}
+        onClick={() => vscodeHost.openFile(outputFile)}
+      >
+        {notificationRowContent}
+      </button>
+    ) : (
+      <div className={notificationRowClassName}>{notificationRowContent}</div>
+    );
+
+    if (!summary) return notificationRow;
+
     return (
-      <div className="group flex min-w-0 items-center gap-3 rounded-sm px-1 py-1 text-sm hover:bg-muted/30">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <JobControlButton
-            label={
-              isTerminalClosed
-                ? closedLabel
-                : t("commandExecutionPanel.openJob", {
-                    displayId: info?.displayId ?? backgroundJobId,
-                  })
-            }
-            inert={isTerminalClosed && !canOpenOutputFile}
-            onClick={openTerminalOrOutputFile}
-          >
-            <TerminalIcon className="size-3" />
-          </JobControlButton>
-          <code
-            className="min-w-0 flex-1 truncate bg-transparent p-0 font-mono text-foreground text-xs"
-            title={resolvedCommand ?? backgroundJobId}
-          >
-            {resolvedCommand ?? backgroundJobId}
-          </code>
-        </div>
-        {status && <NotificationStatus status={status} summary={summary} />}
-      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>{notificationRow}</TooltipTrigger>
+        <TooltipContent>
+          <span className="block max-w-sm whitespace-pre-wrap break-words">
+            {summary}
+          </span>
+        </TooltipContent>
+      </Tooltip>
     );
   }
 
@@ -410,40 +426,6 @@ function recoverNotificationCommand(
 
   return summary.slice(prefix.length, markerIndex);
 }
-
-const NotificationStatus: FC<{
-  status: "completed" | "failed" | "stopped";
-  summary?: string;
-}> = ({ status, summary }) => {
-  const { t } = useTranslation();
-  const label =
-    status === "completed"
-      ? t("backgroundJobNotifications.completedNoExit")
-      : status === "failed"
-        ? t("backgroundJobNotifications.failedNoExit")
-        : t("backgroundJobNotifications.stopped");
-  const statusContent = (
-    <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs">
-      {label}
-      {status === "failed" && (
-        <X aria-hidden="true" className="size-4 text-destructive" />
-      )}
-    </span>
-  );
-
-  if (!summary) return statusContent;
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{statusContent}</TooltipTrigger>
-      <TooltipContent>
-        <span className="block max-w-sm whitespace-pre-wrap break-words">
-          {summary}
-        </span>
-      </TooltipContent>
-    </Tooltip>
-  );
-};
 
 const BackgroundJobStatus: FC<{
   status: "completed" | "failed" | "stopped";

--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -423,16 +423,11 @@ const NotificationStatus: FC<{
         ? t("backgroundJobNotifications.failedNoExit")
         : t("backgroundJobNotifications.stopped");
   const statusContent = (
-    <span
-      className={cn(
-        "inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs",
-        {
-          "text-destructive": status === "failed",
-        },
-      )}
-    >
+    <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs">
       {label}
-      {status === "failed" && <X aria-hidden="true" className="size-4" />}
+      {status === "failed" && (
+        <X aria-hidden="true" className="size-4 text-destructive" />
+      )}
     </span>
   );
 

--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -109,61 +109,49 @@ const ToggleExpandButton: FC<{ expanded: boolean; onToggle: () => void }> = ({
   );
 };
 
-const BackgroundJobIdButton: FC<{
-  displayId: string;
+/**
+ * The badge in front of a job/terminal panel: opens the live terminal, or --
+ * once that terminal is gone -- its recorded output file.
+ */
+const JobControlButton: FC<{
+  label: string;
   isActive?: boolean;
+  /** Nothing left to open: keep the badge, drop the interaction. */
+  inert?: boolean;
   onClick: () => void;
-}> = ({ displayId, isActive, onClick }) => {
-  const { t } = useTranslation();
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
+  children: React.ReactNode;
+}> = ({ label, isActive, inert, onClick, children }) => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      {inert ? (
+        // A plain span rather than a disabled button: disabled buttons swallow
+        // pointer events, which would hide the tooltip explaining why nothing
+        // can be opened anymore.
+        <span
+          aria-label={label}
+          className="inline-flex size-[16px] shrink-0 cursor-default items-center justify-center rounded-sm bg-secondary text-muted-foreground opacity-60"
+        >
+          {children}
+        </span>
+      ) : (
         <Button
           size="sm"
+          aria-label={label}
           className={cn("size-[16px] rounded-sm ring-primary", {
             "ring-1": isActive,
           })}
           variant="secondary"
           onClick={onClick}
         >
-          <div className="font-bold font-mono text-[10px]">{displayId}</div>
+          {children}
         </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <span>{t("commandExecutionPanel.openJob", { displayId })}</span>
-      </TooltipContent>
-    </Tooltip>
-  );
-};
-
-const OpenTerminalButton: FC<{
-  name: string;
-  isActive?: boolean;
-  onClick: () => void;
-}> = ({ name, isActive, onClick }) => {
-  const { t } = useTranslation();
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          size="sm"
-          className={cn("size-[16px] rounded-sm ring-primary", {
-            "ring-1": isActive,
-          })}
-          variant="secondary"
-          onClick={onClick}
-        >
-          <TerminalIcon className="size-3" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <span>{t("commandExecutionPanel.openTerminal", { name })}</span>
-      </TooltipContent>
-    </Tooltip>
-  );
-};
+      )}
+    </TooltipTrigger>
+    <TooltipContent>
+      <span>{label}</span>
+    </TooltipContent>
+  </Tooltip>
+);
 
 export const CommandPanelContainer: FC<{
   icon: React.ReactNode;
@@ -193,9 +181,9 @@ export const CommandPanelContainer: FC<{
         <div className="flex min-w-0 flex-1 space-x-3">
           {icon}
           <ScrollArea className="max-h-[80px] min-w-0 flex-1 overflow-y-auto">
-            <span className="whitespace-pre-wrap text-balance break-all">
+            <div className="whitespace-pre-wrap text-balance break-all">
               {title}
-            </span>
+            </div>
           </ScrollArea>
         </div>
         <div
@@ -234,6 +222,8 @@ export const BackgroundJobPanel: FC<{
   appearance?: "default" | "notification";
   /** Command fallback for persisted notification messages. */
   command?: string;
+  /** Summary fallback for persisted notification messages. */
+  summary?: string;
   status?: "completed" | "failed" | "stopped";
   exitCode?: number;
   outputFile?: string;
@@ -246,6 +236,7 @@ export const BackgroundJobPanel: FC<{
   output,
   appearance = "default",
   command,
+  summary,
   status,
   exitCode,
   outputFile,
@@ -265,7 +256,13 @@ export const BackgroundJobPanel: FC<{
     () => terminals?.find((tm) => tm.backgroundJobId === backgroundJobId),
     [backgroundJobId, terminals],
   );
-  const resolvedCommand = info?.command ?? command;
+  const isNotification = appearance === "notification";
+  const recoveredNotificationCommand = isNotification
+    ? recoverNotificationCommand(summary, status)
+    : undefined;
+  const resolvedCommand = isNotification
+    ? (recoveredNotificationCommand ?? info?.command ?? command)
+    : (info?.command ?? command);
   const hasTrackedJob = Boolean(info?.command);
   const copyCommand = resolvedCommand ?? lastCommand;
   const displayTerminalName = formatTerminalDisplayName(
@@ -276,59 +273,130 @@ export const BackgroundJobPanel: FC<{
     ? (displayTerminalName ?? t("commandExecutionPanel.userTerminal"))
     : (resolvedCommand ?? backgroundJobId);
   const isActive = liveTerminal?.isActive ?? false;
-  const isNotification = appearance === "notification";
 
-  const openTerminal = useCallback(() => {
+  // Terminals closed after the read keep their badge, so the panel still reads
+  // as a terminal/job panel; the badge then falls back to the output file.
+  const isTerminalClosed = terminals !== undefined && !liveTerminal;
+  const canOpenOutputFile = isTerminalClosed && outputFile !== undefined;
+
+  const openTerminalOrOutputFile = useCallback(() => {
+    if (isTerminalClosed) {
+      if (outputFile) vscodeHost.openFile(outputFile);
+      return;
+    }
     openBackgroundJobTerminal?.(backgroundJobId);
-  }, [backgroundJobId, openBackgroundJobTerminal]);
+  }, [
+    backgroundJobId,
+    isTerminalClosed,
+    openBackgroundJobTerminal,
+    outputFile,
+  ]);
+
+  const closedLabel = canOpenOutputFile
+    ? t("commandExecutionPanel.terminalClosedOpenOutput")
+    : t("commandExecutionPanel.terminalClosed");
   const jobControl = isUserTerminal
-    ? liveTerminal && (
-        <OpenTerminalButton
-          name={liveTerminal.name}
+    ? (liveTerminal || isTerminalClosed) && (
+        <JobControlButton
+          label={
+            isTerminalClosed
+              ? closedLabel
+              : t("commandExecutionPanel.openTerminal", {
+                  name: liveTerminal?.name ?? terminalName,
+                })
+          }
           isActive={!isNotification && isActive}
-          onClick={openTerminal}
-        />
+          inert={isTerminalClosed && !canOpenOutputFile}
+          onClick={openTerminalOrOutputFile}
+        >
+          <TerminalIcon className="size-3" />
+        </JobControlButton>
       )
     : hasTrackedJob &&
       info?.displayId && (
-        <BackgroundJobIdButton
-          displayId={info.displayId}
+        <JobControlButton
+          label={
+            isTerminalClosed
+              ? closedLabel
+              : t("commandExecutionPanel.openJob", {
+                  displayId: info.displayId,
+                })
+          }
           isActive={!isNotification && isActive}
-          onClick={openTerminal}
-        />
+          inert={isTerminalClosed && !canOpenOutputFile}
+          onClick={openTerminalOrOutputFile}
+        >
+          <div className="font-bold font-mono text-[10px]">
+            {info.displayId}
+          </div>
+        </JobControlButton>
       );
 
-  return (
-    <CommandPanelContainer
-      icon={
-        ((isNotification && status) || jobControl) && (
-          <div className="flex shrink-0 items-center gap-2">
-            {isNotification && status && (
+  if (isNotification) {
+    const notificationSummary = formatNotificationSummary(
+      summary,
+      resolvedCommand,
+    );
+
+    return (
+      <div className="group flex min-w-0 items-center gap-3 rounded-sm px-1 py-1 text-sm hover:bg-muted/30">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <JobControlButton
+            label={
+              isTerminalClosed
+                ? closedLabel
+                : t("commandExecutionPanel.openJob", {
+                    displayId: info?.displayId ?? backgroundJobId,
+                  })
+            }
+            inert={isTerminalClosed && !canOpenOutputFile}
+            onClick={openTerminalOrOutputFile}
+          >
+            <TerminalIcon className="size-3" />
+          </JobControlButton>
+          <code
+            className="min-w-0 flex-1 truncate bg-transparent p-0 font-mono text-foreground text-xs"
+            title={resolvedCommand ?? backgroundJobId}
+          >
+            {resolvedCommand ?? backgroundJobId}
+          </code>
+        </div>
+        {(status || notificationSummary) && (
+          <div className="flex min-w-0 max-w-[50%] shrink-0 items-center gap-1.5">
+            {notificationSummary && (
+              <span
+                className="min-w-0 truncate text-muted-foreground text-xs"
+                title={summary}
+              >
+                {notificationSummary}
+              </span>
+            )}
+            {status && (
               <BackgroundJobStatus
                 status={status}
                 exitCode={exitCode}
                 iconOnly
               />
             )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <CommandPanelContainer
+      icon={
+        jobControl && (
+          <div className="flex shrink-0 items-center gap-2 self-start">
             {jobControl}
           </div>
         )
       }
       title={
-        <div
-          className={cn("flex items-center", {
-            "flex-nowrap gap-1.5": isNotification,
-            "flex-wrap gap-x-2 gap-y-1": !isNotification,
-          })}
-        >
-          <span
-            className={cn({
-              "min-w-0 truncate whitespace-nowrap": isNotification,
-            })}
-          >
-            {title}
-          </span>
-          {status && !isNotification && (
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span>{title}</span>
+          {status && (
             <BackgroundJobStatus status={status} exitCode={exitCode} />
           )}
         </div>
@@ -347,6 +415,38 @@ export const BackgroundJobPanel: FC<{
     />
   );
 };
+
+function recoverNotificationCommand(
+  summary: string | undefined,
+  status: "completed" | "failed" | "stopped" | undefined,
+): string | undefined {
+  const prefix = 'Background command "';
+  if (!summary?.startsWith(prefix) || !status) return undefined;
+
+  const lifecycleMarker =
+    status === "completed"
+      ? '" completed'
+      : status === "stopped"
+        ? '" was stopped'
+        : '" failed';
+  const markerIndex = summary.lastIndexOf(lifecycleMarker);
+  if (markerIndex < prefix.length) return undefined;
+
+  return summary.slice(prefix.length, markerIndex);
+}
+
+function formatNotificationSummary(
+  summary: string | undefined,
+  command: string | undefined,
+): string | undefined {
+  if (!summary || !command) return summary;
+
+  const commandPrefix = `Background command "${command}" `;
+  if (!summary.startsWith(commandPrefix)) return summary;
+
+  const conciseSummary = summary.slice(commandPrefix.length);
+  return conciseSummary.charAt(0).toUpperCase() + conciseSummary.slice(1);
+}
 
 const BackgroundJobStatus: FC<{
   status: "completed" | "failed" | "stopped";
@@ -376,16 +476,14 @@ const BackgroundJobStatus: FC<{
 
   if (iconOnly) {
     return (
-      <span className="inline-flex shrink-0 items-center">
-        <Icon
-          className={cn("size-4", {
-            "text-emerald-700 dark:text-emerald-300": status === "completed",
-            "text-error": status === "failed",
-            "text-zinc-500 dark:text-zinc-400": status === "stopped",
-          })}
-        />
-        <span className="sr-only">{label}</span>
-      </span>
+      <Icon
+        aria-hidden="true"
+        className={cn("size-4 shrink-0", {
+          "text-emerald-700 dark:text-emerald-300": status === "completed",
+          "text-error": status === "failed",
+          "text-zinc-500 dark:text-zinc-400": status === "stopped",
+        })}
+      />
     );
   }
 

--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -12,8 +12,8 @@ import { useVisibleTerminals } from "@/lib/hooks/use-visible-terminals";
 import { formatTerminalDisplayName } from "@/lib/terminal-display-name";
 import { cn } from "@/lib/utils";
 import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
+import type { TFunction } from "i18next";
 import {
-  Check,
   CheckIcon,
   ChevronsDownUpIcon,
   ChevronsUpDownIcon,
@@ -21,7 +21,6 @@ import {
   CircleStop,
   CopyIcon,
   FileText,
-  Pause,
   TerminalIcon,
   X,
   XCircle,
@@ -333,11 +332,6 @@ export const BackgroundJobPanel: FC<{
       );
 
   if (isNotification) {
-    const notificationSummary = formatNotificationSummary(
-      summary,
-      resolvedCommand,
-    );
-
     return (
       <div className="group flex min-w-0 items-center gap-3 rounded-sm px-1 py-1 text-sm hover:bg-muted/30">
         <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -361,24 +355,12 @@ export const BackgroundJobPanel: FC<{
             {resolvedCommand ?? backgroundJobId}
           </code>
         </div>
-        {(status || notificationSummary) && (
-          <div className="flex min-w-0 max-w-[50%] shrink-0 items-center gap-1.5">
-            {notificationSummary && (
-              <span
-                className="min-w-0 truncate text-muted-foreground text-xs"
-                title={summary}
-              >
-                {notificationSummary}
-              </span>
-            )}
-            {status && (
-              <BackgroundJobStatus
-                status={status}
-                exitCode={exitCode}
-                iconOnly
-              />
-            )}
-          </div>
+        {status && (
+          <NotificationStatus
+            status={status}
+            exitCode={exitCode}
+            summary={summary}
+          />
         )}
       </div>
     );
@@ -435,57 +417,53 @@ function recoverNotificationCommand(
   return summary.slice(prefix.length, markerIndex);
 }
 
-function formatNotificationSummary(
-  summary: string | undefined,
-  command: string | undefined,
-): string | undefined {
-  if (!summary || !command) return summary;
+const NotificationStatus: FC<{
+  status: "completed" | "failed" | "stopped";
+  exitCode?: number;
+  summary?: string;
+}> = ({ status, exitCode, summary }) => {
+  const { t } = useTranslation();
+  const label = getBackgroundJobStatusLabel(status, exitCode, t);
+  const statusContent = (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs",
+        {
+          "text-destructive": status === "failed",
+        },
+      )}
+    >
+      {label}
+      {status === "failed" && <X aria-hidden="true" className="size-4" />}
+    </span>
+  );
 
-  const commandPrefix = `Background command "${command}" `;
-  if (!summary.startsWith(commandPrefix)) return summary;
+  if (!summary) return statusContent;
 
-  const conciseSummary = summary.slice(commandPrefix.length);
-  return conciseSummary.charAt(0).toUpperCase() + conciseSummary.slice(1);
-}
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{statusContent}</TooltipTrigger>
+      <TooltipContent>
+        <span className="block max-w-sm whitespace-pre-wrap break-words">
+          {summary}
+        </span>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
 
 const BackgroundJobStatus: FC<{
   status: "completed" | "failed" | "stopped";
   exitCode?: number;
-  iconOnly?: boolean;
-}> = ({ status, exitCode, iconOnly = false }) => {
+}> = ({ status, exitCode }) => {
   const { t } = useTranslation();
-  const Icon = iconOnly
-    ? status === "completed"
-      ? Check
-      : status === "failed"
-        ? X
-        : Pause
-    : status === "completed"
+  const Icon =
+    status === "completed"
       ? CircleCheck
       : status === "stopped"
         ? CircleStop
         : XCircle;
-  const label =
-    status === "completed"
-      ? t("backgroundJobNotifications.completed", { exitCode: exitCode ?? 0 })
-      : status === "failed"
-        ? exitCode === undefined
-          ? t("backgroundJobNotifications.failedNoExit")
-          : t("backgroundJobNotifications.failed", { exitCode })
-        : t("backgroundJobNotifications.stopped");
-
-  if (iconOnly) {
-    return (
-      <Icon
-        aria-hidden="true"
-        className={cn("size-4 shrink-0", {
-          "text-emerald-700 dark:text-emerald-300": status === "completed",
-          "text-error": status === "failed",
-          "text-zinc-500 dark:text-zinc-400": status === "stopped",
-        })}
-      />
-    );
-  }
+  const label = getBackgroundJobStatusLabel(status, exitCode, t);
 
   return (
     <span
@@ -502,6 +480,20 @@ const BackgroundJobStatus: FC<{
     </span>
   );
 };
+
+function getBackgroundJobStatusLabel(
+  status: "completed" | "failed" | "stopped",
+  exitCode: number | undefined,
+  t: TFunction,
+): string {
+  return status === "completed"
+    ? t("backgroundJobNotifications.completed", { exitCode: exitCode ?? 0 })
+    : status === "failed"
+      ? exitCode === undefined
+        ? t("backgroundJobNotifications.failedNoExit")
+        : t("backgroundJobNotifications.failed", { exitCode })
+      : t("backgroundJobNotifications.stopped");
+}
 
 const OpenOutputFileButton: FC<{ outputFile: string }> = ({ outputFile }) => {
   const { t } = useTranslation();

--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -355,13 +355,7 @@ export const BackgroundJobPanel: FC<{
             {resolvedCommand ?? backgroundJobId}
           </code>
         </div>
-        {status && (
-          <NotificationStatus
-            status={status}
-            exitCode={exitCode}
-            summary={summary}
-          />
-        )}
+        {status && <NotificationStatus status={status} summary={summary} />}
       </div>
     );
   }
@@ -419,11 +413,15 @@ function recoverNotificationCommand(
 
 const NotificationStatus: FC<{
   status: "completed" | "failed" | "stopped";
-  exitCode?: number;
   summary?: string;
-}> = ({ status, exitCode, summary }) => {
+}> = ({ status, summary }) => {
   const { t } = useTranslation();
-  const label = getBackgroundJobStatusLabel(status, exitCode, t);
+  const label =
+    status === "completed"
+      ? t("backgroundJobNotifications.completedNoExit")
+      : status === "failed"
+        ? t("backgroundJobNotifications.failedNoExit")
+        : t("backgroundJobNotifications.stopped");
   const statusContent = (
     <span
       className={cn(

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -585,6 +585,7 @@
   "backgroundJobNotifications": {
     "title": "Notifications",
     "completed": "Completed (exit {{exitCode}})",
+    "completedNoExit": "Completed",
     "failed": "Failed (exit {{exitCode}})",
     "failedNoExit": "Failed",
     "stopped": "Stopped",

--- a/packages/vscode-webui/src/i18n/locales/en.json
+++ b/packages/vscode-webui/src/i18n/locales/en.json
@@ -520,6 +520,8 @@
     "expand": "Expand",
     "openJob": "Open Job {{displayId}}",
     "openTerminal": "Open terminal {{name}}",
+    "terminalClosed": "The terminal has been closed",
+    "terminalClosedOpenOutput": "The terminal has been closed, open its output log",
     "userTerminal": "User terminal",
     "stop": "STOP"
   },
@@ -581,9 +583,7 @@
     "diffTitle": "User Edits"
   },
   "backgroundJobNotifications": {
-    "title": "Background job notifications",
-    "notificationCount_one": "{{count}} notification",
-    "notificationCount_other": "{{count}} notifications",
+    "title": "Notifications",
     "completed": "Completed (exit {{exitCode}})",
     "failed": "Failed (exit {{exitCode}})",
     "failedNoExit": "Failed",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -514,6 +514,8 @@
     "expand": "展開",
     "openJob": "ジョブ {{displayId}} を開く",
     "openTerminal": "ターミナル {{name}} を開く",
+    "terminalClosed": "このターミナルは閉じられています",
+    "terminalClosedOpenOutput": "このターミナルは閉じられています。出力ログを開きます",
     "userTerminal": "ユーザーターミナル",
     "stop": "停止"
   },
@@ -580,9 +582,7 @@
     "diffTitle": "ユーザー編集"
   },
   "backgroundJobNotifications": {
-    "title": "バックグラウンドジョブ通知",
-    "notificationCount_one": "{{count}} 件の通知",
-    "notificationCount_other": "{{count}} 件の通知",
+    "title": "通知",
     "completed": "完了（終了コード {{exitCode}}）",
     "failed": "失敗（終了コード {{exitCode}}）",
     "failedNoExit": "失敗",

--- a/packages/vscode-webui/src/i18n/locales/jp.json
+++ b/packages/vscode-webui/src/i18n/locales/jp.json
@@ -584,6 +584,7 @@
   "backgroundJobNotifications": {
     "title": "通知",
     "completed": "完了（終了コード {{exitCode}}）",
+    "completedNoExit": "完了",
     "failed": "失敗（終了コード {{exitCode}}）",
     "failedNoExit": "失敗",
     "stopped": "停止",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -512,6 +512,8 @@
     "expand": "펼치기",
     "openJob": "작업 {{displayId}} 열기",
     "openTerminal": "터미널 {{name}} 열기",
+    "terminalClosed": "이 터미널은 닫혔습니다",
+    "terminalClosedOpenOutput": "이 터미널은 닫혔습니다. 출력 로그를 엽니다",
     "userTerminal": "사용자 터미널",
     "stop": "중지"
   },
@@ -573,9 +575,7 @@
     "diffTitle": "사용자 편집"
   },
   "backgroundJobNotifications": {
-    "title": "백그라운드 작업 알림",
-    "notificationCount_one": "알림 {{count}}개",
-    "notificationCount_other": "알림 {{count}}개",
+    "title": "알림",
     "completed": "완료됨(종료 코드 {{exitCode}})",
     "failed": "실패(종료 코드 {{exitCode}})",
     "failedNoExit": "실패",

--- a/packages/vscode-webui/src/i18n/locales/ko.json
+++ b/packages/vscode-webui/src/i18n/locales/ko.json
@@ -577,6 +577,7 @@
   "backgroundJobNotifications": {
     "title": "알림",
     "completed": "완료됨(종료 코드 {{exitCode}})",
+    "completedNoExit": "완료됨",
     "failed": "실패(종료 코드 {{exitCode}})",
     "failedNoExit": "실패",
     "stopped": "중지됨",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -512,6 +512,8 @@
     "expand": "展开",
     "openJob": "打开任务 {{displayId}}",
     "openTerminal": "打开终端 {{name}}",
+    "terminalClosed": "该终端已关闭",
+    "terminalClosedOpenOutput": "该终端已关闭，点击打开输出日志",
     "userTerminal": "用户终端",
     "stop": "停止"
   },
@@ -578,9 +580,7 @@
     "diffTitle": "用户编辑"
   },
   "backgroundJobNotifications": {
-    "title": "后台任务通知",
-    "notificationCount_one": "{{count}} 条通知",
-    "notificationCount_other": "{{count}} 条通知",
+    "title": "通知",
     "completed": "已完成（退出码 {{exitCode}}）",
     "failed": "失败（退出码 {{exitCode}}）",
     "failedNoExit": "失败",

--- a/packages/vscode-webui/src/i18n/locales/zh.json
+++ b/packages/vscode-webui/src/i18n/locales/zh.json
@@ -582,6 +582,7 @@
   "backgroundJobNotifications": {
     "title": "通知",
     "completed": "已完成（退出码 {{exitCode}}）",
+    "completedNoExit": "已完成",
     "failed": "失败（退出码 {{exitCode}}）",
     "failedNoExit": "失败",
     "stopped": "已停止",

--- a/packages/vscode-webui/src/lib/hooks/use-visible-terminals.ts
+++ b/packages/vscode-webui/src/lib/hooks/use-visible-terminals.ts
@@ -15,7 +15,9 @@ export const useVisibleTerminals = () => {
   });
 
   if (!data) {
-    return { terminals: [], openBackgroundJobTerminal: undefined };
+    // `undefined` (not `[]`) while loading, so callers can tell "not loaded
+    // yet" apart from "this terminal is gone".
+    return { terminals: undefined, openBackgroundJobTerminal: undefined };
   }
 
   return {


### PR DESCRIPTION
## Summary
- present sent and queued background-job notifications with the same compact command and lifecycle layout
- recover readable commands from legacy notification summaries and align queued notification rows with their header
- preserve terminal navigation after closure by falling back to recorded output logs
- add localized labels and focused component regression coverage

## Test plan
- [x] `bun run test src/features/tools/components/__tests__/command-execution-panel.test.tsx src/features/chat/components/queued-messages.test.tsx src/components/message/__tests__/background-job-notifications.test.tsx`
- [x] `bun check`
- [x] `git diff --check`
- [x] `bun tsc`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-7ed41eed798944e980ce26b9f9d59f67)