### PR TITLE
fix(common): require confirmation for proactive memory updates

### DIFF
--- a/packages/common/src/base/prompts/__tests__/__snapshots__/auto-memory.test.ts.snap
+++ b/packages/common/src/base/prompts/__tests__/__snapshots__/auto-memory.test.ts.snap
@@ -73,7 +73,9 @@ Memory file rules:
 - type must be one of: user, feedback, project, reference.
 - Prefer updating an existing topic file over creating a duplicate.
 
-When the user asks you to remember something, write or update the relevant topic file and update MEMORY.md. When the user asks you to forget something, remove or edit the relevant topic file and update MEMORY.md. Ask a follow-up only if the memory to remove is ambiguous.
+A background memory agent automatically reviews completed tasks and updates long-term memory when it finds durable information. Leave proactive memory capture to that agent by default. If you independently identify something worth remembering, do not update memory unless you first ask the user and receive explicit confirmation.
+
+A direct user request to remember or forget something already counts as confirmation. When the user asks you to remember something, write or update the relevant topic file and update MEMORY.md. When the user asks you to forget something, remove or edit the relevant topic file and update MEMORY.md. Ask a follow-up only if the memory to remove is ambiguous.
 
 The long-term memory directory is an explicit exception to the normal relative-path tool rule. You may use the absolute paths above when reading or writing memory files.
 

--- a/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
+++ b/packages/common/src/base/prompts/__tests__/auto-memory.test.ts
@@ -71,6 +71,15 @@ describe("long-term memory prompt helpers", () => {
     expect(staticPrompt).toContain(
       "delivered separately as its own system reminder",
     );
+    expect(staticPrompt).toContain(
+      "A background memory agent automatically reviews completed tasks",
+    );
+    expect(staticPrompt).toContain(
+      "do not update memory unless you first ask the user and receive explicit confirmation",
+    );
+    expect(staticPrompt).toContain(
+      "A direct user request to remember or forget something already counts as confirmation",
+    );
   });
 
   it("dynamic prompt renders the live MEMORY.md index inline", () => {

--- a/packages/common/src/base/prompts/auto-memory.ts
+++ b/packages/common/src/base/prompts/auto-memory.ts
@@ -134,7 +134,9 @@ Memory file rules:
 - type must be one of: user, feedback, project, reference.
 - Prefer updating an existing topic file over creating a duplicate.
 
-When the user asks you to remember something, write or update the relevant topic file and update MEMORY.md. When the user asks you to forget something, remove or edit the relevant topic file and update MEMORY.md. Ask a follow-up only if the memory to remove is ambiguous.
+A background memory agent automatically reviews completed tasks and updates long-term memory when it finds durable information. Leave proactive memory capture to that agent by default. If you independently identify something worth remembering, do not update memory unless you first ask the user and receive explicit confirmation.
+
+A direct user request to remember or forget something already counts as confirmation. When the user asks you to remember something, write or update the relevant topic file and update MEMORY.md. When the user asks you to forget something, remove or edit the relevant topic file and update MEMORY.md. Ask a follow-up only if the memory to remove is ambiguous.
 
 The long-term memory directory is an explicit exception to the normal relative-path tool rule. You may use the absolute paths above when reading or writing memory files.
 


### PR DESCRIPTION
## Summary
- tell foreground agents that the background memory agent automatically captures durable information
- require explicit user confirmation before a foreground agent proactively updates memory
- preserve direct remember and forget requests as confirmation, with prompt assertions and snapshots

## Test plan
- [x] Run the auto-memory prompt tests
- [x] Run `bun check`
- [x] Run `bun tsc`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9346af82cf554ebba192f1be540075fb)