### PR TITLE
fix(vscode): avoid UTF-8 marker in Ctrl+C logs

### DIFF
--- a/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
@@ -258,6 +258,43 @@ describe("TerminalJob", () => {
     assert.strictEqual(harness.finishEvents[0]?.status, "stopped");
   });
 
+  it("discards an interrupted UTF-8 marker before Ctrl+C output", async () => {
+    let finishOutput: (() => void) | undefined;
+    const outputStopped = new Promise<void>((resolve) => {
+      finishOutput = resolve;
+    });
+    const harness = createHarness({
+      read: async function* () {
+        yield "ready\uFFFD";
+        yield "^";
+        yield "C";
+        await outputStopped;
+      },
+    });
+
+    await flushPromises();
+    assert.deepStrictEqual(harness.lifecycle, [
+      "output:$ sleep 10\n",
+      "output:ready",
+    ]);
+
+    harness.executionEndEmitter.fire({
+      execution: harness.execution,
+      exitCode: 130,
+    });
+    finishOutput?.();
+    await flushPromises();
+    await flushPromises();
+
+    assert.deepStrictEqual(harness.lifecycle, [
+      "output:$ sleep 10\n",
+      "output:ready",
+      "output:^C",
+      "file-closed",
+      "event-fired",
+    ]);
+  });
+
   it("preserves a trailing replacement character after normal completion", async () => {
     const harness = createHarness({
       read: async function* () {

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -59,7 +59,7 @@ export class TerminalJob implements vscode.Disposable {
   private exitCode: number | undefined;
   private stopRequested = false;
   private finished = false;
-  private outputStreamFinished: Promise<void> | undefined;
+  private outputStreamFinished: Promise<string> | undefined;
 
   readonly id: string;
   readonly outputFile: string;
@@ -157,7 +157,15 @@ export class TerminalJob implements vscode.Disposable {
       }
     } finally {
       try {
-        await this.outputStreamFinished;
+        const pendingTerminalSuffix = (await this.outputStreamFinished) ?? "";
+        const finalSuffix =
+          this.stopRequested || this.exitCode === 130
+            ? pendingTerminalSuffix.replace(/\uFFFD+/u, "")
+            : pendingTerminalSuffix;
+        if (finalSuffix.length > 0) {
+          await this.outputWriter.append(finalSuffix);
+          this.outputManager.addChunk(finalSuffix);
+        }
       } catch (outputError) {
         executionError = ExecutionError.create(
           outputError instanceof Error
@@ -224,19 +232,20 @@ export class TerminalJob implements vscode.Disposable {
    */
   private async processOutputStream(
     outputStream: AsyncIterable<string>,
-  ): Promise<void> {
+  ): Promise<string> {
     const sanitizer = new PlainOutputSanitizer();
-    let pendingReplacementCharacters = "";
+    let pendingTerminalSuffix = "";
     const appendPlainText = async (plainText: string) => {
       if (plainText.length === 0) return;
 
-      const text = pendingReplacementCharacters + plainText;
-      const trailingReplacements = text.match(/\uFFFD+$/u)?.[0] ?? "";
+      const text = pendingTerminalSuffix + plainText;
+      const trailingTerminalSuffix =
+        text.match(/\uFFFD+(?:\^C(?:\r?\n)?|\^)?$/u)?.[0] ?? "";
       const completeText = text.slice(
         0,
-        text.length - trailingReplacements.length,
+        text.length - trailingTerminalSuffix.length,
       );
-      pendingReplacementCharacters = trailingReplacements;
+      pendingTerminalSuffix = trailingTerminalSuffix;
       if (completeText.length === 0) return;
 
       await this.outputWriter.append(completeText);
@@ -249,14 +258,10 @@ export class TerminalJob implements vscode.Disposable {
     await appendPlainText(sanitizer.end());
 
     // VS Code exposes terminal output as decoded strings, so the original
-    // bytes are unavailable here. If terminal disposal interrupted a UTF-8
-    // sequence, its decoder can leave U+FFFD at the very end of the stream.
-    // Hold that trailing marker until completion and discard it only when the
-    // job was stopped. A naturally completed job still preserves U+FFFD.
-    if (!this.stopRequested && pendingReplacementCharacters.length > 0) {
-      await this.outputWriter.append(pendingReplacementCharacters);
-      this.outputManager.addChunk(pendingReplacementCharacters);
-    }
+    // bytes are unavailable here. Keep a trailing U+FFFD and an optional ^C
+    // marker buffered until the execution result identifies an interrupted
+    // command. Normal completion still preserves legitimate replacement text.
+    return pendingTerminalSuffix;
   }
 
   /**


### PR DESCRIPTION
## Summary
- buffer a trailing UTF-8 replacement marker together with split Ctrl+C output until the terminal exit result is known
- discard only the spurious marker for interrupted jobs while preserving Ctrl+C and legitimate replacement text
- add a regression test covering the marker, caret, and C arriving in separate chunks

## Test plan
- [x] Run the VS Code test suite (217 passing)
- [x] Run bun check
- [x] Run bun tsc
- [x] Run git diff --check

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5c0618e35a7548d2b206bfabb7feefae)