### PR TITLE
fix(vscode): retain Ctrl+C terminal cleanup suffix

### DIFF
--- a/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
@@ -267,7 +267,8 @@ describe("TerminalJob", () => {
       read: async function* () {
         yield "ready\uFFFD";
         yield "^";
-        yield "C";
+        yield "C\r\n";
+        yield "   \r\r";
         await outputStopped;
       },
     });
@@ -289,7 +290,7 @@ describe("TerminalJob", () => {
     assert.deepStrictEqual(harness.lifecycle, [
       "output:$ sleep 10\n",
       "output:ready",
-      "output:^C",
+      "output:^C\r\n   \r\r",
       "file-closed",
       "event-fired",
     ]);

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -240,7 +240,7 @@ export class TerminalJob implements vscode.Disposable {
 
       const text = pendingTerminalSuffix + plainText;
       const trailingTerminalSuffix =
-        text.match(/\uFFFD+(?:\^C(?:\r?\n)?|\^)?$/u)?.[0] ?? "";
+        text.match(/\uFFFD+(?:\^C[ \t\r\n]*|\^)?$/u)?.[0] ?? "";
       const completeText = text.slice(
         0,
         text.length - trailingTerminalSuffix.length,
@@ -258,9 +258,10 @@ export class TerminalJob implements vscode.Disposable {
     await appendPlainText(sanitizer.end());
 
     // VS Code exposes terminal output as decoded strings, so the original
-    // bytes are unavailable here. Keep a trailing U+FFFD and an optional ^C
-    // marker buffered until the execution result identifies an interrupted
-    // command. Normal completion still preserves legitimate replacement text.
+    // bytes are unavailable here. Keep a trailing U+FFFD, an optional ^C, and
+    // the terminal's trailing line-cleanup whitespace buffered until the
+    // execution result identifies an interrupted command. Normal completion
+    // still preserves legitimate replacement text.
     return pendingTerminalSuffix;
   }
 


### PR DESCRIPTION
## Summary
- keep interrupted UTF-8 replacement markers buffered across Ctrl+C terminal cleanup whitespace
- remove the spurious marker after exit code 130 while preserving the terminal's `^C` and cleanup output
- cover split Ctrl+C output followed by spaces and carriage returns

## Test plan
- [x] `bun run test -- --grep \"interrupted UTF-8 marker\"` from `packages/vscode`
- [x] `bun run test` from `packages/vscode` (217 passing)
- [x] `bun check`
- [x] `bun tsc`
- [x] `git diff --check`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5c0618e35a7548d2b206bfabb7feefae)