### PR TITLE
fix(webhooks): include subtasks in delivery scan

### DIFF
--- a/packages/livekit-cf/src/do/livestore-client/do.ts
+++ b/packages/livekit-cf/src/do/livestore-client/do.ts
@@ -105,7 +105,7 @@ export class LiveStoreClientDO
     await this.getStore();
     // // Make sure to only subscribe once
     // if (this.storeSubscription === undefined) {
-    //   this.storeSubscription = store.subscribe(catalog.queries.tasks$, {
+    //   this.storeSubscription = store.subscribe(catalog.queries.allTasks$, {
     //     // FIXME(meng): implement this with store.events stream when it's ready
     //     onUpdate: (tasks) => this.onTasksUpdateThrottled.call(tasks),
     //   });
@@ -126,7 +126,7 @@ export class LiveStoreClientDO
 
   private onTasksUpdate = async (force?: boolean) => {
     const store = await this.getStore();
-    const tasks = store.query(catalog.queries.tasks$);
+    const tasks = store.query(catalog.queries.allTasks$);
     const oneMinuteAgo = moment().subtract(1, "minute");
 
     const updatedTasks = tasks.filter(

--- a/packages/livekit/src/livestore/default-queries.test.ts
+++ b/packages/livekit/src/livestore/default-queries.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { allTasks$, tasks$ } from "./default-queries";
+
+describe("task queries", () => {
+  it("keeps the task-list query scoped to root tasks", () => {
+    expect(tasks$.hash).toContain('.where("parentId", "=", null)');
+  });
+
+  it("does not exclude child tasks from the all-tasks query", () => {
+    expect(allTasks$.hash).not.toContain("parentId");
+  });
+});

--- a/packages/livekit/src/livestore/default-queries.ts
+++ b/packages/livekit/src/livestore/default-queries.ts
@@ -24,6 +24,13 @@ export const tasks$ = queryDb(
   },
 );
 
+export const allTasks$ = queryDb(
+  () => tables.tasks.orderBy("createdAt", "desc"),
+  {
+    label: "allTasks",
+  },
+);
+
 export const makeSubTaskQuery = (taskId: string) =>
   queryDb(() => tables.tasks.where("parentId", "=", taskId), {
     label: "subTasks",


### PR DESCRIPTION
## Summary

- keep the existing root-task query used by task-list consumers
- add an all-task query for webhook delivery
- include updated subtasks in the Cloudflare webhook scan so their real
  `parentId` reaches the existing payload serializer
- add a regression that pins root-only and all-task query semantics separately

Fixes #1663

## Root cause

The webhook path reused `tasks$`, which intentionally filters
`parentId = null`. Child rows were therefore excluded before payload
serialization; changing the serializer alone could not repair the behavior.

## Test plan

- LiveKit package test suite (`142 passed`)
- TypeScript checks for `packages/livekit` and `packages/livekit-cf`
- Biome check for all modified files
- `git diff --check`

## Boundary

No database schema or webhook payload contract changes. The patch only changes
which recently updated task rows are eligible for webhook delivery. The local
pre-push script also requires Bun, which is unavailable on this workstation;
the focused suites above passed and the upstream CI remains the full-repository
gate.
