### PR TITLE
fix(chat): deliver background job notifications at step boundaries

### DIFF
--- a/packages/cli/src/lib/__tests__/background-job-notification-delivery.test.ts
+++ b/packages/cli/src/lib/__tests__/background-job-notification-delivery.test.ts
@@ -1,0 +1,98 @@
+import type { BackgroundJobTerminalEvent } from "@getpochi/common";
+import type { Message } from "@getpochi/livekit";
+import { describe, expect, it } from "vitest";
+import {
+  deliverBackgroundJobNotifications,
+  takeBackgroundJobNotificationMessage,
+} from "../background-job-notification-delivery";
+
+describe("takeBackgroundJobNotificationMessage", () => {
+  it("drains every pending event into one message", () => {
+    const pending = [event("bgjob-cmd-1"), event("bgjob-cmd-2")];
+
+    const message = takeBackgroundJobNotificationMessage(pending);
+
+    expect(pending).toHaveLength(0);
+    expect(message?.parts).toHaveLength(2);
+  });
+
+  it("returns nothing when no job finished", () => {
+    expect(takeBackgroundJobNotificationMessage([])).toBeUndefined();
+  });
+});
+
+describe("deliverBackgroundJobNotifications", () => {
+  it("delivers at a step boundary that continues the loop", () => {
+    const pending = [event("bgjob-cmd-1")];
+    const chat = fakeChat();
+
+    const delivered = deliverBackgroundJobNotifications("next", pending, chat);
+
+    expect(delivered).toBe(true);
+    expect(chat.messages).toHaveLength(1);
+    expect(chat.messages[0].role).toBe("user");
+    expect(chat.messages[0].parts).toEqual([
+      expect.objectContaining({
+        type: "data-background-job-notification",
+        data: expect.objectContaining({ backgroundJobId: "bgjob-cmd-1" }),
+      }),
+    ]);
+    // Drained, so the drain at the end of the task does not repeat it.
+    expect(pending).toHaveLength(0);
+  });
+
+  it("delivers nothing when no job finished during the step", () => {
+    const chat = fakeChat();
+
+    expect(deliverBackgroundJobNotifications("next", [], chat)).toBe(false);
+    expect(chat.messages).toHaveLength(0);
+  });
+
+  it("keeps notifications pending while the step is retried", () => {
+    const pending = [event("bgjob-cmd-1")];
+    const chat = fakeChat();
+
+    const delivered = deliverBackgroundJobNotifications("retry", pending, chat);
+
+    expect(delivered).toBe(false);
+    expect(chat.messages).toHaveLength(0);
+    expect(pending).toHaveLength(1);
+  });
+
+  it("leaves the finished step to drain notifications itself", () => {
+    const pending = [event("bgjob-cmd-1")];
+    const chat = fakeChat();
+
+    const delivered = deliverBackgroundJobNotifications(
+      "finished",
+      pending,
+      chat,
+    );
+
+    expect(delivered).toBe(false);
+    expect(chat.messages).toHaveLength(0);
+    expect(pending).toHaveLength(1);
+  });
+});
+
+function fakeChat() {
+  const messages: Message[] = [];
+  return {
+    messages,
+    appendOrReplaceMessage(message: Message) {
+      messages.push(message);
+    },
+  };
+}
+
+function event(backgroundJobId: string): BackgroundJobTerminalEvent {
+  return {
+    taskId: "task-1",
+    backgroundJobId,
+    outputFile: `/tmp/${backgroundJobId}.log`,
+    status: "completed",
+    command: `run ${backgroundJobId}`,
+    exitCode: 0,
+    finishedAt: 1,
+  };
+}

--- a/packages/cli/src/lib/background-job-notification-delivery.ts
+++ b/packages/cli/src/lib/background-job-notification-delivery.ts
@@ -1,0 +1,54 @@
+import type { BackgroundJobTerminalEvent } from "@getpochi/common";
+import {
+  type Message,
+  createBackgroundJobNotificationMessage,
+} from "@getpochi/livekit";
+
+export type StepResult = "finished" | "next" | "retry";
+
+export interface BackgroundJobNotificationTarget {
+  appendOrReplaceMessage(message: Message): void;
+}
+
+/**
+ * Drains every pending background job event into a single user message.
+ *
+ * The pending list is emptied, so a notification is never delivered twice.
+ */
+export function takeBackgroundJobNotificationMessage(
+  pending: BackgroundJobTerminalEvent[],
+): Message | undefined {
+  const events = pending.splice(0);
+  return events.length > 0
+    ? createBackgroundJobNotificationMessage(events)
+    : undefined;
+}
+
+/**
+ * Delivers background jobs that finished while the step loop was running as
+ * part of the continuation request the loop is about to send.
+ *
+ * Without this the model only learns about them once the whole task ends,
+ * which is both slow and often too late to be actionable. Riding along with
+ * the continuation keeps the request count unchanged.
+ */
+export function deliverBackgroundJobNotifications(
+  stepResult: StepResult,
+  pending: BackgroundJobTerminalEvent[],
+  chat: BackgroundJobNotificationTarget,
+): boolean {
+  // "retry" resends the last message as is, so injecting a notification would
+  // change what is being retried. "finished" drains separately because it also
+  // has to decide whether one more step is needed.
+  if (stepResult !== "next") {
+    return false;
+  }
+
+  const message = takeBackgroundJobNotificationMessage(pending);
+  if (!message) {
+    return false;
+  }
+
+  chat.appendOrReplaceMessage(message);
+  return true;
+}

--- a/packages/cli/src/lib/background-job-notification-delivery.ts
+++ b/packages/cli/src/lib/background-job-notification-delivery.ts
@@ -10,10 +10,7 @@ export interface BackgroundJobNotificationTarget {
   appendOrReplaceMessage(message: Message): void;
 }
 
-/**
- * Drains every pending event into one user message, so a notification is
- * never delivered twice.
- */
+/** Drains the pending events into one message. */
 export function takeBackgroundJobNotificationMessage(
   pending: BackgroundJobTerminalEvent[],
 ): Message | undefined {
@@ -23,10 +20,7 @@ export function takeBackgroundJobNotificationMessage(
     : undefined;
 }
 
-/**
- * Delivers jobs that finished mid loop as part of the continuation request
- * the loop is about to send, instead of only when the task ends.
- */
+/** Delivers jobs that finished mid loop with the next continuation request. */
 export function deliverBackgroundJobNotifications(
   stepResult: StepResult,
   pending: BackgroundJobTerminalEvent[],

--- a/packages/cli/src/lib/background-job-notification-delivery.ts
+++ b/packages/cli/src/lib/background-job-notification-delivery.ts
@@ -11,9 +11,8 @@ export interface BackgroundJobNotificationTarget {
 }
 
 /**
- * Drains every pending background job event into a single user message.
- *
- * The pending list is emptied, so a notification is never delivered twice.
+ * Drains every pending event into one user message, so a notification is
+ * never delivered twice.
  */
 export function takeBackgroundJobNotificationMessage(
   pending: BackgroundJobTerminalEvent[],
@@ -25,21 +24,15 @@ export function takeBackgroundJobNotificationMessage(
 }
 
 /**
- * Delivers background jobs that finished while the step loop was running as
- * part of the continuation request the loop is about to send.
- *
- * Without this the model only learns about them once the whole task ends,
- * which is both slow and often too late to be actionable. Riding along with
- * the continuation keeps the request count unchanged.
+ * Delivers jobs that finished mid loop as part of the continuation request
+ * the loop is about to send, instead of only when the task ends.
  */
 export function deliverBackgroundJobNotifications(
   stepResult: StepResult,
   pending: BackgroundJobTerminalEvent[],
   chat: BackgroundJobNotificationTarget,
 ): boolean {
-  // "retry" resends the last message as is, so injecting a notification would
-  // change what is being retried. "finished" drains separately because it also
-  // has to decide whether one more step is needed.
+  // "retry" resends the last message as is, and "finished" has its own drain.
   if (stepResult !== "next") {
     return false;
   }

--- a/packages/cli/src/task-runner.ts
+++ b/packages/cli/src/task-runner.ts
@@ -35,7 +35,6 @@ import {
   type LiveKitStore,
   type Message,
   type Task,
-  createBackgroundJobNotificationMessage,
   processContentOutput,
 } from "@getpochi/livekit";
 import { LiveChatKit } from "@getpochi/livekit/node";
@@ -61,6 +60,10 @@ import {
 } from "ai";
 import type z from "zod";
 import { BackgroundJobManager } from "./lib/background-job-manager";
+import {
+  deliverBackgroundJobNotifications,
+  takeBackgroundJobNotificationMessage,
+} from "./lib/background-job-notification-delivery";
 import type { FileSystem } from "./lib/file-system";
 import { readEnvironment } from "./lib/read-environment";
 import { createSpinner } from "./lib/spinner";
@@ -460,10 +463,9 @@ export class TaskRunner {
   }
 
   private takePendingBackgroundJobNotifications(): Message | undefined {
-    const events = this.pendingBackgroundJobNotifications.splice(0);
-    return events.length > 0
-      ? createBackgroundJobNotificationMessage(events)
-      : undefined;
+    return takeBackgroundJobNotificationMessage(
+      this.pendingBackgroundJobNotifications,
+    );
   }
 
   /**
@@ -537,6 +539,13 @@ export class TaskRunner {
     if (result === "retry") {
       this.stepCount.throwIfReachedMaxRetries();
     }
+
+    // Deliver at this step boundary instead of waiting for the task to end.
+    deliverBackgroundJobNotifications(
+      result,
+      this.pendingBackgroundJobNotifications,
+      this.chat,
+    );
 
     this.abortSignal?.throwIfAborted();
     await this.chatKit.chat.sendMessage();

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.test.tsx
@@ -1,18 +1,38 @@
+import type { BackgroundJobNotification } from "@getpochi/common";
 import type { Message, Task } from "@getpochi/livekit";
 import type { Todo } from "@getpochi/tools";
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatToolbar } from "./chat-toolbar";
 
-const chatSubmitMocks = vi.hoisted(() => ({
-  useChatSubmit: vi.fn(() => ({
-    handleSubmit: vi.fn(),
-    handleSteerSubmit: vi.fn(),
-    handleSteerQueuedMessage: vi.fn(),
-    handleStop: vi.fn(),
-    pauseQueueRef: { current: false },
-  })),
+const chatSubmitMocks = vi.hoisted(() => {
+  const sendQueuedMessage = vi.fn(() => Promise.resolve(true));
+  const setQueuedMessages = {
+    current: undefined as
+      | React.Dispatch<React.SetStateAction<unknown[]>>
+      | undefined,
+  };
+  return {
+    sendQueuedMessage,
+    setQueuedMessages,
+    useChatSubmit: vi.fn((props: { setQueuedMessages: unknown }) => {
+      setQueuedMessages.current = props.setQueuedMessages as React.Dispatch<
+        React.SetStateAction<unknown[]>
+      >;
+      return {
+        handleSubmit: vi.fn(),
+        handleSteerSubmit: vi.fn(),
+        handleSteerQueuedMessage: vi.fn(),
+        handleStop: vi.fn(),
+        sendQueuedMessage,
+      };
+    }),
+  };
+});
+const backgroundJobMocks = vi.hoisted(() => ({
+  notifications: [] as unknown[],
+  acknowledge: vi.fn(() => Promise.resolve()),
 }));
 const userEditsMocks = vi.hoisted(() => ({
   userEdits: [] as Array<{
@@ -105,8 +125,8 @@ vi.mock("@/lib/hooks/use-add-complete-tool-calls", () => ({
 }));
 vi.mock("@/lib/hooks/use-background-job-notifications", () => ({
   useBackgroundJobNotifications: () => ({
-    notifications: [],
-    acknowledge: undefined,
+    notifications: backgroundJobMocks.notifications,
+    acknowledge: backgroundJobMocks.acknowledge,
   }),
 }));
 vi.mock("@/lib/hooks/use-custom-agents", () => ({
@@ -189,7 +209,11 @@ const auditTodo: Todo = {
   priority: "medium",
 };
 
-function renderToolbar(isSubTask: boolean, lastCheckpointHash?: string) {
+function renderToolbar(
+  isSubTask: boolean,
+  lastCheckpointHash?: string,
+  deliverBackgroundJobNotificationsRef?: React.RefObject<() => boolean>,
+) {
   render(
     <ChatToolbar
       chat={
@@ -229,13 +253,33 @@ function renderToolbar(isSubTask: boolean, lastCheckpointHash?: string) {
       todoPaused={false}
       onTodoPausedChange={vi.fn()}
       taskId="task-1"
+      deliverBackgroundJobNotificationsRef={
+        deliverBackgroundJobNotificationsRef
+      }
     />,
   );
+}
+
+function notification(backgroundJobId: string): BackgroundJobNotification {
+  return {
+    notificationId: `${backgroundJobId}:terminal`,
+    backgroundJobId,
+    outputFile: `/tmp/${backgroundJobId}.log`,
+    command: `run ${backgroundJobId}`,
+    status: "completed",
+    summary: `Background command "${backgroundJobId}" completed`,
+    exitCode: 0,
+    finishedAt: 1,
+  };
 }
 
 describe("ChatToolbar", () => {
   beforeEach(() => {
     chatSubmitMocks.useChatSubmit.mockClear();
+    chatSubmitMocks.sendQueuedMessage.mockClear();
+    chatSubmitMocks.setQueuedMessages.current = undefined;
+    backgroundJobMocks.notifications = [];
+    backgroundJobMocks.acknowledge.mockClear();
     userEditsMocks.userEdits = [];
   });
 
@@ -300,5 +344,88 @@ describe("ChatToolbar", () => {
         clearTerminalContextSelections: expect.any(Function),
       }),
     );
+  });
+
+  describe("background job notification delivery", () => {
+    it("sends a queued notification instead of a plain continuation", async () => {
+      backgroundJobMocks.notifications = [notification("bgjob-cmd-1")];
+      const deliverRef: React.RefObject<() => boolean> = {
+        current: () => false,
+      };
+
+      renderToolbar(false, undefined, deliverRef);
+
+      let delivered: boolean | undefined;
+      await act(async () => {
+        delivered = deliverRef.current();
+      });
+
+      expect(delivered).toBe(true);
+      // The guard is kept so an intentional manual approval mode is not
+      // silently turned into auto approve by a notification.
+      expect(chatSubmitMocks.sendQueuedMessage).toHaveBeenCalledWith(0, {
+        keepAutoApproveGuard: true,
+      });
+    });
+
+    it("delivers nothing when no notification is queued", async () => {
+      const deliverRef: React.RefObject<() => boolean> = {
+        current: () => false,
+      };
+
+      renderToolbar(false, undefined, deliverRef);
+
+      let delivered: boolean | undefined;
+      await act(async () => {
+        delivered = deliverRef.current();
+      });
+
+      expect(delivered).toBe(false);
+      expect(chatSubmitMocks.sendQueuedMessage).not.toHaveBeenCalled();
+    });
+
+    it("delivers nothing while a queued user message is ahead of the notification", async () => {
+      backgroundJobMocks.notifications = [notification("bgjob-cmd-1")];
+      const deliverRef: React.RefObject<() => boolean> = {
+        current: () => false,
+      };
+
+      renderToolbar(false, undefined, deliverRef);
+
+      await act(async () => {
+        chatSubmitMocks.setQueuedMessages.current?.((current) => [
+          { parts: [{ type: "text", text: "hello" }], raw: { text: "hello" } },
+          ...current,
+        ]);
+      });
+
+      let delivered: boolean | undefined;
+      await act(async () => {
+        delivered = deliverRef.current();
+      });
+
+      expect(delivered).toBe(false);
+      expect(chatSubmitMocks.sendQueuedMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not send the same notification twice when the decision is evaluated again", async () => {
+      backgroundJobMocks.notifications = [notification("bgjob-cmd-1")];
+      const deliverRef: React.RefObject<() => boolean> = {
+        current: () => false,
+      };
+
+      renderToolbar(false, undefined, deliverRef);
+
+      let second: boolean | undefined;
+      await act(async () => {
+        deliverRef.current();
+        second = deliverRef.current();
+      });
+
+      // Still true: the pending delivery starts the next request, so the caller
+      // must not start a plain continuation on top of it.
+      expect(second).toBe(true);
+      expect(chatSubmitMocks.sendQueuedMessage).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -61,6 +61,7 @@ import { useTerminalContextState } from "../hooks/use-terminal-context-state";
 import {
   enqueueBackgroundJobNotifications,
   getBackgroundJobNotificationIds,
+  getDeliverableBackgroundJobNotificationIndex,
 } from "../lib/background-job-notification-queue";
 import { ChatInputForm, type ChatInputFormHandle } from "./chat-input-form";
 import { ErrorMessageView } from "./error-message-view";
@@ -95,6 +96,14 @@ interface ChatToolbarProps {
   isRepairingMermaid?: boolean;
   mcpConfigOverride?: McpConfigOverride;
   getSystemPrompt?: () => string | undefined;
+  /**
+   * Registration slot for the mid-loop background job notification delivery.
+   *
+   * The queue lives in this component while the automatic continuation
+   * decision lives in the page, so the page hands down a ref that is filled in
+   * with a callback it can invoke at a step boundary.
+   */
+  deliverBackgroundJobNotificationsRef?: React.RefObject<() => boolean>;
   onToolCallApprovalVisible?: () => void;
   onToolsExecutionStarted?: () => void;
   onToolsExecutionEnded?: () => void;
@@ -121,6 +130,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
   isRepairingMermaid = false,
   mcpConfigOverride,
   getSystemPrompt,
+  deliverBackgroundJobNotificationsRef,
   onToolCallApprovalVisible,
   onToolsExecutionStarted,
   onToolsExecutionEnded,
@@ -309,6 +319,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     handleSteerSubmit,
     handleSteerQueuedMessage,
     handleStop,
+    sendQueuedMessage,
   } = useChatSubmit({
     chat,
     input,
@@ -343,6 +354,42 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
       }
     },
   });
+
+  // Identity of the last dispatched notification entry. It keeps a second
+  // evaluation of the same continuation decision from sending the entry twice
+  // while the queue state update is still pending.
+  const deliveredNotificationsRef = useRef<DraftMessage>(undefined);
+
+  /**
+   * Delivers pending background job notifications as the next request instead
+   * of waiting for the task to become idle. Returns true when the caller must
+   * not start its own request, because this delivery already starts one.
+   */
+  const deliverBackgroundJobNotifications = useCallback(() => {
+    const index = getDeliverableBackgroundJobNotificationIndex(queuedMessages);
+    if (index === undefined) {
+      return false;
+    }
+
+    const message = queuedMessages[index];
+    if (deliveredNotificationsRef.current === message) {
+      return true;
+    }
+    deliveredNotificationsRef.current = message;
+
+    // Deferred to a microtask, so the send starts from the same place the SDK
+    // would have started its own automatic continuation instead of re-entering
+    // it while it is still applying the tool output.
+    void Promise.resolve().then(() =>
+      sendQueuedMessage(index, { keepAutoApproveGuard: true }),
+    );
+    return true;
+  }, [queuedMessages, sendQueuedMessage]);
+
+  if (deliverBackgroundJobNotificationsRef) {
+    deliverBackgroundJobNotificationsRef.current =
+      deliverBackgroundJobNotifications;
+  }
 
   const chatInputFormRef = useRef<ChatInputFormHandle>(null);
   const handleCurrentInputSubmit = useCallback(async () => {

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -96,13 +96,7 @@ interface ChatToolbarProps {
   isRepairingMermaid?: boolean;
   mcpConfigOverride?: McpConfigOverride;
   getSystemPrompt?: () => string | undefined;
-  /**
-   * Registration slot for the mid-loop background job notification delivery.
-   *
-   * The queue lives in this component while the automatic continuation
-   * decision lives in the page, so the page hands down a ref that is filled in
-   * with a callback it can invoke at a step boundary.
-   */
+  /** Filled in with the delivery callback, for the page to call at a step boundary. */
   deliverBackgroundJobNotificationsRef?: React.RefObject<() => boolean>;
   onToolCallApprovalVisible?: () => void;
   onToolsExecutionStarted?: () => void;
@@ -355,15 +349,14 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     },
   });
 
-  // Identity of the last dispatched notification entry. It keeps a second
-  // evaluation of the same continuation decision from sending the entry twice
+  // Last dispatched entry, so a re-evaluated decision does not send it twice
   // while the queue state update is still pending.
   const deliveredNotificationsRef = useRef<DraftMessage>(undefined);
 
   /**
-   * Delivers pending background job notifications as the next request instead
-   * of waiting for the task to become idle. Returns true when the caller must
-   * not start its own request, because this delivery already starts one.
+   * Delivers pending notifications as the next request instead of waiting for
+   * the task to become idle. Returns true when the caller must not start its
+   * own request, because this delivery already starts one.
    */
   const deliverBackgroundJobNotifications = useCallback(() => {
     const index = getDeliverableBackgroundJobNotificationIndex(queuedMessages);
@@ -377,9 +370,8 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     }
     deliveredNotificationsRef.current = message;
 
-    // Deferred to a microtask, so the send starts from the same place the SDK
-    // would have started its own automatic continuation instead of re-entering
-    // it while it is still applying the tool output.
+    // Deferred, so the send starts where the SDK would have started its own
+    // continuation instead of re-entering it mid tool output.
     void Promise.resolve().then(() =>
       sendQueuedMessage(index, { keepAutoApproveGuard: true }),
     );

--- a/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
+++ b/packages/vscode-webui/src/features/chat/components/chat-toolbar.tsx
@@ -349,14 +349,12 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     },
   });
 
-  // Last dispatched entry, so a re-evaluated decision does not send it twice
-  // while the queue state update is still pending.
+  // Last dispatched entry, so a re-evaluated decision does not send it twice.
   const deliveredNotificationsRef = useRef<DraftMessage>(undefined);
 
   /**
-   * Delivers pending notifications as the next request instead of waiting for
-   * the task to become idle. Returns true when the caller must not start its
-   * own request, because this delivery already starts one.
+   * Delivers pending notifications instead of waiting for the task to become
+   * idle. Returns true when this delivery already starts the next request.
    */
   const deliverBackgroundJobNotifications = useCallback(() => {
     const index = getDeliverableBackgroundJobNotificationIndex(queuedMessages);
@@ -370,8 +368,7 @@ export const ChatToolbar: React.FC<ChatToolbarProps> = ({
     }
     deliveredNotificationsRef.current = message;
 
-    // Deferred, so the send starts where the SDK would have started its own
-    // continuation instead of re-entering it mid tool output.
+    // Deferred, so the send does not re-enter the SDK mid tool output.
     void Promise.resolve().then(() =>
       sendQueuedMessage(index, { keepAutoApproveGuard: true }),
     );

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.test.tsx
@@ -605,6 +605,72 @@ describe("useChatSubmit", () => {
     });
   });
 
+  describe("sendQueuedMessage", () => {
+    it("sends the queued message without stopping the current run", async () => {
+      const first = draftMessage({ text: "first queued message" });
+      const second = draftMessage({ text: "second queued message" });
+      const context = setup({
+        isLoading: false,
+        queuedMessages: [first, second],
+      });
+
+      let sent: boolean | undefined;
+      await act(async () => {
+        sent = await context.result.current.sendQueuedMessage(0);
+      });
+
+      expect(sent).toBe(true);
+      expect(context.stopChat).not.toHaveBeenCalled();
+      expect(context.sendMessage).toHaveBeenCalledWith({
+        parts: ["text:first queued message"],
+      });
+      expect(context.queuedMessages).toEqual([second]);
+    });
+
+    it("resets the auto approve guard like a user submission by default", async () => {
+      chatStateMocks.autoApproveGuard.current = "manual";
+      const context = setup({
+        isLoading: false,
+        queuedMessages: [draftMessage({ text: "queued message" })],
+      });
+
+      await act(async () => {
+        await context.result.current.sendQueuedMessage(0);
+      });
+
+      expect(chatStateMocks.autoApproveGuard.current).toBe("auto");
+    });
+
+    it("keeps the auto approve guard when the caller asks for it", async () => {
+      chatStateMocks.autoApproveGuard.current = "manual";
+      const context = setup({
+        isLoading: false,
+        queuedMessages: [draftMessage({ text: "queued message" })],
+      });
+
+      await act(async () => {
+        await context.result.current.sendQueuedMessage(0, {
+          keepAutoApproveGuard: true,
+        });
+      });
+
+      expect(context.sendMessage).toHaveBeenCalledOnce();
+      expect(chatStateMocks.autoApproveGuard.current).toBe("manual");
+    });
+
+    it("does nothing when the index has no matching queued message", async () => {
+      const context = setup({ isLoading: false, queuedMessages: [] });
+
+      let sent: boolean | undefined;
+      await act(async () => {
+        sent = await context.result.current.sendQueuedMessage(0);
+      });
+
+      expect(sent).toBe(false);
+      expect(context.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
   it("captures selection context when the message is created and reuses it when a queued message is later steered, instead of re-reading it at flush time", async () => {
     const queueTimeActiveSelection: ActiveSelection = {
       filepath: "/workspace/queued.ts",

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -49,10 +49,8 @@ export interface DraftMessage {
 
 interface SendChatMessageOptions {
   /**
-   * Keeps the current auto approve guard instead of resetting it to "auto".
-   * Used for messages that are not a fresh user intent, e.g. background job
-   * notifications delivered while the agent loop is running, which must not
-   * silently re-enable auto approve.
+   * Keeps the current auto approve guard instead of resetting it to "auto",
+   * for messages that are not a fresh user intent.
    */
   keepAutoApproveGuard?: boolean;
 }
@@ -455,10 +453,8 @@ export function useChatSubmit({
 
   /**
    * Sends a queued message right away, without the steer stop-and-wait dance.
-   *
-   * Callers are responsible for only using it where starting a request is
-   * already legal, e.g. from the automatic continuation decision, where the
-   * previous request has finished and the next one is about to start.
+   * Only for callers where starting a request is already legal, e.g. the
+   * automatic continuation decision.
    */
   const sendQueuedMessage = useCallback(
     async (index: number, options?: SendChatMessageOptions) => {

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -47,6 +47,16 @@ export interface DraftMessage {
   };
 }
 
+interface SendChatMessageOptions {
+  /**
+   * Keeps the current auto approve guard instead of resetting it to "auto".
+   * Used for messages that are not a fresh user intent, e.g. background job
+   * notifications delivered while the agent loop is running, which must not
+   * silently re-enable auto approve.
+   */
+  keepAutoApproveGuard?: boolean;
+}
+
 interface UseChatSubmitProps {
   chat: UseChatReturn;
   input: ChatInput;
@@ -281,7 +291,7 @@ export function useChatSubmit({
   );
 
   const sendChatMessage = useCallback(
-    async (message: DraftMessage) => {
+    async (message: DraftMessage, options?: SendChatMessageOptions) => {
       const shouldCreateTodo = message.raw.isTodoMode && canCreateTodo;
       if (message.raw.text && shouldCreateTodo) {
         onBeforeSendText?.(message.raw.text);
@@ -291,7 +301,9 @@ export function useChatSubmit({
         pendingApproval.stopCountdown();
       }
 
-      autoApproveGuard.current = "auto";
+      if (!options?.keepAutoApproveGuard) {
+        autoApproveGuard.current = "auto";
+      }
       await sendMessage({
         parts: message.parts,
       });
@@ -441,10 +453,34 @@ export function useChatSubmit({
     ],
   );
 
+  /**
+   * Sends a queued message right away, without the steer stop-and-wait dance.
+   *
+   * Callers are responsible for only using it where starting a request is
+   * already legal, e.g. from the automatic continuation decision, where the
+   * previous request has finished and the next one is about to start.
+   */
+  const sendQueuedMessage = useCallback(
+    async (index: number, options?: SendChatMessageOptions) => {
+      logger.debug("sendQueuedMessage");
+
+      const message = queuedMessages[index];
+      if (!message) {
+        return false;
+      }
+
+      setQueuedMessages((messages) => messages.filter((_, i) => i !== index));
+      await sendChatMessage(message, options);
+      return true;
+    },
+    [queuedMessages, setQueuedMessages, sendChatMessage],
+  );
+
   return {
     handleSubmit,
     handleSteerSubmit,
     handleSteerQueuedMessage,
     handleStop,
+    sendQueuedMessage,
   };
 }

--- a/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
+++ b/packages/vscode-webui/src/features/chat/hooks/use-chat-submit.ts
@@ -48,10 +48,7 @@ export interface DraftMessage {
 }
 
 interface SendChatMessageOptions {
-  /**
-   * Keeps the current auto approve guard instead of resetting it to "auto",
-   * for messages that are not a fresh user intent.
-   */
+  /** Keeps the guard instead of resetting it to "auto", for non user intent. */
   keepAutoApproveGuard?: boolean;
 }
 
@@ -452,9 +449,8 @@ export function useChatSubmit({
   );
 
   /**
-   * Sends a queued message right away, without the steer stop-and-wait dance.
-   * Only for callers where starting a request is already legal, e.g. the
-   * automatic continuation decision.
+   * Sends a queued message without the steer stop-and-wait, only for callers
+   * where starting a request is already legal.
    */
   const sendQueuedMessage = useCallback(
     async (index: number, options?: SendChatMessageOptions) => {

--- a/packages/vscode-webui/src/features/chat/lib/background-job-notification-queue.test.ts
+++ b/packages/vscode-webui/src/features/chat/lib/background-job-notification-queue.test.ts
@@ -4,6 +4,8 @@ import type { DraftMessage } from "../hooks/use-chat-submit";
 import {
   enqueueBackgroundJobNotifications,
   getBackgroundJobNotificationIds,
+  getDeliverableBackgroundJobNotificationIndex,
+  isBackgroundJobNotificationMessage,
 } from "./background-job-notification-queue";
 
 describe("enqueueBackgroundJobNotifications", () => {
@@ -69,6 +71,67 @@ describe("enqueueBackgroundJobNotifications", () => {
     ]);
   });
 });
+
+describe("isBackgroundJobNotificationMessage", () => {
+  it("detects a notification-only queue entry", () => {
+    const [message] = enqueueBackgroundJobNotifications(
+      [],
+      [notification("bgjob-cmd-1")],
+    );
+
+    expect(isBackgroundJobNotificationMessage(message)).toBe(true);
+  });
+
+  it("rejects user typed and mixed messages", () => {
+    expect(isBackgroundJobNotificationMessage(regularMessage())).toBe(false);
+    expect(
+      isBackgroundJobNotificationMessage({
+        parts: [
+          { type: "text", text: "hello" },
+          {
+            type: "data-background-job-notification",
+            data: notification("bgjob-cmd-1"),
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(isBackgroundJobNotificationMessage({ parts: [] })).toBe(false);
+  });
+});
+
+describe("getDeliverableBackgroundJobNotificationIndex", () => {
+  it("delivers a notification waiting at the head of the queue", () => {
+    const messages = enqueueBackgroundJobNotifications(
+      [],
+      [notification("bgjob-cmd-1")],
+    );
+
+    expect(getDeliverableBackgroundJobNotificationIndex(messages)).toBe(0);
+  });
+
+  it("delivers nothing when the queue is empty", () => {
+    expect(getDeliverableBackgroundJobNotificationIndex([])).toBeUndefined();
+  });
+
+  it("delivers nothing while a queued user message is ahead of it", () => {
+    const messages = enqueueBackgroundJobNotifications(
+      [regularMessage()],
+      [notification("bgjob-cmd-1")],
+    );
+
+    expect(messages).toHaveLength(2);
+    expect(
+      getDeliverableBackgroundJobNotificationIndex(messages),
+    ).toBeUndefined();
+  });
+});
+
+function regularMessage(text = "hello"): DraftMessage {
+  return {
+    parts: [{ type: "text", text }],
+    raw: { text },
+  };
+}
 
 function notification(backgroundJobId: string): BackgroundJobNotification {
   return {

--- a/packages/vscode-webui/src/features/chat/lib/background-job-notification-queue.ts
+++ b/packages/vscode-webui/src/features/chat/lib/background-job-notification-queue.ts
@@ -11,7 +11,6 @@ export function getBackgroundJobNotificationIds(
   );
 }
 
-/** A queue entry that only carries notifications, i.e. was not typed by the user. */
 export function isBackgroundJobNotificationMessage(
   message: Pick<DraftMessage, "parts">,
 ): boolean {
@@ -24,10 +23,8 @@ export function isBackgroundJobNotificationMessage(
 }
 
 /**
- * Index of the notification deliverable in the middle of a running loop.
- *
- * Only the head is eligible: queued user input is only sent by an explicit
- * steer, and delivering from behind it would reorder the queue.
+ * Only the head is deliverable mid loop: queued user input is sent by an
+ * explicit steer, and delivering from behind it would reorder the queue.
  */
 export function getDeliverableBackgroundJobNotificationIndex(
   messages: readonly Pick<DraftMessage, "parts">[],
@@ -36,10 +33,7 @@ export function getDeliverableBackgroundJobNotificationIndex(
   return head && isBackgroundJobNotificationMessage(head) ? 0 : undefined;
 }
 
-/**
- * Adds notifications to one non-removable queue entry, merging into the
- * waiting entry so a single dequeue sends all of them.
- */
+/** Merges notifications into one non-removable queue entry. */
 export function enqueueBackgroundJobNotifications(
   messages: DraftMessage[],
   notifications: readonly BackgroundJobNotification[],

--- a/packages/vscode-webui/src/features/chat/lib/background-job-notification-queue.ts
+++ b/packages/vscode-webui/src/features/chat/lib/background-job-notification-queue.ts
@@ -11,10 +11,7 @@ export function getBackgroundJobNotificationIds(
   );
 }
 
-/**
- * A queue entry that only carries background job notifications, i.e. it was
- * created by the notification queue rather than typed by the user.
- */
+/** A queue entry that only carries notifications, i.e. was not typed by the user. */
 export function isBackgroundJobNotificationMessage(
   message: Pick<DraftMessage, "parts">,
 ): boolean {
@@ -27,12 +24,10 @@ export function isBackgroundJobNotificationMessage(
 }
 
 /**
- * Index of the queued notification that may be delivered in the middle of a
- * running agent loop, or `undefined` when nothing may be delivered yet.
+ * Index of the notification deliverable in the middle of a running loop.
  *
- * Only the head of the queue is eligible: queued user input keeps the running
- * loop untouched (steering it is an explicit user action), and delivering a
- * notification from behind a queued user message would reorder the queue.
+ * Only the head is eligible: queued user input is only sent by an explicit
+ * steer, and delivering from behind it would reorder the queue.
  */
 export function getDeliverableBackgroundJobNotificationIndex(
   messages: readonly Pick<DraftMessage, "parts">[],
@@ -42,9 +37,8 @@ export function getDeliverableBackgroundJobNotificationIndex(
 }
 
 /**
- * Adds notifications to one non-removable queue entry. If a notification
- * entry is already waiting, new parts are merged into it so one dequeue sends
- * every notification available at that send point in a single user message.
+ * Adds notifications to one non-removable queue entry, merging into the
+ * waiting entry so a single dequeue sends all of them.
  */
 export function enqueueBackgroundJobNotifications(
   messages: DraftMessage[],

--- a/packages/vscode-webui/src/features/chat/lib/background-job-notification-queue.ts
+++ b/packages/vscode-webui/src/features/chat/lib/background-job-notification-queue.ts
@@ -12,6 +12,36 @@ export function getBackgroundJobNotificationIds(
 }
 
 /**
+ * A queue entry that only carries background job notifications, i.e. it was
+ * created by the notification queue rather than typed by the user.
+ */
+export function isBackgroundJobNotificationMessage(
+  message: Pick<DraftMessage, "parts">,
+): boolean {
+  return (
+    message.parts.length > 0 &&
+    message.parts.every(
+      (part) => part.type === "data-background-job-notification",
+    )
+  );
+}
+
+/**
+ * Index of the queued notification that may be delivered in the middle of a
+ * running agent loop, or `undefined` when nothing may be delivered yet.
+ *
+ * Only the head of the queue is eligible: queued user input keeps the running
+ * loop untouched (steering it is an explicit user action), and delivering a
+ * notification from behind a queued user message would reorder the queue.
+ */
+export function getDeliverableBackgroundJobNotificationIndex(
+  messages: readonly Pick<DraftMessage, "parts">[],
+): number | undefined {
+  const head = messages[0];
+  return head && isBackgroundJobNotificationMessage(head) ? 0 : undefined;
+}
+
+/**
  * Adds notifications to one non-removable queue entry. If a notification
  * entry is already waiting, new parts are merged into it so one dequeue sends
  * every notification available at that send point in a single user message.
@@ -38,13 +68,7 @@ export function enqueueBackgroundJobNotifications(
     type: "data-background-job-notification" as const,
     data: notification,
   }));
-  const existingIndex = messages.findIndex(
-    (message) =>
-      message.parts.length > 0 &&
-      message.parts.every(
-        (part) => part.type === "data-background-job-notification",
-      ),
-  );
+  const existingIndex = messages.findIndex(isBackgroundJobNotificationMessage);
 
   if (existingIndex === -1) {
     return [

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -244,13 +244,9 @@ function Chat({ user, uid, info }: ChatProps) {
         return true;
       };
 
-      // A background job that finished while the loop was running is delivered
-      // as this continuation request, so the model sees it at the current step
-      // boundary instead of only after the task ends. The notification message
-      // triggers the request itself, hence the automatic continuation is
-      // skipped. Placing this after the continuation decision keeps every
-      // intentional pause (todo pause, auto approve stop, aborted task) intact:
-      // a paused loop is not resumed by a notification.
+      // A job that finished mid loop is delivered as this continuation
+      // request, so the notification message starts it instead. Running after
+      // the continuation decision keeps every intentional pause intact.
       const continueAutomatically = (shouldContinue: boolean) => {
         if (!shouldContinue) {
           return false;

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -244,9 +244,8 @@ function Chat({ user, uid, info }: ChatProps) {
         return true;
       };
 
-      // A job that finished mid loop is delivered as this continuation
-      // request, so the notification message starts it instead. Running after
-      // the continuation decision keeps every intentional pause intact.
+      // The notification starts this continuation request itself. Running
+      // after the decision keeps every intentional pause intact.
       const continueAutomatically = (shouldContinue: boolean) => {
         if (!shouldContinue) {
           return false;

--- a/packages/vscode-webui/src/features/chat/page.tsx
+++ b/packages/vscode-webui/src/features/chat/page.tsx
@@ -90,6 +90,10 @@ function Chat({ user, uid, info }: ChatProps) {
   const todoPausedRef = useLatest(todoPaused);
   const todoModeActiveRef = useRef(false);
   const lastAutoContinueStateRef = useRef<string | undefined>(undefined);
+  // Filled in by <ChatToolbar>, which owns the queued messages.
+  const deliverBackgroundJobNotificationsRef = useRef<() => boolean>(
+    () => false,
+  );
   const { initSubtaskAutoApproveSettings } = useSettingsStore();
   const defaultUser = {
     name: t("chatPage.defaultUserName"),
@@ -240,6 +244,20 @@ function Chat({ user, uid, info }: ChatProps) {
         return true;
       };
 
+      // A background job that finished while the loop was running is delivered
+      // as this continuation request, so the model sees it at the current step
+      // boundary instead of only after the task ends. The notification message
+      // triggers the request itself, hence the automatic continuation is
+      // skipped. Placing this after the continuation decision keeps every
+      // intentional pause (todo pause, auto approve stop, aborted task) intact:
+      // a paused loop is not resumed by a notification.
+      const continueAutomatically = (shouldContinue: boolean) => {
+        if (!shouldContinue) {
+          return false;
+        }
+        return !deliverBackgroundJobNotificationsRef.current();
+      };
+
       if (chatAbortController.current.signal.aborted) {
         return false;
       }
@@ -257,7 +275,9 @@ function Chat({ user, uid, info }: ChatProps) {
 
       const shouldContinueTodo = getTodoContinuationDecision(candidateMessages);
       if (shouldContinueTodo !== undefined) {
-        return claimAutoContinue(!todoPausedRef.current && shouldContinueTodo);
+        return continueAutomatically(
+          claimAutoContinue(!todoPausedRef.current && shouldContinueTodo),
+        );
       }
 
       if (shouldStopAutoApprove({ messages: candidateMessages })) {
@@ -268,10 +288,12 @@ function Chat({ user, uid, info }: ChatProps) {
         return false;
       }
 
-      return claimAutoContinue(
-        lastAssistantMessageIsCompleteWithToolCalls({
-          messages: candidateMessages,
-        }),
+      return continueAutomatically(
+        claimAutoContinue(
+          lastAssistantMessageIsCompleteWithToolCalls({
+            messages: candidateMessages,
+          }),
+        ),
       );
     },
     onOverrideMessages,
@@ -497,6 +519,9 @@ function Chat({ user, uid, info }: ChatProps) {
           isRepairingMermaid={!!repairingChart}
           mcpConfigOverride={mcpConfigOverride}
           getSystemPrompt={() => chatKit.latestSystemPrompt}
+          deliverBackgroundJobNotificationsRef={
+            deliverBackgroundJobNotificationsRef
+          }
           onToolCallApprovalVisible={onToolCallApprovalVisible}
           onToolsExecutionStarted={chatKit.markStartToolsExecution}
           onToolsExecutionEnded={chatKit.markEndToolsExecution}


### PR DESCRIPTION
## Summary

- Background job completion notifications (from `executeCommand` with `background: true`) were only handed to the model once the whole turn had ended. Mid-loop they sat in the queue, so they arrived late and often after the model had already moved past the point where they were actionable.
- Deliver them at the **agent loop step boundary** instead, riding along with the continuation request that is issued anyway — no extra request, latency is now at most one step.
- `packages/vscode-webui`: the auto-dequeue effect in `chat-toolbar.tsx` gated delivery on `taskStatus` being idle. Delivery is now also attempted from the auto-continuation decision chain (`page.tsx` -> `continueAutomatically`), so it inherits every existing safety gate: an intentional pause (`autoApproveGuard === "stop"`, paused todo loop) is never resumed by a notification, and `sendQueuedMessage(..., { keepAutoApproveGuard: true })` makes sure a one-shot manual approval is not upgraded to auto. Only a background-job notification sitting at the queue head is eligible; user-typed queued messages keep their previous behaviour. Dedup is keyed on message identity (`deliveredNotificationsRef`) rather than an in-flight boolean, so an aborted send cannot stall the queue.
- `packages/cli`: `TaskRunner` had the same gate — it only drained `pendingBackgroundJobNotifications` on a `"finished"` step. The drain now also happens right before the continuation `chat.sendMessage()` when the step result is `"next"`. The decision lives in a new pure helper, `src/lib/background-job-notification-delivery.ts`, so it is unit-testable without the full `TaskRunner` harness. `"retry"` steps never inject (the retry must re-send the same state), and the end-of-task `waitForAsyncWork()` drain is untouched.

Not in scope: `packages/cli/src/running-task-adaptor.ts` creates per-task `BackgroundJobManager`s but never subscribes to `onDidFinish`, so that path surfaces no background job notifications at all. Pre-existing, worth a follow-up.

## Test plan

- [x] `cd packages/cli && bun run test` — 16 files / 132 tests pass, including 6 new tests for the delivery helper (drains all pending events into one message; `"next"` delivers and empties the queue; `"retry"` / `"finished"` / empty queue do not).
- [x] `cd packages/vscode-webui && bun run test` — 77 files / 532 tests pass, including new coverage for the queue helpers, `sendQueuedMessage` (guard preservation, single-entry removal) and the toolbar delivery callback (head notification delivers once; user message ahead blocks it).
- [x] `bun tsc` clean in both packages; `bun fix` / `bun check` clean at the repo root.
- [x] Manual: start a 25s background job, then run a sequence of short tool calls — the notification now arrives mid-loop instead of after `attemptCompletion`; two jobs finishing near the same boundary are batched into one notification message; a job started immediately before `attemptCompletion` is still awaited and delivered by the existing end-of-task drain.

Note: the local `pre-push` hook could not run `packages/vscode`'s extension tests in this worktree (`IPC handle ... is longer than 103 chars` — the checkout path exceeds the macOS unix socket limit). Every other hook step passed; this change does not touch `packages/vscode`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-98432c863b7443779e3b27f5d90db811)