### PR TITLE
docs: add weekly update #40

### DIFF
--- a/packages/docs/content/docs/developer-updates/2026-09-04-weekly-update-40.mdx
+++ b/packages/docs/content/docs/developer-updates/2026-09-04-weekly-update-40.mdx
@@ -1,0 +1,28 @@
+---
+title: 'Weekly Update #40'
+---
+# Weekly Update #40
+
+### TL;DR
+
+Pochi 0.70 is expected on September 9. It is shaping up to make long-running command work more continuous: commands that need more time will keep running in the background, completed jobs will reach Pochi sooner, and large pasted prompts will no longer make the chat input unresponsive. A unified place to manage background work is also on the way.
+
+More below!
+
+### 🚀 Features
+
+- **Long commands will keep running instead of timing out:** When a supported command reaches its foreground time limit, Pochi will move the same process into a background terminal instead of stopping or restarting it. Existing output and live updates will carry over, and the terminal will remain interactive while Pochi continues with other work.
+
+  This will be especially useful for builds, test suites, setup scripts, and other commands whose duration is difficult to predict. [**#1930**](https://github.com/TabbyML/pochi/pull/1930)
+
+### ✨ Enhancements
+
+- **Background-job results will reach Pochi sooner:** When a background command finishes during an active task, Pochi will receive the result at the next safe step instead of waiting until the turn ends. This will let it react to completed tests, builds, and other jobs while the result is still useful, without resuming a task you intentionally paused. [**#1932**](https://github.com/TabbyML/pochi/pull/1932)
+
+### 🐛 Bug Fixes
+
+- **Large pastes will keep the chat input responsive:** Work planned for Pochi 0.70 will prevent the composer from becoming unresponsive for several seconds when you paste a large block of text.
+
+### 👀 Coming Up
+
+- **Manage background work in one place:** A unified panel in the chat will bring background tasks and terminals together, with live status indicators and collapsible history for busy sessions. This will make it easier to see what is still running and reopen the work you need without searching across separate views. [**#1926**](https://github.com/TabbyML/pochi/pull/1926)

--- a/packages/docs/content/docs/developer-updates/index.mdx
+++ b/packages/docs/content/docs/developer-updates/index.mdx
@@ -16,6 +16,14 @@ Here you will find highlights on features, enhancements, and bug fixes, plus ins
 
 --- */}
 
+## [Weekly Update #40](./2026-09-04-weekly-update-40)
+
+#### September 4, 2026
+
+<include>./2026-09-04-weekly-update-40.mdx</include>
+
+---
+
 ## [Weekly Update #39](./2026-08-30-weekly-update-39)
 
 #### August 30, 2026


### PR DESCRIPTION
## Summary
- publish Weekly Developer Update #40 for September 4, 2026
- preview Pochi 0.70's continuous background-command workflow, earlier job results, and responsive large-paste handling
- retain the upcoming unified background-work panel as a written preview while deferring visual media

## Test plan
- [x] Run `git diff --check`
- [x] Verify update number, date, index link, and include path
- [x] Confirm no media placeholder or asset was added for the unified background-work preview
- [ ] Run `bun check` (blocked: dependencies are unavailable in the isolated worktree; `npm-run-all` was not found)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-9747a6c44d1446dbb7a359c288e38a3e)