### PR TITLE
chore(vscode): bump version to 0.69.0-dev

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -276,7 +276,7 @@
     },
     "packages/vscode": {
       "name": "pochi",
-      "version": "0.67.0-dev",
+      "version": "0.69.0-dev",
       "dependencies": {
         "@ai-sdk/google-vertex": "catalog:",
         "@getpochi/common": "workspace:*",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pochi",
-  "version": "0.67.0-dev",
+  "version": "0.69.0-dev",
   "description": "Pochi is your AI powered team mate. Now available in research preview.",
   "displayName": "Pochi (Research Preview)",
   "publisher": "TabbyML",


### PR DESCRIPTION
## Summary
- Bump `packages/vscode` version from `0.67.0-dev` to `0.69.0-dev` for the new dev cycle
- Update `bun.lock` to match

## Test plan
- [x] Pre-push hook (dep-check + full turbo test suite) passed

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-3a958ea066954611a1dc2b97899899b7)