### PR TITLE
feat(vscode-webui): show trailing status icons for background command notifications

### DIFF
--- a/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
+++ b/packages/vscode-webui/src/features/tools/components/__tests__/command-execution-panel.test.tsx
@@ -278,6 +278,12 @@ describe("BackgroundJobPanel job control", () => {
     expect(command?.classList.contains("truncate")).toBe(true);
     expect(command?.getAttribute("title")).toBe(longCommand);
     expect(command?.textContent).toBe(longCommand);
+    expect(command?.nextElementSibling?.classList.contains("size-3.5")).toBe(
+      true,
+    );
+    expect(command?.nextElementSibling?.childElementCount).toBe(0);
+    expect(container.querySelectorAll("svg")).toHaveLength(1);
+    expect(container.querySelector(".lucide-terminal")).not.toBeNull();
   });
 
   it("recovers the actual command when structured data contains a legacy ID", () => {
@@ -298,7 +304,7 @@ describe("BackgroundJobPanel job control", () => {
     expect(screen.queryByText("bgjob-cmd-legacy")).toBeNull();
   });
 
-  it("does not render a trailing status icon for a stopped notification", () => {
+  it("renders a trailing stopped icon while retaining the terminal icon", () => {
     jobInfo = undefined;
 
     const { container } = render(
@@ -311,11 +317,14 @@ describe("BackgroundJobPanel job control", () => {
       />,
     );
 
-    expect(container.querySelector(".lucide-octagon")).toBeNull();
+    expect(container.querySelector("code")?.nextElementSibling).toBe(
+      container.querySelector(".lucide-circle-slash")?.parentElement,
+    );
+    expect(container.querySelectorAll(".lucide-circle-slash")).toHaveLength(1);
     expect(container.querySelectorAll(".lucide-terminal")).toHaveLength(1);
   });
 
-  it("puts failure details in the notification row tooltip without a trailing icon", async () => {
+  it("shows a trailing failure icon with details in the notification row tooltip", async () => {
     jobInfo = undefined;
     const fullSummary =
       'Background command "bun run build" failed: dependency unavailable';
@@ -332,7 +341,12 @@ describe("BackgroundJobPanel job control", () => {
     );
 
     expect(screen.getByText("bun run build")).toBeDefined();
-    expect(container.querySelector(".lucide-triangle-alert")).toBeNull();
+    expect(container.querySelectorAll(".lucide-triangle-alert")).toHaveLength(
+      1,
+    );
+    expect(container.querySelector("code")?.nextElementSibling).toBe(
+      container.querySelector(".lucide-triangle-alert")?.parentElement,
+    );
     const row = screen.getByLabelText("backgroundJobNotifications.openOutput");
     expect(screen.queryByText(fullSummary)).toBeNull();
 

--- a/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
+++ b/packages/vscode-webui/src/features/tools/components/command-execution-panel.tsx
@@ -19,10 +19,12 @@ import {
   ChevronsDownUpIcon,
   ChevronsUpDownIcon,
   CircleCheck,
+  CircleSlash,
   CircleStop,
   CopyIcon,
   FileText,
   TerminalIcon,
+  TriangleAlert,
   XCircle,
 } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
@@ -339,6 +341,24 @@ export const BackgroundJobPanel: FC<{
         >
           {resolvedCommand ?? backgroundJobId}
         </code>
+        <span
+          className="inline-flex size-3.5 shrink-0 items-center justify-center text-muted-foreground/75"
+          aria-hidden="true"
+        >
+          {status === "failed" && (
+            <TriangleAlert
+              className="size-3.5"
+              style={{
+                color:
+                  "color-mix(in srgb, var(--vscode-notificationsWarningIcon-foreground) 55%, var(--muted-foreground))",
+              }}
+              strokeWidth={1.5}
+            />
+          )}
+          {status === "stopped" && (
+            <CircleSlash className="size-3.5" strokeWidth={1.5} />
+          )}
+        </span>
       </>
     );
     const notificationRow = outputFile ? (


### PR DESCRIPTION
## Summary
- Render a trailing `TriangleAlert` icon for failed background commands and a `CircleSlash` icon for stopped background commands in the `BackgroundJobPanel` notification rows.
- Add test coverage in `command-execution-panel.test.tsx` to assert the presence of these trailing status icons while retaining the terminal icon.

## Screenshot
<img width="898" height="346" alt="image" src="https://github.com/user-attachments/assets/2f070aeb-d6c3-4cba-825e-8ab06dd3f5cc" />



## Test plan
- Run the unit tests: `bun run test src/features/tools/components/__tests__/command-execution-panel.test.tsx` inside `packages/vscode-webui` and verify they pass.
- Verify status icons render correctly in the vscode-webui background command notification row.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-001030d2b8024a2fa53792c6e0a5450d)