### PR TITLE
fix(vscode): echo the command in background job output and terminals

### DIFF
--- a/packages/vscode/src/integrations/terminal/__test__/pty-terminal.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/pty-terminal.test.ts
@@ -68,6 +68,52 @@ describe("PtyTerminal", () => {
     assert.strictEqual(onCloseRequested.callCount, 0);
   });
 
+  it("echoes the command before replayed output", () => {
+    const ptyProcess = {
+      subscribeWithReplay: () => ({
+        replay: ["before timeout\n"],
+        disposable: { dispose: sinon.stub() },
+      }),
+      onExit: () => ({ dispose: sinon.stub() }),
+      write: sinon.stub(),
+      resize: sinon.stub(),
+    };
+    const { PtyTerminal } = proxyquire
+      .noCallThru()
+      .noPreserveCache()
+      .load("../pty-terminal", {
+        vscode: { EventEmitter: TestEventEmitter },
+      }) as typeof import("../pty-terminal");
+    const terminal = new PtyTerminal(
+      ptyProcess as never,
+      sinon.stub(),
+      "sleep 100",
+    );
+    const output: string[] = [];
+    terminal.onDidWrite((data) => output.push(data));
+
+    terminal.open();
+
+    assert.deepStrictEqual(output, [
+      "\u001b[1m$ sleep 100\u001b[0m\r\n",
+      "before timeout\n",
+    ]);
+  });
+
+  it("renders multi-line commands with terminal line endings", () => {
+    const { buildCommandBanner } = proxyquire
+      .noCallThru()
+      .noPreserveCache()
+      .load("../pty-terminal", {
+        vscode: { EventEmitter: TestEventEmitter },
+      }) as typeof import("../pty-terminal");
+
+    assert.strictEqual(
+      buildCommandBanner("echo one\necho two"),
+      "\u001b[1m$ echo one\r\necho two\u001b[0m\r\n",
+    );
+  });
+
   it("detaches without stopping the underlying process", () => {
     const onCloseRequested = sinon.stub();
     const dataSubscription = { dispose: sinon.stub() };

--- a/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
+++ b/packages/vscode/src/integrations/terminal/__test__/terminal-job.test.ts
@@ -357,6 +357,7 @@ describe("TerminalJob", () => {
     assert.strictEqual(harness.job.isFinished, true);
     assert.deepStrictEqual(harness.lifecycle, [
       "output:$ sleep 10\n",
+      "manager:$ sleep 10\n",
       "output:before timeout\n",
       "manager:before timeout\n",
       "output:after timeout\n",

--- a/packages/vscode/src/integrations/terminal/pty-terminal.ts
+++ b/packages/vscode/src/integrations/terminal/pty-terminal.ts
@@ -1,6 +1,14 @@
 import * as vscode from "vscode";
 import type { PtyProcess } from "./pty-process";
 
+/**
+ * Display-only echo of the command, mirroring the `$ <command>` line that
+ * starts the persisted log. The pty runs the command non-interactively, so
+ * without this the terminal shows nothing until the command writes output.
+ */
+export const buildCommandBanner = (command: string) =>
+  `\u001b[1m$ ${command.replace(/\r?\n/g, "\r\n")}\u001b[0m\r\n`;
+
 export class PtyTerminal implements vscode.Pseudoterminal, vscode.Disposable {
   private readonly writeEmitter = new vscode.EventEmitter<string>();
   private readonly closeEmitter = new vscode.EventEmitter<number | undefined>();
@@ -16,6 +24,7 @@ export class PtyTerminal implements vscode.Pseudoterminal, vscode.Disposable {
   constructor(
     private readonly ptyProcess: PtyProcess,
     private readonly onCloseRequested: () => void,
+    command?: string,
   ) {
     const subscription = ptyProcess.subscribeWithReplay((data) => {
       if (this.opened) {
@@ -25,6 +34,7 @@ export class PtyTerminal implements vscode.Pseudoterminal, vscode.Disposable {
       }
     });
     this.pendingOutput.unshift(...subscription.replay);
+    if (command) this.pendingOutput.unshift(buildCommandBanner(command));
     this.disposables.push(subscription.disposable);
     this.disposables.push(
       ptyProcess.onExit(({ exitCode }) => {

--- a/packages/vscode/src/integrations/terminal/terminal-job.ts
+++ b/packages/vscode/src/integrations/terminal/terminal-job.ts
@@ -110,7 +110,9 @@ export class TerminalJob implements vscode.Disposable {
         command: config.command,
       });
       TerminalJob.jobs.set(this.id, this);
-      this.enqueueFileOutput(`$ ${config.command}\n`, false);
+      // The echoed command is part of the readable output so the in-memory
+      // manager stays consistent with the persisted log file.
+      this.enqueueOutput(`$ ${config.command}\n`);
       if (ptyProcess) {
         this.initializePtyTerminal(ptyProcess);
       } else {
@@ -254,9 +256,13 @@ export class TerminalJob implements vscode.Disposable {
 
   private createPtyTerminalView(): void {
     if (!this.ptyProcess || this.terminal) return;
-    const ptyTerminal = new PtyTerminal(this.ptyProcess, () => {
-      this.detachPtyTerminalView(ptyTerminal);
-    });
+    const ptyTerminal = new PtyTerminal(
+      this.ptyProcess,
+      () => {
+        this.detachPtyTerminalView(ptyTerminal);
+      },
+      this.config.command,
+    );
     this.ptyTerminal = ptyTerminal;
     try {
       this.terminal = createTerminal({
@@ -487,16 +493,16 @@ export class TerminalJob implements vscode.Disposable {
       text.length - trailingTerminalSuffix.length,
     );
     this.pendingTerminalSuffix = trailingTerminalSuffix;
-    this.enqueueFileOutput(completeText, true);
+    this.enqueueOutput(completeText);
   }
 
-  private enqueueFileOutput(text: string, addToManager: boolean): void {
+  private enqueueOutput(text: string): void {
     if (text.length === 0 || this.persistenceError) return;
     this.pendingOutputCharacters += text.length;
     this.updatePtyOutputFlowControl();
     const write = this.outputQueue.then(async () => {
       await this.outputWriter.append(text);
-      if (addToManager) this.outputManager.addChunk(text);
+      this.outputManager.addChunk(text);
     });
     this.outputQueue = write
       .catch((error) => {
@@ -572,7 +578,7 @@ export class TerminalJob implements vscode.Disposable {
           ? this.pendingTerminalSuffix.replace(/\uFFFD+/gu, "")
           : this.pendingTerminalSuffix;
       this.pendingTerminalSuffix = "";
-      this.enqueueFileOutput(finalSuffix, true);
+      this.enqueueOutput(finalSuffix);
     }
     await this.outputQueue;
     executionError ??= this.persistenceError;


### PR DESCRIPTION
## Summary

- A pty background job runs its command non-interactively, so there is no prompt or shell echo. For a command that prints nothing (e.g. `sleep 100`) the job panel *and* the terminal view were completely blank, which is indistinguishable from a broken job.
- The `$ <command>` header was written to the log file only (`addToManager: false`), so the log file, the in-memory `OutputManager` (panel preview + what `readOutput()` returns to the model) and the terminal view all disagreed. The header now goes to `OutputManager` too, and the `addToManager` flag is dropped since every call site passed `true` (`enqueueFileOutput` → `enqueueOutput`).
- `PtyTerminal` gained an optional `command` argument and renders a display-only bold banner (`\e[1m$ <command>\e[0m\r\n`) ahead of the replay buffer. It never goes through `enqueueOutput`, so the log file and manager do not get a duplicate line, and it is re-rendered whenever the terminal view is rebuilt (detach/reopen, or the first open after a foreground command is backgrounded).

Result — all three consumers now start with the same line:

| Consumer | First line |
| --- | --- |
| Output file | `$ sleep 100` |
| OutputManager / panel / `readOutput()` | `$ sleep 100` |
| VS Code terminal view | `$ sleep 100` (bold) |

Note: `OutputManager`'s status now flips `idle` → `running` at job creation because `addChunk` sets it. This does not affect `assertBackgroundJobReadInterval`, which only throws when a `previousReadAt` exists and the gap is under 1s. The shell-integration path is untouched — it types the command into an interactive shell and already echoes.

## Test plan

- [x] `packages/vscode`: `bun tsc` + `bun run test` (mocha, 235 passing on this branch).
- [x] New `PtyTerminal` cases: banner is emitted before replayed output; multi-line commands are normalised to CRLF so xterm does not stair-step them.
- [x] `terminal-job` lifecycle assertion updated to expect `manager:$ sleep 10\n`, which also pins that the header is written to the file *and* the manager exactly once.
- [x] Root `bun check` (biome ×2, ast-grep, i18n/eslint).

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-8986ad3c7fe54db2a63aa1db97ff3759)