### PR TITLE
fix(vscode-webui): count running background tasks in manage panel badge

### DIFF
--- a/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.test.tsx
@@ -536,7 +536,27 @@ describe("BackgroundJobManagePanel", () => {
     ).toBeNull();
   });
 
-  it("takes the drawer to a task and back again", () => {
+  it("lets a task detail render before sliding it in", async () => {
+    isDevMode = true;
+    backgroundTasks = [{ id: "task-1", title: "A background task" }];
+
+    renderBackgroundJobManagePanel();
+
+    fireEvent.click(screen.getByText("A background task"));
+
+    expect(screen.getByTestId("background-task-detail")).toBeDefined();
+    expect(screen.getByTestId("background-task-layer").dataset.state).toBe(
+      "closed",
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("background-task-layer").dataset.state).toBe(
+        "open",
+      ),
+    );
+  });
+
+  it("takes the drawer to a task and back again", async () => {
     isDevMode = true;
     backgroundTasks = [{ id: "task-1", title: "A background task" }];
     backgroundJobs = [runningJob];
@@ -548,8 +568,10 @@ describe("BackgroundJobManagePanel", () => {
     expect(screen.getByTestId("background-task-detail").textContent).toContain(
       "task-1",
     );
-    expect(screen.getByTestId("background-task-layer").dataset.state).toBe(
-      "open",
+    await waitFor(() =>
+      expect(screen.getByTestId("background-task-layer").dataset.state).toBe(
+        "open",
+      ),
     );
     expect(
       screen.getByTestId("background-job-list-layer").hasAttribute("inert"),

--- a/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.test.tsx
@@ -13,7 +13,7 @@ const copyToClipboard = vi.fn();
 let backgroundJobs: BackgroundJobEntry[] = [];
 let backgroundCommands: Record<string, { isVisible: boolean }> | undefined = {};
 let isDevMode = false;
-let backgroundTasks: Array<{ id: string; title: string }> = [];
+let backgroundTasks: Array<{ id: string; title: string; status?: string }> = [];
 
 // Radix positions the tooltip with one, and jsdom has none.
 vi.stubGlobal(
@@ -67,6 +67,8 @@ vi.mock("@/features/settings", () => ({
 vi.mock("./background-task-debug-panel", () => ({
   BackgroundTasksLabel: "Background tasks",
   useBackgroundTasks: () => backgroundTasks,
+  isBackgroundTaskRunning: (status: string) =>
+    status === "pending-model" || status === "pending-tool",
   BackgroundTaskRow: ({
     task,
     onSelect,
@@ -501,6 +503,37 @@ describe("BackgroundJobManagePanel", () => {
     expect(screen.getByText("Background tasks")).toBeDefined();
     expect(screen.getByText("A background task")).toBeDefined();
     expect(screen.queryByText("managePanel.empty")).toBeNull();
+  });
+
+  it("counts running background tasks into the badge in dev mode", () => {
+    isDevMode = true;
+    backgroundJobs = [runningJob];
+    backgroundTasks = [
+      { id: "task-1", title: "A running task", status: "pending-tool" },
+      { id: "task-2", title: "A finished task", status: "completed" },
+    ];
+
+    renderBackgroundJobManagePanel();
+
+    expect(
+      screen
+        .getByTestId("background-job-manage-panel-toggle")
+        .querySelector(".bg-blue-500")?.textContent,
+    ).toBe("2");
+  });
+
+  it("leaves running background tasks out of the badge outside dev mode", () => {
+    backgroundTasks = [
+      { id: "task-1", title: "A running task", status: "pending-tool" },
+    ];
+
+    renderBackgroundJobManagePanel();
+
+    expect(
+      screen
+        .getByTestId("background-job-manage-panel-toggle")
+        .querySelector(".bg-blue-500"),
+    ).toBeNull();
   });
 
   it("takes the drawer to a task and back again", () => {

--- a/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BackgroundJobEntry } from "../lib/build-background-job-list";
 import { BackgroundJobManagePanel } from "./background-job-manage-panel";
 
@@ -13,6 +19,7 @@ const copyToClipboard = vi.fn();
 let backgroundJobs: BackgroundJobEntry[] = [];
 let backgroundCommands: Record<string, { isVisible: boolean }> | undefined = {};
 let isDevMode = false;
+let useRealSheet = false;
 let backgroundTasks: Array<{ id: string; title: string; status?: string }> = [];
 
 // Radix positions the tooltip with one, and jsdom has none.
@@ -33,13 +40,20 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-// The drawer is rendered inline so the content is always assertable.
-vi.mock("@/components/ui/sheet", () => ({
-  Sheet: ({ children }: { children: ReactNode }) => <>{children}</>,
-  SheetContent: ({ children }: { children: ReactNode }) => <>{children}</>,
-  SheetTitle: ({ children }: { children: ReactNode }) => <>{children}</>,
-  SheetTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
+// Row tests render inline; lifecycle tests exercise the real drawer.
+vi.mock("@/components/ui/sheet", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui/sheet")>();
+  return {
+    Sheet: (props: ComponentProps<typeof actual.Sheet>) =>
+      useRealSheet ? <actual.Sheet {...props} /> : <>{props.children}</>,
+    SheetContent: (props: ComponentProps<typeof actual.SheetContent>) =>
+      useRealSheet ? <actual.SheetContent {...props} /> : <>{props.children}</>,
+    SheetTitle: (props: ComponentProps<typeof actual.SheetTitle>) =>
+      useRealSheet ? <actual.SheetTitle {...props} /> : <>{props.children}</>,
+    SheetTrigger: (props: ComponentProps<typeof actual.SheetTrigger>) =>
+      useRealSheet ? <actual.SheetTrigger {...props} /> : <>{props.children}</>,
+  };
+});
 
 vi.mock("../hooks/use-background-job-list", () => ({
   useBackgroundJobList: () => backgroundJobs,
@@ -132,6 +146,7 @@ describe("BackgroundJobManagePanel", () => {
     backgroundJobs = [];
     backgroundCommands = { "bgjob-cmd-1": { isVisible: true } };
     isDevMode = false;
+    useRealSheet = false;
     backgroundTasks = [];
   });
 
@@ -553,6 +568,76 @@ describe("BackgroundJobManagePanel", () => {
       expect(screen.getByTestId("background-task-layer").dataset.state).toBe(
         "open",
       ),
+    );
+  });
+
+  describe("delayed task detail entry", () => {
+    beforeEach(() => {
+      useRealSheet = true;
+      isDevMode = true;
+      backgroundTasks = [{ id: "task-1", title: "A background task" }];
+      vi.useFakeTimers({
+        toFake: ["requestAnimationFrame", "cancelAnimationFrame"],
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it.each([0, 1])(
+      "keeps the list usable after closing during entry (%i frames)",
+      (elapsedFrames) => {
+        renderBackgroundJobManagePanel();
+        fireEvent.click(
+          screen.getByTestId("background-job-manage-panel-toggle"),
+        );
+        fireEvent.click(screen.getByText("A background task"));
+        if (elapsedFrames > 0) act(() => vi.advanceTimersToNextFrame());
+
+        fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
+        expect(screen.queryByRole("dialog")).toBeNull();
+        act(() => {
+          vi.advanceTimersToNextFrame();
+          vi.advanceTimersToNextFrame();
+        });
+
+        fireEvent.click(
+          screen.getByTestId("background-job-manage-panel-toggle"),
+        );
+        expect(screen.getByTestId("background-task-layer").dataset.state).toBe(
+          "closed",
+        );
+        expect(
+          screen.getByTestId("background-job-list-layer").hasAttribute("inert"),
+        ).toBe(false);
+
+        fireEvent.click(screen.getByText("A background task"));
+        act(() => vi.advanceTimersToNextFrame());
+        expect(screen.getByTestId("background-task-layer").dataset.state).toBe(
+          "closed",
+        );
+        act(() => vi.advanceTimersToNextFrame());
+        expect(screen.getByTestId("background-task-layer").dataset.state).toBe(
+          "open",
+        );
+      },
+    );
+
+    it.each([0, 1])(
+      "releases pending animation frames on unmount (%i frames)",
+      (elapsedFrames) => {
+        const { unmount } = renderBackgroundJobManagePanel();
+        fireEvent.click(
+          screen.getByTestId("background-job-manage-panel-toggle"),
+        );
+        fireEvent.click(screen.getByText("A background task"));
+        if (elapsedFrames > 0) act(() => vi.advanceTimersToNextFrame());
+
+        unmount();
+
+        expect(vi.getTimerCount()).toBe(0);
+      },
     );
   });
 

--- a/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.tsx
@@ -28,7 +28,7 @@ import {
   ListIcon,
   XIcon,
 } from "lucide-react";
-import { Children, type ReactNode, useRef, useState } from "react";
+import { Children, type ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useBackgroundJobList } from "../hooks/use-background-job-list";
 import type {
@@ -91,7 +91,10 @@ function ManagePanel({
   const [isOpen, setIsOpen] = useState(false);
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
+  const cancelDetailOpenRef = useRef<() => void>(undefined);
   const backgroundJobs = useBackgroundJobList(taskId, messages);
+
+  useEffect(() => () => cancelDetailOpenRef.current?.(), []);
 
   const runningCount =
     backgroundJobs.filter((job) => job.status === "running").length +
@@ -103,6 +106,7 @@ function ManagePanel({
       onOpenChange={(open) => {
         setIsOpen(open);
         if (!open) {
+          cancelDetailOpenRef.current?.();
           setIsDetailOpen(false);
           setDetailTaskId(null);
         }
@@ -145,10 +149,13 @@ function ManagePanel({
               backgroundJobs={backgroundJobs}
               tasks={tasks}
               onSelectTask={(id) => {
+                cancelDetailOpenRef.current?.();
                 setDetailTaskId(id);
                 // A detail paints its thread a frame late, so sliding right
                 // away animates a blank panel and stalls on that render.
-                afterNextPaint(() => setIsDetailOpen(true));
+                cancelDetailOpenRef.current = afterNextPaint(() =>
+                  setIsDetailOpen(true),
+                );
               }}
             />
           </div>
@@ -165,7 +172,10 @@ function ManagePanel({
               <BackgroundTaskDetail
                 taskId={detailTaskId}
                 isOpen={isDetailOpen}
-                onBack={() => setIsDetailOpen(false)}
+                onBack={() => {
+                  cancelDetailOpenRef.current?.();
+                  setIsDetailOpen(false);
+                }}
               />
             )}
           </div>
@@ -176,7 +186,10 @@ function ManagePanel({
 }
 
 function afterNextPaint(callback: () => void) {
-  requestAnimationFrame(() => requestAnimationFrame(callback));
+  let frame = requestAnimationFrame(() => {
+    frame = requestAnimationFrame(callback);
+  });
+  return () => cancelAnimationFrame(frame);
 }
 
 function PanelBody({

--- a/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.tsx
@@ -39,6 +39,7 @@ import {
   BackgroundTaskDetail,
   BackgroundTaskRow,
   BackgroundTasksLabel,
+  isBackgroundTaskRunning,
   useBackgroundTasks,
 } from "./background-task-debug-panel";
 import { RowStatusIndicator, type RowStatusTone } from "./row-status-indicator";
@@ -50,16 +51,51 @@ export function BackgroundJobManagePanel({
   taskId: string;
   messages: Message[];
 }) {
-  const { t } = useTranslation();
   const [isDevMode] = useIsDevMode();
+
+  return isDevMode === true ? (
+    <DevManagePanel taskId={taskId} messages={messages} />
+  ) : (
+    <ManagePanel taskId={taskId} messages={messages} tasks={NoTasks} />
+  );
+}
+
+const NoTasks: readonly Task[] = [];
+
+/**
+ * Background tasks are only shown in dev mode, and hooks cannot be
+ * conditional, so their query lives in its own component.
+ */
+function DevManagePanel({
+  taskId,
+  messages,
+}: {
+  taskId: string;
+  messages: Message[];
+}) {
+  const tasks = useBackgroundTasks();
+
+  return <ManagePanel taskId={taskId} messages={messages} tasks={tasks} />;
+}
+
+function ManagePanel({
+  taskId,
+  messages,
+  tasks,
+}: {
+  taskId: string;
+  messages: Message[];
+  tasks: readonly Task[];
+}) {
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
   const backgroundJobs = useBackgroundJobList(taskId, messages);
 
-  const runningCount = backgroundJobs.filter(
-    (job) => job.status === "running",
-  ).length;
+  const runningCount =
+    backgroundJobs.filter((job) => job.status === "running").length +
+    tasks.filter((task) => isBackgroundTaskRunning(task.status)).length;
 
   return (
     <Sheet
@@ -105,17 +141,14 @@ export function BackgroundJobManagePanel({
             inert={isDetailOpen}
             className="flex min-h-0 flex-1 flex-col"
           >
-            {isDevMode === true ? (
-              <DevPanelBody
-                backgroundJobs={backgroundJobs}
-                onSelectTask={(id) => {
-                  setDetailTaskId(id);
-                  setIsDetailOpen(true);
-                }}
-              />
-            ) : (
-              <PanelBody backgroundJobs={backgroundJobs} tasks={NoTasks} />
-            )}
+            <PanelBody
+              backgroundJobs={backgroundJobs}
+              tasks={tasks}
+              onSelectTask={(id) => {
+                setDetailTaskId(id);
+                setIsDetailOpen(true);
+              }}
+            />
           </div>
           <div
             data-testid="background-task-layer"
@@ -140,30 +173,6 @@ export function BackgroundJobManagePanel({
   );
 }
 
-const NoTasks: readonly Task[] = [];
-
-/**
- * Background tasks are only shown in dev mode, and hooks cannot be
- * conditional, so their query lives in its own component.
- */
-function DevPanelBody({
-  backgroundJobs,
-  onSelectTask,
-}: {
-  backgroundJobs: BackgroundJobEntry[];
-  onSelectTask: (taskId: string) => void;
-}) {
-  const tasks = useBackgroundTasks();
-
-  return (
-    <PanelBody
-      backgroundJobs={backgroundJobs}
-      tasks={tasks}
-      onSelectTask={onSelectTask}
-    />
-  );
-}
-
 function PanelBody({
   backgroundJobs,
   tasks,
@@ -171,7 +180,7 @@ function PanelBody({
 }: {
   backgroundJobs: BackgroundJobEntry[];
   tasks: readonly Task[];
-  onSelectTask?: (taskId: string) => void;
+  onSelectTask: (taskId: string) => void;
 }) {
   const { t } = useTranslation();
   const commands = useRunningFirst(backgroundJobs);
@@ -202,7 +211,7 @@ function PanelBody({
               <li key={task.id}>
                 <BackgroundTaskRow
                   task={task}
-                  onSelect={() => onSelectTask?.(task.id)}
+                  onSelect={() => onSelectTask(task.id)}
                 />
               </li>
             ))}

--- a/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-job-manage-panel.tsx
@@ -146,7 +146,9 @@ function ManagePanel({
               tasks={tasks}
               onSelectTask={(id) => {
                 setDetailTaskId(id);
-                setIsDetailOpen(true);
+                // A detail paints its thread a frame late, so sliding right
+                // away animates a blank panel and stalls on that render.
+                afterNextPaint(() => setIsDetailOpen(true));
               }}
             />
           </div>
@@ -171,6 +173,10 @@ function ManagePanel({
       </SheetContent>
     </Sheet>
   );
+}
+
+function afterNextPaint(callback: () => void) {
+  requestAnimationFrame(() => requestAnimationFrame(callback));
 }
 
 function PanelBody({

--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.test.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BackgroundTaskDetail,
   BackgroundTaskRow,
@@ -105,12 +105,19 @@ describe("BackgroundTaskDetail", () => {
     messageRows = [];
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("focuses the back button when the detail opens", () => {
+    const focus = vi.spyOn(HTMLElement.prototype, "focus");
+
     openTaskDetail();
 
     expect(document.activeElement).toBe(
       screen.getByLabelText("Back to the background job list"),
     );
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
   });
 
   it("uses a single borderless scroll area that fills the remaining height", () => {

--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
@@ -48,10 +48,14 @@ export function BackgroundTaskRow({
   );
 }
 
+export function isBackgroundTaskRunning(status: Task["status"]): boolean {
+  return status === "pending-model" || status === "pending-tool";
+}
+
 function BackgroundTaskStatusIndicator({ status }: { status: Task["status"] }) {
   return (
     <RowStatusIndicator
-      isRunning={status === "pending-model" || status === "pending-tool"}
+      isRunning={isBackgroundTaskRunning(status)}
       tone={statusTone(status)}
     />
   );

--- a/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
+++ b/packages/vscode-webui/src/features/chat/components/background-task-debug-panel.tsx
@@ -102,7 +102,9 @@ export function BackgroundTaskDetail({
       : undefined;
 
   useEffect(() => {
-    if (isOpen) backButtonRef.current?.focus();
+    // Focusing while the detail is still transformed off screen would have the
+    // browser scroll its container sideways, dragging the panel with it.
+    if (isOpen) backButtonRef.current?.focus({ preventScroll: true });
   }, [isOpen]);
 
   return (


### PR DESCRIPTION
## Summary

- The background-jobs trigger in the chat toolbar badges the number of running background *jobs*, but in dev mode the panel also lists background *tasks* — so the badge under-reported what the panel showed.
- Running background tasks are now counted into the badge as well. Outside dev mode the panel does not list tasks, so nothing is queried and the count is unchanged.
- To reach the task list from the badge, the dev gate moved one level up: `BackgroundJobManagePanel` now only branches on dev mode, `DevManagePanel` owns the `useBackgroundTasks()` query, and `ManagePanel` holds the previous body and receives `tasks`. Non-dev mode passes an empty constant. The running-status predicate was extracted as `isBackgroundTaskRunning` so its definition isn't duplicated across the two files.

## Test plan

- [x] `bun run test -- src/features/chat/components` — 5 files, 59 tests pass, including two new cases:
  - running background tasks are counted into the badge in dev mode
  - running background tasks are left out of the badge outside dev mode
- [x] RED verified: reverting the count to jobs-only fails the new dev-mode badge test and nothing else
- [x] `bun check` clean
- [x] `bun tsc` clean
- [ ] Manual: in dev mode, start a background command and a background task, confirm the toolbar badge shows the combined running count

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-5ece13b407544e96bce35bd1f69dfc1f)