### PR TITLE
fix: open file references with a line range suffix

### DIFF
--- a/packages/vscode-webui/src/components/message/markdown.tsx
+++ b/packages/vscode-webui/src/components/message/markdown.tsx
@@ -2,6 +2,7 @@ import { useReplaceJobIdsInContent } from "@/features/chat";
 import { FileBadge, IssueBadge } from "@/features/tools";
 import { CustomHtmlTags } from "@/lib/constants";
 import { cn } from "@/lib/utils";
+import { parseFilePathLineRange } from "@/lib/utils/file";
 import { isKnownProgrammingLanguage } from "@/lib/utils/languages";
 import { isVSCodeEnvironment, vscodeHost } from "@/lib/vscode";
 import {
@@ -108,21 +109,35 @@ function InlineCodeComponent({
       );
     };
 
+    // a file path may carry a line range suffix, e.g. `src/main.ts:42-56`
+    const { path, startLine, endLine } = parseFilePathLineRange(children);
+
     // children may be file path, folder path, symbol or normal text, we need to handle each case
-    if (isFilePath(children)) {
-      const pathSeparatorCount = (children.match(/[\/\\]/g) || []).length;
+    if (isFilePath(path)) {
+      const pathSeparatorCount = (path.match(/[\/\\]/g) || []).length;
       return (
         <FileBadge
-          path={children}
+          path={path}
+          startLine={startLine}
+          endLine={endLine}
           fallbackGlobPattern={
             // glob pattern use `/` as path separator even on windows; when applied, glob pattern will match paths with both `/` and `\`
-            pathSeparatorCount >= 2 ? `**/${children}` : undefined
+            pathSeparatorCount >= 2 ? `**/${path}` : undefined
           }
         />
       );
     }
-    if (isFolderPath(children)) {
-      return <FileBadge path={children} isDirectory={true} />;
+    if (isFolderPath(path)) {
+      // a line range only makes sense for files
+      const isDirectory = startLine === undefined;
+      return (
+        <FileBadge
+          path={path}
+          startLine={startLine}
+          endLine={endLine}
+          isDirectory={isDirectory}
+        />
+      );
     }
   }
 
@@ -435,8 +450,12 @@ export function MessageMarkdown({
     return {
       file: (props: FileComponentProps) => {
         const { children } = props;
-        const filepath = String(children);
-        return <FileBadge path={filepath} />;
+        const { path, startLine, endLine } = parseFilePathLineRange(
+          String(children),
+        );
+        return (
+          <FileBadge path={path} startLine={startLine} endLine={endLine} />
+        );
       },
       "custom-agent": (props: CustomAgentComponentProps) => {
         const { id, path } = props;

--- a/packages/vscode-webui/src/lib/utils/__tests__/file.test.ts
+++ b/packages/vscode-webui/src/lib/utils/__tests__/file.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isFolder, getBaseName, addLineBreak } from "../file";
+import {
+  isFolder,
+  getBaseName,
+  addLineBreak,
+  parseFilePathLineRange,
+} from "../file";
 
 describe("isFolder", () => {
   describe("should return true for folders", () => {
@@ -149,6 +154,57 @@ describe("getBaseName", () => {
 
   it("should handle Windows paths", () => {
     expect(getBaseName("C:\\path\\to\\file.txt")).toBe("file.txt");
+  });
+});
+
+describe("parseFilePathLineRange", () => {
+  it("should parse a single line suffix", () => {
+    expect(parseFilePathLineRange("src/tau2/utils/llm_utils.py:434")).toEqual({
+      path: "src/tau2/utils/llm_utils.py",
+      startLine: 434,
+      endLine: 434,
+    });
+  });
+
+  it("should parse a line range suffix", () => {
+    expect(
+      parseFilePathLineRange("src/tau2/orchestrator/orchestrator.py:717-725"),
+    ).toEqual({
+      path: "src/tau2/orchestrator/orchestrator.py",
+      startLine: 717,
+      endLine: 725,
+    });
+  });
+
+  it("should ignore a trailing column", () => {
+    expect(parseFilePathLineRange("src/main.ts:42:8")).toEqual({
+      path: "src/main.ts",
+      startLine: 42,
+      endLine: 42,
+    });
+  });
+
+  it("should keep Windows drive letters intact", () => {
+    expect(parseFilePathLineRange("C:\\src\\main.ts:42")).toEqual({
+      path: "C:\\src\\main.ts",
+      startLine: 42,
+      endLine: 42,
+    });
+    expect(parseFilePathLineRange("C:\\src\\main.ts")).toEqual({
+      path: "C:\\src\\main.ts",
+    });
+  });
+
+  it("should return the path unchanged when there is no suffix", () => {
+    expect(parseFilePathLineRange("src/main.ts")).toEqual({
+      path: "src/main.ts",
+    });
+    expect(parseFilePathLineRange("pochi://-/plan.md")).toEqual({
+      path: "pochi://-/plan.md",
+    });
+    expect(parseFilePathLineRange("src/main.ts:0")).toEqual({
+      path: "src/main.ts:0",
+    });
   });
 });
 

--- a/packages/vscode-webui/src/lib/utils/file.ts
+++ b/packages/vscode-webui/src/lib/utils/file.ts
@@ -153,6 +153,55 @@ export const isFolder = (filePath: string) => {
   return true;
 };
 
+export interface FilePathWithLineRange {
+  path: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+const lineRangeSegmentPattern = /^\d+(?:-\d+)?$/;
+
+/**
+ * Parses the trailing line range suffix of a file path, e.g.
+ * - `src/main.ts:42` -> `{ path: "src/main.ts", startLine: 42, endLine: 42 }`
+ * - `src/main.ts:42-56` -> `{ path: "src/main.ts", startLine: 42, endLine: 56 }`
+ * - `src/main.ts:42:8` -> `{ path: "src/main.ts", startLine: 42, endLine: 42 }` (column is ignored)
+ *
+ * Returns the untouched path when there is no valid suffix.
+ */
+export const parseFilePathLineRange = (text: string): FilePathWithLineRange => {
+  const segments = text.split(":");
+  const trailing: string[] = [];
+  // At most two trailing segments are consumed: `<line>[-<endLine>][:<column>]`
+  while (
+    segments.length > 1 &&
+    trailing.length < 2 &&
+    lineRangeSegmentPattern.test(segments[segments.length - 1])
+  ) {
+    trailing.unshift(segments.pop() as string);
+  }
+
+  const path = segments.join(":");
+  if (trailing.length === 0 || path.length === 0) {
+    return { path: text };
+  }
+
+  const [start, end] = trailing[0].split("-");
+  const startLine = Number.parseInt(start, 10);
+  if (!Number.isFinite(startLine) || startLine <= 0) {
+    return { path: text };
+  }
+
+  const parsedEndLine =
+    end === undefined ? startLine : Number.parseInt(end, 10);
+  const endLine =
+    Number.isFinite(parsedEndLine) && parsedEndLine >= startLine
+      ? parsedEndLine
+      : startLine;
+
+  return { path, startLine, endLine };
+};
+
 /**
  * Adds a zero-width space (U+200B) after each URL special character
  * to improve line breaking in URIs.

--- a/packages/vscode/src/lib/__test__/open-file.test.ts
+++ b/packages/vscode/src/lib/__test__/open-file.test.ts
@@ -126,6 +126,57 @@ describe("openFile", () => {
     ]);
   });
 
+  it("opens a file referenced with a line range suffix", async () => {
+    const fileUri = vscode.Uri.joinPath(testDirectory, "line-range.txt");
+    await vscode.workspace.fs.writeFile(
+      fileUri,
+      Buffer.from("one\ntwo\nthree\nfour\nfive\n"),
+    );
+    const showTextDocument = sinon.stub().resolves();
+    const showErrorMessage = sinon.stub();
+    const openFile = loadOpenFile({
+      window: overrideObject(vscode.window, {
+        showTextDocument,
+        showErrorMessage,
+      }),
+    });
+
+    await openFile(`${fileUri.fsPath}:2-4`, undefined);
+
+    assert.strictEqual(showErrorMessage.called, false);
+    assert.strictEqual(showTextDocument.calledOnce, true);
+    assert.strictEqual(
+      showTextDocument.firstCall.args[0].fsPath,
+      fileUri.fsPath,
+    );
+    const selection = showTextDocument.firstCall.args[1].selection;
+    assert.strictEqual(selection.start.line, 1);
+    assert.strictEqual(selection.end.line, 3);
+  });
+
+  it("opens a file referenced with a single line suffix", async () => {
+    const fileUri = vscode.Uri.joinPath(testDirectory, "single-line.txt");
+    await vscode.workspace.fs.writeFile(
+      fileUri,
+      Buffer.from("one\ntwo\nthree\n"),
+    );
+    const showTextDocument = sinon.stub().resolves();
+    const showErrorMessage = sinon.stub();
+    const openFile = loadOpenFile({
+      window: overrideObject(vscode.window, {
+        showTextDocument,
+        showErrorMessage,
+      }),
+    });
+
+    await openFile(`${fileUri.fsPath}:3`, undefined);
+
+    assert.strictEqual(showErrorMessage.called, false);
+    const selection = showTextDocument.firstCall.args[1].selection;
+    assert.strictEqual(selection.start.line, 2);
+    assert.strictEqual(selection.end.line, 2);
+  });
+
   it("opens empty base64 content without showing a missing-file error", async () => {
     const filePath = vscode.Uri.joinPath(testDirectory, "empty.txt").fsPath;
     const stat = sinon.stub().rejects(vscode.FileSystemError.FileNotFound());

--- a/packages/vscode/src/lib/open-file.ts
+++ b/packages/vscode/src/lib/open-file.ts
@@ -49,6 +49,31 @@ const showFileSystemError = (filePath: string, error: unknown): void => {
   void vscode.window.showErrorMessage(`${message}: ${filePath}`);
 };
 
+const lineRangeSuffixPattern = /:(\d+)(?:-(\d+))?$/;
+
+/**
+ * Parses a trailing `:<line>` or `:<start>-<end>` suffix, which is commonly
+ * appended to file paths when referencing source locations.
+ */
+const parseLineRangeSuffix = (
+  filePath: string,
+): { startLine: number; endLine: number; suffixLength: number } | undefined => {
+  const match = lineRangeSuffixPattern.exec(filePath);
+  if (!match) return undefined;
+
+  const startLine = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(startLine) || startLine <= 0) return undefined;
+
+  const parsedEndLine =
+    match[2] === undefined ? startLine : Number.parseInt(match[2], 10);
+  const endLine =
+    Number.isFinite(parsedEndLine) && parsedEndLine >= startLine
+      ? parsedEndLine
+      : startLine;
+
+  return { startLine, endLine, suffixLength: match[0].length };
+};
+
 export type OpenFileOptions = {
   start?: number;
   end?: number;
@@ -116,6 +141,23 @@ export const openFile = async (
         await vscode.commands.executeCommand("vscode.open", tempFile);
         return;
       }
+    }
+
+    const lineRange = parseLineRangeSuffix(resolvedPath);
+    if (lineRange) {
+      logger.info("File not found, retrying without line range suffix", {
+        filePath,
+      });
+      await openFile(
+        filePath.slice(0, filePath.length - lineRange.suffixLength),
+        cwd,
+        {
+          ...options,
+          start: options?.start ?? lineRange.startLine,
+          end: options?.end ?? lineRange.endLine,
+        },
+      );
+      return;
     }
 
     if (options?.fallbackGlobPattern) {


### PR DESCRIPTION
## Summary
- File references such as `src/tau2/utils/llm_utils.py:434` or `src/tau2/orchestrator/orchestrator.py:717-725` were rendered as **directory** badges (`isFilePath` requires the string to end with an extension, so the `:434` suffix pushed them into the `isFolderPath` branch) and the suffix stayed in the badge `path`.
- Clicking then called `openFile("…py:434")`, whose `stat` fails with `FileNotFound`, so the click only produced a "File not found" error.
- Added `parseFilePathLineRange()` and used it in the markdown renderer (inline code and the `<file>` tag) so the badge opens the clean path with the referenced lines selected, while still displaying the `:434` / `:717-725` suffix. Windows drive letters, `pochi://` URIs and invalid ranges are left untouched.
- Added a defensive fallback in `openFile`: when a missing path ends with a line range suffix, it retries with the suffix stripped and the range applied as the selection, so references from other sources (terminal output, agents) work too.

## Test plan
- [x] `bun run test` in `packages/vscode-webui` (new `parseFilePathLineRange` cases)
- [x] `bun run test` in `packages/vscode` (new `openFile` tests for `:3` and `:2-4`)
- [x] `bun check`
- [x] `bun tsc`
- [ ] Manual: click a `path:line` badge in a chat message and confirm the editor opens at that line

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1c6bda36d34046e78dd6c7b34cf98544)