### PR TITLE
fix(vendor-pochi): authenticate model list requests

### DIFF
--- a/packages/vendor-pochi/src/vendor.ts
+++ b/packages/vendor-pochi/src/vendor.ts
@@ -80,7 +80,9 @@ export class Pochi extends VendorBase {
       !this.cachedModels ||
       Object.keys(this.cachedModels).length === 0
     ) {
-      const apiClient: PochiApiClient = hc<PochiApi>(getServerBaseUrl());
+      const apiClient: PochiApiClient = hc<PochiApi>(getServerBaseUrl(), {
+        fetch: buildCustomFetchImpl(),
+      });
       const data = await withRetry(
         async () => {
           const response = await apiClient.api.models.$get();


### PR DESCRIPTION
## Summary
- authenticate `/api/models` requests with the stored Pochi session token
- expose account-specific models, including internal-only models, in the model selector

## Test plan
- [x] Run `bun tsc` in `packages/vendor-pochi`
- [x] Run root `bun check`
- [x] Fetch models through `Pochi().fetchModels(true)` and verify `google/gemini-3.1-flash-lite` is returned

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-13e2241c2c8e4c2582fcf64a0a8fd6aa)